### PR TITLE
Support Node dev for Stackblitz

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3306,6 +3306,48 @@
         }
       }
     },
+    "node_modules/@remix-run/express": {
+      "version": "0.0.0-experimental-e18af792a",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-0.0.0-experimental-e18af792a.tgz",
+      "integrity": "sha512-/LIPldRMW5hjj4CR4Mu/ex7dtUGjUk5xpwr4+V6qDJpvT3TiGF4orivSEz7lMWIuavv+UZr/BfCS6ovVZKb5EQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@remix-run/node": "0.0.0-experimental-e18af792a"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "express": "^4.17.1"
+      }
+    },
+    "node_modules/@remix-run/node": {
+      "version": "0.0.0-experimental-e18af792a",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-0.0.0-experimental-e18af792a.tgz",
+      "integrity": "sha512-ZyGtVslF3VP/6YtmjryRW2z4nfcWSeuinuvSjdozVxQ5eEoH4fkgHWeY/3bLEYjJC+ju1zus1e7E5AObRikKOQ==",
+      "dependencies": {
+        "@remix-run/server-runtime": "0.0.0-experimental-e18af792a",
+        "@remix-run/web-fetch": "^4.1.3",
+        "@remix-run/web-file": "^3.0.2",
+        "@remix-run/web-stream": "^1.0.3",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "cookie-signature": "^1.1.0",
+        "source-map-support": "^0.5.21",
+        "stream-slice": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/node/node_modules/cookie-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.0.tgz",
+      "integrity": "sha512-R0BOPfLGTitaKhgKROKZQN6iyq2iDQcH1DOF8nJoaWapguX5bC2w+Q/I9NmmM5lfcvEarnLZr+cCvmEYYSXvYA==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/@remix-run/oxygen": {
       "resolved": "packages/remix-oxygen",
       "link": true
@@ -3328,6 +3370,25 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@remix-run/serve": {
+      "version": "0.0.0-experimental-e18af792a",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-0.0.0-experimental-e18af792a.tgz",
+      "integrity": "sha512-cwPksC9nEeBSRBUaJ2ZDd7h+vQ2wH5EG4AzAYNJqOny0ekh5qcS+/vFSIx86x3EXJ9KFWHUMpaNS9IUh1AXoqA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@remix-run/express": "0.0.0-experimental-e18af792a",
+        "compression": "^1.7.4",
+        "express": "^4.17.1",
+        "morgan": "^1.10.0"
+      },
+      "bin": {
+        "remix-serve": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@remix-run/server-runtime": {
       "version": "0.0.0-experimental-e18af792a",
       "license": "MIT",
@@ -3346,6 +3407,64 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@remix-run/web-blob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.0.4.tgz",
+      "integrity": "sha512-AfegzZvSSDc+LwnXV+SwROTrDtoLiPxeFW+jxgvtDAnkuCX1rrzmVJ6CzqZ1Ai0bVfmJadkG5GxtAfYclpPmgw==",
+      "dependencies": {
+        "@remix-run/web-stream": "^1.0.0",
+        "web-encoding": "1.1.5"
+      }
+    },
+    "node_modules/@remix-run/web-fetch": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.2.tgz",
+      "integrity": "sha512-aRNaaa0Fhyegv/GkJ/qsxMhXvyWGjPNgCKrStCvAvV1XXphntZI0nQO/Fl02LIQg3cGL8lDiOXOS1gzqDOlG5w==",
+      "dependencies": {
+        "@remix-run/web-blob": "^3.0.4",
+        "@remix-run/web-form-data": "^3.0.3",
+        "@remix-run/web-stream": "^1.0.3",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "data-uri-to-buffer": "^3.0.1",
+        "mrmime": "^1.0.0"
+      },
+      "engines": {
+        "node": "^10.17 || >=12.3"
+      }
+    },
+    "node_modules/@remix-run/web-fetch/node_modules/data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@remix-run/web-file": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.0.2.tgz",
+      "integrity": "sha512-eFC93Onh/rZ5kUNpCQersmBtxedGpaXK2/gsUl49BYSGK/DvuPu3l06vmquEDdcPaEuXcsdGP0L7zrmUqrqo4A==",
+      "dependencies": {
+        "@remix-run/web-blob": "^3.0.3"
+      }
+    },
+    "node_modules/@remix-run/web-form-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.0.3.tgz",
+      "integrity": "sha512-wL4veBtVPazSpXfPMzrbmeV3IxuxCfcQYPerQ8BXRO5ahAEVw23tv7xS+yoX0XDO5j+vpRaSbhHJK1H5gF7eYQ==",
+      "dependencies": {
+        "web-encoding": "1.1.5"
+      }
+    },
+    "node_modules/@remix-run/web-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.0.3.tgz",
+      "integrity": "sha512-wlezlJaA5NF6SsNMiwQnnAW6tnPzQ5I8qk0Y0pSohm0eHKa2FQ1QhEKLVVcDDu02TmkfHgnux0igNfeYhDOXiA==",
+      "dependencies": {
+        "web-streams-polyfill": "^3.1.1"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -4865,6 +4984,15 @@
       "version": "2.0.6",
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
@@ -5229,6 +5357,12 @@
       "peerDependencies": {
         "esbuild": ">=0.10.0"
       }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "optional": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -5742,7 +5876,6 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5873,6 +6006,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -6733,6 +6879,65 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7874,7 +8079,6 @@
     },
     "node_modules/es-abstract": {
       "version": "1.20.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7941,7 +8145,6 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -9812,7 +10015,6 @@
     },
     "node_modules/for-each": {
       "version": "0.3.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
@@ -9943,7 +10145,6 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -9960,7 +10161,6 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10079,7 +10279,6 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -10309,7 +10508,6 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10344,7 +10542,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -10808,7 +11005,6 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.0",
@@ -10858,7 +11054,6 @@
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -10877,7 +11072,6 @@
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -10898,7 +11092,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -10934,7 +11127,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.6",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10976,7 +11168,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -11050,6 +11241,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "license": "MIT",
@@ -11092,7 +11297,6 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11110,7 +11314,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -11175,7 +11378,6 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -11214,7 +11416,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -11235,7 +11436,6 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -11249,7 +11449,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -11263,7 +11462,6 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
@@ -11299,7 +11497,6 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -13260,11 +13457,66 @@
       "version": "0.5.3",
       "license": "MIT"
     },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -13728,6 +13980,16 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -15795,7 +16057,6 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -16989,6 +17250,11 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/stream-slice": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
