### PR TITLE
Local ESLint rules for development

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,11 @@
+const path = require('path');
+
+const rulesDirPlugin = require('eslint-plugin-rulesdir');
+
+rulesDirPlugin.RULES_DIR = path.join(__dirname, 'eslint-rules');
+
 module.exports = {
+  plugins: ['rulesdir'],
   extends: ['plugin:hydrogen/recommended', 'plugin:hydrogen/typescript'],
   rules: {
     '@typescript-eslint/ban-ts-comment': 'off',
@@ -9,5 +16,6 @@ module.exports = {
     'no-case-declarations': 'off',
     // TODO: Remove jest plugin from hydrogen/eslint-plugin
     'jest/no-deprecated-functions': 'off',
+    'rulesdir/no-missing-seo': 'error',
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,6 @@ module.exports = {
     'no-case-declarations': 'off',
     // TODO: Remove jest plugin from hydrogen/eslint-plugin
     'jest/no-deprecated-functions': 'off',
-    'rulesdir/no-missing-seo': 'error',
+    'rulesdir/no-missing-seo': 'warn',
   },
 };

--- a/app/routes/products/$productHandle.tsx
+++ b/app/routes/products/$productHandle.tsx
@@ -144,6 +144,8 @@ export default function Product() {
   );
 }
 
+export const handle = {};
+
 export function ProductForm() {
   const addToCartFetcher = useFetcher();
   const isHydrated = useIsHydrated();

--- a/app/routes/products/$productHandle.tsx
+++ b/app/routes/products/$productHandle.tsx
@@ -144,8 +144,6 @@ export default function Product() {
   );
 }
 
-export const handle = {};
-
 export function ProductForm() {
   const addToCartFetcher = useFetcher();
   const isHydrated = useIsHydrated();

--- a/eslint-rules/no-missing-seo.js
+++ b/eslint-rules/no-missing-seo.js
@@ -1,0 +1,49 @@
+module.exports = {
+  meta: {
+    type: 'best-practices',
+    docs: {
+      description: 'Use hydrogen/remix-seo to validate SEO on your pages',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      ExportNamedDeclaration(node) {
+        if (
+          !context.getFilename().includes('routes') ||
+          node.declaration?.type !== 'VariableDeclaration'
+        ) {
+          return;
+        }
+
+        const {declarations} = node.declaration;
+        const hasHandleExport = declarations.some(
+          (declaration) => declaration.id.name === 'handle',
+        );
+
+        if (!hasHandleExport) {
+          return;
+        }
+
+        declarations.forEach((declaration) => {
+          if (declaration.id.name !== 'handle') {
+            return;
+          }
+
+          const hasSeoKey = declaration.init.properties.includes(
+            (property) => !property.key.name === 'seo',
+          );
+
+          if (hasSeoKey) {
+            return;
+          }
+
+          context.report(
+            node,
+            'Ensure that all routes define an seo field on the handle export',
+          );
+        });
+      },
+    };
+  },
+};

--- a/eslint-rules/no-missing-seo.js
+++ b/eslint-rules/no-missing-seo.js
@@ -31,7 +31,7 @@ module.exports = {
           }
 
           const hasSeoKey = declaration.init.properties.includes(
-            (property) => !property.key.name === 'seo',
+            (property) => property.key.name === 'seo',
           );
 
           if (hasSeoKey) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,6 @@
       "devDependencies": {
         "@playwright/test": "^1.27.1",
         "@remix-run/dev": "0.0.0-experimental-e18af792a",
-        "@remix-run/eslint-config": "0.0.0-experimental-e18af792a",
-        "@shopify/eslint-plugin": "^42.0.1",
         "@shopify/mini-oxygen": "^0.2.0",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
@@ -40,6 +38,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.20.0",
         "eslint-plugin-hydrogen": "0.12.2",
+        "eslint-plugin-rulesdir": "^0.2.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.16",
         "postcss-cli": "^10.0.0",
@@ -120,46 +119,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.19.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/eslint-plugin": {
-      "version": "7.19.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-rule-composer": "^0.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/eslint-parser": ">=7.11.0",
-        "eslint": ">=7.5.0"
       }
     },
     "node_modules/@babel/generator": {
@@ -1457,71 +1416,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.18.6.tgz",
-      "integrity": "sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
-      "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.19.0",
-        "@babel/plugin-syntax-jsx": "^7.18.6",
-        "@babel/types": "^7.19.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-development": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz",
-      "integrity": "sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.18.6.tgz",
-      "integrity": "sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.18.6",
       "dev": true,
@@ -1789,26 +1683,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-react": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.18.6.tgz",
-      "integrity": "sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-validator-option": "^7.18.6",
-        "@babel/plugin-transform-react-display-name": "^7.18.6",
-        "@babel/plugin-transform-react-jsx": "^7.18.6",
-        "@babel/plugin-transform-react-jsx-development": "^7.18.6",
-        "@babel/plugin-transform-react-pure-annotations": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -2501,14 +2375,6 @@
         "node": ">=16.13"
       }
     },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-scope": "5.1.1"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -2656,44 +2522,6 @@
         }
       }
     },
