### PR TITLE
Pagination

### DIFF
--- a/templates/demo-store/app/components/Pagination.tsx
+++ b/templates/demo-store/app/components/Pagination.tsx
@@ -1,0 +1,131 @@
+import {useCallback, useEffect} from 'react';
+import type {PageInfo} from '@shopify/hydrogen-react/storefront-api-types';
+
+import {useInView} from 'react-intersection-observer';
+import {useTransition, useLocation, useNavigate} from '@remix-run/react';
+
+import {Button} from '~/components';
+
+type Connection = {
+  pageInfo: PageInfo;
+  nodes: unknown[];
+};
+
+type Props<Resource extends Connection> = {
+  connection: Resource;
+  autoLoadOnScroll?: boolean;
+};
+
+export function Pagination<Resource extends Connection>({
+  connection,
+  children = () => null,
+  autoLoadOnScroll = false,
+}: Props<Resource> & {
+  children: (props: {nodes: Resource['nodes']}) => React.ReactNode;
+}) {
+  const transition = useTransition();
+  const isIdle = transition.state === 'idle';
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const navigate = useNavigate();
+
+  const {ref, inView} = useInView({
+    threshold: 0,
+  });
+
+  const {
+    pageInfo: {startCursor, endCursor, hasPreviousPage, hasNextPage},
+    nodes,
+  } = connection;
+
+  const loadNextPage = useCallback(() => {
+    if (!autoLoadOnScroll) return;
+    if (!inView) return;
+    if (!hasNextPage) return;
+    if (!endCursor) return;
+    if (!isIdle) return;
+
+    const href =
+      location.pathname + `?index&cursor=${endCursor}&direction=next`;
+
+    navigate(href, {
+      state: {
+        nodes,
+        pageInfo: {startCursor, endCursor, hasPreviousPage, hasNextPage},
+      },
+    });
+  }, [
+    autoLoadOnScroll,
+    endCursor,
+    hasNextPage,
+    hasPreviousPage,
+    inView,
+    isIdle,
+    nodes,
+    location.pathname,
+    navigate,
+    startCursor,
+  ]);
+
+  useEffect(loadNextPage, [endCursor, inView]);
+
+  return (
+    <>
+      {hasPreviousPage && (
+        <div className="flex items-center justify-center mt-6">
+          <Button
+            to={`?${new URLSearchParams({
+              q: params.get('q') || '',
+              cursor: startCursor || '',
+              direction: 'previous',
+            }).toString()}`}
+            disabled={!isIdle}
+            variant="secondary"
+            width="full"
+            prefetch="intent"
+            state={{
+              pageInfo: {
+                endCursor,
+                startCursor,
+                hasNextPage,
+              },
+              nodes,
+            }}
+          >
+            {transition.state === 'loading'
+              ? 'Loading...'
+              : 'Load previous products'}
+          </Button>
+        </div>
+      )}
+
+      {children({nodes})}
+
+      {hasNextPage && endCursor && (
+        <div ref={ref} className="flex items-center justify-center mt-6">
+          <Button
+            to={`?${new URLSearchParams({
+              q: params.get('q') || '',
+              cursor: endCursor || '',
+              direction: 'next',
+            }).toString()}`}
+            disabled={!isIdle}
+            variant="secondary"
+            width="full"
+            prefetch="intent"
+            state={{
+              pageInfo: {
+                endCursor,
+                startCursor,
+                hasPreviousPage,
+              },
+              nodes,
+            }}
+          >
+            {transition.state !== 'idle' ? 'Loading...' : 'Load more products'}
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/templates/demo-store/app/components/ProductGrid.tsx
+++ b/templates/demo-store/app/components/ProductGrid.tsx
@@ -44,6 +44,7 @@ export function ProductGrid({
     if (!fetcher.data) return;
 
     const {collection} = fetcher.data;
+
     setProducts((prev: Product[]) => [...prev, ...collection.products.nodes]);
     setNextPage(collection.products.pageInfo.hasNextPage);
     setEndCursor(collection.products.pageInfo.endCursor);

--- a/templates/demo-store/app/components/index.ts
+++ b/templates/demo-store/app/components/index.ts
@@ -8,7 +8,6 @@ export {ProductSwimlane} from './ProductSwimlane';
 export {ProductGrid} from './ProductGrid';
 export {Skeleton} from './Skeleton';
 export {Button} from './Button';
-export {Grid} from './Grid';
 export {CountrySelector} from './CountrySelector';
 export {Cart} from './Cart';
 export {CartLoading} from './CartLoading';
@@ -21,4 +20,7 @@ export {FeaturedCollections} from './FeaturedCollections';
 export {Hero} from './Hero';
 export {SortFilter} from './SortFilter';
 export {Breadcrumbs} from './Breadcrumbs';
+export {Grid} from './Grid';
+export {Pagination} from './Pagination';
+// Sue me
 export * from './Icon';

--- a/templates/demo-store/app/routes/products/index.tsx
+++ b/templates/demo-store/app/routes/products/index.tsx
@@ -1,23 +1,44 @@
 import type {LoaderArgs, MetaFunction} from '@shopify/hydrogen-remix';
-import {useLoaderData} from '@remix-run/react';
-import type {
-  Collection,
-  ProductConnection,
-} from '@shopify/hydrogen-react/storefront-api-types';
+import {useLoaderData, type Params} from '@remix-run/react';
+import type {ProductConnection} from '@shopify/hydrogen-react/storefront-api-types';
 import invariant from 'tiny-invariant';
-import {PageHeader, Section, ProductGrid} from '~/components';
+import {PageHeader, Section, ProductCard, Grid, Pagination} from '~/components';
 import {PRODUCT_CARD_FRAGMENT} from '~/data';
+import {getImageLoadingPriority} from '~/lib/const';
+const PAGE_BY = 4;
+
+function getPaginationVariables(
+  searchParams = new URLSearchParams(),
+  pageBy: number,
+) {
+  const cursor = searchParams.get('cursor') ?? undefined;
+  const direction =
+    searchParams.get('direction') === 'previous' ? 'previous' : 'next';
+  const isNext = direction === 'next';
+
+  const prevPage = {
+    last: pageBy,
+    startCursor: cursor ?? null,
+  };
+
+  const nextPage = {
+    first: pageBy,
+    endCursor: cursor ?? null,
+  };
+
+  const variables = isNext ? nextPage : prevPage;
+
+  return variables;
+}
 
 export async function loader({request, context: {storefront}}: LoaderArgs) {
-  const cursor = new URL(request.url).searchParams.get('cursor') ?? undefined;
+  const searchParams = new URLSearchParams(new URL(request.url).search);
+  const variables = getPaginationVariables(searchParams, PAGE_BY);
 
   const data = await storefront.query<{
     products: ProductConnection;
   }>(ALL_PRODUCTS_QUERY, {
-    variables: {
-      pageBy: 48,
-      cursor,
-    },
+    variables,
   });
 
   invariant(data, 'No data returned from Shopify API');
@@ -39,12 +60,19 @@ export default function AllProducts() {
     <>
       <PageHeader heading="All Products" variant="allCollections" />
       <Section>
-        <ProductGrid
-          key="products"
-          url="/products"
-          collection={{products} as Collection}
-          data-test="product-grid"
-        />
+        <Pagination connection={products}>
+          {({nodes}) => {
+            const itemsMarkup = nodes.map((product, i) => (
+              <ProductCard
+                key={product.id}
+                product={product}
+                loading={getImageLoadingPriority(i)}
+              />
+            ));
+
+            return <Grid data-test="product-grid">{itemsMarkup}</Grid>;
+          }}
+        </Pagination>
       </Section>
     </>
   );
@@ -55,14 +83,17 @@ const ALL_PRODUCTS_QUERY = `#graphql
   query AllProducts(
     $country: CountryCode
     $language: LanguageCode
-    $pageBy: Int!
-    $cursor: String
+    $first: Int
+    $last: Int
+    $startCursor: String
+    $endCursor: String
   ) @inContext(country: $country, language: $language) {
-    products(first: $pageBy, after: $cursor) {
+    products(first: $first, last: $last, before: $startCursor, after: $endCursor) {
       nodes {
         ...ProductCard
       }
       pageInfo {
+        hasPreviousPage
         hasNextPage
         startCursor
         endCursor


### PR DESCRIPTION
This PR adds Pagination primitives `usePagination` hook  that returns the correct partial connection (ie: `pagInfo` and `nodes`) based on the url and navigation `state` object (effectively a cache).

This hook is used in 2 new components `InfiniteScrollPagination` and `ForwardNextPagination` that both accept a connection from the loader data and wrap a render prop to minimally produce either a intersection-observer based load more UI or arrows on either side to progress through the paginated items.

In this PR I've added them to the Products grid only (`/products`) and you can swap them out by just changing the wrapping component. I've left the commented out code to do this.

Other note below on using location state:

### Location state as cache

You can associate arbitrary data with a location by using the `state` prop of provided to the `Link` component. This data is persisted in the browser as part of the History API, but is not exposed in the same way that `hash` and `search` are visible in the URL. `state` is hidden from the user, but available to the application to store partial data required to render a view without relying on a client side cache implementation.

### Limitations

Because Firefox saves state objects to the user's disk so they can be restored after the user restarts the browser, we impose a size limit of 16 MiB on the serialized representation of a state object. If you pass a state object whose serialized representation is larger than this to pushState(), the method will throw an exception. (via [mdn](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method))