+      "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA=="
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "engines": {
@@ -17064,7 +17330,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -17077,7 +17342,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -18334,7 +18598,6 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -18698,6 +18961,18 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
@@ -18916,6 +19191,17 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dependencies": {
+        "util": "^0.12.3"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "0.9.0"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -18951,7 +19237,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -18980,7 +19265,6 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
@@ -19389,13 +19673,36 @@
       "dependencies": {
         "@oclif/core": "^1.20.4",
         "@remix-run/dev": "0.0.0-experimental-e18af792a",
+        "@remix-run/node": "0.0.0-experimental-e18af792a",
         "@shopify/cli-kit": "^3.23.0",
         "@shopify/mini-oxygen": "^1.0.0",
         "esbuild": "^0.15.12",
-        "fs-extra": "^10.1.0"
+        "fs-extra": "^10.1.0",
+        "ws": "^8.11.0"
       },
       "devDependencies": {
-        "@types/fs-extra": "^9.0.13"
+        "@types/fs-extra": "^9.0.13",
+        "@types/ws": "^8.5.3"
+      }
+    },
+    "packages/cli/node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "packages/hydrogen": {
@@ -19411,7 +19718,13 @@
     "packages/hydrogen-remix": {
       "name": "@shopify/hydrogen-remix",
       "version": "0.0.1",
+      "devDependencies": {
+        "@remix-run/express": "0.0.0-experimental-e18af792a",
+        "@remix-run/node": "0.0.0-experimental-e18af792a"
+      },
       "peerDependencies": {
+        "@remix-run/express": "*",
+        "@remix-run/node": "*",
         "@remix-run/oxygen": "*",
         "@remix-run/react": "*",
         "@shopify/hydrogen": "*"
@@ -21404,6 +21717,38 @@
         "eslint-plugin-testing-library": "^5.0.5"
       }
     },
