### PR TITLE
Fix double slash in build asset URL

### DIFF
--- a/packages/cli/utils/config.ts
+++ b/packages/cli/utils/config.ts
@@ -35,7 +35,8 @@ export async function getRemixConfig(
 
     const hydrogenAssetBase = process.env.HYDROGEN_ASSET_BASE_URL;
     if (hydrogenAssetBase) {
-      config.publicPath = hydrogenAssetBase + config.publicPath;
+      const suffix = config.publicPath?.replace(/\\/g, '/').replace(/^\//, '');
+      config.publicPath = hydrogenAssetBase + suffix;
     }
 
     config.serverBuildTarget = 'cloudflare-workers';


### PR DESCRIPTION
The default value for `publicPath` is `/build/` instead of `build/` so the result was `...//build/` 😬 