### PR TITLE
[Attempt 2] Add GlobalProvider to handle Menu and Cart drawers state (Global context)

### DIFF
--- a/app/components/Drawer.tsx
+++ b/app/components/Drawer.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState} from 'react';
+import {Fragment} from 'react';
 import {Dialog, Transition} from '@headlessui/react';
 
 import {Heading, IconClose} from '~/components';
@@ -94,21 +94,3 @@ export function Drawer({
 
 /* Use for associating arialabelledby with the title*/
 Drawer.Title = Dialog.Title;
-
-export function useDrawer(openDefault = false) {
-  const [isOpen, setIsOpen] = useState(openDefault);
-
-  function openDrawer() {
-    setIsOpen(true);
-  }
-
-  function closeDrawer() {
-    setIsOpen(false);
-  }
-
-  return {
-    isOpen,
-    openDrawer,
-    closeDrawer,
-  };
-}

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -5,7 +5,6 @@ import {
 } from '~/lib/utils';
 import {
   Drawer,
-  useDrawer,
   Text,
   Input,
   IconAccount,
@@ -26,6 +25,7 @@ import {Disclosure} from '@headlessui/react';
 import type {LayoutData} from '~/data';
 import {Suspense, useEffect} from 'react';
 import {useCart} from '~/hooks/useCart';
+import {useGlobal} from '~/hooks/useGlobal';
 
 export function Layout({
   children,
@@ -60,39 +60,28 @@ export function Layout({
 }
 
 function Header({title, menu}: {title: string; menu?: EnhancedMenu}) {
+  const {cartOpen, toggleCart, menuOpen, toggleMenu} = useGlobal();
   const isHome = useIsHomePath();
-
-  const {
-    isOpen: isCartOpen,
-    openDrawer: openCart,
-    closeDrawer: closeCart,
-  } = useDrawer();
-
-  const {
-    isOpen: isMenuOpen,
-    openDrawer: openMenu,
-    closeDrawer: closeMenu,
-  } = useDrawer();
 
   return (
     <>
       <Suspense fallback={null}>
-        <CartDrawer isOpen={isCartOpen} onClose={closeCart} />
+        <CartDrawer isOpen={cartOpen} onClose={toggleCart} />
       </Suspense>
       {menu && (
-        <MenuDrawer isOpen={isMenuOpen} onClose={closeMenu} menu={menu} />
+        <MenuDrawer isOpen={menuOpen} onClose={toggleMenu} menu={menu} />
       )}
       <DesktopHeader
         isHome={isHome}
         title={title}
         menu={menu}
-        openCart={openCart}
+        openCart={toggleCart}
       />
       <MobileHeader
         isHome={isHome}
         title={title}
-        openCart={openCart}
-        openMenu={openMenu}
+        openCart={toggleCart}
+        openMenu={toggleMenu}
       />
     </>
   );

--- a/app/hooks/useGlobal.tsx
+++ b/app/hooks/useGlobal.tsx
@@ -1,0 +1,49 @@
+import React, {
+  useContext,
+  createContext,
+  useState,
+  useCallback,
+  useMemo,
+} from 'react';
+
+interface GlobalStateType {
+  cartOpen: boolean;
+  menuOpen: boolean;
+  toggleCart: () => void;
+  toggleMenu: () => void;
+}
+
+const initialState: GlobalStateType = {
+  cartOpen: false,
+  menuOpen: false,
+  toggleCart: () => null,
+  toggleMenu: () => null,
+};
+
+const GlobalContext = createContext(initialState);
+
+export const GlobalProvider = ({children}: {children: React.ReactNode}) => {
+  const [cartOpen, setCartOpen] = useState<boolean>(initialState.cartOpen);
+  const [menuOpen, setMenuOpen] = useState<boolean>(initialState.menuOpen);
+
+  const toggleCart = useCallback(
+    () => setCartOpen((cartOpen) => !cartOpen),
+    [],
+  );
+
+  const toggleMenu = useCallback(
+    () => setMenuOpen((menuOpen) => !menuOpen),
+    [],
+  );
+
+  const value = useMemo(
+    () => ({cartOpen, menuOpen, toggleCart, toggleMenu}),
+    [cartOpen, menuOpen, toggleCart, toggleMenu],
+  );
+
+  return (
+    <GlobalContext.Provider value={value}>{children}</GlobalContext.Provider>
+  );
+};
+
+export const useGlobal = () => useContext(GlobalContext);

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -20,6 +20,7 @@ import {getCart, getLayoutData, getCountries} from '~/data';
 import {GenericError} from './components/GenericError';
 import {NotFound} from './components/NotFound';
 import {getSession} from './lib/session.server';
+import {GlobalProvider} from '~/hooks/useGlobal';
 
 import styles from './styles/app.css';
 import favicon from '../public/favicon.svg';
@@ -72,9 +73,11 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <Layout data={data}>
-          <Outlet />
-        </Layout>
+        <GlobalProvider>
+          <Layout data={data}>
+            <Outlet />
+          </Layout>
+        </GlobalProvider>
         <ScrollRestoration />
         <Scripts />
         <LiveReload />

--- a/app/routes/products/$productHandle.tsx
+++ b/app/routes/products/$productHandle.tsx
@@ -4,7 +4,6 @@ import {
   useLoaderData,
   Await,
   useSearchParams,
-  Form,
   useLocation,
   useTransition,
   useFetcher,
@@ -27,6 +26,7 @@ import {
 import {getProductData, getRecommendedProducts} from '~/data';
 import {getExcerpt} from '~/lib/utils';
 import {useIsHydrated} from '~/hooks/useIsHydrated';
+import {useGlobal} from '~/hooks/useGlobal';
 import invariant from 'tiny-invariant';
 import clsx from 'clsx';
 
@@ -114,6 +114,7 @@ export default function Product() {
 export function ProductForm() {
   const addToCartFetcher = useFetcher();
   const isHydrated = useIsHydrated();
+  const {toggleCart} = useGlobal();
   const closeRef = useRef<HTMLButtonElement>(null);
   const [currentSearchParams] = useSearchParams();
   const transition = useTransition();
@@ -277,7 +278,11 @@ export function ProductForm() {
           ))}
         <div className="grid items-stretch gap-4">
           {selectedVariant && (
-            <addToCartFetcher.Form method="post" action="/cart">
+            <addToCartFetcher.Form
+              method="post"
+              action="/cart"
+              onSubmit={toggleCart}
+            >
               <input
                 type="hidden"
                 name="variantId"


### PR DESCRIPTION
The goal is to add a simple Context Provider to handle UI state such as the Cart and Menu drawers.

This allows us to toggle the Cart drawer when submitting an add to cart mutation either from the PDP or from a Product Item as well as other use cases.

This is the global context alternative to #94 