+    "@remix-run/express": {
+      "version": "0.0.0-experimental-e18af792a",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-0.0.0-experimental-e18af792a.tgz",
+      "integrity": "sha512-/LIPldRMW5hjj4CR4Mu/ex7dtUGjUk5xpwr4+V6qDJpvT3TiGF4orivSEz7lMWIuavv+UZr/BfCS6ovVZKb5EQ==",
+      "devOptional": true,
+      "requires": {
+        "@remix-run/node": "0.0.0-experimental-e18af792a"
+      }
+    },
+    "@remix-run/node": {
+      "version": "0.0.0-experimental-e18af792a",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-0.0.0-experimental-e18af792a.tgz",
+      "integrity": "sha512-ZyGtVslF3VP/6YtmjryRW2z4nfcWSeuinuvSjdozVxQ5eEoH4fkgHWeY/3bLEYjJC+ju1zus1e7E5AObRikKOQ==",
+      "requires": {
+        "@remix-run/server-runtime": "0.0.0-experimental-e18af792a",
+        "@remix-run/web-fetch": "^4.1.3",
+        "@remix-run/web-file": "^3.0.2",
+        "@remix-run/web-stream": "^1.0.3",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "cookie-signature": "^1.1.0",
+        "source-map-support": "^0.5.21",
+        "stream-slice": "^0.1.2"
+      },
+      "dependencies": {
+        "cookie-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.0.tgz",
+          "integrity": "sha512-R0BOPfLGTitaKhgKROKZQN6iyq2iDQcH1DOF8nJoaWapguX5bC2w+Q/I9NmmM5lfcvEarnLZr+cCvmEYYSXvYA=="
+        }
+      }
+    },
     "@remix-run/oxygen": {
       "version": "file:packages/remix-oxygen",
       "requires": {
@@ -21421,6 +21766,19 @@
         "type-fest": "^2.17.0"
       }
     },
