### PR TITLE
Use local type augmentation 

### DIFF
--- a/packages/hydrogen-remix/src/templates/routes/discounts.$code.tsx
+++ b/packages/hydrogen-remix/src/templates/routes/discounts.$code.tsx
@@ -15,6 +15,7 @@ import {cartCreate, cartDiscountCodesUpdate} from '../cart';
  * @preserve
  */
 export async function loader({request, context, params}: LoaderArgs) {
+  // N.B. This route will probably be removed in the future.
   const session = context.session as any;
   const {code} = params;
 

--- a/packages/hydrogen-remix/src/types.ts
+++ b/packages/hydrogen-remix/src/types.ts
@@ -1,3 +1,8 @@
+/**
+ * TODO: Remove this file after packaged routes are removed or refactored to accept an argument
+ * which injects the StorefrontClient, session, etc.
+ */
+
 import type {StorefrontClient} from '@shopify/h2-test-hydrogen';
 import type {Params} from '@remix-run/react';
 import type {

--- a/rfc/guide-internationalization.md
+++ b/rfc/guide-internationalization.md
@@ -635,8 +635,7 @@ export function getLocaleFromRequest(request: Request): Locale {
      CountryCode,
      LanguageCode,
    } from '@shopify/hydrogen-react/storefront-api-types';
-   import {redirect} from '@remix-run/oxygen';
-   import type {AppLoadContext, ActionFunction} from '@shopify/hydrogen-remix';
+   import {redirect, type AppLoadContext, type ActionFunction} from '@remix-run/oxygen';
    import invariant from 'tiny-invariant';
    import {updateCartBuyerIdentity} from '~/data';
    import {countries} from '~/data/countries';

--- a/rfc/i18n.md
+++ b/rfc/i18n.md
@@ -352,8 +352,7 @@ const {lang} = useParams();
      CountryCode,
      LanguageCode,
    } from '@shopify/hydrogen-react/storefront-api-types';
-   import {redirect} from '@remix-run/oxygen';
-   import {type ActionFunction} from '@shopify/hydrogen-remix';
+   import {redirect, type ActionFunction} from '@remix-run/oxygen';
    import invariant from 'tiny-invariant';
    import {updateCartBuyerIdentity} from '~/data';
    import {getSession} from '~/lib/session.server';

--- a/templates/demo-store/app/data/index.ts
+++ b/templates/demo-store/app/data/index.ts
@@ -20,7 +20,7 @@ import type {
 import {type EnhancedMenu, parseMenu, assertApiErrors} from '~/lib/utils';
 import invariant from 'tiny-invariant';
 import {logout} from '~/routes/account/__private/logout';
-import type {AppLoadContext} from '@shopify/hydrogen-remix';
+import type {AppLoadContext} from '@remix-run/oxygen';
 
 export interface LayoutData {
   headerMenu: EnhancedMenu;

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -1,5 +1,10 @@
-import {defer, type LinksFunction, type MetaFunction} from '@remix-run/oxygen';
-import type {LoaderArgs, Storefront} from '@shopify/hydrogen-remix';
+import {
+  defer,
+  type LinksFunction,
+  type MetaFunction,
+  type LoaderArgs,
+} from '@remix-run/oxygen';
+import type {Storefront} from '@shopify/hydrogen-remix';
 import {
   Links,
   Meta,

--- a/templates/demo-store/app/routes/[robots.txt].tsx
+++ b/templates/demo-store/app/routes/[robots.txt].tsx
@@ -1,4 +1,4 @@
-import {type LoaderArgs} from '@shopify/hydrogen-remix';
+import {type LoaderArgs} from '@remix-run/oxygen';
 
 export const loader = ({request}: LoaderArgs) => {
   const url = new URL(request.url);

--- a/templates/demo-store/app/routes/[sitemap.xml].tsx
+++ b/templates/demo-store/app/routes/[sitemap.xml].tsx
@@ -1,5 +1,5 @@
 import {flattenConnection} from '@shopify/hydrogen-react';
-import type {LoaderArgs} from '@shopify/hydrogen-remix';
+import type {LoaderArgs} from '@remix-run/oxygen';
 import {
   CollectionConnection,
   PageConnection,

--- a/templates/demo-store/app/routes/account.tsx
+++ b/templates/demo-store/app/routes/account.tsx
@@ -24,8 +24,7 @@ import {
   ProductSwimlane,
 } from '~/components';
 import {FeaturedCollections} from '~/components/FeaturedCollections';
-import {redirect, json, defer} from '@remix-run/oxygen';
-import type {LoaderArgs} from '@shopify/hydrogen-remix';
+import {redirect, json, defer, type LoaderArgs} from '@remix-run/oxygen';
 import {flattenConnection} from '@shopify/hydrogen-react';
 import {getCustomer} from '~/data';
 import {getFeaturedData} from './featured-products';

--- a/templates/demo-store/app/routes/account/__private/address/$id.tsx
+++ b/templates/demo-store/app/routes/account/__private/address/$id.tsx
@@ -1,5 +1,4 @@
-import {json, redirect} from '@remix-run/oxygen';
-import type {ActionFunction} from '@shopify/hydrogen-remix';
+import {json, redirect, type ActionFunction} from '@remix-run/oxygen';
 import {
   Form,
   useActionData,

--- a/templates/demo-store/app/routes/account/__private/edit.tsx
+++ b/templates/demo-store/app/routes/account/__private/edit.tsx
@@ -1,5 +1,4 @@
-import {json, redirect} from '@remix-run/oxygen';
-import type {ActionFunction} from '@shopify/hydrogen-remix';
+import {json, redirect, type ActionFunction} from '@remix-run/oxygen';
 import {
   useActionData,
   Form,

--- a/templates/demo-store/app/routes/account/__private/logout.ts
+++ b/templates/demo-store/app/routes/account/__private/logout.ts
@@ -1,6 +1,9 @@
-import {redirect} from '@remix-run/oxygen';
-import type {ActionFunction, AppLoadContext} from '@shopify/hydrogen-remix';
-import {LoaderArgs} from '@remix-run/server-runtime';
+import {
+  redirect,
+  type ActionFunction,
+  type AppLoadContext,
+  type LoaderArgs,
+} from '@remix-run/oxygen';
 import {getLocaleFromRequest} from '~/lib/utils';
 
 export async function logout(request: Request, context: AppLoadContext) {

--- a/templates/demo-store/app/routes/account/__private/orders.$id.tsx
+++ b/templates/demo-store/app/routes/account/__private/orders.$id.tsx
@@ -1,7 +1,11 @@
 import invariant from 'tiny-invariant';
 import clsx from 'clsx';
-import {redirect, json, type MetaFunction} from '@remix-run/oxygen';
-import type {LoaderArgs} from '@shopify/hydrogen-remix';
+import {
+  redirect,
+  json,
+  type MetaFunction,
+  type LoaderArgs,
+} from '@remix-run/oxygen';
 import {useLoaderData} from '@remix-run/react';
 import {Money, Image, flattenConnection} from '@shopify/hydrogen-react';
 import {statusMessage} from '~/lib/utils';

--- a/templates/demo-store/app/routes/account/__public/activate.$id.$activationToken.tsx
+++ b/templates/demo-store/app/routes/account/__public/activate.$id.$activationToken.tsx
@@ -1,8 +1,10 @@
-import {type MetaFunction, redirect, json} from '@remix-run/oxygen';
 import {
+  type MetaFunction,
+  redirect,
+  json,
   type ActionFunction,
-  isStorefrontApiError,
-} from '@shopify/hydrogen-remix';
+} from '@remix-run/oxygen';
+import {isStorefrontApiError} from '@shopify/hydrogen-remix';
 import {Form, useActionData} from '@remix-run/react';
 import {useRef, useState} from 'react';
 import {activateAccount} from '~/data';

--- a/templates/demo-store/app/routes/account/__public/login.tsx
+++ b/templates/demo-store/app/routes/account/__public/login.tsx
@@ -1,9 +1,11 @@
-import {type MetaFunction, redirect, json} from '@remix-run/oxygen';
 import {
+  type MetaFunction,
   type ActionFunction,
   type LoaderArgs,
-  isStorefrontApiError,
-} from '@shopify/hydrogen-remix';
+  redirect,
+  json,
+} from '@remix-run/oxygen';
+import {isStorefrontApiError} from '@shopify/hydrogen-remix';
 import {Form, useActionData, useLoaderData} from '@remix-run/react';
 import {useState} from 'react';
 import {login} from '~/data';

--- a/templates/demo-store/app/routes/account/__public/recover.tsx
+++ b/templates/demo-store/app/routes/account/__public/recover.tsx
@@ -1,5 +1,10 @@
-import {type MetaFunction, redirect, json} from '@remix-run/oxygen';
-import type {ActionFunction, LoaderArgs} from '@shopify/hydrogen-remix';
+import {
+  type MetaFunction,
+  type ActionFunction,
+  type LoaderArgs,
+  redirect,
+  json,
+} from '@remix-run/oxygen';
 import {Form, useActionData} from '@remix-run/react';
 import {useState} from 'react';
 import {sendPasswordResetEmail} from '~/data';

--- a/templates/demo-store/app/routes/account/__public/register.tsx
+++ b/templates/demo-store/app/routes/account/__public/register.tsx
@@ -1,9 +1,11 @@
-import {type MetaFunction, redirect, json} from '@remix-run/oxygen';
 import {
+  type MetaFunction,
+  redirect,
+  json,
   type ActionFunction,
   type LoaderArgs,
-  isStorefrontApiError,
-} from '@shopify/hydrogen-remix';
+} from '@remix-run/oxygen';
+import {isStorefrontApiError} from '@shopify/hydrogen-remix';
 import {Form, useActionData} from '@remix-run/react';
 import {useState} from 'react';
 import {login, registerCustomer} from '~/data';

--- a/templates/demo-store/app/routes/account/__public/reset.$id.$resetToken.tsx
+++ b/templates/demo-store/app/routes/account/__public/reset.$id.$resetToken.tsx
@@ -1,8 +1,10 @@
-import {type MetaFunction, redirect, json} from '@remix-run/oxygen';
 import {
+  type MetaFunction,
   type ActionFunction,
-  isStorefrontApiError,
-} from '@shopify/hydrogen-remix';
+  redirect,
+  json,
+} from '@remix-run/oxygen';
+import {isStorefrontApiError} from '@shopify/hydrogen-remix';
 import {Form, useActionData} from '@remix-run/react';
 import {useRef, useState} from 'react';
 import {resetPassword} from '~/data';

--- a/templates/demo-store/app/routes/api/products.tsx
+++ b/templates/demo-store/app/routes/api/products.tsx
@@ -1,5 +1,4 @@
-import {json} from '@remix-run/oxygen';
-import type {LoaderArgs} from '@shopify/hydrogen-remix';
+import {json, type LoaderArgs} from '@remix-run/oxygen';
 import {flattenConnection} from '@shopify/hydrogen-react';
 import {ProductConnection} from '@shopify/hydrogen-react/storefront-api-types';
 import invariant from 'tiny-invariant';

--- a/templates/demo-store/app/routes/collections/$collectionHandle.tsx
+++ b/templates/demo-store/app/routes/collections/$collectionHandle.tsx
@@ -1,9 +1,10 @@
-import {json, type MetaFunction, type SerializeFrom} from '@remix-run/oxygen';
 import {
+  json,
+  type MetaFunction,
+  type SerializeFrom,
   type LoaderArgs,
-  RESOURCE_TYPES,
-  notFoundMaybeRedirect,
-} from '@shopify/hydrogen-remix';
+} from '@remix-run/oxygen';
+import {RESOURCE_TYPES, notFoundMaybeRedirect} from '@shopify/hydrogen-remix';
 import {useLoaderData} from '@remix-run/react';
 import type {
   Collection as CollectionType,

--- a/templates/demo-store/app/routes/collections/all.tsx
+++ b/templates/demo-store/app/routes/collections/all.tsx
@@ -1,5 +1,4 @@
-import {redirect} from '@remix-run/oxygen';
-import {LoaderArgs} from '@shopify/hydrogen-remix';
+import {redirect, type LoaderArgs} from '@remix-run/oxygen';
 
 export async function loader({params}: LoaderArgs) {
   return redirect(params?.lang ? `${params.lang}/products` : '/products');

--- a/templates/demo-store/app/routes/collections/index.tsx
+++ b/templates/demo-store/app/routes/collections/index.tsx
@@ -1,5 +1,5 @@
-import {json, type MetaFunction} from '@remix-run/oxygen';
-import {RESOURCE_TYPES, type LoaderArgs} from '@shopify/hydrogen-remix';
+import {json, type MetaFunction, type LoaderArgs} from '@remix-run/oxygen';
+import {RESOURCE_TYPES} from '@shopify/hydrogen-remix';
 import {useLoaderData} from '@remix-run/react';
 import type {
   Collection,

--- a/templates/demo-store/app/routes/featured-products.tsx
+++ b/templates/demo-store/app/routes/featured-products.tsx
@@ -1,5 +1,4 @@
-import type {LoaderArgs} from '@shopify/hydrogen-remix';
-import {json} from '@remix-run/oxygen';
+import {json, type LoaderArgs} from '@remix-run/oxygen';
 import {flattenConnection} from '@shopify/hydrogen-react';
 import type {
   CollectionConnection,

--- a/templates/demo-store/app/routes/index.tsx
+++ b/templates/demo-store/app/routes/index.tsx
@@ -1,9 +1,5 @@
-import {defer} from '@remix-run/oxygen';
-import {
-  type LoaderArgs,
-  RESOURCE_TYPES,
-  notFoundMaybeRedirect,
-} from '@shopify/hydrogen-remix';
+import {defer, type LoaderArgs} from '@remix-run/oxygen';
+import {RESOURCE_TYPES, notFoundMaybeRedirect} from '@shopify/hydrogen-remix';
 import {Suspense} from 'react';
 import {Await, useLoaderData} from '@remix-run/react';
 import {ProductSwimlane, FeaturedCollections, Hero} from '~/components';

--- a/templates/demo-store/app/routes/journal/$journalHandle.tsx
+++ b/templates/demo-store/app/routes/journal/$journalHandle.tsx
@@ -3,12 +3,9 @@ import {
   type MetaFunction,
   type SerializeFrom,
   type LinksFunction,
-} from '@remix-run/oxygen';
-import {
-  RESOURCE_TYPES,
-  notFoundMaybeRedirect,
   type LoaderArgs,
-} from '@shopify/hydrogen-remix';
+} from '@remix-run/oxygen';
+import {RESOURCE_TYPES, notFoundMaybeRedirect} from '@shopify/hydrogen-remix';
 import {useLoaderData} from '@remix-run/react';
 import {Image} from '@shopify/hydrogen-react';
 import {Blog} from '@shopify/hydrogen-react/storefront-api-types';

--- a/templates/demo-store/app/routes/journal/index.tsx
+++ b/templates/demo-store/app/routes/journal/index.tsx
@@ -1,5 +1,4 @@
-import {json, type MetaFunction} from '@remix-run/oxygen';
-import type {LoaderArgs} from '@shopify/hydrogen-remix';
+import {json, type MetaFunction, type LoaderArgs} from '@remix-run/oxygen';
 import {useLoaderData} from '@remix-run/react';
 import {flattenConnection, Image} from '@shopify/hydrogen-react';
 import type {Article, Blog} from '@shopify/hydrogen-react/storefront-api-types';

--- a/templates/demo-store/app/routes/og-image.tsx
+++ b/templates/demo-store/app/routes/og-image.tsx
@@ -1,5 +1,5 @@
 import {getShareableImage} from '~/lib/seo/image';
-import type {LoaderFunction} from '@shopify/hydrogen-remix';
+import type {LoaderFunction} from '@remix-run/oxygen';
 
 function SharableImage(props: any) {
   const {title} = props;

--- a/templates/demo-store/app/routes/pages/$pageHandle.tsx
+++ b/templates/demo-store/app/routes/pages/$pageHandle.tsx
@@ -1,9 +1,10 @@
-import {json, MetaFunction, SerializeFrom} from '@remix-run/oxygen';
 import {
-  notFoundMaybeRedirect,
-  RESOURCE_TYPES,
+  json,
+  type MetaFunction,
+  type SerializeFrom,
   type LoaderArgs,
-} from '@shopify/hydrogen-remix';
+} from '@remix-run/oxygen';
+import {notFoundMaybeRedirect, RESOURCE_TYPES} from '@shopify/hydrogen-remix';
 import type {Page as PageType} from '@shopify/hydrogen-react/storefront-api-types';
 import {useLoaderData} from '@remix-run/react';
 import invariant from 'tiny-invariant';

--- a/templates/demo-store/app/routes/policies/$policyHandle.tsx
+++ b/templates/demo-store/app/routes/policies/$policyHandle.tsx
@@ -1,5 +1,5 @@
-import {json, type MetaFunction} from '@remix-run/oxygen';
-import {notFoundMaybeRedirect, type LoaderArgs} from '@shopify/hydrogen-remix';
+import {json, type MetaFunction, type LoaderArgs} from '@remix-run/oxygen';
+import {notFoundMaybeRedirect} from '@shopify/hydrogen-remix';
 import {useLoaderData} from '@remix-run/react';
 
 import {PageHeader, Section, Button} from '~/components';

--- a/templates/demo-store/app/routes/policies/index.tsx
+++ b/templates/demo-store/app/routes/policies/index.tsx
@@ -1,5 +1,10 @@
-import {json, type MetaFunction, type SerializeFrom} from '@remix-run/oxygen';
-import {type LoaderArgs, RESOURCE_TYPES} from '@shopify/hydrogen-remix';
+import {
+  json,
+  type MetaFunction,
+  type SerializeFrom,
+  type LoaderArgs,
+} from '@remix-run/oxygen';
+import {RESOURCE_TYPES} from '@shopify/hydrogen-remix';
 import {useLoaderData} from '@remix-run/react';
 import type {ShopPolicy} from '@shopify/hydrogen-react/storefront-api-types';
 import invariant from 'tiny-invariant';

--- a/templates/demo-store/app/routes/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/products/$productHandle.tsx
@@ -1,11 +1,7 @@
 import {type ReactNode, useRef, Suspense, useMemo} from 'react';
 import {Disclosure, Listbox} from '@headlessui/react';
-import {defer} from '@remix-run/oxygen';
-import {
-  notFoundMaybeRedirect,
-  RESOURCE_TYPES,
-  type LoaderArgs,
-} from '@shopify/hydrogen-remix';
+import {defer, type LoaderArgs} from '@remix-run/oxygen';
+import {notFoundMaybeRedirect, RESOURCE_TYPES} from '@shopify/hydrogen-remix';
 import {
   useLoaderData,
   Await,

--- a/templates/demo-store/app/routes/products/index.tsx
+++ b/templates/demo-store/app/routes/products/index.tsx
@@ -1,5 +1,5 @@
-import {MetaFunction} from '@remix-run/oxygen';
-import {type LoaderArgs, RESOURCE_TYPES} from '@shopify/hydrogen-remix';
+import {type MetaFunction, type LoaderArgs} from '@remix-run/oxygen';
+import {RESOURCE_TYPES} from '@shopify/hydrogen-remix';
 import {useLoaderData} from '@remix-run/react';
 import type {ProductConnection} from '@shopify/hydrogen-react/storefront-api-types';
 import invariant from 'tiny-invariant';

--- a/templates/demo-store/app/routes/search.tsx
+++ b/templates/demo-store/app/routes/search.tsx
@@ -1,5 +1,5 @@
-import {defer} from '@remix-run/oxygen';
-import {RESOURCE_TYPES, type LoaderArgs} from '@shopify/hydrogen-remix';
+import {defer, type LoaderArgs} from '@remix-run/oxygen';
+import {RESOURCE_TYPES} from '@shopify/hydrogen-remix';
 import {flattenConnection} from '@shopify/hydrogen-react';
 import {Await, Form, useLoaderData} from '@remix-run/react';
 import type {

--- a/templates/demo-store/remix.env.d.ts
+++ b/templates/demo-store/remix.env.d.ts
@@ -2,6 +2,8 @@
 /// <reference types="@remix-run/oxygen" />
 /// <reference types="@shopify/oxygen-workers-types" />
 
+import type {StorefrontClient} from '@shopify/h2-test-hydrogen';
+
 /**
  * Declare expected Env parameter in fetch handler.
  */
@@ -16,10 +18,12 @@ declare global {
 /**
  * Declare local additions to `AppLoadContext` to include the session utilities we injected in `server.ts`.
  */
-declare module '@shopify/hydrogen-remix' {
+declare module '@remix-run/server-runtime' {
   export interface AppLoadContext {
     waitUntil: ExecutionContext['waitUntil'];
     session: import('~/lib/session.server').HydrogenSession;
+    storefront: StorefrontClient['storefront'];
+    fetch: StorefrontClient['fetch'];
     cache: Cache;
     env: Env;
   }

--- a/templates/demo-store/server.ts
+++ b/templates/demo-store/server.ts
@@ -2,7 +2,6 @@
 import * as remixBuild from '@remix-run/dev/server-build';
 import {createRequestHandler, getBuyerIp} from '@remix-run/oxygen';
 import {
-  type AppLoadContext,
   createStorefrontClient,
   proxyLiquidRoute,
 } from '@shopify/hydrogen-remix';
@@ -81,7 +80,7 @@ export default {
             storefront,
             fetch,
             env,
-          } as AppLoadContext;
+          };
         },
       });
 

--- a/templates/hello-world/app/root.tsx
+++ b/templates/hello-world/app/root.tsx
@@ -1,5 +1,9 @@
-import {defer, type LinksFunction, type MetaFunction} from '@remix-run/oxygen';
-import type {LoaderArgs} from '@shopify/hydrogen-remix';
+import {
+  defer,
+  type LinksFunction,
+  type MetaFunction,
+  type LoaderArgs,
+} from '@remix-run/oxygen';
 import {
   Links,
   Meta,

--- a/templates/hello-world/remix.env.d.ts
+++ b/templates/hello-world/remix.env.d.ts
@@ -2,13 +2,16 @@
 /// <reference types="@remix-run/oxygen" />
 /// <reference types="@shopify/oxygen-workers-types" />
 
+import type {StorefrontClient} from '@shopify/h2-test-hydrogen';
 import {HydrogenSession} from '../server';
 
 /**
  * Declare local additions to `AppLoadContext` to include the session utilities we injected in `server.ts`.
  */
-declare module '@shopify/hydrogen-remix' {
+declare module '@remix-run/server-runtime' {
   export interface AppLoadContext {
     session: HydrogenSession;
+    storefront: StorefrontClient['storefront'];
+    fetch: StorefrontClient['fetch'];
   }
 }


### PR DESCRIPTION
Instead of splitting type imports from `hydrogen-remix`, let's just update the types for `AppLoadContext` defined in `remix.env.d.ts`. This means all Remix server-related imports will come from the current adapter (e.g. `@remix-run/oxygen`).

This also updates the override to `@remix-run/server-runtime` to make it possible to switch adapters and retain the types 🚀 