### PR TITLE
Allow `token` to be passed to `shopify hydrogen init`.

### DIFF
--- a/.changeset/fuzzy-insects-reply.md
+++ b/.changeset/fuzzy-insects-reply.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-h2-test': patch
+---
+
+Allow a `token` to be passed to `init` to support private GitHub repo templates

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -14,6 +14,11 @@ export default class Init extends Command {
       description: 'The template to use',
       env: 'SHOPIFY_HYDROGEN_FLAG_TEMPLATE',
       default: '../../templates/demo-store',
+      required: true,
+    }),
+    token: Flags.string({
+      description:
+        'A GitHub token used to access access private repository templates',
     }),
   };
 
@@ -28,15 +33,18 @@ export default class Init extends Command {
 function runInit({
   template,
   typescript,
+  token,
 }: {
   template: string;
   typescript?: Boolean;
+  token?: string;
 }) {
   const defaults = [
     '--template',
     template,
     '--install',
     typescript ? '--typescript' : '',
+    token ? `--token ${token}` : '',
   ];
 
   remixCli.run(['create', ...defaults]);


### PR DESCRIPTION
This unlocks the usage of our private `h2` repo during developer preview.

See: https://remix.run/docs/en/v1/pages/stacks#--template