### PR TITLE
Updated path for favicon

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -22,6 +22,7 @@ import {NotFound} from './components/NotFound';
 import {getSession} from './lib/session.server';
 
 import styles from './styles/app.css';
+import favicon from '../public/favicon.svg';
 
 export const links: LinksFunction = () => {
   return [
@@ -34,7 +35,7 @@ export const links: LinksFunction = () => {
       rel: 'preconnect',
       href: 'https://shop.app',
     },
-    {rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg'},
+    {rel: 'icon', type: 'image/svg+xml', href: favicon},
   ];
 };
 


### PR DESCRIPTION
Currently returns 500 in production (https://h2-demo-store-f1f4fa724b7467f41f07.o2.myshopify.dev/).

I *think* this should solve it.

![image](https://user-images.githubusercontent.com/1930455/196752821-921b3753-88ab-4f94-b988-98c3c319f3d4.png)
