### PR TITLE
Handle all cart mutations on `/cart` actions

### DIFF
--- a/app/data/index.ts
+++ b/app/data/index.ts
@@ -373,6 +373,7 @@ const PRODUCT_QUERY = `#graphql
       id
       title
       vendor
+      handle
       descriptionHtml
       options {
         name

--- a/app/hooks/useIsHydrated.tsx
+++ b/app/hooks/useIsHydrated.tsx
@@ -1,0 +1,12 @@
+import {useState, useEffect} from 'react';
+
+// @feedback - This hook could be replaced by remix-utils's ow hook should we want to go down this route.
+export function useIsHydrated() {
+  const [isHydrated, setHydrated] = useState<boolean>(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return isHydrated;
+}

--- a/app/routes/cart.tsx
+++ b/app/routes/cart.tsx
@@ -1,7 +1,12 @@
-import type {LoaderArgs} from '@hydrogen/remix';
-import {type ActionFunction, json, defer} from '@hydrogen/remix';
+import {
+  type LoaderArgs,
+  type ActionFunction,
+  redirect,
+  json,
+  defer,
+} from '@hydrogen/remix';
 import invariant from 'tiny-invariant';
-import {getTopProducts, updateLineItem} from '~/data';
+import {addLineItem, createCart, getTopProducts, updateLineItem} from '~/data';
 import {getSession} from '~/lib/session.server';
 
 export async function loader({params}: LoaderArgs) {
@@ -18,32 +23,67 @@ export async function loader({params}: LoaderArgs) {
 }
 
 export const action: ActionFunction = async ({request, context, params}) => {
+  let cart;
+
   const [session, formData] = await Promise.all([
     getSession(request, context),
     new URLSearchParams(await request.text()),
   ]);
 
+  const redirectTo = formData.get('redirectTo');
   const intent = formData.get('intent');
-  invariant(intent, 'Missing intent');
+  invariant(intent, 'Missing cart intent');
 
-  const lineId = formData.get('lineId');
-  invariant(lineId, 'Missing lineId');
-
+  // 1. Grab the cart ID from the session
   const cartId = await session.get('cartId');
-  invariant(cartId, 'Missing cartId');
-
-  // TODO: Support redirect when JS is disabled
-  // const redirect = formData.get("redirect");
 
   switch (intent) {
+    case 'addToCart': {
+      const variantId = formData.get('variantId');
+      invariant(variantId, 'Missing variantId');
+
+      // We only need a Set-Cookie header if we're creating
+      // a new cart (aka adding cartId to the session)
+      const headers = new Headers();
+
+      // 2. If none exists, create a cart (SFAPI)
+      if (!cartId) {
+        cart = await createCart({
+          cart: {lines: [{merchandiseId: variantId}]},
+          params,
+        });
+
+        session.set('cartId', cart.id);
+        headers.set('Set-Cookie', await session.commit());
+      } else {
+        // 3. Else, update the cart with the variant ID (SFAPI)
+        cart = await addLineItem({
+          cartId,
+          lines: [{merchandiseId: variantId}],
+          params,
+        });
+      }
+
+      // if JS is disabled, this will redirect back to the referer
+      if (redirectTo) {
+        return redirect(redirectTo);
+      }
+
+      // returned inside the fetcher.data
+      return json({cart});
+    }
+
     case 'set-quantity': {
+      const lineId = formData.get('lineId');
+      invariant(lineId, 'Missing lineId');
+      invariant(cartId, 'Missing cartId');
       const quantity = Number(formData.get('quantity'));
-      await updateLineItem({
+      cart = await updateLineItem({
         cartId,
         lineItem: {id: lineId, quantity},
         params,
       });
-      break;
+      return json({cart});
     }
 
     case 'remove-line-item': {
@@ -51,16 +91,26 @@ export const action: ActionFunction = async ({request, context, params}) => {
        * We're re-using the same mutation as setting a quantity of 0,
        * but theoretically we could use the `cartLinesRemove` mutation.
        */
+      const lineId = formData.get('lineId');
+      invariant(lineId, 'Missing lineId');
+      invariant(cartId, 'Missing cartId');
       await updateLineItem({
         cartId,
         lineItem: {id: lineId, quantity: 0},
         params,
       });
-      break;
+      return json({cart});
+    }
+
+    default: {
+      // eslint-disable-next-line no-console
+      console.warn(`Cart intent ${intent} not supported`);
     }
   }
 
-  return json({ok: true});
+  return json({
+    ok: true,
+  });
 };
 
 export default function Cart() {


### PR DESCRIPTION
The PDP add to cart `Form` action was being handled on the same `/products/$handle` route action. Other cart mutations such as "remove-line-item" and "set-quantity" found on `CartDetails` are being handled via `/cart` actions.

This PR consolidates all cart mutations to be handled via `/cart` actions. This will make instrumenting Cart events much easier and provide a consistent endpoint for all cart mutations.
