### PR TITLE
Add /discounts/$code?redirect magic route

### DIFF
--- a/packages/hydrogen-remix/templates/routes/discounts.$code.tsx
+++ b/packages/hydrogen-remix/templates/routes/discounts.$code.tsx
@@ -37,7 +37,7 @@ export async function loader({request, context, params}: LoaderArgs) {
     });
 
     if (graphqlCartErrors?.length) {
-      return json({errors: graphqlCartErrors});
+      return redirect(redirectUrl);
     }
 
     // cart created - we only need a Set-Cookie header if we're creating
@@ -47,15 +47,11 @@ export async function loader({request, context, params}: LoaderArgs) {
   }
 
   // apply discount to the cart
-  const {errors: graphqlDiscountErrors} = await cartDiscountCodesUpdate({
+  await cartDiscountCodesUpdate({
     cartId,
     discountCodes: [code],
     context,
   });
-
-  if (graphqlDiscountErrors?.length) {
-    return json({errors: graphqlDiscountErrors}, {headers});
-  }
 
   return redirect(redirectUrl, {headers});
 }


### PR DESCRIPTION
Closes https://github.com/Shopify/h2/issues/135
```
/**
 * Automatically applies a discount found on the url
 * If a cart exists it's updated with the discount, otherwise a cart is created with the discount already applied
 * @param ?redirect an optional path to return to otherwise return to the home page
 * @example
 * Example path applying a discount and redirecting
 * ```ts
 * /discounts/FREESHIPPING?redirect=/products
 * ```
 */
 ```
