### PR TITLE
Pass storefront credentials directly to handleRequest

### DIFF
--- a/packages/@hydrogen/remix/server.ts
+++ b/packages/@hydrogen/remix/server.ts
@@ -14,6 +14,7 @@ export function createRequestHandler(
     request: Request,
     {
       storefront,
+      context,
       ...options
     }: Omit<Parameters<typeof handleRequest>[1], 'loadContext'> &
       HydrogenHandlerParams,
@@ -21,9 +22,10 @@ export function createRequestHandler(
     try {
       return handleRequest(request, {
         ...options,
-        loadContext: {storefront: createStorefrontClient(storefront)},
+        context: {...context, storefront: createStorefrontClient(storefront)},
       });
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error(e);
 
       return new Response('Internal Error', {status: 500});

--- a/packages/@remix-run/oxygen/server.ts
+++ b/packages/@remix-run/oxygen/server.ts
@@ -21,13 +21,13 @@ export function createRequestHandler<Context = unknown>({
     request: Request,
     // This may be temporary unless we adjust @shopify/oxygen-workers-types
     {
-      ctx,
       env,
-      loadContext,
+      context,
     }: {
-      ctx: Omit<ExecutionContext, 'passThroughOnException'>;
       env: any;
-      loadContext: any;
+      context: Omit<ExecutionContext, 'passThroughOnException'> & {
+        [key: string]: any;
+      };
     },
   ) => {
     try {
@@ -41,17 +41,13 @@ export function createRequestHandler<Context = unknown>({
         return fetch(request.url.replace(url.origin, assetBasePath), request);
       }
 
-      loadContext = {
-        ...loadContext,
-        ...(await getLoadContext?.(request)),
-      };
-
       return await handleRequest(request, {
         env,
-        ...ctx,
-        ...loadContext,
+        ...context,
+        ...(await getLoadContext?.(request)),
       } as AppLoadContext);
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error(e);
 
       return new Response('Internal Error', {status: 500});

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -12,12 +12,12 @@ export default {
   async fetch(
     request: Request,
     env: Env,
-    ctx: ExecutionContext,
+    context: ExecutionContext,
   ): Promise<Response> {
     try {
       return await requestHandler(request, {
         env,
-        ctx,
+        context,
         storefront: {
           publicStorefrontToken: '3b580e70970c4528da70c98e097c2fa0',
           storeDomain: 'hydrogen-preview',
@@ -25,6 +25,7 @@ export default {
         },
       });
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error(error);
       return new Response('An unexpected error occurred', {status: 500});
     }


### PR DESCRIPTION
I noticed we currently wouldn't support Linkpop's use case where the storefront credentials depends on the request path.
This PR changes the way we pass the storefront credentials from `createRequestHandler` to `handleRequest` so that the credentials can be dynamic. Also, this way we have access to the `env` object to create the storefront client.

There are other alternatives, though:
- Call `createRequestHandler` inside the `fetch` handler, then call `requestHandler` with that.
- Convert the `storefront` property passed to `createRequestHandler` to a function that can dynamically decide the credentials.

I think the approach in this PR is the simplest but it's open to discussion.

---

Aside from that, we are naming a variable `ctx` for the "execution context" (`ctx.waitUntil`). Should we rename it to something else? Runtime? 🤔 