### PR TITLE
Add a remix-friendly `<ShopPayCheckoutButton />`

### DIFF
--- a/templates/demo-store/app/components/ShopPayCheckoutButton.tsx
+++ b/templates/demo-store/app/components/ShopPayCheckoutButton.tsx
@@ -1,14 +1,24 @@
 import {CartLineInput} from '@shopify/hydrogen-react/storefront-api-types';
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 /**
  * React wrapper for Shopify's shop pay web component
  * @param lines an array of CartLineInput[] to add to the cart
- * @returns
  */
 export function ShopPayCheckoutButton({lines}: {lines: CartLineInput[]}) {
   const appended = useRef(false);
   const [loaded, setLoaded] = useState(false);
+
+  // map lines to variants the web component can understand
+  const variants = useMemo(() => {
+    return lines
+      .map((line) => {
+        if (!line?.merchandiseId) return null;
+        return `${line.merchandiseId.split('/').pop()}:${line?.quantity || 1}`;
+      })
+      .filter(Boolean)
+      .join(',');
+  }, [lines]);
 
   useEffect(() => {
     if (appended.current) return;
@@ -36,7 +46,7 @@ export function ShopPayCheckoutButton({lines}: {lines: CartLineInput[]}) {
       {loaded ? (
         <shop-pay-button
           store-url="https://hydrogen-preview.myshopify.com"
-          variants={`${variant.id.split('/').pop()}:${quantity}`}
+          variants={variants}
         />
       ) : (
         <p>Loading...</p>

--- a/templates/demo-store/app/components/ShopPayCheckoutButton.tsx
+++ b/templates/demo-store/app/components/ShopPayCheckoutButton.tsx
@@ -1,0 +1,46 @@
+import {CartLineInput} from '@shopify/hydrogen-react/storefront-api-types';
+import {useEffect, useRef, useState} from 'react';
+
+/**
+ * React wrapper for Shopify's shop pay web component
+ * @param lines an array of CartLineInput[] to add to the cart
+ * @returns
+ */
+export function ShopPayCheckoutButton({lines}: {lines: CartLineInput[]}) {
+  const appended = useRef(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (appended.current) return;
+
+    const isRegistered =
+      document.createElement('shop-pay-button').constructor !== HTMLElement;
+    if (isRegistered) {
+      setLoaded(true);
+      return;
+    }
+
+    // Load and append shop pay web component
+    const script = document.createElement('script');
+    script.src = 'https://cdn.shopify.com/shopifycloud/shop-js/client.js';
+    script.onload = function () {
+      setLoaded(true);
+    };
+    document.head.appendChild(script);
+
+    appended.current = true;
+  }, []);
+
+  return (
+    <>
+      {loaded ? (
+        <shop-pay-button
+          store-url="https://hydrogen-preview.myshopify.com"
+          variants={`${variant.id.split('/').pop()}:${quantity}`}
+        />
+      ) : (
+        <p>Loading...</p>
+      )}
+    </>
+  );
+}

--- a/templates/demo-store/app/components/index.ts
+++ b/templates/demo-store/app/components/index.ts
@@ -23,5 +23,6 @@ export {Breadcrumbs} from './Breadcrumbs';
 export {Grid} from './Grid';
 export {FeaturedProducts} from './FeaturedProducts';
 export {Pagination, getPaginationVariables, usePagination} from './Pagination';
+export {ShopPayCheckoutButton} from './ShopPayCheckoutButton';
 // Sue me
 export * from './Icon';

--- a/templates/demo-store/app/routes/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/products/$productHandle.tsx
@@ -211,8 +211,12 @@ export function ProductForm() {
             />
             {!isOutOfStock && (
               <ShopPayCheckoutButton
-                selectedVariant={selectedVariant}
-                quantity={1}
+                lines={[
+                  {
+                    merchandiseId: selectedVariant.id,
+                    quantity: 1,
+                  },
+                ]}
               />
             )}
           </div>

--- a/templates/demo-store/app/routes/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/products/$productHandle.tsx
@@ -26,6 +26,7 @@ import {
   Text,
   Link,
   Button,
+  ShopPayCheckoutButton,
 } from '~/components';
 import {getExcerpt, variantToCartLine} from '~/lib/utils';
 import invariant from 'tiny-invariant';
@@ -209,7 +210,10 @@ export function ProductForm() {
               isOutOfStock={isOutOfStock}
             />
             {!isOutOfStock && (
-              <ShopPayButton variantIds={[selectedVariant?.id!]} />
+              <ShopPayCheckoutButton
+                selectedVariant={selectedVariant}
+                quantity={1}
+              />
             )}
           </div>
         )}


### PR DESCRIPTION
Hydrogen UI's `<ShopPayButton />` does not currently work in on v2, because it has a dependency on the `<ShopifyProvider />` which we don't use on v2.

This is user-land component could serve as a stop gap until ShopPayButton is decoupled.

Use

```tsx
<ShopPayCheckoutButton
  // typed as CartLineInput[] to be consistent with CartLinesAddForm
  lines={[
    {
      merchandiseId: selectedVariant.id,
      quantity: 1,
    },
  ]}
/>
```

🎩 Guide
- Click "Shop pay" on any product page https://ph0674nj2-f1f4fa724b7467f41f07.myshopify.dev/
