### PR TITLE
Use relative paths for fonts to fix prod

### DIFF
--- a/app/styles/custom-font.css
+++ b/app/styles/custom-font.css
@@ -2,12 +2,12 @@
   font-family: 'IBMPlexSerif';
   font-display: swap;
   font-weight: 400;
-  src: url('/fonts/IBMPlexSerif-Text.woff2') format('woff2');
+  src: url('../../fonts/IBMPlexSerif-Text.woff2') format('woff2');
 }
 @font-face {
   font-family: 'IBMPlexSerif';
   font-display: swap;
   font-weight: 400;
   font-style: italic;
-  src: url('/fonts/IBMPlexSerif-TextItalic.woff2') format('woff2');
+  src: url('../../fonts/IBMPlexSerif-TextItalic.woff2') format('woff2');
 }


### PR DESCRIPTION
Due to how assets are deployed to Oxygen / Shopify CDN, public assets cannot be referenced directly from the root:

- The CSS file `app/styles/custom-font.css` is served from `https://cdn.shopify.com/oxygen/<id1>/<id2>/<id3>/build/_assets/<file-name>` in production, where all the IDs are dynamic and depend on the shop and current deployment.
- An asset referenced from that file like `url('/fonts/...')` would be requested to `https://cdn.shopify.com/fonts/...`, which doesn't exist. Therefore, we need to use relative paths to keep the ids in the URL. The `../../` fixes the URL to `https://cdn.shopify.com/oxygen/<id1>/<id2>/<id3>/fonts/IBMPlexSerif-Text.woff2`, which is served correctly.