-    "node_modules/@remix-run/eslint-config": {
-      "version": "0.0.0-experimental-e18af792a",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-0.0.0-experimental-e18af792a.tgz",
-      "integrity": "sha512-ydPr31yvbITpKlpxC+yXRBYRg69U9jLQCnDeSBPnEIzCaxb8oBUGsliXaOzUBIWpX47X/ApWR5LOIRnFLc7JCg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/eslint-parser": "^7.18.2",
-        "@babel/preset-react": "^7.18.6",
-        "@rushstack/eslint-patch": "^1.1.0",
-        "@typescript-eslint/eslint-plugin": "^5.12.1",
-        "@typescript-eslint/parser": "^5.12.1",
-        "eslint-import-resolver-node": "0.3.6",
-        "eslint-import-resolver-typescript": "^2.5.0",
-        "eslint-plugin-import": "^2.25.4",
-        "eslint-plugin-jest": "^26.1.1",
-        "eslint-plugin-jest-dom": "^4.0.1",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0",
-        "eslint-plugin-testing-library": "^5.0.5"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "typescript": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@remix-run/oxygen": {
       "resolved": "packages/@remix-run/oxygen",
       "link": true
@@ -2752,90 +2580,6 @@
       "version": "2.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rushstack/eslint-patch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
-      "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==",
-      "dev": true
-    },
-    "node_modules/@shopify/eslint-plugin": {
-      "version": "42.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/eslint-parser": "^7.16.3",
-        "@babel/eslint-plugin": "^7.14.5",
-        "@typescript-eslint/eslint-plugin": "^5.4.0",
-        "@typescript-eslint/parser": "^5.4.0",
-        "change-case": "^4.1.2",
-        "common-tags": "^1.8.2",
-        "doctrine": "^2.1.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-module-utils": "^2.7.1",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-import": "^2.25.3",
-        "eslint-plugin-jest": "^25.3.0",
-        "eslint-plugin-jest-formatting": "^3.1.0",
-        "eslint-plugin-jsx-a11y": "^6.5.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.1.0",
-        "eslint-plugin-promise": "^6.0.0",
-        "eslint-plugin-react": "^7.30.0",
-        "eslint-plugin-react-hooks": "^4.3.0",
-        "eslint-plugin-sort-class-members": "^1.14.0",
-        "jsx-ast-utils": "^3.2.1",
-        "pkg-dir": "^5.0.0",
-        "pluralize": "^8.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.3.0"
-      }
-    },
-    "node_modules/@shopify/eslint-plugin/node_modules/doctrine": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@shopify/eslint-plugin/node_modules/eslint-plugin-jest": {
-      "version": "25.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.0.0 || ^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        },
-        "jest": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@shopify/eslint-plugin/node_modules/pkg-dir": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/@shopify/hydrogen-ui-alpha": {
       "version": "2022.7.4",
@@ -3374,25 +3118,6 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
-      "integrity": "sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^5.0.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
       "dev": true,
@@ -3400,12 +3125,6 @@
       "dependencies": {
         "@types/estree": "*"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
-      "dev": true
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.0",
@@ -3503,11 +3222,6 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
       "dev": true,
       "license": "MIT"
     },
@@ -4086,15 +3800,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/aria-query": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.1.tgz",
-      "integrity": "sha512-4cPQjOYM2mqq7mZG8CSxkUvL2Yv/x29VhGq5LKehTsxRnoVQps1YGt9NyjcNQsznEsD4rr8a6zGxqeNTqJWjpA==",
-      "dev": true,
-      "dependencies": {
-        "deep-equal": "^2.0.5"
-      }
-    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "dev": true,
@@ -4156,23 +3861,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.flatmap": {
@@ -4279,17 +3967,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axe-core": {
@@ -4721,20 +4398,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/camel-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "dev": true,
@@ -4757,21 +4420,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/capital-case": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "node_modules/capital-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/chai": {
       "version": "4.3.6",
@@ -4805,30 +4453,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/change-case": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/change-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
@@ -5133,14 +4757,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/common-tags": {
-      "version": "1.8.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "dev": true,
@@ -5264,21 +4880,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/constant-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      }
-    },
-    "node_modules/constant-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -5612,38 +5213,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/deep-equal": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-      "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "es-get-iterator": "^1.1.1",
-        "get-intrinsic": "^1.0.1",
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.2",
-        "is-regex": "^1.1.1",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.4",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.3",
-        "which-boxed-primitive": "^1.0.1",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/deep-equal/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -5802,26 +5371,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
-      "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
-      "dev": true
-    },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dot-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/dotenv": {
       "version": "16.0.2",
       "dev": true,