+    "@remix-run/serve": {
+      "version": "0.0.0-experimental-e18af792a",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-0.0.0-experimental-e18af792a.tgz",
+      "integrity": "sha512-cwPksC9nEeBSRBUaJ2ZDd7h+vQ2wH5EG4AzAYNJqOny0ekh5qcS+/vFSIx86x3EXJ9KFWHUMpaNS9IUh1AXoqA==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@remix-run/express": "0.0.0-experimental-e18af792a",
+        "compression": "^1.7.4",
+        "express": "^4.17.1",
+        "morgan": "^1.10.0"
+      }
+    },
     "@remix-run/server-runtime": {
       "version": "0.0.0-experimental-e18af792a",
       "requires": {
@@ -21431,6 +21789,60 @@
         "react-router-dom": "^6.2.2",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3"
+      }
+    },
+    "@remix-run/web-blob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-blob/-/web-blob-3.0.4.tgz",
+      "integrity": "sha512-AfegzZvSSDc+LwnXV+SwROTrDtoLiPxeFW+jxgvtDAnkuCX1rrzmVJ6CzqZ1Ai0bVfmJadkG5GxtAfYclpPmgw==",
+      "requires": {
+        "@remix-run/web-stream": "^1.0.0",
+        "web-encoding": "1.1.5"
+      }
+    },
+    "@remix-run/web-fetch": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-fetch/-/web-fetch-4.3.2.tgz",
+      "integrity": "sha512-aRNaaa0Fhyegv/GkJ/qsxMhXvyWGjPNgCKrStCvAvV1XXphntZI0nQO/Fl02LIQg3cGL8lDiOXOS1gzqDOlG5w==",
+      "requires": {
+        "@remix-run/web-blob": "^3.0.4",
+        "@remix-run/web-form-data": "^3.0.3",
+        "@remix-run/web-stream": "^1.0.3",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "data-uri-to-buffer": "^3.0.1",
+        "mrmime": "^1.0.0"
+      },
+      "dependencies": {
+        "data-uri-to-buffer": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+          "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+        }
+      }
+    },
+    "@remix-run/web-file": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-file/-/web-file-3.0.2.tgz",
+      "integrity": "sha512-eFC93Onh/rZ5kUNpCQersmBtxedGpaXK2/gsUl49BYSGK/DvuPu3l06vmquEDdcPaEuXcsdGP0L7zrmUqrqo4A==",
+      "requires": {
+        "@remix-run/web-blob": "^3.0.3"
+      }
+    },
+    "@remix-run/web-form-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-form-data/-/web-form-data-3.0.3.tgz",
+      "integrity": "sha512-wL4veBtVPazSpXfPMzrbmeV3IxuxCfcQYPerQ8BXRO5ahAEVw23tv7xS+yoX0XDO5j+vpRaSbhHJK1H5gF7eYQ==",
+      "requires": {
+        "web-encoding": "1.1.5"
+      }
+    },
+    "@remix-run/web-stream": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/web-stream/-/web-stream-1.0.3.tgz",
+      "integrity": "sha512-wlezlJaA5NF6SsNMiwQnnAW6tnPzQ5I8qk0Y0pSohm0eHKa2FQ1QhEKLVVcDDu02TmkfHgnux0igNfeYhDOXiA==",
+      "requires": {
+        "web-streams-polyfill": "^3.1.1"
       }
     },
     "@rollup/pluginutils": {
@@ -21553,11 +21965,22 @@
       "requires": {
         "@oclif/core": "^1.20.4",
         "@remix-run/dev": "0.0.0-experimental-e18af792a",
+        "@remix-run/node": "0.0.0-experimental-e18af792a",
         "@shopify/cli-kit": "^3.23.0",
         "@shopify/mini-oxygen": "^1.0.0",
         "@types/fs-extra": "^9.0.13",
+        "@types/ws": "^8.5.3",
         "esbuild": "^0.15.12",
-        "fs-extra": "^10.1.0"
+        "fs-extra": "^10.1.0",
+        "ws": "^8.11.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "requires": {}
+        }
       }
     },
     "@shopify/cli-kit": {
@@ -21922,7 +22345,10 @@
     },
     "@shopify/hydrogen-remix": {
       "version": "file:packages/hydrogen-remix",
-      "requires": {}
+      "requires": {
+        "@remix-run/express": "0.0.0-experimental-e18af792a",
+        "@remix-run/node": "0.0.0-experimental-e18af792a"
+      }
     },
     "@shopify/mini-oxygen": {
       "version": "1.0.0",
@@ -22505,6 +22931,15 @@
     "@types/unist": {
       "version": "2.0.6"
     },
+    "@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
@@ -22685,6 +23120,12 @@
       "requires": {
         "tslib": "^1.13.0"
       }
+    },
+    "@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "optional": true
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -23008,8 +23449,7 @@
       }
     },
     "available-typed-arrays": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.0.5"
     },
     "axe-core": {
       "version": "4.4.3",
@@ -23083,6 +23523,16 @@
     },
     "base64-js": {
       "version": "1.5.1"
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "big.js": {
       "version": "5.2.2"
@@ -23627,6 +24077,58 @@
         "crc32-stream": "^4.0.2",
         "normalize-path": "^3.0.0",
         "readable-stream": "^3.6.0"
+      }
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+          "optional": true,
+          "peer": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "concat-map": {
@@ -24385,7 +24887,6 @@
     },
     "es-abstract": {
       "version": "1.20.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -24441,7 +24942,6 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -25580,7 +26080,6 @@
     },
     "for-each": {
       "version": "0.3.3",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -25659,7 +26158,6 @@
     },
     "function.prototype.name": {
       "version": "1.1.5",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -25668,8 +26166,7 @@
       }
     },
     "functions-have-names": {
-      "version": "1.2.3",
-      "dev": true
+      "version": "1.2.3"
     },
     "fuzzy": {
       "version": "0.1.3",
@@ -25739,7 +26236,6 @@
     },
     "get-symbol-description": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -25894,8 +26390,7 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "has-flag": {
       "version": "4.0.0"
@@ -25911,7 +26406,6 @@
     },
     "has-tostringtag": {
       "version": "1.0.0",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -26231,7 +26725,6 @@
     },
     "internal-slot": {
       "version": "1.0.3",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -26259,7 +26752,6 @@
     },
     "is-arguments": {
       "version": "1.1.1",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -26270,7 +26762,6 @@
     },
     "is-bigint": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -26283,7 +26774,6 @@
     },
     "is-boolean-object": {
       "version": "1.1.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -26293,8 +26783,7 @@
       "version": "2.0.5"
     },
     "is-callable": {
-      "version": "1.2.6",
-      "dev": true
+      "version": "1.2.6"
     },
     "is-ci": {
       "version": "1.2.1",
@@ -26317,7 +26806,6 @@
     },
     "is-date-object": {
       "version": "1.0.5",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -26353,6 +26841,14 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0"
     },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-glob": {
       "version": "4.0.3",
       "requires": {
@@ -26373,15 +26869,13 @@
       "dev": true
     },
     "is-negative-zero": {
-      "version": "2.0.2",
-      "dev": true
+      "version": "2.0.2"
     },
     "is-number": {
       "version": "7.0.0"
     },
     "is-number-object": {
       "version": "1.0.7",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -26417,7 +26911,6 @@
     },
     "is-regex": {
       "version": "1.1.4",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -26438,7 +26931,6 @@
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -26448,21 +26940,18 @@
     },
     "is-string": {
       "version": "1.0.7",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-symbol": {
       "version": "1.0.4",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
     },
     "is-typed-array": {
       "version": "1.1.9",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -26480,7 +26969,6 @@
     },
     "is-weakref": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -27678,8 +28166,56 @@
     "mkdirp-classic": {
       "version": "0.5.3"
     },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "optional": true,
