### PR TITLE
Fix multiple option variants and available filter

### DIFF
--- a/templates/demo-store/app/components/SortFilter.tsx
+++ b/templates/demo-store/app/components/SortFilter.tsx
@@ -174,7 +174,18 @@ function getAppliedFilterLink(
   location: Location,
 ) {
   const paramsClone = new URLSearchParams(params);
-  paramsClone.delete(filter.urlParam);
+  if (filter.urlParam.key === 'variantOption') {
+    const variantOptions = paramsClone.getAll('variantOption');
+    const filteredVariantOptions = variantOptions.filter(
+      (options) => !options.includes(filter.urlParam.value),
+    );
+    paramsClone.delete(filter.urlParam.key);
+    for (const filteredVariantOption of filteredVariantOptions) {
+      paramsClone.append(filter.urlParam.key, filteredVariantOption);
+    }
+  } else {
+    paramsClone.delete(filter.urlParam.key);
+  }
   return `${location.pathname}?${paramsClone.toString()}`;
 }
 
@@ -287,9 +298,11 @@ function filterInputToParams(
           params.set(key, value.toString());
         } else {
           const {name, value: val} = value as {name: string; value: string};
-          const newInput = {[name]: val};
-
-          filterInputToParams(type, newInput, params);
+          const allVariants = params.getAll(`variantOption`);
+          const newVariant = `${name}:${val}`;
+          if (!allVariants.includes(newVariant)) {
+            params.append('variantOption', newVariant);
+          }
         }
       });
       break;


### PR DESCRIPTION
We were originally allowing any value in the url to be an optional variant.
Now we encode all optional variants with the search param `variantOption` and the value as `<variant>:<selection>`
`variantOption=color%3AFED+Green`

This makes sure we don't show in the applied filters other values like `cursor` or `sorted by`

I also fixed the `available` filter which was failing because of types.

### Feedback required
Seems to be akward to remove a search param with the same name and different values.
I ended up rebuilding the params each time just to achieve this.