@@ -5958,31 +5507,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.0",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.1.0",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-get-iterator/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.0.0",
@@ -6755,131 +6279,6 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7",
-        "resolve": "^1.20.0"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-import-resolver-typescript": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
-      "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "glob": "^7.2.0",
-        "is-glob": "^4.0.3",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "*",
-        "eslint-plugin-import": "*"
-      }
-    },
-    "node_modules/eslint-import-resolver-typescript/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/eslint-import-resolver-typescript/node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/eslint-module-utils": {
-      "version": "2.7.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=4.19.1"
-      }
-    },
-    "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint-plugin-eslint-comments": {
       "version": "3.2.0",
       "dev": true,
@@ -6928,78 +6327,6 @@
         "eslint": ">=8.0.0"
       }
     },
-    "node_modules/eslint-plugin-import": {
-      "version": "2.26.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
-        "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/doctrine": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/json5": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/eslint-plugin-import/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
     "node_modules/eslint-plugin-jest": {
       "version": "26.9.0",
       "dev": true,
@@ -7021,36 +6348,6 @@
         "jest": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-jest-dom": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-4.0.2.tgz",
-      "integrity": "sha512-Jo51Atwyo2TdcUncjmU+UQeSTKh3sc2LF/M5i/R3nTU0Djw9V65KGJisdm/RtuKhy2KH/r7eQ1n6kwYFPNdHlA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.3",
-        "@testing-library/dom": "^8.11.1",
-        "requireindex": "^1.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
-        "npm": ">=6",
-        "yarn": ">=1"
-      },
-      "peerDependencies": {
-        "eslint": "^6.8.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jest-formatting": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=0.8.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -7099,55 +6396,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
       "dev": true,
@@ -7166,17 +6414,6 @@
         "eslint-config-prettier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-promise": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -7252,37 +6489,11 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-sort-class-members": {
-      "version": "1.15.2",
+    "node_modules/eslint-plugin-rulesdir": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.1.tgz",
+      "integrity": "sha512-t7rQvEyfE4JZJu6dPl4/uVr6Fr0fxopBhzVbtq3isfOHMKdlIe9xW/5CtIaWZI0E1U+wzAk0lEnZC8laCD5YLA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=0.8.0"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.9.1.tgz",
-      "integrity": "sha512-6BQp3tmb79jLLasPHJmy8DnxREe+2Pgf7L+7o09TSWPfdqqtQfRZmZNetr5mOs3yqZk/MRNxpN3RUpJe0wB4LQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/utils": "^5.13.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-rule-composer": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
       }
@@ -8080,14 +7291,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "node_modules/for-in": {
       "version": "1.0.2",
       "dev": true,
@@ -8629,20 +7832,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/header-case": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/header-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/history": {
       "version": "5.3.0",
       "license": "MIT",
@@ -8878,21 +8067,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "dev": true,
@@ -9094,15 +8268,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "dev": true,
@@ -9181,15 +8346,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "dev": true,
@@ -9240,24 +8396,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typed-array": {
-      "version": "1.1.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "dev": true,
@@ -9269,34 +8407,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9785,19 +8901,6 @@
         "get-func-name": "^2.0.0"
       }
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/lower-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "dev": true,
@@ -9815,15 +8918,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
-      "dev": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -10955,20 +10049,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/no-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
       "dev": true,
@@ -11348,22 +10428,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "dev": true,
@@ -11610,20 +10674,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/param-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -11687,20 +10737,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/pascal-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "dev": true,
@@ -11708,20 +10744,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/path-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -11918,14 +10940,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/pluralize": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/posix-character-classes": {
@@ -12665,32 +11679,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "dev": true,
@@ -12872,12 +11860,6 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
     },
     "node_modules/react-router": {
       "version": "6.3.0",
@@ -13223,15 +12205,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/requireindex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.5"
-      }
-    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "license": "MIT"
@@ -13565,21 +12538,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/sentence-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
-    "node_modules/sentence-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/serve-static": {
       "version": "1.15.0",
       "dev": true,
@@ -13703,20 +12661,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/snake-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/snake-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/snapdragon": {
       "version": "0.8.2",
@@ -15276,32 +14220,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/upper-case": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/upper-case-first/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/upper-case/node_modules/tslib": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "dev": true,
@@ -15622,40 +14540,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "dev": true,
-      "dependencies": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "dev": true,
@@ -15902,28 +14786,6 @@
           "version": "6.3.0",
           "dev": true
         }
-      }
-    },
-    "@babel/eslint-parser": {
-      "version": "7.19.1",
-      "dev": true,
-      "requires": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        }
-      }
-    },
-    "@babel/eslint-plugin": {
-      "version": "7.19.1",
-      "dev": true,
-      "requires": {
-        "eslint-rule-composer": "^0.3.0"
       }
     },
     "@babel/generator": {
@@ -16681,47 +15543,6 @@
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
-    "@babel/plugin-transform-react-display-name": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.18.6.tgz",
-      "integrity": "sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.18.6"
-      }
-    },
-    "@babel/plugin-transform-react-jsx": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
-      "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.19.0",
-        "@babel/plugin-syntax-jsx": "^7.18.6",
-        "@babel/types": "^7.19.0"
-      }
-    },
-    "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz",
-      "integrity": "sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==",
-      "dev": true,
-      "requires": {
-        "@babel/plugin-transform-react-jsx": "^7.18.6"
-      }
-    },
-    "@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.18.6.tgz",
-      "integrity": "sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      }
-    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.18.6",
       "dev": true,
