### PR TITLE
Add support for discounts on CartTotal

### DIFF
--- a/packages/hydrogen-remix/templates/routes/cart/CartDiscountCodesUpdate.tsx
+++ b/packages/hydrogen-remix/templates/routes/cart/CartDiscountCodesUpdate.tsx
@@ -74,7 +74,7 @@ async function action({request, context}: ActionArgs) {
   invariant(formDiscountCodes, 'Missing discountCodes');
   const discountCodes = (formDiscountCodes || []) as string[];
 
-  let cart;
+  let cart: Cart;
 
   // we fetch teh previous discountCodes to
   // diff them after mutating for analytics
@@ -93,17 +93,20 @@ async function action({request, context}: ActionArgs) {
 
   cart = firstCart;
 
+  const sortedDiscountCodes: {applicables: string[]; notApplicables: string[]} =
+    {applicables: [], notApplicables: []};
+
   // after the first mutation we find which discounts are actually applicable vs which ones are not
   const {applicables, notApplicables} = cart.discountCodes.reduce(
     (sort, discount) => {
       if (discount.applicable) {
-        sort.applicables = [...sort.applicables, discount.code];
+        sort.applicables.push(discount.code);
       } else {
-        sort.notApplicables = [...sort.notApplicables, discount.code];
+        sort.notApplicables.push(discount.code);
       }
       return sort;
     },
-    {applicables: [], notApplicables: []},
+    sortedDiscountCodes,
   );
 
   if (notApplicables?.length) {

--- a/templates/demo-store/app/components/Cart.tsx
+++ b/templates/demo-store/app/components/Cart.tsx
@@ -106,19 +106,20 @@ function CartDiscounts({
   const {discountCodesUpdating} = useCartDiscountCodesUpdating();
   const [hovered, setHovered] = useState(false);
 
-  const discounts = discountCodesUpdating
-    ? discountCodesUpdating
-    : discountCodes;
-
-  const optimisticDiscounts =
-    discounts?.map(({code}) => code).join(', ') || null;
+  const optimisticDiscounts = (
+    discountCodesUpdating
+      ? discountCodesUpdating
+      : discountCodes?.length
+      ? discountCodes.map(({code}) => code)
+      : []
+  ) as string[];
 
   return (
     <>
       {/* Have existing discount, display it with a remove option */}
-      <dl className={clsx(optimisticDiscounts ? 'grid' : 'hidden')}>
+      <dl className={clsx(optimisticDiscounts?.length ? 'grid' : 'hidden')}>
         <div className="flex items-center justify-between font-medium">
-          <Text as="dt">Discount(s)</Text>
+          <Text as="dt">Discount</Text>
           <div
             className="flex items-center justify-between"
             onMouseEnter={() => setHovered(true)}
@@ -129,7 +130,7 @@ function CartDiscounts({
               discountCodes={[]}
             >
               {() => (
-                <button>
+                <button className="mt-1">
                   <IconRemove
                     aria-hidden="true"
                     style={{height: 18, marginRight: 4}}
@@ -137,7 +138,10 @@ function CartDiscounts({
                 </button>
               )}
             </CartDiscountCodesUpdateForm>
-            <Text as="dd">{optimisticDiscounts}</Text>
+            {/* @todo: support multiple discounts display/remove */}
+            <Text as="dd">
+              {optimisticDiscounts?.length ? optimisticDiscounts[0] : ''}
+            </Text>
           </div>
         </div>
       </dl>
@@ -147,7 +151,7 @@ function CartDiscounts({
         {() => (
           <div
             className={clsx(
-              optimisticDiscounts ? 'hidden' : 'flex',
+              optimisticDiscounts?.length ? 'hidden' : 'flex',
               'items-center justify-between',
             )}
           >

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -248,6 +248,12 @@ const CART_QUERY = `#graphql
     discountCodes {
       code
     }
+    discountAllocations {
+      discountedAmount {
+        amount
+        currencyCode
+      }
+    }
   }
 
   fragment MoneyFragment on MoneyV2 {

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -247,6 +247,7 @@ const CART_QUERY = `#graphql
     }
     discountCodes {
       code
+      applicable
     }
     discountAllocations {
       discountedAmount {

--- a/templates/demo-store/tests/cart.test.ts
+++ b/templates/demo-store/tests/cart.test.ts
@@ -37,9 +37,7 @@ test.describe('Cart', () => {
       'should have the correct item quantities',
     ).toEqual(4);
 
-    const priceInStore = await page
-      .locator('[data-test=subtotal]')
-      .textContent();
+    const priceInStore = await page.locator('[data-test=total]').textContent();
 
     await page.locator('a :text("Checkout")').click();
 


### PR DESCRIPTION
Closes https://github.com/Shopify/h2/issues/286

Add support for discount totals to the cart.

---
UPDATED 

https://user-images.githubusercontent.com/12080141/205336902-2c6699c1-2821-4d31-89bb-61e37586caf2.mp4

---

Note: I discovered a potential issue with the SFAPI. If you apply a random discount code (or miss-type a real one) the cart seems to just accepts it without returning any graphql error. 

I think the discount validation is actually done at checkout not at the cart API level. 😢  CC @vixdug 

🎩 Help

1. go to https://swxpgbadt-f1f4fa724b7467f41f07.myshopify.dev/
2. add a product(s) to the cart
3. apply a discount such as `H2O` 
4. Should see a 10% discount acros
s the order/total

--- 

TODO — based on feedback
~- Fix optimistic discount application~
~- Add `applicable` check before displaying the code as applied~

See updated video



