### PR TITLE
Make product card label visible

### DIFF
--- a/templates/demo-store/app/components/ProductCard.tsx
+++ b/templates/demo-store/app/components/ProductCard.tsx
@@ -60,13 +60,6 @@ export function ProductCard({
       >
         <div className={clsx('grid gap-6', className)}>
           <div className="card-image aspect-[4/5] bg-primary/5">
-            <Text
-              as="label"
-              size="fine"
-              className="absolute top-0 right-0 m-4 text-right text-notice"
-            >
-              {cardLabel}
-            </Text>
             {image && (
               <Image
                 className="aspect-[4/5] w-full object-cover fadeIn"
@@ -83,6 +76,13 @@ export function ProductCard({
                 loading={loading}
               />
             )}
+            <Text
+              as="label"
+              size="fine"
+              className="absolute top-0 right-0 m-4 text-right text-notice"
+            >
+              {cardLabel}
+            </Text>
           </div>
           <div className="grid gap-1">
             <Text


### PR DESCRIPTION
Small PR to bring the Product label above the image.

<img width="278" alt="Screenshot 2022-11-22 at 15 28 19" src="https://user-images.githubusercontent.com/462077/203339517-e909f99f-5fa0-4526-93cc-b128d5e18570.png">
