### PR TITLE
Add `getCartId` session getter

### DIFF
--- a/docs/resources/cart/CartBuyerIdentityUpdate.md
+++ b/docs/resources/cart/CartBuyerIdentityUpdate.md
@@ -138,7 +138,7 @@ Example use:
 ```jsx
 export async function action({request, context}) {
   const {session} = context;
-  const cartId = await session.get('cartId');
+  const cartId = await session.getCartId();
   const buyerIdentity = formData.get('buyerIdentity')
     ? JSON.parse(formData.get('buyerIdentity'))
     : [];

--- a/docs/resources/cart/CartDiscountCodesUpdate.md
+++ b/docs/resources/cart/CartDiscountCodesUpdate.md
@@ -146,7 +146,7 @@ Example use:
 ```jsx
 export async function action({request, context}) {
   const {session} = context;
-  const cartId = await session.get('cartId');
+  const cartId = await session.getCartId();
   const discountCodes = formData.get('discountCodes')
     ? JSON.parse(formData.get('discountCodes'))
     : [];

--- a/docs/resources/cart/CartLinesAdd.md
+++ b/docs/resources/cart/CartLinesAdd.md
@@ -200,7 +200,7 @@ Example use:
 ```jsx
 export async function action({request, context}) {
   const {session} = context;
-  const cartId = await session.get('cartId');
+  const cartId = await session.getCartId();
   const lines = formData.get('lines') ? JSON.parse(formData.get('lines')) : [];
 
   // add cart lines to the cart

--- a/docs/resources/cart/CartLinesRemove.md
+++ b/docs/resources/cart/CartLinesRemove.md
@@ -183,7 +183,7 @@ Example use:
 ```jsx
 export async function action({request, context}) {
   const {session} = context;
-  const cartId = await session.get('cartId');
+  const cartId = await session.getCartId();
   const lineIds = formData.get('lineIds')
     ? JSON.parse(formData.get('lineIds'))
     : [];

--- a/docs/resources/cart/CartLinesUpdate.md
+++ b/docs/resources/cart/CartLinesUpdate.md
@@ -167,7 +167,7 @@ Example use:
 ```jsx
 export async function action({request, context}) {
   const {session} = context;
-  const cartId = await session.get('cartId');
+  const cartId = await session.getCartId();
   const lines = formData.get('lines') ? JSON.parse(formData.get('lines')) : [];
 
   // update cart lines

--- a/packages/hydrogen-remix/templates/routes/cart/CartLinesRemove.tsx
+++ b/packages/hydrogen-remix/templates/routes/cart/CartLinesRemove.tsx
@@ -60,7 +60,7 @@ const ACTION_PATH = '/cart/CartLinesRemove';
 async function action({request, context}: ActionArgs) {
   const formData = await request.formData();
 
-  const cartId = await context.session.get('cartId');
+  const cartId = await context.session.getCartId();
   invariant(cartId, 'Missing cartId');
 
   invariant(formData.get('lineIds'), 'Missing lineIds');

--- a/packages/hydrogen-remix/templates/routes/cart/CartLinesUpdate.tsx
+++ b/packages/hydrogen-remix/templates/routes/cart/CartLinesUpdate.tsx
@@ -64,7 +64,7 @@ async function action({request, context}: ActionArgs) {
   const formData = await request.formData();
 
   // 1. Grab the cart ID from the session
-  const cartId = await session.get('cartId');
+  const cartId = await session.getCartId();
   invariant(cartId, 'Missing cartId');
 
   invariant(formData.get('lines'), 'Missing lines');

--- a/packages/hydrogen-remix/templates/routes/discounts.$code.tsx
+++ b/packages/hydrogen-remix/templates/routes/discounts.$code.tsx
@@ -27,7 +27,7 @@ export async function loader({request, context, params}: LoaderArgs) {
     return redirect(redirectUrl);
   }
 
-  let cartId = await session.get('cartId');
+  let cartId = await session.getCartId();
 
   // if no existing cart, create one
   if (!cartId) {

--- a/rfc/guide-internationalization.md
+++ b/rfc/guide-internationalization.md
@@ -656,7 +656,7 @@ export function getLocaleFromRequest(request: Request): Locale {
      const path = formData.get('path');
      const toLocale = countries[`${languageCode}-${countryCode}`.toLowerCase()];
 
-     const cartId = await session.get('cartId');
+     const cartId = await session.getCartId();
 
      // Update cart buyer's country code if we have a cart id
      if (cartId) {

--- a/rfc/i18n.md
+++ b/rfc/i18n.md
@@ -375,7 +375,7 @@ const {lang} = useParams();
 
      if (hreflang !== 'EN-US') newPrefixPath = `/${hreflang.toLowerCase()}`;
 
-     const cartId = await session.get('cartId');
+     const cartId = await session.getCartId();
 
      // Update cart buyer's country code if we have a cart id
      if (cartId) {

--- a/templates/demo-store/app/lib/session.server.ts
+++ b/templates/demo-store/app/lib/session.server.ts
@@ -35,6 +35,10 @@ export class HydrogenSession {
     return this.session.get(key);
   }
 
+  getCartId() {
+    return this.session.get('cartId');
+  }
+
   destroy() {
     return this.sessionStorage.destroySession(this.session);
   }

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -58,7 +58,7 @@ export const meta: MetaFunction = () => ({
 
 export async function loader({context, request}: LoaderArgs) {
   const [cartId, layout, selectedLocale] = await Promise.all([
-    context.session.get('cartId'),
+    context.session.getCartId(),
     getLayoutData(context),
     getLocaleFromRequest(request),
   ]);


### PR DESCRIPTION
The reasoning behind this PR is to reduce the tight coupling of the persisted `cartId` key with our full stack components and localization logic.

The thinking is that with this approach end-users can adjust the `cartId` to whatever they like in their custom `/lib/session.server` without affecting other internal logic so long as `getCartId()` becomes a required method.

Not willing to die on this hill, just thought it could be a good idea.



