### PR TITLE
Add an option to override the API version

### DIFF
--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -47,6 +47,7 @@ export type CreateStorefrontClientOptions = {
 type StorefrontCommonOptions = {
   variables?: ExecutionArgs['variableValues'];
   headers?: HeadersInit;
+  storefrontApiVersion?: string;
 };
 
 export type StorefrontQueryOptions = StorefrontCommonOptions & {
@@ -102,6 +103,7 @@ export function createStorefrontClient(
     variables,
     cache: cacheOptions,
     headers = [],
+    storefrontApiVersion,
   }: StorefrontQueryOptions | StorefrontMutationOptions): Promise<T> {
     const userHeaders =
       headers instanceof Headers
@@ -110,7 +112,7 @@ export function createStorefrontClient(
         ? Object.fromEntries(headers)
         : headers;
 
-    const url = getStorefrontApiUrl();
+    const url = getStorefrontApiUrl({storefrontApiVersion});
     const requestInit = {
       method: 'POST',
       headers: {...defaultHeaders, ...userHeaders},


### PR DESCRIPTION
Sometimes a merchant may want to opt into a newer version of the storefront API for only a single request. This adds the ability to pass `storefrontApiVersion` directly to `context.storefront.query` and `context.storefront.mutate`.

```ts
  const {urlRedirects} = await context.storefront.query(REDIRECT_QUERY, {
    variables: {
      url: pathname + search,
    },
    storefrontApiVersion: '2023-01'
  });
```