### PR TITLE
Do not minify worker bundle in development

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
           oxygen_deployment_token: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_28966968 }}
           oxygen_worker_dir: build/worker
           oxygen_client_dir: build/client
-          build_command: 'HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL npm run build'
+          build_command: 'HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL npm run build:prod'
           # Hardcode message and timestamp if manual dispatch
           commit_message: ${{ github.event.head_commit.message || 'Manual deployment' }}
           commit_timestamp: ${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf build && npm run build:css && remix build && npm run bundle:worker && npm run copy:assets",
+    "build": "rimraf build && npm run build:css && remix build && npm run copy:assets && npm run bundle:worker --",
+    "build:prod": "npm run build -- --sourcemap --minify",
     "build:css": "postcss styles --base styles --dir app/styles --env production",
-    "bundle:worker": "esbuild worker/index.ts --bundle --outfile=build/worker/index.js --sourcemap --minify --format=esm --log-override:this-is-undefined-in-esm=silent --define:process.env.REMIX_DEV_SERVER_WS_PORT=\\\"8002\\\" && echo '{\"type\":\"module\",\"main\":\"./index.js\",\"exports\":{\".\":\"./index.js\",\"./index.js\":\"./index.js\"}}' > build/worker/package.json",
+    "bundle:worker": "esbuild worker/index.ts --bundle --outfile=build/worker/index.js --format=esm --log-override:this-is-undefined-in-esm=silent --define:process.env.REMIX_DEV_SERVER_WS_PORT=\\\"8002\\\"",
     "copy:assets": "cp -r public/* build/client",
     "deploy": "//todo",
     "dev:remix": "remix watch",


### PR DESCRIPTION
This uses NPM script arguments to only minify and generate source maps when building for production.

I've also removed the generated `package.json` since it seems it's not needed for Oxygen deployments.

cc @blittle