@@ -16902,20 +15723,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      }
-    },
-    "@babel/preset-react": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.18.6.tgz",
-      "integrity": "sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-validator-option": "^7.18.6",
-        "@babel/plugin-transform-react-display-name": "^7.18.6",
-        "@babel/plugin-transform-react-jsx": "^7.18.6",
-        "@babel/plugin-transform-react-jsx-development": "^7.18.6",
-        "@babel/plugin-transform-react-pure-annotations": "^7.18.6"
       }
     },
     "@babel/preset-typescript": {
@@ -17293,13 +16100,6 @@
         "@miniflare/shared": "2.9.0"
       }
     },
-    "@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "5.1.1"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -17401,30 +16201,6 @@
         "xdm": "^2.0.0"
       }
     },
-    "@remix-run/eslint-config": {
-      "version": "0.0.0-experimental-e18af792a",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-0.0.0-experimental-e18af792a.tgz",
-      "integrity": "sha512-ydPr31yvbITpKlpxC+yXRBYRg69U9jLQCnDeSBPnEIzCaxb8oBUGsliXaOzUBIWpX47X/ApWR5LOIRnFLc7JCg==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.18.6",
-        "@babel/eslint-parser": "^7.18.2",
-        "@babel/preset-react": "^7.18.6",
-        "@rushstack/eslint-patch": "^1.1.0",
-        "@typescript-eslint/eslint-plugin": "^5.12.1",
-        "@typescript-eslint/parser": "^5.12.1",
-        "eslint-import-resolver-node": "0.3.6",
-        "eslint-import-resolver-typescript": "^2.5.0",
-        "eslint-plugin-import": "^2.25.4",
-        "eslint-plugin-jest": "^26.1.1",
-        "eslint-plugin-jest-dom": "^4.0.1",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0",
-        "eslint-plugin-testing-library": "^5.0.5"
-      }
-    },
     "@remix-run/oxygen": {
       "version": "file:packages/@remix-run/oxygen",
       "requires": {
@@ -17465,64 +16241,6 @@
         "estree-walker": {
           "version": "2.0.2",
           "dev": true
-        }
-      }
-    },
-    "@rushstack/eslint-patch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
-      "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==",
-      "dev": true
-    },
-    "@shopify/eslint-plugin": {
-      "version": "42.0.1",
-      "dev": true,
-      "requires": {
-        "@babel/eslint-parser": "^7.16.3",
-        "@babel/eslint-plugin": "^7.14.5",
-        "@typescript-eslint/eslint-plugin": "^5.4.0",
-        "@typescript-eslint/parser": "^5.4.0",
-        "change-case": "^4.1.2",
-        "common-tags": "^1.8.2",
-        "doctrine": "^2.1.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-module-utils": "^2.7.1",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-import": "^2.25.3",
-        "eslint-plugin-jest": "^25.3.0",
-        "eslint-plugin-jest-formatting": "^3.1.0",
-        "eslint-plugin-jsx-a11y": "^6.5.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.1.0",
-        "eslint-plugin-promise": "^6.0.0",
-        "eslint-plugin-react": "^7.30.0",
-        "eslint-plugin-react-hooks": "^4.3.0",
-        "eslint-plugin-sort-class-members": "^1.14.0",
-        "jsx-ast-utils": "^3.2.1",
-        "pkg-dir": "^5.0.0",
-        "pluralize": "^8.0.0"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "eslint-plugin-jest": {
-          "version": "25.7.0",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/experimental-utils": "^5.0.0"
-          }
-        },
-        "pkg-dir": {
-          "version": "5.0.0",
-          "dev": true,
-          "requires": {
-            "find-up": "^5.0.0"
-          }
         }
       }
     },
