### PR TITLE
Infinite loading and pagination

### DIFF
--- a/app/components/CollectionCard.tsx
+++ b/app/components/CollectionCard.tsx
@@ -1,0 +1,30 @@
+import type {Collection} from '@shopify/hydrogen-ui-alpha/storefront-api-types';
+import {Heading, Link} from '~/components';
+
+export function CollectionCard({
+  collection,
+  loading,
+}: {
+  collection: Collection;
+  loading?: HTMLImageElement['loading'];
+}) {
+  return (
+    <Link to={`/collections/${collection.handle}`} className="grid gap-4">
+      <div className="card-image bg-primary/5 aspect-[3/2]">
+        {collection?.image && (
+          <img
+            alt={collection.title}
+            src={collection.image.url}
+            height={400}
+            sizes="(max-width: 32em) 100vw, 33vw"
+            width={600}
+            loading={loading}
+          />
+        )}
+      </div>
+      <Heading as="h3" size="copy">
+        {collection.title}
+      </Heading>
+    </Link>
+  );
+}

--- a/app/components/CollectionGrid.tsx
+++ b/app/components/CollectionGrid.tsx
@@ -1,0 +1,76 @@
+import type {
+  Collection,
+  CollectionConnection,
+} from '@shopify/hydrogen-ui-alpha/storefront-api-types';
+import {useState} from 'react';
+import {Link} from '~/components';
+import {CollectionCard} from '~/components/CollectionCard';
+import {MoreGridItems} from '~/components/MoreGridItems';
+import {Grid} from '~/components/Grid';
+import {getImageLoadingPriority} from '~/lib/const';
+import clsx from "clsx";
+
+export function CollectionGrid({
+  collections: initialCollections,
+  ...props
+}: {
+  collections: CollectionConnection;
+  [key: string]: any;
+}) {
+  const [collections, setProducts] = useState<
+    CollectionConnection['nodes'] | []
+  >(initialCollections?.nodes || []);
+  const [hasNextPage, setHasNextPage] = useState<boolean>(
+    initialCollections?.pageInfo?.hasNextPage || false
+  );
+  const [cursor, setCursor] = useState<string | null>(
+    initialCollections?.pageInfo?.endCursor || null
+  );
+
+  if (!collections?.length) {
+    return (
+      <>
+        <p>No collections found</p>
+        <Link to="/products">
+          <p className="underline">Browse catalog</p>
+        </Link>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Grid items={collections.length === 3 ? 3 : 2}>
+        {collections.map((collection, i) => (
+          <CollectionCard
+            collection={collection as Collection}
+            key={collection.id}
+            loading={getImageLoadingPriority(i, 2)}
+          />
+        ))}
+      </Grid>
+
+      {/* Load additional collections on scroll */}
+      {hasNextPage && cursor && (
+        <MoreGridItems
+          {...props}
+          cursor={cursor}
+          key={cursor}
+          className={clsx(
+            'grid-cols-1',
+            'md:grid-cols-2',
+            'grid gap-2 gap-y-6 md:gap-4 lg:gap-6',
+            'grid-flow-row'
+          )}
+          pageBy={2}
+          placeholderItem={
+            <div className="h-[310px] sm:h-[480px] md:h-[315px] lg:h-[386px] xl:h-[348px] 2xl:h-[560px] bg-gray-100"></div>
+          }
+          setCursor={setCursor}
+          setHasNextPage={setHasNextPage}
+          setItems={setProducts}
+        />
+      )}
+    </>
+  );
+}

--- a/app/components/Grid.tsx
+++ b/app/components/Grid.tsx
@@ -21,7 +21,7 @@ export function Grid({
     default: `grid-cols-1 ${items === 2 && "md:grid-cols-2"}  ${
       items === 3 && "sm:grid-cols-3"
     } ${items > 3 && "md:grid-cols-3"} ${items >= 4 && "lg:grid-cols-4"}`,
-    products: `grid-cols-2 ${items >= 3 && "md:grid-cols-3"} ${
+    products: `grid-cols-2 ${items >= 3 && "md:grid-cols-2"} ${
       items >= 4 && "lg:grid-cols-4"
     }`,
     auto: "auto-cols-auto",

--- a/app/components/MoreGridItems.tsx
+++ b/app/components/MoreGridItems.tsx
@@ -1,13 +1,13 @@
-import {useEffect, cloneElement, useRef, useCallback} from 'react';
-import {useInView} from 'react-intersection-observer';
-import {useFetcher} from '@remix-run/react';
+import { useEffect, cloneElement, useRef, useCallback } from "react";
+import { useInView } from "react-intersection-observer";
+import { useFetcher } from "@remix-run/react";
 
-interface MoreGridItems {
+interface MoreGridItemsProps {
   className?: string;
   cursor: string;
   pageBy?: number;
   placeholderItem?: React.ReactElement<
-    {key: number},
+    { key: number },
     string | React.JSXElementConstructor<any>
   >;
   setCursor: (value: string | null) => void;
@@ -21,7 +21,7 @@ interface MoreGridItems {
   to enable infinite loading
 */
 export function MoreGridItems({
-  className = 'grid-flow-row grid gap-2 gap-y-6 md:gap-4 lg:gap-6 grid-cols-2 md:grid-cols-2 lg:grid-cols-4',
+  className = "grid-flow-row grid gap-2 gap-y-6 md:gap-4 lg:gap-6 grid-cols-2 md:grid-cols-2 lg:grid-cols-4",
   cursor,
   pageBy = 4,
   placeholderItem = (
@@ -31,11 +31,11 @@ export function MoreGridItems({
   setHasNextPage,
   setItems,
   ...props
-}: MoreGridItems) {
-  const {load, type, data, state} = useFetcher();
+}: MoreGridItemsProps) {
+  const { load, type, data, state } = useFetcher();
   const fetching = useRef(false);
 
-  const {ref, inView} = useInView({
+  const { ref, inView } = useInView({
     threshold: 0,
     triggerOnce: true,
   });
@@ -43,7 +43,7 @@ export function MoreGridItems({
   // load next set of items
   const loadNextPage = useCallback(() => {
     if (!inView) return;
-    if (type !== 'init') return;
+    if (type !== "init") return;
     if (fetching.current) return;
     fetching.current = true;
 
@@ -53,7 +53,7 @@ export function MoreGridItems({
 
   // merge grid results and update state
   const onPageLoadedMergeItems = useCallback(() => {
-    if (state !== 'idle') return;
+    if (state !== "idle") return;
     if (!data) return;
 
     const result =
@@ -62,7 +62,7 @@ export function MoreGridItems({
       data?.collections; // /collections
 
     if (!result) {
-      return console.warn('Paginated query data not supported', {data});
+      return console.warn("Paginated query data not supported", { data });
     }
 
     const hasNextPage = result?.pageInfo?.hasNextPage || false;
@@ -91,8 +91,8 @@ export function MoreGridItems({
   return (
     <div className={className} ref={ref} {...props}>
       {/* placeholder row of item that will be observed */}
-      {new Array(pageBy).fill('').map((_, i) => {
-        return cloneElement(placeholderItem, {key: i});
+      {new Array(pageBy).fill("").map((_, i) => {
+        return cloneElement(placeholderItem, { key: i });
       })}
     </div>
   );

--- a/app/components/MoreGridItems.tsx
+++ b/app/components/MoreGridItems.tsx
@@ -1,0 +1,99 @@
+import {useEffect, cloneElement, useRef, useCallback} from 'react';
+import {useInView} from 'react-intersection-observer';
+import {useFetcher} from '@remix-run/react';
+
+interface MoreGridItems {
+  className?: string;
+  cursor: string;
+  pageBy?: number;
+  placeholderItem?: React.ReactElement<
+    {key: number},
+    string | React.JSXElementConstructor<any>
+  >;
+  setCursor: (value: string | null) => void;
+  setHasNextPage: (value: boolean) => void;
+  setItems: (value: any) => any;
+  [key: string]: any;
+}
+
+/*
+  A multipurpose observer-aware grid component
+  to enable infinite loading
+*/
+export function MoreGridItems({
+  className = 'grid-flow-row grid gap-2 gap-y-6 md:gap-4 lg:gap-6 grid-cols-2 md:grid-cols-2 lg:grid-cols-4',
+  cursor,
+  pageBy = 4,
+  placeholderItem = (
+    <div className="bg-gray-400 h-[244px] sm:h-[280px] md:h-[500px] lg:h-[300px] xl:h-[348px] 2xl:h-[500px]"></div>
+  ),
+  setCursor,
+  setHasNextPage,
+  setItems,
+  ...props
+}: MoreGridItems) {
+  const {load, type, data, state} = useFetcher();
+  const fetching = useRef(false);
+
+  const {ref, inView} = useInView({
+    threshold: 0,
+    triggerOnce: true,
+  });
+
+  // load next set of items
+  const loadNextPage = useCallback(() => {
+    if (!inView) return;
+    if (type !== 'init') return;
+    if (fetching.current) return;
+    fetching.current = true;
+
+    const href = window.location.pathname + `?index&cursor=${cursor}`;
+    load(href);
+  }, [cursor, type, load, inView]);
+
+  // merge grid results and update state
+  const onPageLoadedMergeItems = useCallback(() => {
+    if (state !== 'idle') return;
+    if (!data) return;
+
+    const result =
+      data?.collection?.products || // /collection/$handle
+      data?.products || // /products
+      data?.collections; // /collections
+
+    if (!result) {
+      return console.warn('Paginated query data not supported', {data});
+    }
+
+    const hasNextPage = result?.pageInfo?.hasNextPage || false;
+    const endCursor = result?.pageInfo?.endCursor || null;
+    const pageItems = result?.nodes || null;
+
+    if (!hasNextPage) {
+      setCursor(null);
+      setHasNextPage(false);
+    } else {
+      setCursor(endCursor);
+      setHasNextPage(true);
+    }
+
+    if (pageItems?.length) {
+      setItems((items: []) => [...items, ...pageItems]);
+    }
+  }, [data, state]);
+
+  // when the placeholder grid comes into view, fetch new page
+  useEffect(loadNextPage, [cursor, type, load, inView]);
+
+  // when the new page results are ready update the state
+  useEffect(onPageLoadedMergeItems, [data, state]);
+
+  return (
+    <div className={className} ref={ref} {...props}>
+      {/* placeholder row of item that will be observed */}
+      {new Array(pageBy).fill('').map((_, i) => {
+        return cloneElement(placeholderItem, {key: i});
+      })}
+    </div>
+  );
+}

--- a/app/components/ProductCard.tsx
+++ b/app/components/ProductCard.tsx
@@ -59,13 +59,6 @@ export function ProductCard({
     >
       <div className={styles}>
         <div className="card-image aspect-[4/5] bg-primary/5">
-          <Text
-            as="label"
-            size="fine"
-            className="absolute top-0 right-0 m-4 text-right text-notice"
-          >
-            {cardLabel}
-          </Text>
           {image && (
             <Image
               className="aspect-[4/5] w-full object-cover fadeIn"
@@ -83,6 +76,13 @@ export function ProductCard({
               loading={loading}
             />
           )}
+          <Text
+            as="label"
+            size="fine"
+            className="absolute top-0 right-0 m-4 text-right text-notice"
+          >
+            {cardLabel}
+          </Text>
         </div>
         <div className="grid gap-1">
           <Text

--- a/app/components/ProductGrid.tsx
+++ b/app/components/ProductGrid.tsx
@@ -1,14 +1,14 @@
 import { Link } from "~/components";
 import type { ProductConnection } from "@shopify/hydrogen-ui-alpha/storefront-api-types";
-import { ProductGridPaginated } from '~/components/ProductGridPaginated';
+import { ProductGridPaginated } from "~/components/ProductGridPaginated";
 import { ProductGridInfinite } from "~/components/ProductGridInfinite";
 
 export function ProductGrid({
-  paginated = false,
+  paginated = true,
   products,
   ...props
 }: {
-  paginated?: boolean
+  paginated?: boolean;
   products: ProductConnection;
   [key: string]: any;
 }) {
@@ -23,19 +23,13 @@ export function ProductGrid({
     );
   }
 
-    /* TODO:
+  /* TODO:
       - Optional consideration: Virtualization if very long list (need to consider impact of scroll position, etc.)
     */
 
-  return (
-    paginated
-      ? <ProductGridPaginated
-          {...props}
-          products={products}
-        />
-      : <ProductGridInfinite
-          {...props}
-          products={products}
-        />
+  return paginated ? (
+    <ProductGridPaginated {...props} products={products} />
+  ) : (
+    <ProductGridInfinite {...props} products={products} />
   );
 }

--- a/app/components/ProductGridInfinite.tsx
+++ b/app/components/ProductGridInfinite.tsx
@@ -1,0 +1,51 @@
+import {useState} from 'react';
+import {Grid, ProductCard} from '~/components';
+import {getImageLoadingPriority} from '~/lib/const';
+import type {ProductConnection} from '@shopify/hydrogen-ui-alpha/storefront-api-types';
+import {MoreGridItems} from '~/components/MoreGridItems';
+
+export function ProductGridInfinite({
+  products: initialProducts,
+  ...props
+}: {
+  products: ProductConnection;
+  [key: string]: any;
+}) {
+  const [products, setProducts] = useState<ProductConnection['nodes'] | []>(
+    initialProducts?.nodes || []
+  );
+  const [hasNextPage, setHasNextPage] = useState<boolean>(
+    initialProducts?.pageInfo?.hasNextPage || false
+  );
+  const [cursor, setCursor] = useState<string | null>(
+    initialProducts?.pageInfo?.endCursor || null
+  );
+
+  return (
+    <>
+      <Grid layout="products">
+        {products.map((product: any, index) => {
+          return (
+            <ProductCard
+              key={product.id}
+              product={product}
+              loading={getImageLoadingPriority(index)}
+            />
+          );
+        })}
+      </Grid>
+
+      {/* Load additional collection products on scroll */}
+      {hasNextPage && cursor && (
+        <MoreGridItems
+          {...props}
+          cursor={cursor}
+          key={cursor}
+          setCursor={setCursor}
+          setHasNextPage={setHasNextPage}
+          setItems={setProducts}
+        />
+      )}
+    </>
+  );
+}

--- a/app/components/ProductGridPaginated.tsx
+++ b/app/components/ProductGridPaginated.tsx
@@ -1,0 +1,69 @@
+import {Button, Grid, ProductCard} from '~/components';
+import {getImageLoadingPriority} from '~/lib/const';
+import type {ProductConnection} from '@shopify/hydrogen-ui-alpha/storefront-api-types';
+import {useTransition} from '@remix-run/react';
+
+export function ProductGridPaginated({
+  products: initialProducts,
+}: {
+  products: ProductConnection;
+}) {
+  const transition = useTransition();
+
+  /* TODO:
+    - Load More -> Passes pages in location state via Link component
+
+    - product grid prepends location state products if found
+    -- if found, never render a previous page link (because you'll already have it since page 1)
+*/
+
+  const {hasNextPage, hasPreviousPage, startCursor, endCursor} =
+    initialProducts?.pageInfo;
+
+  const products = initialProducts?.nodes;
+
+  return (
+    <>
+      {hasPreviousPage && (
+        <div className="flex items-center justify-center mt-6">
+          <Button
+            to={`.?cursor=${startCursor}&direction=previous`}
+            disabled={transition.state !== 'idle'}
+            variant="secondary"
+            width="full"
+            prefetch="intent"
+          >
+            {transition.state !== 'idle'
+              ? 'Loading...'
+              : 'Load previous products'}
+          </Button>
+        </div>
+      )}
+
+      <Grid layout="products">
+        {products.map((product, i) => (
+          <ProductCard
+            key={product.id}
+            product={product}
+            loading={getImageLoadingPriority(i)}
+          />
+        ))}
+      </Grid>
+
+      {hasNextPage && (
+        <div className="flex items-center justify-center mt-6">
+          <Button
+            to={`.?cursor=${endCursor}&direction=next`}
+            disabled={transition.state !== 'idle'}
+            variant="secondary"
+            width="full"
+            preventScrollReset
+            prefetch="intent"
+          >
+            {transition.state !== 'idle' ? 'Loading...' : 'Load more products'}
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/components/ProductGridPaginated.tsx
+++ b/app/components/ProductGridPaginated.tsx
@@ -1,7 +1,7 @@
-import {Button, Grid, ProductCard} from '~/components';
-import {getImageLoadingPriority} from '~/lib/const';
-import type {ProductConnection} from '@shopify/hydrogen-ui-alpha/storefront-api-types';
-import {useTransition} from '@remix-run/react';
+import { Button, Grid, ProductCard } from "~/components";
+import { getImageLoadingPriority } from "~/lib/const";
+import type { ProductConnection } from "@shopify/hydrogen-ui-alpha/storefront-api-types";
+import { useTransition, useLocation } from "@remix-run/react";
 
 export function ProductGridPaginated({
   products: initialProducts,
@@ -10,38 +10,66 @@ export function ProductGridPaginated({
 }) {
   const transition = useTransition();
 
-  /* TODO:
-    - Load More -> Passes pages in location state via Link component
-
-    - product grid prepends location state products if found
-    -- if found, never render a previous page link (because you'll already have it since page 1)
-*/
-
-  const {hasNextPage, hasPreviousPage, startCursor, endCursor} =
+  const { hasNextPage, hasPreviousPage, startCursor, endCursor } =
     initialProducts?.pageInfo;
 
   const products = initialProducts?.nodes;
+  const location = useLocation();
+  const state = location.state as any;
+  const search = new URLSearchParams(location.search);
+  const isPrevious = search.get("direction") === "previous";
+
+  let stateStartCursor =
+    state?.startCursor === undefined ? startCursor : state.startCursor;
+
+  let stateEndCursor =
+    state?.endCursor === undefined ? endCursor : state.endCursor;
+
+  let currentlyShownProducts = products;
+
+  if (state?.products) {
+    if (isPrevious) {
+      currentlyShownProducts = [...products, ...state.products];
+      stateStartCursor = startCursor;
+    } else {
+      currentlyShownProducts = [...state?.products, ...products];
+      stateEndCursor = endCursor;
+    }
+  }
+
+  let previousPageExists =
+    state?.hasPreviousPage === undefined
+      ? hasPreviousPage
+      : state.hasPreviousPage;
+  let nextPageExists =
+    state?.hasNextPage === undefined ? hasNextPage : state.hasNextPage;
 
   return (
     <>
-      {hasPreviousPage && (
+      {previousPageExists && (
         <div className="flex items-center justify-center mt-6">
           <Button
-            to={`?cursor=${startCursor}&direction=previous`}
-            disabled={transition.state !== 'idle'}
+            to={`?cursor=${stateStartCursor}&direction=previous`}
+            disabled={transition.state !== "idle"}
             variant="secondary"
             width="full"
             prefetch="intent"
+            state={{
+              endCursor: stateEndCursor,
+              startCursor: stateStartCursor,
+              hasNextPage: nextPageExists,
+              products: currentlyShownProducts,
+            }}
           >
-            {transition.state !== 'idle'
-              ? 'Loading...'
-              : 'Load previous products'}
+            {transition.state === "loading"
+              ? "Loading..."
+              : "Load previous products"}
           </Button>
         </div>
       )}
 
       <Grid layout="products">
-        {products.map((product, i) => (
+        {currentlyShownProducts.map((product, i) => (
           <ProductCard
             key={product.id}
             product={product}
@@ -50,17 +78,22 @@ export function ProductGridPaginated({
         ))}
       </Grid>
 
-      {hasNextPage && (
+      {nextPageExists && (
         <div className="flex items-center justify-center mt-6">
           <Button
-            to={`.?cursor=${endCursor}&direction=next`}
-            disabled={transition.state !== 'idle'}
+            to={`.?cursor=${stateEndCursor}&direction=next`}
+            disabled={transition.state !== "idle"}
             variant="secondary"
             width="full"
-            preventScrollReset
             prefetch="intent"
+            state={{
+              endCursor: stateEndCursor,
+              startCursor: stateStartCursor,
+              hasPreviousPage: previousPageExists,
+              products: currentlyShownProducts,
+            }}
           >
-            {transition.state !== 'idle' ? 'Loading...' : 'Load more products'}
+            {transition.state !== "idle" ? "Loading..." : "Load more products"}
           </Button>
         </div>
       )}

--- a/app/components/ProductGridPaginated.tsx
+++ b/app/components/ProductGridPaginated.tsx
@@ -27,7 +27,7 @@ export function ProductGridPaginated({
       {hasPreviousPage && (
         <div className="flex items-center justify-center mt-6">
           <Button
-            to={`.?cursor=${startCursor}&direction=previous`}
+            to={`?cursor=${startCursor}&direction=previous`}
             disabled={transition.state !== 'idle'}
             variant="secondary"
             width="full"

--- a/app/routes/$lang/collections/$collectionHandle.tsx
+++ b/app/routes/$lang/collections/$collectionHandle.tsx
@@ -1,4 +1,0 @@
-import Component, { loader, meta } from '~/routes/collections/$collectionHandle';
-
-export { loader, meta };
-export default Component;

--- a/app/routes/$lang/collections/$handle.tsx
+++ b/app/routes/$lang/collections/$handle.tsx
@@ -1,0 +1,4 @@
+import Component, { loader, meta } from '~/routes/collections/$handle';
+
+export { loader, meta };
+export default Component;

--- a/app/routes/$lang/products/$handle.tsx
+++ b/app/routes/$lang/products/$handle.tsx
@@ -1,0 +1,4 @@
+import Component, { loader, action, ProductForm } from '~/routes/products/$handle';
+
+export { loader, action, ProductForm };
+export default Component;

--- a/app/routes/$lang/products/$productHandle.tsx
+++ b/app/routes/$lang/products/$productHandle.tsx
@@ -1,4 +1,0 @@
-import Component, { loader, action, ProductForm } from '~/routes/products/$productHandle';
-
-export { loader, action, ProductForm };
-export default Component;

--- a/app/routes/collections/$handle.tsx
+++ b/app/routes/collections/$handle.tsx
@@ -5,7 +5,7 @@ import {
   type LoaderArgs,
 } from "@remix-run/cloudflare";
 import { useLoaderData } from "@remix-run/react";
-import type {ProductConnection } from "@shopify/hydrogen-ui-alpha/storefront-api-types";
+import type { ProductConnection } from "@shopify/hydrogen-ui-alpha/storefront-api-types";
 import invariant from "tiny-invariant";
 import { PageHeader, Section, Text } from "~/components";
 import { ProductGrid } from "~/components/ProductGrid";
@@ -24,7 +24,7 @@ export async function loader({ params, request }: LoaderArgs) {
 
   const collection = await getCollection({
     handle,
-    pageBy: 4,
+    pageBy: 2,
     direction,
     cursor,
     params,
@@ -46,7 +46,6 @@ export const meta: MetaFunction = ({
 
 export default function Collection() {
   const { collection } = useLoaderData<typeof loader>();
-
   return (
     <>
       <PageHeader heading={collection.title}>

--- a/app/routes/collections/$handle.tsx
+++ b/app/routes/collections/$handle.tsx
@@ -5,19 +5,30 @@ import {
   type LoaderArgs,
 } from "@remix-run/cloudflare";
 import { useLoaderData } from "@remix-run/react";
-import type { Collection as CollectionType } from "@shopify/hydrogen-ui-alpha/storefront-api-types";
+import type {ProductConnection } from "@shopify/hydrogen-ui-alpha/storefront-api-types";
 import invariant from "tiny-invariant";
 import { PageHeader, Section, Text } from "~/components";
 import { ProductGrid } from "~/components/ProductGrid";
 import { getCollection } from "~/data";
 
 export async function loader({ params, request }: LoaderArgs) {
-  const { collectionHandle } = params;
+  const { handle } = params;
 
-  invariant(collectionHandle, "Missing collectionHandle param");
+  invariant(handle, "Missing collection handle param");
 
-  const cursor = new URL(request.url).searchParams.get("cursor") ?? undefined;
-  const collection = await getCollection({ handle: collectionHandle, cursor, params });
+  const searchParams = new URL(request.url).searchParams;
+
+  const cursor = searchParams.get("cursor") ?? undefined;
+  const direction =
+    searchParams.get("direction") === "previous" ? "previous" : "next";
+
+  const collection = await getCollection({
+    handle,
+    pageBy: 4,
+    direction,
+    cursor,
+    params,
+  });
 
   return json({ collection });
 }
@@ -52,8 +63,7 @@ export default function Collection() {
       <Section>
         <ProductGrid
           key={collection.id}
-          collection={collection as CollectionType}
-          url={`/collections/${collection.handle}`}
+          products={collection.products as ProductConnection}
         />
       </Section>
     </>

--- a/app/routes/products/$handle.tsx
+++ b/app/routes/products/$handle.tsx
@@ -40,11 +40,11 @@ import clsx from "clsx";
 import { getSession } from "~/lib/session.server";
 
 export const loader = async ({ params, request }: LoaderArgs) => {
-  const { productHandle } = params;
-  invariant(productHandle, "Missing productHandle param, check route filename");
+  const { handle } = params;
+  invariant(handle, "Missing handle param, check route filename");
 
   const { shop, product } = await getProductData(
-    productHandle,
+    handle,
     new URL(request.url).searchParams,
     params
   );

--- a/app/routes/products/index.tsx
+++ b/app/routes/products/index.tsx
@@ -1,35 +1,36 @@
-import type { LoaderArgs, MetaFunction } from "@remix-run/cloudflare";
-import { useLoaderData } from "@remix-run/react";
-import type { Collection } from "@shopify/hydrogen-ui-alpha/storefront-api-types";
-import { PageHeader, Section, ProductGrid } from "~/components";
-import { getAllProducts } from "~/data";
+import {json, type LoaderArgs, type MetaFunction} from '@remix-run/cloudflare';
+import {useLoaderData} from '@remix-run/react';
+import type {ProductConnection} from '@shopify/hydrogen-ui-alpha/storefront-api-types';
+import {PageHeader, Section, ProductGrid} from '~/components';
+import {getAllProducts} from '~/data';
 
-export async function loader({ request, params }: LoaderArgs) {
-  const cursor = new URL(request.url).searchParams.get("cursor") ?? undefined;
-  const products = await getAllProducts({ cursor, params });
+export async function loader({request, params}: LoaderArgs) {
+  const searchParams = new URL(request.url).searchParams;
 
-  return products;
+  const cursor = searchParams.get('cursor') ?? undefined;
+  const direction =
+    searchParams.get('direction') === 'previous' ? 'previous' : 'next';
+
+  return json({
+    products: await getAllProducts({cursor, pageBy: 4, direction, params}),
+  });
 }
 
 export const meta: MetaFunction = () => {
   return {
-    title: "All Products",
-    description: "All Products",
+    title: 'All Products',
+    description: 'All Products',
   };
 };
 
 export default function AllProducts() {
-  const products = useLoaderData<typeof loader>();
+  const {products} = useLoaderData<typeof loader>();
 
   return (
     <>
       <PageHeader heading="All Products" variant="allCollections" />
       <Section>
-        <ProductGrid
-          key="products"
-          url="/products"
-          collection={{ products } as Collection}
-        />
+        <ProductGrid key="products" products={products as ProductConnection} />
       </Section>
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "graphql-tag": "^2.12.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^9.4.0",
         "react-use": "^17.4.0",
         "tiny-invariant": "^1.2.0",
         "typographic-base": "^1.0.4"
@@ -12427,6 +12428,14 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-intersection-observer": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.0.tgz",
+      "integrity": "sha512-v0403CmomOVlzhqFXlzOxg0ziLcVq8mfbP0AwAcEQWgZmR2OulOT79Ikznw4UlB3N+jlUYqLMe4SDHUOyp0t2A==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0|| ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -24315,6 +24324,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-intersection-observer": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.4.0.tgz",
+      "integrity": "sha512-v0403CmomOVlzhqFXlzOxg0ziLcVq8mfbP0AwAcEQWgZmR2OulOT79Ikznw4UlB3N+jlUYqLMe4SDHUOyp0t2A==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "graphql-tag": "^2.12.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.4.0",
     "react-use": "^17.4.0",
     "tiny-invariant": "^1.2.0",
     "typographic-base": "^1.0.4"


### PR DESCRIPTION
This is a clean PR replacing https://github.com/Shopify/h2-demo-store/pull/59 which became too difficult to merge back to main.

# Quick demo:
https://screenshot.click/13-23-iwnci-10qow.mp4

# Completed:
- Adds infinite loading & pagination (optional) to `/products` & `/collections/$handle`
- Adds infinite loading `/collections`

# Todo:
- Extend MoreGridItems to add infinite on `/journal`
- Add orders pagination on `/account`
- Sync with @brophdawg11 about leveraging `Link.state` in the pagination.


---

@brophdawg11's comment
> One nuance here that Ryan and I chatted about after the huddles - this location state will work great for client-side back/forward navigations, but won't available during SSR if the user does a hard reload - and then will be available client side so could result in hydration issues or flickers of SSR-ing only the "trailing" pages and then client-side rendering the prepended pages from location state.

> To avoid this, hard reloads should ignore the client side state and should effectively be treated as if you shared the URL to a new browser. Probably requires some form of isHydrated check to see if we got SSR'd without the previous pages and then we know not to prepend them.

---

@benjaminsehl @cartogram @brophdawg11

