### PR TITLE
Allow a template to be passed to `hydrogen init`

### DIFF
--- a/.changeset/big-cheetahs-peel.md
+++ b/.changeset/big-cheetahs-peel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-h2-test': patch
+---
+
+Allow a `--template` to be passed to `hydrogen init`

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -10,6 +10,11 @@ export default class Init extends Command {
       description: 'Use TypeScript',
       env: 'SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT',
     }),
+    template: Flags.string({
+      description: 'The template to use',
+      env: 'SHOPIFY_HYDROGEN_FLAG_TEMPLATE',
+      default: '../../templates/demo-store',
+    }),
   };
 
   async run(): Promise<void> {
@@ -20,10 +25,16 @@ export default class Init extends Command {
   }
 }
 
-function runInit({typescript}: {typescript?: Boolean}) {
+function runInit({
+  template,
+  typescript,
+}: {
+  template: string;
+  typescript?: Boolean;
+}) {
   const defaults = [
     '--template',
-    '../../templates/demo-store',
+    template,
     '--install',
     typescript ? '--typescript' : '',
   ];


### PR DESCRIPTION
Right now it's hardcoded, so we can't spin up new templates