### PR TITLE
[Attempt 1] Toggle cart drawer on add to cart (vis session.flash)

### DIFF
--- a/app/components/Drawer.tsx
+++ b/app/components/Drawer.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import {Dialog, Transition} from '@headlessui/react';
 
 import {Heading, IconClose} from '~/components';
@@ -97,6 +97,10 @@ Drawer.Title = Dialog.Title;
 
 export function useDrawer(openDefault = false) {
   const [isOpen, setIsOpen] = useState(openDefault);
+
+  useEffect(() => {
+    setIsOpen(openDefault ? true : false);
+  }, [openDefault]);
 
   function openDrawer() {
     setIsOpen(true);

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -34,9 +34,10 @@ export function Layout({
   children: React.ReactNode;
   data?: {
     layout: LayoutData;
+    toggleCart: boolean;
   };
 }) {
-  const {layout} = data || {};
+  const {layout, toggleCart} = data || {};
 
   return (
     <>
@@ -49,6 +50,7 @@ export function Layout({
         <Header
           title={layout?.shop.name ?? 'Hydrogen'}
           menu={layout?.headerMenu}
+          toggleCart={toggleCart}
         />
         <main role="main" id="mainContent" className="flex-grow">
           {children}
@@ -59,20 +61,35 @@ export function Layout({
   );
 }
 
-function Header({title, menu}: {title: string; menu?: EnhancedMenu}) {
+function Header({
+  title,
+  menu,
+  toggleCart,
+}: {
+  title: string;
+  menu?: EnhancedMenu;
+  toggleCart?: boolean;
+}) {
   const isHome = useIsHomePath();
 
   const {
     isOpen: isCartOpen,
     openDrawer: openCart,
     closeDrawer: closeCart,
-  } = useDrawer();
+  } = useDrawer(toggleCart);
 
   const {
     isOpen: isMenuOpen,
     openDrawer: openMenu,
     closeDrawer: closeMenu,
   } = useDrawer();
+
+  useEffect(() => {
+    // toggle the cart drawer after add to cart
+    if (toggleCart) {
+      openCart();
+    }
+  }, [openCart, toggleCart]);
 
   return (
     <>

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -84,13 +84,6 @@ function Header({
     closeDrawer: closeMenu,
   } = useDrawer();
 
-  useEffect(() => {
-    // toggle the cart drawer after add to cart
-    if (toggleCart) {
-      openCart();
-    }
-  }, [openCart, toggleCart]);
-
   return (
     <>
       <Suspense fallback={null}>

--- a/app/lib/session.server.ts
+++ b/app/lib/session.server.ts
@@ -38,6 +38,10 @@ export async function getSession(request: Request, context: AppLoadContext) {
       session.unset(key);
     },
 
+    flash(key: string, value: any): void {
+      session.flash(key, value);
+    },
+
     async commit(): Promise<string> {
       return await sessionStorage.commitSession(session);
     },

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -52,12 +52,22 @@ export const loader: LoaderFunction = async function loader({
 }) {
   const session = await getSession(request, context);
   const cartId = await session.get('cartId');
+  const toggleCart = await session.get('toggleCart');
 
-  return defer({
-    layout: await getLayoutData(params),
-    countries: getCountries(),
-    cart: cartId ? getCart({cartId, params}) : undefined,
-  });
+  return defer(
+    {
+      toggleCart: toggleCart ?? false,
+      layout: await getLayoutData(params),
+      countries: getCountries(),
+      cart: cartId ? getCart({cartId, params}) : undefined,
+    },
+    {
+      headers: {
+        // required to commit the flash of toggleCart
+        'Set-Cookie': await session.commit(),
+      },
+    },
+  );
 };
 
 export default function App() {

--- a/app/routes/cart.tsx
+++ b/app/routes/cart.tsx
@@ -18,7 +18,7 @@ export async function loader({params}: LoaderArgs) {
       headers: {
         'Cache-Control': 'max-age=600',
       },
-    }
+    },
   );
 }
 

--- a/app/routes/cart.tsx
+++ b/app/routes/cart.tsx
@@ -18,7 +18,7 @@ export async function loader({params}: LoaderArgs) {
       headers: {
         'Cache-Control': 'max-age=600',
       },
-    },
+    }
   );
 }
 
@@ -52,9 +52,6 @@ export const action: ActionFunction = async ({request, context, params}) => {
           cart: {lines: [{merchandiseId: variantId}]},
           params,
         });
-
-        session.set('cartId', cart.id);
-        headers.set('Set-Cookie', await session.commit());
       } else {
         // 3. Else, update the cart with the variant ID (SFAPI)
         cart = await addLineItem({
@@ -64,13 +61,17 @@ export const action: ActionFunction = async ({request, context, params}) => {
         });
       }
 
+      session.flash('toggleCart', true);
+      session.set('cartId', cart.id);
+      headers.set('Set-Cookie', await session.commit());
+
       // if JS is disabled, this will redirect back to the referer
       if (redirectTo) {
-        return redirect(redirectTo);
+        return redirect(redirectTo, {headers});
       }
 
       // returned inside the fetcher.data
-      return json({cart});
+      return json({cart}, {headers});
     }
 
     case 'set-quantity': {


### PR DESCRIPTION


https://user-images.githubusercontent.com/12080141/196997387-d57a215a-1493-43e4-8227-91b3e66e23e1.mp4


A lack of a global state/context makes it a bit tricky to perform client side UI changes like toggling the cart drawer after a successful add to cart mutation.

This experimental approach sets a temporary `toggleCart` key (via session.flash) and a `useEffect` to trigger the cart drawer opening.

## Pros:
 - No global state required (less JS)

## Cons:
 - Not optimistic. It only opens the drawer after the add to cart mutation finishes, the root loaders are re-executed and the `useEffect` is triggered by the flash `toggleCart` value.
 - Does not work without JS (useEffect is needed). However, because we defer the cart, there's little value in making in work without JS.

## Alternatives:
1. Extend this example to work without JS. e.g — Make a CSS-only drawer that can be toggled via using `toggleCart` to add a drawer open class.
2. Add a global context provider and trigger the drawer on Form submit (optimistically or not). This won't work without JS
 