@@ -17873,34 +16591,12 @@
         "postcss-selector-parser": "6.0.10"
       }
     },
-    "@testing-library/dom": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
-      "integrity": "sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^5.0.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^27.0.2"
-      }
-    },
     "@types/acorn": {
       "version": "4.0.6",
       "dev": true,
       "requires": {
         "@types/estree": "*"
       }
-    },
-    "@types/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
-      "dev": true
     },
     "@types/better-sqlite3": {
       "version": "7.6.0",
@@ -17988,10 +16684,6 @@
     },
     "@types/json-schema": {
       "version": "7.0.11",
-      "dev": true
-    },
-    "@types/json5": {
-      "version": "0.0.29",
       "dev": true
     },
     "@types/keyv": {
@@ -18324,15 +17016,6 @@
       "version": "2.0.1",
       "dev": true
     },
-    "aria-query": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.1.tgz",
-      "integrity": "sha512-4cPQjOYM2mqq7mZG8CSxkUvL2Yv/x29VhGq5LKehTsxRnoVQps1YGt9NyjcNQsznEsD4rr8a6zGxqeNTqJWjpA==",
-      "dev": true,
-      "requires": {
-        "deep-equal": "^2.0.5"
-      }
-    },
     "arr-diff": {
       "version": "4.0.0",
       "dev": true
@@ -18367,16 +17050,6 @@
     "array-unique": {
       "version": "0.3.2",
       "dev": true
-    },
-    "array.prototype.flat": {
-      "version": "1.3.0",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
-      }
     },
     "array.prototype.flatmap": {
       "version": "1.3.0",
@@ -18434,10 +17107,6 @@
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
       }
