### PR TITLE
Update rules and fix issues with TS lint failures

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 build
+dist
 node_modules
 bin
 *.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,8 +3,14 @@
  */
 module.exports = {
   parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
   rules: {
-    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/ban-ts-comment': [
+      'error',
+      {
+        'ts-expect-error': 'allow-with-description',
+      },
+    ],
     '@typescript-eslint/naming-convention': 'off',
     '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
     'no-useless-escape': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19957,7 +19957,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-h2-test",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "hasInstallScript": true,
       "dependencies": {
         "@oclif/core": "^1.20.4",
@@ -20014,7 +20014,7 @@
         "@headlessui/react": "^1.7.2",
         "@remix-run/react": "0.0.0-experimental-e18af792a",
         "@shopify/cli": "^3.23.0",
-        "@shopify/cli-h2-test": "^4.0.3",
+        "@shopify/cli-h2-test": "^4.0.4",
         "@shopify/h2-test-hydrogen": "^2.0.2",
         "@shopify/h2-test-hydrogen-remix": "^0.0.4",
         "@shopify/h2-test-remix-oxygen": "^0.0.4",
@@ -25178,7 +25178,7 @@
         "@remix-run/eslint-config": "0.0.0-experimental-e18af792a",
         "@remix-run/react": "0.0.0-experimental-e18af792a",
         "@shopify/cli": "^3.23.0",
-        "@shopify/cli-h2-test": "^4.0.3",
+        "@shopify/cli-h2-test": "^4.0.4",
         "@shopify/eslint-plugin": "^42.0.1",
         "@shopify/h2-test-hydrogen": "^2.0.2",
         "@shopify/h2-test-hydrogen-remix": "^0.0.4",

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -9,7 +9,7 @@ import {Flags} from '@oclif/core';
 
 const LOG_WORKER_BUILT = '📦 Worker built';
 
-// @ts-ignore
+// @ts-expect-error the 'parser' property doesn't match
 export default class Build extends Command {
   static description = 'Builds a Hydrogen storefront for production';
   static flags = {
@@ -28,7 +28,7 @@ export default class Build extends Command {
   };
 
   async run(): Promise<void> {
-    // @ts-ignore
+    // @ts-expect-error see above about parser
     const {flags} = await this.parse(Build);
     const directory = flags.path ? path.resolve(flags.path) : process.cwd();
 

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -13,7 +13,7 @@ const LOG_INITIAL_BUILD = '\n🏁 Initial build';
 const LOG_REBUILDING = '🧱 Rebuilding...';
 const LOG_REBUILT = '🚀 Rebuilt';
 
-// @ts-ignore
+// @ts-expect-error the 'parser' property doesn't match
 export default class Dev extends Command {
   static description =
     'Runs Hydrogen storefront in a MiniOxygen worker in development';
@@ -31,7 +31,7 @@ export default class Dev extends Command {
   };
 
   async run(): Promise<void> {
-    // @ts-ignore
+    // @ts-expect-error see above about parser
     const {flags} = await this.parse(Dev);
     const directory = flags.path ? path.resolve(flags.path) : process.cwd();
 

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -2,7 +2,7 @@ import {cli as remixCli} from '@remix-run/dev';
 import Command from '@shopify/cli-kit/node/base-command';
 import {Flags} from '@oclif/core';
 
-// @ts-ignore
+// @ts-expect-error the 'parser' property doesn't match
 export default class Init extends Command {
   static description = 'Creates a new Hydrogen storefront project';
   static flags = {
@@ -18,7 +18,7 @@ export default class Init extends Command {
   };
 
   async run(): Promise<void> {
-    // @ts-ignore
+    // @ts-expect-error see above about 'parser'
     const {flags} = await this.parse(Init);
 
     await runInit({...flags});

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -4,7 +4,7 @@ import {flags} from '../../utils/flags.js';
 import Command from '@shopify/cli-kit/node/base-command';
 import {startMiniOxygen} from '../../utils/mini-oxygen.js';
 
-// @ts-ignore
+// @ts-expect-error the 'parser' property doesn't match
 export default class Preview extends Command {
   static description =
     'Runs an existing Hydrogen storefront build in a MiniOxygen worker';
@@ -14,7 +14,7 @@ export default class Preview extends Command {
   };
 
   async run(): Promise<void> {
-    // @ts-ignore
+    // @ts-expect-error see above about 'parser'
     const {flags} = await this.parse(Preview);
 
     await runPreview({...flags});

--- a/packages/hydrogen-remix/templates/cart.ts
+++ b/packages/hydrogen-remix/templates/cart.ts
@@ -1,3 +1,6 @@
+// These files don't live on their own, they're copied over, so things won't resolve correctly here.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 export {
   cartBuyerIdentityUpdate,
   CartBuyerIdentityUpdateForm,

--- a/packages/hydrogen-remix/templates/cart.ts
+++ b/packages/hydrogen-remix/templates/cart.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export {
   cartBuyerIdentityUpdate,
   CartBuyerIdentityUpdateForm,

--- a/packages/hydrogen-remix/tsconfig.json
+++ b/packages/hydrogen-remix/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
 }

--- a/packages/hydrogen-remix/tsconfig.json
+++ b/packages/hydrogen-remix/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "jsx": "react"
-  }
+  "extends": "../../tsconfig.json"
 }

--- a/templates/demo-store/.eslintignore
+++ b/templates/demo-store/.eslintignore
@@ -1,4 +1,5 @@
 build
+dist
 node_modules
 bin
 *.d.ts

--- a/templates/demo-store/.eslintrc.js
+++ b/templates/demo-store/.eslintrc.js
@@ -4,7 +4,6 @@
 module.exports = {
   extends: ['plugin:hydrogen/recommended', 'plugin:hydrogen/typescript'],
   rules: {
-    '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/naming-convention': 'off',
     'hydrogen/prefer-image-component': 'off',
     'no-useless-escape': 'off',
@@ -12,5 +11,7 @@ module.exports = {
     'no-case-declarations': 'off',
     // TODO: Remove jest plugin from hydrogen/eslint-plugin
     'jest/no-deprecated-functions': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
+    'react-hooks/exhaustive-deps': 'error',
   },
 };

--- a/templates/demo-store/app/components/Button.tsx
+++ b/templates/demo-store/app/components/Button.tsx
@@ -17,7 +17,7 @@ export const Button = forwardRef(
       className?: string;
       variant?: 'primary' | 'secondary' | 'inline';
       width?: 'auto' | 'full';
-      [key: string]: any;
+      [key: string]: unknown;
     },
     ref,
   ) => {

--- a/templates/demo-store/app/components/Cart.tsx
+++ b/templates/demo-store/app/components/Cart.tsx
@@ -397,7 +397,7 @@ function CartLinePrice({
 }: {
   line: CartLine;
   priceType?: 'regular' | 'compareAt';
-  [key: string]: any;
+  [key: string]: unknown;
 }) {
   const {lineUpdating} = useCartLineUpdating(line);
 

--- a/templates/demo-store/app/components/FeaturedCollections.tsx
+++ b/templates/demo-store/app/components/FeaturedCollections.tsx
@@ -10,7 +10,7 @@ export function FeaturedCollections({
 }: {
   collections: SerializeFrom<Collection[]>;
   title?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }) {
   const items = collections.filter((item) => item.image).length;
   const haveCollections = collections.length > 0;

--- a/templates/demo-store/app/components/Grid.tsx
+++ b/templates/demo-store/app/components/Grid.tsx
@@ -15,7 +15,7 @@ export function Grid({
   gap?: 'default' | 'blog';
   items?: number;
   layout?: 'default' | 'products' | 'auto' | 'blog';
-  [key: string]: any;
+  [key: string]: unknown;
 }) {
   const layouts = {
     default: `grid-cols-1 ${items === 2 && 'md:grid-cols-2'}  ${

--- a/templates/demo-store/app/components/Input.tsx
+++ b/templates/demo-store/app/components/Input.tsx
@@ -9,7 +9,7 @@ export function Input({
   className?: string;
   type?: string;
   variant: 'search' | 'minisearch';
-  [key: string]: any;
+  [key: string]: unknown;
 }) {
   const variants = {
     search:

--- a/templates/demo-store/app/components/Pagination.tsx
+++ b/templates/demo-store/app/components/Pagination.tsx
@@ -9,12 +9,12 @@ import {useInView, type IntersectionOptions} from 'react-intersection-observer';
 import {useTransition, useLocation, useNavigate} from '@remix-run/react';
 
 type Connection = {
-  nodes: ProductConnection['nodes'] | any[];
+  nodes: ProductConnection['nodes'] | unknown[];
   pageInfo: PageInfo;
 };
 
 type PaginationState = {
-  nodes: ProductConnection['nodes'] | any[];
+  nodes: ProductConnection['nodes'] | unknown[];
   pageInfo: PageInfo | null;
 };
 
@@ -28,9 +28,9 @@ interface PaginationInfo {
   hasNextPage: boolean;
   hasPreviousPage: boolean;
   isLoading: boolean;
-  nextLinkRef: any;
+  nextLinkRef: unknown;
   nextPageUrl: string;
-  nodes: ProductConnection['nodes'] | any[];
+  nodes: ProductConnection['nodes'] | unknown[];
   prevPageUrl: string;
   startCursor: Maybe<string> | undefined;
 }

--- a/templates/demo-store/app/components/ProductGallery.tsx
+++ b/templates/demo-store/app/components/ProductGallery.tsx
@@ -21,7 +21,7 @@ export function ProductGallery({
       className={`swimlane md:grid-flow-row hiddenScroll md:p-0 md:overflow-x-auto md:grid-cols-2 ${className}`}
     >
       {media.map((med, i) => {
-        let mediaProps: Record<string, any> = {};
+        let mediaProps: Record<string, unknown> = {};
         const isFirst = i === 0;
         const isFourth = i === 3;
         const isFullWidth = i % 3 === 0;
@@ -29,7 +29,7 @@ export function ProductGallery({
         const data = {
           ...med,
           image: {
-            // @ts-ignore
+            // @ts-expect-error @TODO: add real types here
             ...med.image,
             altText: med.alt || 'Product image',
           },
@@ -79,7 +79,7 @@ export function ProductGallery({
         return (
           <div
             className={style}
-            // @ts-ignore
+            // @ts-expect-error @TODO: add real types here
             key={med.id || med.image.id}
           >
             {/* TODO: Replace with MediaFile when it's available */}

--- a/templates/demo-store/app/components/Skeleton.tsx
+++ b/templates/demo-store/app/components/Skeleton.tsx
@@ -14,7 +14,7 @@ export function Skeleton({
   width?: string;
   height?: string;
   className?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }) {
   const styles = clsx('rounded bg-primary/10', className);
 

--- a/templates/demo-store/app/components/SortFilter.tsx
+++ b/templates/demo-store/app/components/SortFilter.tsx
@@ -242,7 +242,7 @@ function getSortLink(
 
 function getFilterLink(
   filter: Filter,
-  rawInput: string | Record<string, any>,
+  rawInput: string | Record<string, unknown>,
   params: URLSearchParams,
   location: ReturnType<typeof useLocation>,
 ) {
@@ -323,7 +323,7 @@ function PriceRangeFilter({max, min}: {max?: number; min?: number}) {
 
 function filterInputToParams(
   type: FilterType,
-  rawInput: string | Record<string, any>,
+  rawInput: string | Record<string, unknown>,
   params: URLSearchParams,
 ) {
   const input = typeof rawInput === 'string' ? JSON.parse(rawInput) : rawInput;

--- a/templates/demo-store/app/components/Text.tsx
+++ b/templates/demo-store/app/components/Text.tsx
@@ -19,7 +19,7 @@ export function Text({
   size?: 'lead' | 'copy' | 'fine';
   width?: 'default' | 'narrow' | 'wide';
   children: React.ReactNode;
-  [key: string]: any;
+  [key: string]: unknown;
 }) {
   const colors: Record<string, string> = {
     default: 'inherit',
@@ -115,7 +115,7 @@ export function Section({
   display?: 'grid' | 'flex';
   heading?: string;
   padding?: 'x' | 'y' | 'swimlane' | 'all';
-  [key: string]: any;
+  [key: string]: unknown;
 }) {
   const paddings = {
     x: 'px-6 md:px-8 lg:px-12',
@@ -167,7 +167,7 @@ export function PageHeader({
   className?: string;
   heading?: string;
   variant?: 'default' | 'blogPost' | 'allCollections';
-  [key: string]: any;
+  [key: string]: unknown;
 }) {
   const variants: Record<string, string> = {
     default: 'grid w-full gap-8 p-6 py-8 md:p-8 lg:p-12 justify-items-start',

--- a/templates/demo-store/app/lib/placeholders.ts
+++ b/templates/demo-store/app/lib/placeholders.ts
@@ -189,13 +189,14 @@ const PLACEHOLDERS = {
  * @see https://github.com/Shopify/hydrogen/discussions/1790
  */
 
-export function getHeroPlaceholder(heros: any[]) {
+export function getHeroPlaceholder(heros: unknown[]) {
   if (!heros?.length) return [];
 
   // when we pass a collection without metafields,
   // we merge it with placeholder data
   return heros.map((hero, index) => {
     // assume passed hero has metafields data already
+    // @ts-expect-error the types need to be fixed here to be actual types at some point
     if (hero?.heading?.value) {
       return hero;
     }
@@ -206,21 +207,29 @@ export function getHeroPlaceholder(heros: any[]) {
     // prioritize metafield data if available, else the hero hero values
     // otherwise the placeholder values
     const byLine =
+      // @ts-expect-error the types need to be fixed here to be actual types at some point
       hero?.byLine || hero?.descriptionHtml
-        ? {value: hero.descriptionHtml}
+        ? // @ts-expect-error the types need to be fixed here to be actual types at some point
+          {value: hero.descriptionHtml}
         : placeholder.byline;
 
     const heading =
+      // @ts-expect-error the types need to be fixed here to be actual types at some point
       hero?.heading || hero?.title ? {value: hero.title} : placeholder.heading;
 
     // merge hero placeholder with hero data
     return {
       heading,
       byLine,
+      // @ts-expect-error the types need to be fixed here to be actual types at some point
       cta: hero?.cta || placeholder.cta,
+      // @ts-expect-error the types need to be fixed here to be actual types at some point
       handle: hero?.handle || placeholder.handle,
+      // @ts-expect-error the types need to be fixed here to be actual types at some point
       id: hero?.id || index,
+      // @ts-expect-error the types need to be fixed here to be actual types at some point
       spread: hero?.spread || placeholder.spread,
+      // @ts-expect-error the types need to be fixed here to be actual types at some point
       spreadSecondary: hero?.spreadSecondary || placeholder.spreadSecondary,
       height: placeholder?.height || undefined,
       top: placeholder?.top || undefined,
@@ -230,7 +239,7 @@ export function getHeroPlaceholder(heros: any[]) {
 
 // get product info placeholder data
 export function getProductInfoPlaceholder() {
-  function getMultipleRandom(arr: any[], infos: number) {
+  function getMultipleRandom(arr: unknown[], infos: number) {
     const shuffled = [...arr].sort(() => 0.5 - Math.random());
     return shuffled.slice(0, infos);
   }

--- a/templates/demo-store/app/lib/seo/common.tsx
+++ b/templates/demo-store/app/lib/seo/common.tsx
@@ -31,7 +31,7 @@ export function getTitle({
   return finalTitle || '';
 }
 
-export function recursivelyInvokeOrReturn<T, R extends any[]>(
+export function recursivelyInvokeOrReturn<T, R extends unknown[]>(
   value: T | ((...rest: R) => T),
   ...rest: R
 ): T | Record<string, T> {
@@ -53,7 +53,7 @@ export function recursivelyInvokeOrReturn<T, R extends any[]>(
     const entries = Object.entries(value);
 
     entries.forEach(([key, val]) => {
-      // @ts-expect-error
+      // @ts-expect-error @TODO: add real types here
       result[key] = recursivelyInvokeOrReturn<T, R>(val, ...rest);
     });
 
@@ -63,7 +63,7 @@ export function recursivelyInvokeOrReturn<T, R extends any[]>(
   return value;
 }
 
-function getSeoDefaults(data: any, match: RouteMatch): SeoDescriptor {
+function getSeoDefaults(data: unknown, match: RouteMatch): SeoDescriptor {
   const {id, params, pathname} = match;
 
   let type: SeoDescriptor['type'] = 'page';
@@ -91,8 +91,11 @@ function getSeoDefaults(data: any, match: RouteMatch): SeoDescriptor {
 
   const defaults = {
     type,
+    // @ts-expect-error @TODO: add concrete types
     site: data?.shop?.name,
+    // @ts-expect-error @TODO: add concrete types
     defaultTitle: data?.shop?.name,
+    // @ts-expect-error @TODO: add concrete types
     titleTemplate: `%s | ${data?.shop?.name}`,
     alternates: [],
     robots: {},
@@ -103,7 +106,9 @@ function getSeoDefaults(data: any, match: RouteMatch): SeoDescriptor {
     openGraph: {},
     url: pathname,
     tags: [],
+    // @ts-expect-error @TODO: add concrete types
     title: data?.layout?.shop?.title,
+    // @ts-expect-error @TODO: add concrete types
     description: data?.layout?.shop?.description,
   };
 
@@ -143,8 +148,10 @@ export function useHeadTags(seo: SeoDescriptor) {
   const ogTags: React.ReactNode[] = [];
   const twitterTags: React.ReactNode[] = [];
   const links: React.ReactNode[] = [];
-  const LdJson: WithContext<any> = {
+  // @ts-expect-error @TODO: add actual types here
+  const LdJson: WithContext<unknown> = {
     '@context': 'https://schema.org',
+    // @ts-expect-error @TODO: add actual types here
     '@type': 'Thing',
   };
 
@@ -174,6 +181,7 @@ export function useHeadTags(seo: SeoDescriptor) {
             tags.push(
               <meta key="keywords" name="keywords" content={keywords} />,
             );
+            // @ts-expect-error @TODO: add actual types here
             LdJson.keywords = keywords;
           }
 
@@ -282,6 +290,7 @@ export function useHeadTags(seo: SeoDescriptor) {
           />,
         );
 
+        // @ts-expect-error @TODO: add actual types here
         LdJson.name = value;
 
         break;

--- a/templates/demo-store/app/lib/seo/debugger.tsx
+++ b/templates/demo-store/app/lib/seo/debugger.tsx
@@ -72,7 +72,7 @@ export function Debugger() {
         <span className="font-bold block text-sm py-4 px-4">Tags</span>
 
         {Object.entries(tags).map(([label, entries]) => {
-          if (entries.length < 1) {
+          if (!Array.isArray(entries) || entries.length < 1) {
             return null;
           }
           return (
@@ -84,6 +84,7 @@ export function Debugger() {
                 {label === 'LdJson'
                   ? JSON.stringify(entries, null, 2)
                   : entries.map(
+                      // @ts-expect-error types are wrong here
                       (entry: React.ReactElement, index: number) =>
                         renderToString(entry) + '\n',
                     )}

--- a/templates/demo-store/app/lib/seo/image.tsx
+++ b/templates/demo-store/app/lib/seo/image.tsx
@@ -1,7 +1,7 @@
 import {renderToString} from 'react-dom/server';
 
 export async function getShareableImage(
-  component: React.ReactElement<any, 'svg'>,
+  component: React.ReactElement<unknown, 'svg'>,
 ) {
   try {
     const svg = renderToString(component);

--- a/templates/demo-store/app/lib/session.server.ts
+++ b/templates/demo-store/app/lib/session.server.ts
@@ -39,7 +39,7 @@ export class HydrogenSession {
     return this.sessionStorage.destroySession(this.session);
   }
 
-  flash(key: string, value: any) {
+  flash(key: string, value: unknown) {
     this.session.flash(key, value);
   }
 
@@ -47,7 +47,7 @@ export class HydrogenSession {
     this.session.unset(key);
   }
 
-  set(key: string, value: any) {
+  set(key: string, value: unknown) {
     this.session.set(key, value);
   }
 

--- a/templates/demo-store/app/lib/utils.ts
+++ b/templates/demo-store/app/lib/utils.ts
@@ -144,7 +144,7 @@ function parseItem(customPrefixes = {}) {
     if (!item?.url || !item?.type) {
       // eslint-disable-next-line no-console
       console.warn('Invalid menu item.  Must include a url and type.');
-      // @ts-ignore
+      // @ts-expect-error @TODO: fix return value for correct typing
       return;
     }
 
@@ -189,7 +189,7 @@ export function parseMenu(menu: Menu, customPrefixes = {}): EnhancedMenu {
   if (!menu?.items) {
     // eslint-disable-next-line no-console
     console.warn('Invalid menu passed to parseMenu');
-    // @ts-ignore
+    // @ts-expect-error @TODO: the types here are wrong
     return menu;
   }
 
@@ -245,7 +245,10 @@ export function statusMessage(status: string) {
 /**
  * Errors can exist in an errors object, or nested in a data field.
  */
-export function assertApiErrors(data: Record<string, any> | null | undefined) {
+export function assertApiErrors(
+  data: Record<string, unknown> | null | undefined,
+) {
+  // @ts-expect-error @TODO: add the actual type
   const errorMessage = data?.customerUserErrors?.[0]?.message;
   if (errorMessage) {
     throw new Error(errorMessage);

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -28,10 +28,12 @@ import invariant from 'tiny-invariant';
 import {Cart} from '@shopify/hydrogen-react/storefront-api-types';
 
 export const handle = {
-  // @todo - remove any and type the seo callback
-  seo: (data: any) => ({
+  // @todo - type the seo callback
+  seo: (data: unknown) => ({
+    // @ts-expect-error @TODO: add the actual type
     title: data?.layout?.shop?.name,
     bypassTitleTemplate: true,
+    // @ts-expect-error @TODO: add the actual type
     titleTemplate: `%s | ${data?.layout?.shop?.name}`,
   }),
 };

--- a/templates/demo-store/app/routes/account.tsx
+++ b/templates/demo-store/app/routes/account.tsx
@@ -89,13 +89,13 @@ export default function Authenticated() {
       return (
         <>
           <Modal cancelLink="/account">
-            <Outlet context={{customer: data.customer} as any} />
+            <Outlet context={{customer: data.customer}} />
           </Modal>
           <Account {...data} />
         </>
       );
     } else {
-      return <Outlet context={{customer: data.customer} as any} />;
+      return <Outlet context={{customer: data.customer}} />;
     }
   }
 
@@ -107,6 +107,7 @@ interface Account {
   orders: Order[];
   heading: string;
   addresses: MailingAddress[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   featuredData: any; // @todo: help please
 }
 

--- a/templates/demo-store/app/routes/account/__private/address/$id.tsx
+++ b/templates/demo-store/app/routes/account/__private/address/$id.tsx
@@ -46,8 +46,9 @@ export const action: ActionFunction = async ({request, context, params}) => {
       });
 
       return redirect(params.lang ? `${params.lang}/account` : '/account');
-    } catch (error: any) {
-      return badRequest({formError: error.message});
+    } catch (error: unknown) {
+      // @ts-expect-error @TODO: We don't have any guarantee that this is an error object or not
+      return badRequest({formError: error?.message});
     }
   }
 
@@ -90,8 +91,9 @@ export const action: ActionFunction = async ({request, context, params}) => {
       }
 
       return redirect(params.lang ? `${params.lang}/account` : '/account');
-    } catch (error: any) {
-      return badRequest({formError: error.message});
+    } catch (error: unknown) {
+      // @ts-expect-error @TODO: We don't have any guarantee that this is an error object or not
+      return badRequest({formError: error?.message});
     }
   } else {
     try {
@@ -109,8 +111,9 @@ export const action: ActionFunction = async ({request, context, params}) => {
       }
 
       return redirect(params.lang ? `${params.lang}/account` : '/account');
-    } catch (error: any) {
-      return badRequest({formError: error.message});
+    } catch (error: unknown) {
+      // @ts-expect-error @TODO: We don't have any guarantee that this is an error object or not
+      return badRequest({formError: error?.message});
     }
   }
 };

--- a/templates/demo-store/app/routes/account/__private/edit.tsx
+++ b/templates/demo-store/app/routes/account/__private/edit.tsx
@@ -100,8 +100,9 @@ export const action: ActionFunction = async ({request, context, params}) => {
     await updateCustomer(context, {customerAccessToken, customer});
 
     return redirect(params?.lang ? `${params.lang}/account` : '/account');
-  } catch (error: any) {
-    return badRequest({formError: error.message});
+  } catch (error: unknown) {
+    // @ts-expect-error @TODO: We don't have any guarantee that this is an error object or not
+    return badRequest({formError: error?.message});
   }
 };
 

--- a/templates/demo-store/app/routes/account/__public/activate.$id.$activationToken.tsx
+++ b/templates/demo-store/app/routes/account/__public/activate.$id.$activationToken.tsx
@@ -69,7 +69,7 @@ export const action: ActionFunction = async ({
         'Set-Cookie': await session.commit(),
       },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     if (isStorefrontApiError(error)) {
       return badRequest({
         formError: 'Something went wrong. Please try again later.',

--- a/templates/demo-store/app/routes/account/__public/login.tsx
+++ b/templates/demo-store/app/routes/account/__public/login.tsx
@@ -60,7 +60,7 @@ export const action: ActionFunction = async ({request, context, params}) => {
         'Set-Cookie': await session.commit(),
       },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     if (isStorefrontApiError(error)) {
       return badRequest({
         formError: 'Something went wrong. Please try again later.',

--- a/templates/demo-store/app/routes/account/__public/recover.tsx
+++ b/templates/demo-store/app/routes/account/__public/recover.tsx
@@ -42,7 +42,7 @@ export const action: ActionFunction = async ({request, context}) => {
     await sendPasswordResetEmail(context, {email});
 
     return json({resetRequested: true});
-  } catch (error: any) {
+  } catch (error: unknown) {
     return badRequest({
       formError: 'Something went wrong. Please try again later.',
     });

--- a/templates/demo-store/app/routes/account/__public/register.tsx
+++ b/templates/demo-store/app/routes/account/__public/register.tsx
@@ -56,7 +56,7 @@ export const action: ActionFunction = async ({request, context, params}) => {
         'Set-Cookie': await session.commit(),
       },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     if (isStorefrontApiError(error)) {
       return badRequest({
         formError: 'Something went wrong. Please try again later.',

--- a/templates/demo-store/app/routes/account/__public/reset.$id.$resetToken.tsx
+++ b/templates/demo-store/app/routes/account/__public/reset.$id.$resetToken.tsx
@@ -65,7 +65,7 @@ export const action: ActionFunction = async ({
         'Set-Cookie': await session.commit(),
       },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     if (isStorefrontApiError(error)) {
       return badRequest({
         formError: 'Something went wrong. Please try again later.',

--- a/templates/demo-store/app/routes/collections/$collectionHandle.tsx
+++ b/templates/demo-store/app/routes/collections/$collectionHandle.tsx
@@ -153,7 +153,10 @@ export default function Collection() {
     collection.metafield?.references &&
     flattenConnection<MetafieldReference>(collection.metafield.references)
       .reverse()
-      .reduce<any[]>((acc, collection) => [collection, ...acc], [collection]);
+      .reduce<unknown[]>(
+        (acc, collection) => [collection, ...acc],
+        [collection],
+      );
 
   return (
     <>
@@ -168,6 +171,7 @@ export default function Collection() {
           </div>
         )}
 
+        {/* @ts-expect-error @TODO: add actual types here */}
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       </PageHeader>
       <Section>

--- a/templates/demo-store/app/routes/collections/index.tsx
+++ b/templates/demo-store/app/routes/collections/index.tsx
@@ -94,6 +94,7 @@ export default function Collections() {
                 {nodes.map((collection, i) => (
                   <CollectionCard
                     collection={collection as Collection}
+                    // @ts-expect-error @TODO: fix the type for collection
                     key={collection.id}
                     loading={getImageLoadingPriority(i, 2)}
                   />
@@ -102,6 +103,7 @@ export default function Collections() {
               {hasNextPage && (
                 <div className="flex items-center justify-center mt-6">
                   <Button
+                    // @ts-expect-error @TODO: fix the type for nextLinkRef
                     ref={nextLinkRef}
                     to={nextPageUrl}
                     variant="secondary"

--- a/templates/demo-store/app/routes/index.tsx
+++ b/templates/demo-store/app/routes/index.tsx
@@ -136,6 +136,7 @@ export default function Homepage() {
       )}
 
       {secondaryHero && (
+        // @ts-expect-error @TODO: fix the type for collection
         <Suspense fallback={<Hero {...skeletons[1]} />}>
           <Await resolve={secondaryHero}>
             {({hero}) => {
@@ -163,6 +164,7 @@ export default function Homepage() {
       )}
 
       {tertiaryHero && (
+        // @ts-expect-error @TODO: fix the types
         <Suspense fallback={<Hero {...skeletons[2]} />}>
           <Await resolve={tertiaryHero}>
             {({hero}) => {

--- a/templates/demo-store/app/routes/og-image.tsx
+++ b/templates/demo-store/app/routes/og-image.tsx
@@ -1,7 +1,8 @@
 import {getShareableImage} from '~/lib/seo/image';
 import type {LoaderFunction} from '@shopify/hydrogen-remix';
 
-function SharableImage(props: any) {
+function SharableImage(props: unknown) {
+  // @ts-expect-error @TODO: add actual types here
   const {title} = props;
   return (
     <svg>

--- a/templates/demo-store/app/routes/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/products/$productHandle.tsx
@@ -431,7 +431,7 @@ function ProductOptionLink({
   optionValue: string;
   searchParams: URLSearchParams;
   children?: ReactNode;
-  [key: string]: any;
+  [key: string]: unknown;
 }) {
   const {pathname} = useLocation();
   const isLangPathname = /\/[a-zA-Z]{2}-[a-zA-Z]{2}\//g.test(pathname);
@@ -590,7 +590,9 @@ async function getRecommendedProducts(
   const mergedProducts = products.recommended
     .concat(products.additional.nodes)
     .filter(
+      // @ts-expect-error @TODO: add actual types here
       (value, index, array) =>
+        // @ts-expect-error @TODO: add actual types here
         array.findIndex((value2) => value2.id === value.id) === index,
     );
 

--- a/templates/demo-store/app/routes/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/products/$productHandle.tsx
@@ -590,9 +590,7 @@ async function getRecommendedProducts(
   const mergedProducts = products.recommended
     .concat(products.additional.nodes)
     .filter(
-      // @ts-expect-error @TODO: add actual types here
       (value, index, array) =>
-        // @ts-expect-error @TODO: add actual types here
         array.findIndex((value2) => value2.id === value.id) === index,
     );
 

--- a/templates/demo-store/app/routes/products/index.tsx
+++ b/templates/demo-store/app/routes/products/index.tsx
@@ -68,7 +68,9 @@ export default function AllProducts() {
           }) => {
             const itemsMarkup = nodes.map((product, i) => (
               <ProductCard
+                // @ts-expect-error @TODO: fix the type for product
                 key={product.id}
+                // @ts-expect-error @TODO: fix the type for product
                 product={product}
                 loading={getImageLoadingPriority(i)}
               />
@@ -101,6 +103,7 @@ export default function AllProducts() {
                 {hasNextPage && (
                   <div className="flex items-center justify-center mt-6">
                     <Button
+                      // @ts-expect-error @TODO: fix the type for nextLinkRef
                       ref={nextLinkRef}
                       to={nextPageUrl}
                       variant="secondary"

--- a/templates/demo-store/tests/utils.ts
+++ b/templates/demo-store/tests/utils.ts
@@ -8,7 +8,10 @@ import type {Page, Request} from '@playwright/test';
  * @param page Page
  * @param action Fn
  */
-export async function waitForLoaders(page: Page, action: () => Promise<any>) {
+export async function waitForLoaders(
+  page: Page,
+  action: () => Promise<unknown>,
+) {
   return waitForNetworkSettled(
     page,
     action,
@@ -21,7 +24,7 @@ export async function waitForLoaders(page: Page, action: () => Promise<any>) {
 const DEBUG = false;
 export async function waitForNetworkSettled(
   page: Page,
-  action: () => Promise<any>,
+  action: () => Promise<unknown>,
   requestFilter?: (request: Request) => boolean,
   minimumRequests = 0,
 ) {


### PR DESCRIPTION
☮️ Non-spicy updates:

- Fixes an issue with running `npm run eslint` locally, as it was looking into the `dist` folders and maybe going in an infinite loop or something

🌶️ Spicy updates:

## `any`
Disallows using `any` explicitly. In most cases, the correct typing should be used. If that's not possible, then we should use `unknown`. As a last and final resort, you can `eslint-ignore` it and use `any`

Why? As discussed previously, using `any` is telling TS to "turn off." We can't be doing that if we're building a library (and a template for other to build on), and it makes our library less typesafe as well as affects the types that we expose to devs.

## `useEffect` dep array
In the demo-store repo, eslint will now _error_ instead of _warn_ for not having all the dependencies for a `useEffect` hook. 

Why? This forces us to get these deps correct; having them incorrect nearly always leads to nasty bugs in weird cases, so we need to make sure that our templates are as bulletproof as possible.

## `@ts-ignore`
Disallows using `// @ts-ignore` comments. However, you CAN still use `// @ts-expect-error [description on why this isn't working]`

Why? `@ts-expect-error` is a better version of `@ts-ignore` as it validates that the next line has a TS error; if you've gone and updated the TS and there's no longer an error, then `@ts-expect-error` will actually complain that there's no longer an error there and you can safely remove the comment! Plus it leaves room for a text description, which hopefully can be used to give additional context on the _why_ of the error, and help others gain that context if they want to fix the error. 

