### PR TITLE
Add current Nav links

### DIFF
--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -170,15 +170,29 @@ function MenuMobileNav({
   menu: EnhancedMenu;
   onClose: () => void;
 }) {
+  const styles = {
+    link: "pb-1",
+    linkActive: "pb-1 border-b-2",
+  };
+
   return (
     <nav className="grid gap-4 p-6 sm:gap-6 sm:px-12 sm:py-8">
       {/* Top level menu items */}
       {(menu?.items || []).map((item) => (
-        <Link key={item.id} to={item.to} target={item.target} onClick={onClose}>
-          <Text as="span" size="copy">
-            {item.title}
-          </Text>
-        </Link>
+        <span key={item.id} className="block">
+          <Link
+            to={item.to}
+            target={item.target}
+            onClick={onClose}
+            className={({ isActive }) =>
+              isActive ? styles.linkActive : styles.link
+            }
+          >
+            <Text as="span" size="copy">
+              {item.title}
+            </Text>
+          </Link>
+        </span>
       ))}
     </nav>
   );
@@ -275,6 +289,8 @@ function DesktopHeader({
   const params = useParams();
 
   const styles = {
+    link: "pb-1",
+    linkActive: "pb-1 border-b-2",
     button:
       "relative flex items-center justify-center w-8 h-8 focus:ring-primary/5",
     container: `${
@@ -289,7 +305,7 @@ function DesktopHeader({
   return (
     <header role="banner" className={styles.container}>
       <div className="flex gap-12">
-        <Link className={`font-bold`} to="/" prefetch="intent">
+        <Link className="font-bold" to="/" prefetch="intent">
           {title}
         </Link>
         <nav className="flex gap-8">
@@ -300,6 +316,9 @@ function DesktopHeader({
               to={item.to}
               target={item.target}
               prefetch="intent"
+              className={({ isActive }) =>
+                isActive ? styles.linkActive : styles.link
+              }
             >
               {item.title}
             </Link>

--- a/app/components/Link.tsx
+++ b/app/components/Link.tsx
@@ -1,4 +1,14 @@
-import { Link as RemixLink, useParams } from "@remix-run/react";
+import {
+  Link as RemixLink,
+  useParams,
+  NavLink as RemixNavLink,
+  type NavLinkProps as RemixNavLinkProps,
+  type LinkProps as RemixLinkProps,
+} from "@remix-run/react";
+
+type LinkProps = Omit<RemixLinkProps, "className"> & {
+  className?: RemixNavLinkProps["className"] | RemixLinkProps["className"];
+};
 
 /**
  * In our app, we've chosen to wrap Remix's `Link` component to add
@@ -15,8 +25,8 @@ import { Link as RemixLink, useParams } from "@remix-run/react";
  *
  * Ultimately, it is up to you to decide how to implement this behavior.
  */
-export function Link(props: any) {
-  const { to, ...resOfProps } = props;
+export function Link(props: LinkProps) {
+  const { to, className, ...resOfProps } = props;
   const { lang } = useParams();
 
   let toWithLang = to;
@@ -25,5 +35,11 @@ export function Link(props: any) {
     toWithLang = lang ? `/${lang}${to}` : to;
   }
 
-  return <RemixLink to={toWithLang} {...resOfProps} />;
+  if (typeof className === "function") {
+    return (
+      <RemixNavLink to={toWithLang} className={className} {...resOfProps} />
+    );
+  }
+
+  return <RemixLink to={toWithLang} className={className} {...resOfProps} />;
 }


### PR DESCRIPTION
This PR adds additional style to mobile and desktop nav links when they are matched by the current URL. This is accomplished by conditionally rendering a [NavLink](https://remix.run/docs/en/v1/api/remix#navlink) in place of a Link.

### On mobile

<img width="930" alt="Screenshot 2022-10-18 at 08 43 43" src="https://user-images.githubusercontent.com/462077/196355271-65d9c709-4da9-408b-b316-63e59a4f7e79.png">

### On Desktop

<img width="847" alt="Screenshot 2022-10-18 at 08 44 08" src="https://user-images.githubusercontent.com/462077/196355345-752ad22d-4e7d-4cdd-ad73-b9258325cda9.png">
