### PR TITLE
Dim instead of underline in active menu links

### DIFF
--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -164,11 +164,6 @@ function MenuMobileNav({
   menu: EnhancedMenu;
   onClose: () => void;
 }) {
-  const styles = {
-    link: 'pb-1',
-    linkActive: 'pb-1 border-b-2',
-  };
-
   return (
     <nav className="grid gap-4 p-6 sm:gap-6 sm:px-12 sm:py-8">
       {/* Top level menu items */}
@@ -178,9 +173,7 @@ function MenuMobileNav({
             to={item.to}
             target={item.target}
             onClick={onClose}
-            className={({isActive}) =>
-              isActive ? styles.linkActive : styles.link
-            }
+            className={({isActive}) => (isActive ? 'opacity-50' : undefined)}
           >
             <Text as="span" size="copy">
               {item.title}
@@ -283,8 +276,6 @@ function DesktopHeader({
   const params = useParams();
 
   const styles = {
-    link: 'pb-1',
-    linkActive: 'pb-1 border-b-2',
     button:
       'relative flex items-center justify-center w-8 h-8 focus:ring-primary/5',
     container: `${
@@ -310,9 +301,7 @@ function DesktopHeader({
               to={item.to}
               target={item.target}
               prefetch="intent"
-              className={({isActive}) =>
-                isActive ? styles.linkActive : styles.link
-              }
+              className={({isActive}) => (isActive ? 'opacity-50' : undefined)}
             >
               {item.title}
             </Link>


### PR DESCRIPTION
The descenders in the word Hydrogen, make alignment here optically off. Decided to dim rather than use a border for this reason. Probably still not right, but better.


### Before

<img width="522" alt="Screenshot 2022-10-18 at 17 10 56" src="https://user-images.githubusercontent.com/462077/196470532-574dd848-4458-48c2-b8a6-3718f9d6248c.png">


### After

<img width="521" alt="Screenshot 2022-10-18 at 17 11 06" src="https://user-images.githubusercontent.com/462077/196470513-8e02e79a-bb29-4c9a-a911-95ccb40a3f7f.png">