-    },
-    "available-typed-arrays": {
-      "version": "1.0.5",
-      "dev": true
     },
     "axe-core": {
       "version": "4.4.3",
@@ -18726,20 +17395,6 @@
       "version": "3.1.0",
       "dev": true
     },
-    "camel-case": {
-      "version": "4.1.2",
-      "dev": true,
-      "requires": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
-    },
     "camelcase-css": {
       "version": "2.0.1",
       "dev": true
@@ -18747,21 +17402,6 @@
     "caniuse-lite": {
       "version": "1.0.30001406",
       "dev": true
-    },
-    "capital-case": {
-      "version": "1.0.4",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
     },
     "chai": {
       "version": "4.3.6",
@@ -18784,30 +17424,6 @@
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
-      }
-    },
-    "change-case": {
-      "version": "4.1.2",
-      "dev": true,
-      "requires": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
       }
     },
     "character-entities": {
@@ -18996,10 +17612,6 @@
       "version": "2.0.2",
       "dev": true
     },
-    "common-tags": {
-      "version": "1.8.2",
-      "dev": true
-    },
     "commondir": {
       "version": "1.0.1",
       "dev": true
@@ -19091,21 +17703,6 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-          "dev": true
-        }
-      }
-    },
-    "constant-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
           "dev": true
         }
       }
@@ -19288,37 +17885,6 @@
         "type-detect": "^4.0.0"
       }
     },
-    "deep-equal": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-      "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "es-get-iterator": "^1.1.1",
-        "get-intrinsic": "^1.0.1",
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.2",
-        "is-regex": "^1.1.1",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.4",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.3",
-        "which-boxed-primitive": "^1.0.1",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
-      }
-    },
     "deep-is": {
       "version": "0.1.4",
       "dev": true
@@ -19411,26 +17977,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "dom-accessibility-api": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
-      "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
-      "dev": true
-    },
-    "dot-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
       }
     },
     "dotenv": {
@@ -19542,30 +18088,6 @@
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
-      }
-    },
-    "es-get-iterator": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.0",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.1.0",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
       }
     },
     "es-shim-unscopables": {
@@ -19977,96 +18499,6 @@
       "dev": true,
       "requires": {}
     },
-    "eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.7",
-        "resolve": "^1.20.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "eslint-import-resolver-typescript": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
-      "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.4",
-        "glob": "^7.2.0",
-        "is-glob": "^4.0.3",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "tsconfig-paths": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-          "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-          "dev": true,
-          "requires": {
-            "@types/json5": "^0.0.29",
-            "json5": "^1.0.1",
-            "minimist": "^1.2.6",
-            "strip-bom": "^3.0.0"
-          }
-        }
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.7.4",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "eslint-plugin-es": {
-      "version": "3.0.1",
-      "dev": true,
-      "requires": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "dev": true
-        }
-      }
-    },
     "eslint-plugin-eslint-comments": {
       "version": "3.2.0",
       "dev": true,
@@ -20099,84 +18531,12 @@
         "prettier": "^2.6.2"
       }
     },
-    "eslint-plugin-import": {
-      "version": "2.26.0",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
-        "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
-        "tsconfig-paths": "^3.14.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "doctrine": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "json5": {
-          "version": "1.0.1",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "tsconfig-paths": {
-          "version": "3.14.1",
-          "dev": true,
-          "requires": {
-            "@types/json5": "^0.0.29",
-            "json5": "^1.0.1",
-            "minimist": "^1.2.6",
-            "strip-bom": "^3.0.0"
-          }
-        }
-      }
-    },
     "eslint-plugin-jest": {
       "version": "26.9.0",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
       }
