### PR TITLE
Fix a pagination bug on country change

### DIFF
--- a/.changeset/curvy-apes-yawn.md
+++ b/.changeset/curvy-apes-yawn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/h2-test-hydrogen': patch
+---
+
+Fix a pagination bug on country change

--- a/templates/demo-store/app/components/Pagination.tsx
+++ b/templates/demo-store/app/components/Pagination.tsx
@@ -170,7 +170,7 @@ export function usePagination(
 
   // the only way to prevent hydration mismatches
   useEffect(() => {
-    if (!state) {
+    if (!state || !state?.nodes) {
       setNodes(connection.nodes);
       return;
     }


### PR DESCRIPTION
How to reproduce:

1. Go to `/products` page
2. Scroll to the bottom and see infinite scroll is triggered
3. Change country

Error generated:

<img width="1128" alt="Screenshot 2022-12-08 at 3 44 13 PM" src="https://user-images.githubusercontent.com/2319002/206590181-3ed89ee7-dffd-4146-ad9e-010e5b7f9872.png">


