### PR TITLE
Fix turbo build issues with gitignored files like `.hydrogen`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.ts", "./tsup.config.ts"]
+      "inputs": ["src/**/*.ts", "./tsup.config.ts"],
+      "outputs": ["dist/**", "build/**", ".hydrogen/**"]
     },
     "dev": {
       "dependsOn": [


### PR DESCRIPTION
Turbo caches inputs and matches them using a hash-based output: https://turbo.build/repo/docs/core-concepts/caching. Turbo only considers git-versioned assets as "inputs", and by default tracks `dist` and `build` folders as "outputs." When an input hash matches the output hash, Turbo restores the dist contents to their respective folders from an internal cache and says "HEY I DON'T NEED TO BUILD! I'M ALL DONE!".

However, we introduced git-ignored folders like `.hydrogen`. This means Turbo doesn't know about them, and it does not restore them properly from the internal cache. When it sees that the `dev` dependencies (like `hydrogen-remix#build`) are cache hits, the `.hydrogen` folder is not restored — or it is not restored with the correct contents. This leads to sporadic build errors when Turbo has an active cache.

This PR tells Turbo about these gitignored "output" files to ensure they are accounted for.