-    },
-    "eslint-plugin-jest-dom": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-4.0.2.tgz",
-      "integrity": "sha512-Jo51Atwyo2TdcUncjmU+UQeSTKh3sc2LF/M5i/R3nTU0Djw9V65KGJisdm/RtuKhy2KH/r7eQ1n6kwYFPNdHlA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.16.3",
-        "@testing-library/dom": "^8.11.1",
-        "requireindex": "^1.2.0"
-      }
-    },
-    "eslint-plugin-jest-formatting": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {}
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.6.1",
@@ -20211,46 +18571,12 @@
         }
       }
     },
-    "eslint-plugin-node": {
-      "version": "11.1.0",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "dev": true
-        }
-      }
-    },
     "eslint-plugin-prettier": {
       "version": "4.2.1",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
-    },
-    "eslint-plugin-promise": {
-      "version": "6.1.0",
-      "dev": true,
-      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.31.8",
@@ -20299,22 +18625,10 @@
       "dev": true,
       "requires": {}
     },
-    "eslint-plugin-sort-class-members": {
-      "version": "1.15.2",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-plugin-testing-library": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.9.1.tgz",
-      "integrity": "sha512-6BQp3tmb79jLLasPHJmy8DnxREe+2Pgf7L+7o09TSWPfdqqtQfRZmZNetr5mOs3yqZk/MRNxpN3RUpJe0wB4LQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/utils": "^5.13.0"
-      }
-    },
-    "eslint-rule-composer": {
-      "version": "0.3.0",
+    "eslint-plugin-rulesdir": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.1.tgz",
+      "integrity": "sha512-t7rQvEyfE4JZJu6dPl4/uVr6Fr0fxopBhzVbtq3isfOHMKdlIe9xW/5CtIaWZI0E1U+wzAk0lEnZC8laCD5YLA==",
       "dev": true
     },
     "eslint-scope": {
@@ -20814,13 +19128,6 @@
       "version": "0.187.0",
       "dev": true
     },
-    "for-each": {
-      "version": "0.3.3",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "dev": true
@@ -21149,20 +19456,6 @@
       "version": "2.0.0",
       "dev": true
     },
-    "header-case": {
-      "version": "2.0.4",
-      "dev": true,
-      "requires": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
-    },
     "history": {
       "version": "5.3.0",
       "requires": {
@@ -21313,14 +19606,6 @@
         "is-decimal": "^2.0.0"
       }
     },
-    "is-arguments": {
-      "version": "1.1.1",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "dev": true
@@ -21427,12 +19712,6 @@
       "version": "1.0.0",
       "dev": true
     },
-    "is-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-      "dev": true
-    },
     "is-negative-zero": {
       "version": "2.0.2",
       "dev": true
@@ -21474,12 +19753,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-      "dev": true
-    },
     "is-shared-array-buffer": {
       "version": "1.0.2",
       "dev": true,
@@ -21505,25 +19778,8 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "is-typed-array": {
-      "version": "1.1.9",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-unicode-supported": {
       "version": "0.1.0",
-      "dev": true
-    },
-    "is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
       "dev": true
     },
     "is-weakref": {
@@ -21531,16 +19787,6 @@
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
-      }
-    },
-    "is-weakset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
       }
     },
     "is-windows": {
@@ -21884,19 +20130,6 @@
         "get-func-name": "^2.0.0"
       }
     },
-    "lower-case": {
-      "version": "2.0.2",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
-    },
     "lowercase-keys": {
       "version": "2.0.0",
       "dev": true
@@ -21907,12 +20140,6 @@
       "requires": {
         "yallist": "^4.0.0"
       }
-    },
-    "lz-string": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
-      "dev": true
     },
     "magic-string": {
       "version": "0.25.9",
@@ -22565,20 +20792,6 @@
       "version": "1.0.5",
       "dev": true
     },
-    "no-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
-    },
     "node-addon-api": {
       "version": "1.7.2",
       "dev": true,
@@ -22819,16 +21032,6 @@
       "version": "1.12.2",
       "dev": true
     },