+          "peer": true
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        }
+      }
+    },
     "mri": {
       "version": "1.2.0"
+    },
+    "mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw=="
     },
     "ms": {
       "version": "2.1.2"
@@ -27962,6 +28498,13 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "optional": true,
+      "peer": true
     },
     "once": {
       "version": "1.4.0",
@@ -29218,7 +29761,6 @@
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -29999,6 +30541,11 @@
     "stream-shift": {
       "version": "1.0.1"
     },
+    "stream-slice": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
+      "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA=="
+    },
     "streamsearch": {
       "version": "1.1.0"
     },
@@ -30046,7 +30593,6 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.5",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -30055,7 +30601,6 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.5",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -30840,7 +31385,6 @@
     },
     "unbox-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -31056,6 +31600,18 @@
       "version": "1.2.0",
       "requires": {}
     },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2"
     },
@@ -31161,6 +31717,15 @@
         "defaults": "^1.0.3"
       }
     },
+    "web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "requires": {
+        "@zxing/text-encoding": "0.9.0",
+        "util": "^0.12.3"
+      }
+    },
     "web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -31184,7 +31749,6 @@
     },
     "which-boxed-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -31205,7 +31769,6 @@
     },
     "which-typed-array": {
       "version": "1.1.8",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",

--- a/packages/cli/bin/dev-reload.mjs
+++ b/packages/cli/bin/dev-reload.mjs
@@ -9,4 +9,8 @@
 
 import {runBuild} from '../dist/commands/hydrogen/build.js';
 
-await runBuild({devReload: true, entry: process.argv[2]});
+await runBuild({
+  devReload: true,
+  entry: process.argv[2],
+  node: process.argv.some((arg) => arg === '--node'),
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,19 +5,23 @@
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && tsc",
+    "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "postinstall": "./bin/postinstall.mjs"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^9.0.13"
   },
   "dependencies": {
     "@oclif/core": "^1.20.4",
     "@remix-run/dev": "0.0.0-experimental-e18af792a",
+    "@remix-run/node": "0.0.0-experimental-e18af792a",
     "@shopify/cli-kit": "^3.23.0",
     "@shopify/mini-oxygen": "^1.0.0",
     "esbuild": "^0.15.12",
-    "fs-extra": "^10.1.0"
+    "fs-extra": "^10.1.0",
+    "ws": "^8.11.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^9.0.13",
+    "@types/ws": "^8.5.3"
   },
   "files": [
     "bin",

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -7,6 +7,7 @@ import {flags} from '../../utils/flags.js';
 
 import Command from '@shopify/cli-kit/node/base-command';
 import {Flags} from '@oclif/core';
+import {isWebContainer} from '../../utils/platform.js';
 
 // @ts-ignore
 export default class Build extends Command {
@@ -29,7 +30,7 @@ export default class Build extends Command {
     }),
     node: Flags.boolean({
       env: 'SHOPIFY_HYDROGEN_FLAG_NODE',
-      default: !!process.env.GIT_PROXY?.includes('stackblitz'),
+      default: isWebContainer(),
       hidden: true,
     }),
   };

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -29,7 +29,7 @@ export default class Build extends Command {
     }),
     node: Flags.boolean({
       env: 'SHOPIFY_HYDROGEN_FLAG_NODE',
-      default: false,
+      default: !!process.env.GIT_PROXY?.includes('stackblitz'),
     }),
   };
 

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -30,6 +30,7 @@ export default class Build extends Command {
     node: Flags.boolean({
       env: 'SHOPIFY_HYDROGEN_FLAG_NODE',
       default: !!process.env.GIT_PROXY?.includes('stackblitz'),
+      hidden: true,
     }),
   };
 

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -32,7 +32,7 @@ export default class Dev extends Command {
     }),
     node: Flags.boolean({
       env: 'SHOPIFY_HYDROGEN_FLAG_NODE',
-      default: false,
+      default: !!process.env.GIT_PROXY?.includes('stackblitz'),
     }),
   };
 

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -32,6 +32,8 @@ export default class Dev extends Command {
     }),
     node: Flags.boolean({
       env: 'SHOPIFY_HYDROGEN_FLAG_NODE',
+      description:
+        'Serve the storefront using a Node.js server instead of MiniOxygen',
       default: !!process.env.GIT_PROXY?.includes('stackblitz'),
     }),
   };

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -11,6 +11,7 @@ import {createRequire} from 'module';
 
 import Command from '@shopify/cli-kit/node/base-command';
 import {Flags} from '@oclif/core';