-    "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
     "object-keys": {
       "version": "1.1.1",
       "dev": true
@@ -22977,20 +21180,6 @@
       "version": "0.2.9",
       "dev": true
     },
-    "param-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
-    },
     "parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -23032,37 +21221,9 @@
       "version": "1.3.3",
       "dev": true
     },
-    "pascal-case": {
-      "version": "3.1.2",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
-    },
     "pascalcase": {
       "version": "0.1.1",
       "dev": true
-    },
-    "path-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
     },
     "path-exists": {
       "version": "4.0.0",
@@ -23183,10 +21344,6 @@
       "version": "1.27.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
       "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
-      "dev": true
-    },
-    "pluralize": {
-      "version": "8.0.0",
       "dev": true
     },
     "posix-character-classes": {
@@ -23540,25 +21697,6 @@
         "fast-diff": "^1.1.2"
       }
     },
-    "pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        }
-      }
-    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "dev": true
@@ -23667,12 +21805,6 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
-    },
-    "react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
     },
     "react-router": {
       "version": "6.3.0",
@@ -23908,12 +22040,6 @@
       "version": "2.1.1",
       "dev": true
     },
-    "requireindex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "dev": true
-    },
     "resize-observer-polyfill": {
       "version": "1.5.1"
     },
@@ -24133,21 +22259,6 @@
         }
       }
     },
-    "sentence-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
-    },
     "serve-static": {
       "version": "1.15.0",
       "dev": true,
@@ -24229,20 +22340,6 @@
     "slash": {
       "version": "3.0.0",
       "dev": true
-    },
-    "snake-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "requires": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -25294,32 +23391,6 @@
         "picocolors": "^1.0.0"
       }
     },
-    "upper-case": {
-      "version": "2.0.2",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
-    },
-    "upper-case-first": {
-      "version": "2.0.2",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "dev": true
-        }
-      }
-    },
     "uri-js": {
       "version": "4.4.1",
       "dev": true,
@@ -25506,30 +23577,6 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
-      }
-    },
-    "which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "dev": true,
-      "requires": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
-      }
-    },
-    "which-typed-array": {
-      "version": "1.1.8",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   "devDependencies": {
     "@playwright/test": "^1.27.1",
     "@remix-run/dev": "0.0.0-experimental-e18af792a",
-    "@remix-run/eslint-config": "0.0.0-experimental-e18af792a",
-    "@shopify/eslint-plugin": "^42.0.1",
+    "eslint-plugin-rulesdir": "^0.2.1",
     "@shopify/mini-oxygen": "^0.2.0",
     "@shopify/oxygen-workers-types": "^3.17.2",
     "@shopify/prettier-config": "^1.1.2",


### PR DESCRIPTION
## What is this?

The idea with this PR is to provide a way for us to experiment with some custom ESLint rules for things that might trip merchants up when using the APIs/abstractions we start to define. 

Don't use this to bandage-over bad abstractions with rules, but instead explore how we can encourage best-practises for performance and commerce using the well-adopted practise of linting via ESLint.

Eventually, we can pull anything useful we come up with into the `eslint-plugin-hydrogen` package later on.

I've added the plumbing to support a local rules directory in `eslint-rules` at the root, and added an initial rule for checking that routes have an `seo` key on the handle. Which is something we may introduce in #80, but could easily be missed by merchants (either because they don't know about it or they simply forgot).

An example warning from the GitHub action on this PR:

<img width="944" alt="Screenshot 2022-10-18 at 18 42 50" src="https://user-images.githubusercontent.com/462077/196492095-9a9a2573-0455-4faf-953d-becc2488cfc5.png">

## Questions

I have a tendency to reach for ESLint often, so would love push back on this. Is this useful? Do folks think we will have ideas for additional rules as we continue to build out the remix version? I admit that so far `eslint-plugin-hydrogen` was never as helpful as it could have been so maybe we reconsider doing this, and find other tools for pushing merchants toward the happy path. Thoughts?