+import {isWebContainer} from '../../utils/platform.js';
 
 const miniOxygenPreview =
   miniOxygen.default ?? (miniOxygen as unknown as typeof miniOxygen.default);
@@ -34,7 +35,7 @@ export default class Dev extends Command {
       env: 'SHOPIFY_HYDROGEN_FLAG_NODE',
       description:
         'Serve the storefront using a Node.js server instead of MiniOxygen',
-      default: !!process.env.GIT_PROXY?.includes('stackblitz'),
+      default: isWebContainer(),
     }),
   };
 

--- a/packages/cli/src/utils/node-server.ts
+++ b/packages/cli/src/utils/node-server.ts
@@ -24,7 +24,7 @@ async function setupNodeServer({
 }: NodeServerOptions) {
   if (process.env.NODE_ENV === 'production') {
     console.error(
-      new Error('This Node server should only be used for development!'),
+      new Error('Running node server in production. Using the node server should only be used for development!'),
     );
   }
 

--- a/packages/cli/src/utils/node-server.ts
+++ b/packages/cli/src/utils/node-server.ts
@@ -1,0 +1,107 @@
+import fsExtra from 'fs-extra';
+import childProcess from 'child_process';
+import {createRequire} from 'module';
+import {installGlobals} from '@remix-run/node';
+
+type NodeServerOptions = {
+  port?: number;
+  buildCommand: string;
+  buildPathWorkerFile: string;
+  buildPathClient: string;
+  buildWatchPaths: string[];
+  env: Record<string, string | undefined>;
+};
+
+const HTML_ENDING = '</body></html>';
+
+async function setupNodeServer({
+  port = 3000,
+  buildCommand,
+  buildPathClient,
+  buildWatchPaths,
+  buildPathWorkerFile,
+  env,
+}: NodeServerOptions) {
+  if (process.env.NODE_ENV === 'production') {
+    console.error(
+      new Error('This Node server should only be used for development!'),
+    );
+  }
+
+  installGlobals();
+  const require = createRequire(import.meta.url);
+
+  const express = require('express');
+  const app = express();
+  app.disable('x-powered-by');
+
+  app.use('', express.static(buildPathClient, {immutable: true, maxAge: '1s'}));
+
+  const wsPort = port + 1;
+  const WebSocket = require('ws');
+  const wss = new WebSocket.Server({port: wsPort});
+
+  app.all('*', async (request: any, response: any, next: any) => {
+    const {
+      default: {fetch: fetchHandler},
+    } = require(buildPathWorkerFile);
+
+    request.headers['get'] = (prop: string) => request.headers[prop];
+    const origin = `${request.protocol}://${request.get('host')}`;
+    const url = new URL(request.url, origin);
+    request.url = url.toString();
+
+    // Inject live reload script in HTML responses
+    const decoder = new TextDecoder();
+    const write = response.write.bind(response);
+    response.write = (encoded: Uint8Array) => {
+      const decoded = decoder.decode(encoded);
+      if (!decoded.includes(HTML_ENDING)) return write(encoded);
+
+      return write(
+        decoded.replace(
+          HTML_ENDING,
+          `<script>new WebSocket("ws://localhost:${wsPort}").addEventListener("message", () => window.location.reload());</script>` +
+            HTML_ENDING,
+        ),
+      );
+    };
+
+    try {
+      await fetchHandler(request, env, {response, next});
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  app.listen(port, () => {
+    console.log(`Started Node server. Listening at http://localhost:${port}`);
+  });
+
+  buildWatchPaths.forEach((filepath) => {
+    let lastRefreshTime = 0;
+
+    fsExtra.watch(filepath, {}, async () => {
+      const stat = await fsExtra.stat(filepath);
+      const currentTime = Math.floor(stat.mtimeMs);
+      if (currentTime === lastRefreshTime) return;
+      lastRefreshTime = currentTime;
+
+      childProcess.exec(buildCommand, () => {
+        // Bust cache to always get a fresh build
+        delete require.cache[buildPathWorkerFile];
+
+        // Refresh browser
+        wss.clients.forEach((client: any) => {
+          if (client.readyState === WebSocket.OPEN) {
+            client.send(JSON.stringify({}));
+          }
+        });
+
+        console.log('Server reloaded!');
+      });
+    });
+  });
+}
+
+export {setupNodeServer};

--- a/packages/cli/src/utils/platform.ts
+++ b/packages/cli/src/utils/platform.ts
@@ -1,0 +1,4 @@
+export function isWebContainer() {
+  const {webcontainer} = process.versions;
+  return !!webcontainer && typeof webcontainer === 'string';
+}

--- a/packages/hydrogen-remix/package.json
+++ b/packages/hydrogen-remix/package.json
@@ -8,20 +8,18 @@
   "types": "dist/production/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "tsup --clean --config ../../tsup.config.ts",
-    "dev": "tsup --watch --config ../../tsup.config.ts"
+    "build": "tsup --clean --config ./tsup.config.ts",
+    "dev": "tsup --watch --config ./tsup.config.ts"
   },
   "exports": {
     ".": {
       "types": "./dist/production/index.d.ts",
-      "module": {
-        "development": "./dist/development/index.js",
-        "default": "./dist/production/index.js"
-      },
-      "require": "./dist/index.cjs",
-      "import": {
-        "development": "./dist/development/index.js",
-        "default": "./dist/production/index.js"
+      "node-dev": {
+        "require": "./dist/index.cjs",
+        "default": {
+          "development": "./dist/development/node/index.js",
+          "default": "./dist/production/node/index.js"
+        }
       },
       "default": {
         "development": "./dist/development/index.js",
@@ -35,7 +33,13 @@
   ],
   "peerDependencies": {
     "@remix-run/oxygen": "*",
+    "@remix-run/express": "*",
+    "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@shopify/hydrogen": "*"
+  },
+  "devDependencies": {
+    "@remix-run/express": "0.0.0-experimental-e18af792a",
+    "@remix-run/node": "0.0.0-experimental-e18af792a"
   }
 }

--- a/packages/hydrogen-remix/src/node/index.ts
+++ b/packages/hydrogen-remix/src/node/index.ts
@@ -1,0 +1,5 @@
+export type {LoaderArgs, LoaderFunction, ActionArgs, ActionFunction} from '..';
+
+export * from '@remix-run/node';
+export {createRequestHandler} from './server';
+export * from '@shopify/hydrogen';

--- a/packages/hydrogen-remix/src/node/server.ts
+++ b/packages/hydrogen-remix/src/node/server.ts
@@ -1,0 +1,46 @@
+import {type CreateRequestHandlerOptions} from '@remix-run/oxygen';
+import {createRequestHandler as createExpressRequestHandler} from '@remix-run/express';
+import {InMemoryCache} from '@shopify/hydrogen';
+import {
+  createHydrogenContext,
+  logResponse,
+  type RequestHandlerOptions,
+} from '../server';
+
+export function createRequestHandler({
+  build,
+  mode,
+  getLoadContext,
+}: CreateRequestHandlerOptions) {
+  return async (
+    request: Request,
+    options: RequestHandlerOptions,
+    customContext?: Record<string, any>,
+  ) => {
+    if (!options.cache) {
+      options.cache = new InMemoryCache();
+    }
+
+    const handleRequest = createExpressRequestHandler({
+      build,
+      getLoadContext: (request, response) => ({
+        ...createHydrogenContext(request, options, customContext),
+        ...(getLoadContext?.(request, response) ?? {}),
+      }),
+      mode,
+    });
+
+    const {
+      context: {response, next},
+    } = options;
+
+    try {
+      await handleRequest(request, response, next);
+      logResponse(mode!, request, response.statusCode);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      response.status(500).send('Internal Error');
+    }
+  };
+}

--- a/packages/hydrogen-remix/tsup.config.ts
+++ b/packages/hydrogen-remix/tsup.config.ts
@@ -1,0 +1,25 @@
+import fs from 'fs/promises';
+import {defineConfig} from 'tsup';
+import {
+  entry,
+  devConfig,
+  prodConfig,
+  cjsEntryFile,
+  cjsEntryContent,
+} from '../../tsup.config';
+
+const entryPoints = [entry, 'src/node/index.ts'];
+
+export default [
+  defineConfig({...devConfig, entryPoints}),
+  defineConfig({
+    ...prodConfig,
+    entryPoints,
+    onSuccess: () =>
+      fs.writeFile(
+        cjsEntryFile,
+        cjsEntryContent.replaceAll('index.cjs', 'node/index.cjs'),
+        'utf-8',
+      ),
+  }),
+];

--- a/packages/remix-oxygen/src/index.ts
+++ b/packages/remix-oxygen/src/index.ts
@@ -5,7 +5,11 @@ export {
   createSessionStorage,
 } from './implementations';
 
-export {createRequestHandler, getBuyerIp} from './server';
+export {
+  createRequestHandler,
+  getBuyerIp,
+  type CreateRequestHandlerOptions,
+} from './server';
 
 export {
   createSession,

--- a/packages/remix-oxygen/src/server.ts
+++ b/packages/remix-oxygen/src/server.ts
@@ -11,20 +11,22 @@ type OxygenHandleRequestOptions = {
   };
 };
 
-export function createRequestHandler<Context = unknown>({
-  build,
-  mode,
-  getLoadContext,
-  shouldProxyAsset,
-}: {
+export type CreateRequestHandlerOptions = {
   build: ServerBuild;
   mode?: string;
   getLoadContext?: (
     request: Request,
     params: OxygenHandleRequestOptions,
-  ) => Promise<Context> | Context;
+  ) => Promise<Record<string, any>> | Record<string, any>;
   shouldProxyAsset?: (url: string) => boolean;
-}) {
+};
+
+export function createRequestHandler({
+  build,
+  mode,
+  getLoadContext,
+  shouldProxyAsset,
+}: CreateRequestHandlerOptions) {
   const handleRequest = createRemixRequestHandler(build, mode);
 
   return async (

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,8 +2,10 @@ import {defineConfig} from 'tsup';
 import fs from 'fs/promises';
 import path from 'path';
 
-const entry = 'src/index.ts';
-const outDir = 'dist';
+export const entry = 'src/index.ts';
+export const outDir = 'dist';
+export const cjsEntryContent = `module.exports = process.env.NODE_ENV === 'development' ? require('./development/index.cjs') : require('./production/index.cjs');`;
+export const cjsEntryFile = path.resolve(process.cwd(), outDir, 'index.cjs');
 
 const common = defineConfig({
   entryPoints: [entry],
@@ -12,24 +14,19 @@ const common = defineConfig({
   sourcemap: true,
 });
 
-export default defineConfig([
-  {
-    ...common,
-    env: {NODE_ENV: 'development'},
-    outDir: path.join(outDir, 'development'),
-  },
-  {
-    ...common,
-    env: {NODE_ENV: 'production'},
-    dts: entry,
-    outDir: path.join(outDir, 'production'),
-    minify: true,
-    async onSuccess() {
-      await fs.writeFile(
-        path.resolve(process.cwd(), outDir, 'index.cjs'),
-        `module.exports = process.env.NODE_ENV === 'development' ? require('./development/index.cjs') : require('./production/index.cjs');`,
-        'utf-8',
-      );
-    },
-  },
-]);
+export const devConfig = defineConfig({
+  ...common,
+  env: {NODE_ENV: 'development'},
+  outDir: path.join(outDir, 'development'),
+});
+
+export const prodConfig = defineConfig({
+  ...common,
+  env: {NODE_ENV: 'production'},
+  dts: entry,
+  outDir: path.join(outDir, 'production'),
+  minify: true,
+  onSuccess: () => fs.writeFile(cjsEntryFile, cjsEntryContent, 'utf-8'),
+});
+
+export default [devConfig, prodConfig];


### PR DESCRIPTION
@jplhomer @benjaminsehl  This is more or less what I mentioned in the Google doc:
- Adding a new `@shopify/hydrogen-remix/node` export that basically rewires things to support Node. Most of the code here is reusing exports from the Oxygen request handler.
- Enable the previous code path via Node condition `node-dev` (when passing `--node` flag to the CLI or detecting Stackblitz automatically).
- Serving the app with a custom Node server instead of MiniOxygen.

Most of the changes here are refactoring, I'd recommend checking commits 1 by 1.
Note that the app code itself doesn't change, and even the `oxygen.ts` file remains unmodified.

Do you think this is simple enough for us to maintain? Or should we just discontinue Node environments?


---

To test this locally, change `demo-store/package.json`:

```diff
- "dev": "SESSION_SECRET=foobar concurrently -g -r npm:dev:css \"shopify hydrogen dev --entry oxygen.ts\"",
+ "dev": "SESSION_SECRET=foobar concurrently -g -r npm:dev:css \"shopify hydrogen dev --entry oxygen.ts --node\"",
```