### PR TITLE
Image Component

### DIFF
--- a/packages/hydrogen/src/image.test.ts
+++ b/packages/hydrogen/src/image.test.ts
@@ -1,0 +1,16 @@
+import {test, expect} from '@jest/globals';
+import {generateShopifySrcSet} from './image';
+
+test('src set', () => {
+  expect(
+    generateShopifySrcSet(
+      'https://cdn.shopify.com/static/sample-images/garnished.jpeg',
+      [
+        {width: 200, height: 200, crop: 'center'},
+        {width: 400, height: 400, crop: 'center'},
+      ],
+    ),
+  ).toBe(
+    'https://cdn.shopify.com/static/sample-images/garnished.jpeg?width=200&height=200&crop=center 200w, https://cdn.shopify.com/static/sample-images/garnished.jpeg?width=400&height=400&crop=center 400w',
+  );
+});

--- a/packages/hydrogen/src/image.ts
+++ b/packages/hydrogen/src/image.ts
@@ -191,6 +191,19 @@ function unitsMatch(
     getUnitValueParts(width.toString()).unit ===
     getUnitValueParts(height.toString()).unit
   );
+  /*
+      Given:
+        width = '100px'
+        height = 'auto'
+      Returns:
+        false
+
+      Given:
+        width = '100px'
+        height = '50px'
+      Returns:
+        true
+   */
 }
 
 function getUnitValueParts(value: string) {
@@ -201,6 +214,15 @@ function getUnitValueParts(value: string) {
     unit: unit === '' ? (number === undefined ? 'auto' : 'px') : unit,
     number,
   };
+  /*
+      Given:
+        value = '100px'
+      Returns:
+        {
+          unit: 'px',
+          number: 100
+        }
+   */
 }
 
 function getNormalizedFixedUnit(value?: string | number) {
@@ -222,6 +244,17 @@ function getNormalizedFixedUnit(value?: string | number) {
     default:
       return;
   }
+  /*
+      Given:
+        value = 16px | 1rem | 1em | 16
+      Returns:
+        16
+
+      Given:
+        value = 100%
+      Returns:
+        undefined
+   */
 }
 
 function isFixedWidth(width: string | number) {
@@ -230,6 +263,12 @@ function isFixedWidth(width: string | number) {
     typeof width === 'number' ||
     (typeof width === 'string' && fixedEndings.test(width))
   );
+  /*
+    Given:
+      width = 100 | '100px' | '100em' | '100rem'
+    Returns:
+      true
+  */
 }
 
 export function generateShopifySrcSet(

--- a/packages/hydrogen/src/image.ts
+++ b/packages/hydrogen/src/image.ts
@@ -1,17 +1,5 @@
 import React from 'react';
 
-/* @TODO: 
-  - [x] Support original aspect ratio
-  - [x] Support for non-100% widths
-  - [ ] Create guide/docs
-  - [ ] Picture element
-  - [ ] Support for third party data loaders
-  - [ ] Consider `loaded` render prop, for blurred placeholder
-  - [ ] Write tests
-  - [ ] Bikeshed on prop names
-  - [ ] Improve types / intellisense support
-*/
-
 /*
  * An optional prop you can use to change the
  * default srcSet generation behaviour

--- a/packages/hydrogen/src/image.ts
+++ b/packages/hydrogen/src/image.ts
@@ -1,5 +1,21 @@
 import React from 'react';
 
+/* @TODO: 
+  - [x] Support original aspect ratio
+  - [x] Support for non-100% widths
+  - [ ] Create guide/docs
+  - [ ] Picture element
+  - [ ] Support for third party data loaders
+  - [ ] Consider `loaded` render prop, for blurred placeholder
+  - [ ] Write tests
+  - [ ] Bikeshed on prop names
+  - [ ] Improve types / intellisense support
+*/
+
+/*
+ * An optional prop you can use to change the
+ * default srcSet generation behaviour
+ */
 interface ImageConfig {
   intervals: number;
   startingWidth: number;
@@ -7,41 +23,64 @@ interface ImageConfig {
   placeholderWidth: number;
 }
 
-type ImageComponent = {
-  as?: 'img' | 'source';
-  src: string;
-  width?: string | number;
-  height?: string | number;
-  crop: Crop;
-  sizes: string;
-  aspectRatio: string;
-  scale?: number;
-  priority?: boolean;
-  config?: ImageConfig;
-  alt: string;
-};
+/*
+ * TODO: Expand to include focal point support;
+ * or switch this to be an SF API type
+ */
 
-type Crop = 'center' | 'top' | 'bottom' | 'left' | 'right' | undefined;
+type Crop = 'center' | 'top' | 'bottom' | 'left' | 'right';
 
 export function Image({
   as: Component = 'img',
-  src = 'https://cdn.shopify.com/static/sample-images/garnished.jpeg',
+  src,
+  /*
+   * Supports third party loaders, which are expected to provide
+   * a function that can generate a URL string
+   */
+  loader = shopifyLoader,
+  /*
+   * The default behaviour is a responsive image that fills
+   * the width of its container.
+   */
   width = '100%',
   height,
+  /*
+   * The default crop is center, in the event that AspectRatio is set,
+   * without specifying a crop, Imagery won't return the expected image.
+   */
   crop = 'center',
-  sizes = '(min-width: 768px) 50vw, 100vw',
+  sizes,
+  /*
+   * aspectRatio is a string in the format of 'width/height'
+   * it's used to generate the srcSet URLs, and to set the
+   * aspect ratio of the image element to prevent CLS.
+   */
   aspectRatio,
-  scale,
-  priority,
   config = {
     intervals: 10,
     startingWidth: 300,
     incrementSize: 300,
     placeholderWidth: 100,
   },
-  alt = 'Test Alt Tag',
+  alt,
+  loading = 'lazy',
   ...passthroughProps
-}: ImageComponent) {
+}: {
+  as?: 'img' | 'source';
+  src: string;
+  loader?: Function;
+  width?: string | number;
+  height?: string | number;
+  crop?: Crop;
+  sizes?: string;
+  aspectRatio?: string;
+  config?: ImageConfig;
+  alt?: string;
+  loading?: 'lazy' | 'eager';
+}) {
+  /*
+   * Sanitizes width and height inputs to account for 'number' type
+   */
   let normalizedWidth: string =
     getUnitValueParts(width.toString()).number +
     getUnitValueParts(width.toString()).unit;
@@ -52,24 +91,84 @@ export function Image({
       : getUnitValueParts(height.toString()).number +
         getUnitValueParts(height.toString()).unit;
 
-  if (!isFixedWidth(width)) {
-    const {intervals, startingWidth, incrementSize, placeholderWidth} = config;
+  const {intervals, startingWidth, incrementSize, placeholderWidth} = config;
 
-    const widths = generateImageWidths(
-      width,
-      intervals,
-      startingWidth,
-      incrementSize,
-    );
+  /*
+   * This function creates an array of widths to be used in srcSet
+   */
+  const widths = generateImageWidths(
+    width,
+    intervals,
+    startingWidth,
+    incrementSize,
+  );
 
-    const sizesArray = generateSizes(widths, aspectRatio, crop);
+  /*
+   * We check to see whether the image is fixed width or not,
+   * if fixed, we still provide a srcSet, but only to account for
+   * different pixel densities.
+   */
+  if (isFixedWidth(width)) {
+    let intWidth: number | undefined = getNormalizedFixedUnit(width);
+    let intHeight: number | undefined = getNormalizedFixedUnit(height);
+
+    /*
+     * The aspect ratio for fixed with images is taken from the explicitly
+     * set prop, but if that's not present, and both width and height are
+     * set, we calculate the aspect ratio from the width and height — as
+     * long as they share the same unit type (e.g. both are 'px').
+     */
+    const fixedAspectRatio = aspectRatio
+      ? aspectRatio
+      : unitsMatch(width, height)
+      ? `${intWidth}/${intHeight}`
+      : undefined;
+
+    /*
+     * The Sizes Array generates an array of all of the parts
+     * that make up the srcSet, including the width, height, and crop
+     */
+    const sizesArray =
+      widths === undefined
+        ? undefined
+        : generateSizes(widths, fixedAspectRatio, crop);
 
     return React.createElement(Component, {
       srcSet: generateShopifySrcSet(src, sizesArray),
-      src: generateImagerySrc(
+      src: loader(
+        src,
+        intWidth,
+        intHeight
+          ? intHeight
+          : aspectRatio && intWidth
+          ? intWidth * (parseAspectRatio(aspectRatio) ?? 1)
+          : undefined,
+        normalizedHeight === 'auto' ? undefined : crop,
+      ),
+      alt,
+      sizes: sizes || normalizedWidth,
+      style: {
+        width: normalizedWidth,
+        height: normalizedHeight,
+        aspectRatio,
+      },
+      loading,
+      ...passthroughProps,
+    });
+  } else {
+    const sizesArray =
+      widths === undefined
+        ? undefined
+        : generateSizes(widths, aspectRatio, crop);
+
+    return React.createElement(Component, {
+      srcSet: generateShopifySrcSet(src, sizesArray),
+      src: loader(
         src,
         placeholderWidth,
-        placeholderWidth * parseAspectRatio(aspectRatio),
+        aspectRatio && placeholderWidth
+          ? placeholderWidth * (parseAspectRatio(aspectRatio) ?? 1)
+          : undefined,
       ),
       alt,
       sizes,
@@ -78,31 +177,20 @@ export function Image({
         height: normalizedHeight,
         aspectRatio,
       },
-      ...passthroughProps,
-    });
-  } else {
-    // width is fixed
-    let intWidth: number | undefined = getNormalizedFixedUnit(width);
-    let intHeight: number | undefined = getNormalizedFixedUnit(height);
-
-    return React.createElement(Component, {
-      src: generateImagerySrc(
-        src,
-        intWidth,
-        (aspectRatio && intWidth
-          ? intWidth * parseAspectRatio(aspectRatio)
-          : intHeight) ?? undefined,
-        normalizedHeight === 'auto' ? undefined : crop,
-      ),
-      alt,
-      style: {
-        width: normalizedWidth,
-        height: normalizedHeight,
-        aspectRatio,
-      },
+      loading,
       ...passthroughProps,
     });
   }
+}
+
+function unitsMatch(
+  width: string | number = '100%',
+  height: string | number = 'auto',
+) {
+  return (
+    getUnitValueParts(width.toString()).unit ===
+    getUnitValueParts(height.toString()).unit
+  );
 }
 
 function getUnitValueParts(value: string) {
@@ -115,9 +203,9 @@ function getUnitValueParts(value: string) {
   };
 }
 
-function getNormalizedFixedUnit(value: string | number | undefined) {
+function getNormalizedFixedUnit(value?: string | number) {
   if (value === undefined) {
-    return undefined;
+    return;
   }
 
   const {unit, number} = getUnitValueParts(value.toString());
@@ -132,7 +220,7 @@ function getNormalizedFixedUnit(value: string | number | undefined) {
     case '':
       return number;
     default:
-      return undefined;
+      return;
   }
 }
 
@@ -145,8 +233,8 @@ function isFixedWidth(width: string | number) {
 }
 
 export function generateShopifySrcSet(
-  src = 'https://cdn.shopify.com/static/sample-images/garnished.jpeg',
-  sizesArray: Array<{width: number; height: number; crop: Crop}> | undefined,
+  src: string,
+  sizesArray?: Array<{width?: number; height?: number; crop?: Crop}>,
 ) {
   if (sizesArray?.length === 0 || !sizesArray) {
     return src;
@@ -155,7 +243,7 @@ export function generateShopifySrcSet(
   return sizesArray
     .map(
       (size) =>
-        generateImagerySrc(src, size.width, size.height, size.crop) +
+        shopifyLoader(src, size.width, size.height, size.crop) +
         ' ' +
         size.width +
         'w',
@@ -175,21 +263,26 @@ export function generateShopifySrcSet(
 
 export function generateImageWidths(
   width: string | number = '100%',
-  intervals = 20,
-  startingWidth = 200,
-  incrementSize = 100,
-  scale = 1,
+  intervals: number = 20,
+  startingWidth: number = 200,
+  incrementSize: number = 100,
 ) {
   const responsive = Array.from(
     {length: intervals},
-    (_, i) => (i * incrementSize + startingWidth) * scale,
+    (_, i) => i * incrementSize + startingWidth,
   );
 
-  return isFixedWidth(width) ? [getNormalizedFixedUnit(width)] : responsive;
+  const fixed = Array.from(
+    {length: 3},
+    (_, i) => (i + 1) * (getNormalizedFixedUnit(width) ?? 0),
+  );
+
+  return isFixedWidth(width) ? fixed : responsive;
 }
 
 // Simple utility function to convert 1/1 to [1, 1]
-export function parseAspectRatio(aspectRatio: string) {
+export function parseAspectRatio(aspectRatio?: string) {
+  if (!aspectRatio) return;
   const [width, height] = aspectRatio.split('/');
   return 1 / (Number(width) / Number(height));
   /* 
@@ -206,15 +299,17 @@ export function parseAspectRatio(aspectRatio: string) {
 
 // Generate data needed for Imagery loader
 export function generateSizes(
-  widths: number[] | undefined,
-  aspectRatio: string,
+  widths?: number[],
+  aspectRatio?: string,
   crop: Crop = 'center',
 ) {
   if (!widths) return;
   const sizes = widths.map((width: number) => {
     return {
       width,
-      height: width * parseAspectRatio(aspectRatio),
+      height: aspectRatio
+        ? width * (parseAspectRatio(aspectRatio) ?? 1)
+        : undefined,
       crop,
     };
   });
@@ -228,7 +323,13 @@ export function generateSizes(
   */
 }
 
-export function generateImagerySrc(
+/*
+ * The shopifyLoader function is a simple utility function that takes a src, width,
+ * height, and crop and returns a string that can be used as the src for an image.
+ * It can be used with the Hydrogen Image component or with the next/image component.
+ * (or any others that accept equivalent configuration)
+ */
+export function shopifyLoader(
   src = 'https://cdn.shopify.com/static/sample-images/garnished.jpeg',
   width?: number,
   height?: number,

--- a/packages/hydrogen/src/image.ts
+++ b/packages/hydrogen/src/image.ts
@@ -1,0 +1,275 @@
+import React from 'react';
+
+interface ImageConfig {
+  intervals: number;
+  startingWidth: number;
+  incrementSize: number;
+  placeholderWidth: number;
+}
+
+type ImageComponent = {
+  as?: 'img' | 'source';
+  src: string;
+  width?: string | number;
+  height?: string | number;
+  crop: Crop;
+  sizes: string;
+  aspectRatio: string;
+  scale?: number;
+  priority?: boolean;
+  config?: ImageConfig;
+  alt: string;
+};
+
+type Crop = 'center' | 'top' | 'bottom' | 'left' | 'right' | undefined;
+
+export function Image({
+  as: Component = 'img',
+  src = 'https://cdn.shopify.com/static/sample-images/garnished.jpeg',
+  width = '100%',
+  height,
+  crop = 'center',
+  sizes = '(min-width: 768px) 50vw, 100vw',
+  aspectRatio,
+  scale,
+  priority,
+  config = {
+    intervals: 10,
+    startingWidth: 300,
+    incrementSize: 300,
+    placeholderWidth: 100,
+  },
+  alt = 'Test Alt Tag',
+  ...passthroughProps
+}: ImageComponent) {
+  if (!isFixedWidth(width)) {
+    const {intervals, startingWidth, incrementSize, placeholderWidth} = config;
+
+    const widths = generateImageWidths(
+      width,
+      intervals,
+      startingWidth,
+      incrementSize,
+    );
+
+    const sizesArray = generateSizes(widths, aspectRatio, crop);
+
+    return React.createElement(Component, {
+      srcSet: generateShopifySrcSet(src, sizesArray),
+      src: generateImagerySrc(
+        src,
+        placeholderWidth,
+        parseAspectRatio(aspectRatio) * placeholderWidth,
+      ),
+      alt,
+      width,
+      sizes,
+      style: {aspectRatio},
+      ...passthroughProps,
+    });
+  } else {
+    // width is fixed
+    let intWidth: number | undefined = getNormalizedFixedUnit(width);
+    let intHeight: number | undefined = getNormalizedFixedUnit(height);
+
+    let normalizedWidth: string =
+      getUnitValueParts(width.toString()).number +
+      getUnitValueParts(width.toString()).unit;
+
+    let normalizedHeight: string =
+      height === undefined
+        ? 'auto'
+        : getUnitValueParts(height.toString()).number +
+          getUnitValueParts(height.toString()).unit;
+
+    return React.createElement(Component, {
+      src: generateImagerySrc(
+        src,
+        intWidth,
+        (aspectRatio && intWidth
+          ? parseAspectRatio(aspectRatio) * intWidth
+          : intHeight) ?? undefined,
+        normalizedHeight === 'auto' ? undefined : crop,
+      ),
+      alt,
+      style: {
+        width: normalizedWidth,
+        height: normalizedHeight,
+      },
+      ...passthroughProps,
+    });
+  }
+}
+
+function getUnitValueParts(value: string) {
+  const unit = value.replace(/[0-9.]/g, '');
+  const number = parseFloat(value.replace(unit, ''));
+
+  return {
+    unit: unit === '' ? (number === undefined ? 'auto' : 'px') : unit,
+    number,
+  };
+}
+
+function getNormalizedFixedUnit(value: string | number | undefined) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const {unit, number} = getUnitValueParts(value.toString());
+
+  switch (unit) {
+    case 'em':
+      return number * 16;
+    case 'rem':
+      return number * 16;
+    case 'px':
+      return number;
+    case '':
+      return number;
+    default:
+      return undefined;
+  }
+}
+
+function isFixedWidth(width: string | number) {
+  const fixedEndings = new RegExp('px|em|rem', 'g');
+  return (
+    typeof width === 'number' ||
+    (typeof width === 'string' && fixedEndings.test(width))
+  );
+}
+
+export function generateShopifySrcSet(
+  src = 'https://cdn.shopify.com/static/sample-images/garnished.jpeg',
+  sizesArray: Array<{width: number; height: number; crop: Crop}> | undefined,
+) {
+  if (sizesArray?.length === 0 || !sizesArray) {
+    return src;
+  }
+
+  return sizesArray
+    .map(
+      (size) =>
+        generateImagerySrc(src, size.width, size.height, size.crop) +
+        ' ' +
+        size.width +
+        'w',
+    )
+    .join(`, `);
+  /*
+      Given:
+        src = 'https://cdn.shopify.com/static/sample-images/garnished.jpeg'
+        sizesArray = [
+          {width: 200, height: 200, crop: 'center'},
+          {width: 400, height: 400, crop: 'center'},
+        ]
+      Returns:
+        'https://cdn.shopify.com/static/sample-images/garnished.jpeg?width=200&height=200&crop=center 200w, https://cdn.shopify.com/static/sample-images/garnished.jpeg?width=400&height=400&crop=center 400w'
+   */
+}
+
+export function generateImageWidths(
+  width: string | number = '100%',
+  intervals = 20,
+  startingWidth = 200,
+  incrementSize = 100,
+  scale = 1,
+) {
+  const responsive = Array.from(
+    {length: intervals},
+    (_, i) => (i * incrementSize + startingWidth) * scale,
+  );
+
+  if (typeof width === 'string') {
+    if (width === '100%') {
+      return responsive;
+    } else if (width.endsWith('%') && width !== '100%') {
+      // width is set in percent
+      return responsive;
+    } else if (width.endsWith('px')) {
+      // width is set in pixels
+    } else if (width.endsWith('em')) {
+      // width is set in ems
+    } else if (width.endsWith('rem')) {
+      // width is set in rems
+    } else if (width == 'auto') {
+      // width is set to auto
+    } else {
+      // width is set using some other unit of measurement
+    }
+  }
+
+  if (width === '100%') {
+    return;
+    /* 
+      Given: 
+        width = '100%'
+        intervals = 10
+        startingWidth = 100
+        incrementSize = 100
+      Returns: 
+        [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+    */
+  }
+  // @TODO: if width !== 100% handle relative/fixed sizes: vw/em/rem/px
+  return [1000];
+}
+
+// Simple utility function to convert 1/1 to [1, 1]
+export function parseAspectRatio(aspectRatio: string) {
+  const [width, height] = aspectRatio.split('/');
+  return Number(width) / Number(height);
+  /* 
+    Given: 
+      '1/1'
+    Returns: 
+      0.5
+  */
+}
+
+// Generate data needed for Imagery loader
+export function generateSizes(
+  widths: number[] | undefined,
+  aspectRatio: string,
+  crop: Crop = 'center',
+) {
+  if (!widths) return;
+  const sizes = widths.map((width: number) => {
+    return {
+      width,
+      height: width * parseAspectRatio(aspectRatio),
+      crop,
+    };
+  });
+  return sizes;
+  /* 
+    Given: 
+      ([100, 200], 1/1, 'center')
+    Returns: 
+      [{width: 100, height: 100, crop: 'center'}, 
+      {width: 200, height: 200, crop: 'center'}]
+  */
+}
+
+export function generateImagerySrc(
+  src = 'https://cdn.shopify.com/static/sample-images/garnished.jpeg',
+  width?: number,
+  height?: number,
+  crop?: Crop,
+) {
+  const url = new URL(src);
+  width && url.searchParams.append('width', width.toString());
+  height && url.searchParams.append('height', height.toString());
+  crop && url.searchParams.append('crop', crop);
+  return url.href;
+  /*
+    Given:
+      src = 'https://cdn.shopify.com/static/sample-images/garnished.jpeg'
+      width = 100
+      height = 100
+      crop = 'center'
+    Returns:
+      'https://cdn.shopify.com/static/sample-images/garnished.jpeg?width=100&height=100&crop=center'
+  */
+}

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -10,3 +10,4 @@ export {InMemoryCache} from './cache/in-memory';
 
 export {RESOURCE_TYPES, REQUIRED_RESOURCES} from './routing/types';
 export {notFoundMaybeRedirect} from './routing/redirect';
+export {Image} from './image';

--- a/templates/demo-store/app/routes/image-demo.tsx
+++ b/templates/demo-store/app/routes/image-demo.tsx
@@ -1,0 +1,72 @@
+import {type LoaderArgs} from '@shopify/remix-oxygen';
+import {useLoaderData} from '@remix-run/react';
+import {json} from '@shopify/remix-oxygen';
+import {Image} from '@shopify/hydrogen';
+
+export async function loader({context: {storefront}}: LoaderArgs) {
+  const data: ImageRFCData = await storefront.query(
+    `#graphql
+      query {
+        product(handle: "snowboard") {
+         featuredImage {
+           ...Image
+         }
+        }
+      }
+      ${IMAGE_FRAGMENT}
+    `,
+    {
+      variables: {},
+    },
+  );
+
+  return json(data.product.featuredImage);
+}
+
+const IMAGE_FRAGMENT = `#graphql
+  fragment Image on Image {
+    altText
+    url
+  }
+`;
+
+type ImageRFCData = {
+  product: {
+    featuredImage: {
+      altText: string;
+      url: string;
+    };
+  };
+};
+
+export default function ImageRFC() {
+  const {altText, url} = useLoaderData<typeof loader>();
+
+  return (
+    <>
+      <Image src={url} alt={altText} aspectRatio="1/1" sizes="100vw" />
+      <Image src={url} alt={altText} width={100} height={200} />
+      <Image src={url} alt={altText} width="5rem" />
+    </>
+  );
+
+  /* Picture component should look something like:
+      <Picture
+        width="100%"
+        {...props}>
+        <Image 
+          src={data.src} 
+          aspectRatio="4/5" 
+          sizes="100vw" 
+          media="(min-width: 800px)" />
+        <Image 
+          src={data.src} 
+          aspectRatio="2/3" 
+          sizes="100vw" 
+          media="(min-width: 1200px)" />
+    </Picture>
+
+    When inside <Picture /> the <Image /> component should render a <source> element,
+    the last <Image /> component should render an <img> element.
+  */
+}

--- a/templates/demo-store/app/routes/image-demo.tsx
+++ b/templates/demo-store/app/routes/image-demo.tsx
@@ -44,7 +44,13 @@ export default function ImageRFC() {
 
   return (
     <>
-      <Image src={url} alt={altText} aspectRatio="1/1" sizes="100vw" />
+      <Image
+        loading="eager"
+        src={url}
+        alt={altText}
+        aspectRatio="1/1"
+        sizes="100vw"
+      />
       <Image
         src={url}
         alt={altText}
@@ -52,6 +58,7 @@ export default function ImageRFC() {
         width="50vw"
         sizes="50vw"
       />
+      <Image src={url} alt={altText} width="30vw" sizes="30vw" />
       <Image src={url} alt={altText} width={100} height={200} />
       <Image src={url} alt={altText} width="5rem" />
     </>

--- a/templates/demo-store/app/routes/image-demo.tsx
+++ b/templates/demo-store/app/routes/image-demo.tsx
@@ -45,6 +45,13 @@ export default function ImageRFC() {
   return (
     <>
       <Image src={url} alt={altText} aspectRatio="1/1" sizes="100vw" />
+      <Image
+        src={url}
+        alt={altText}
+        aspectRatio="4/3"
+        width="50vw"
+        sizes="50vw"
+      />
       <Image src={url} alt={altText} width={100} height={200} />
       <Image src={url} alt={altText} width="5rem" />
     </>


### PR DESCRIPTION
## Replaced by https://github.com/Shopify/hydrogen-react/pull/114

Demo Link: https://n5jyshg6a-f1f4fa724b7467f41f07.myshopify.dev/image-demo?shopify_employee_access=true

`<Image />` now supports all unit types, both for responsive and fixed with images.

**Todo:**
- [x] Write tests
- [x] Write guide/docs
- [ ] Migrate to Storefront Kit
- [ ] Add support for Picture element (could wait until post 2.0)

## Picture Element

Picture component should look something like:

```jsx
 <Picture
  width="100%"
  {...props}>
  <Image 
      src={data.src} 
      aspectRatio="4/5" 
      sizes="100vw" 
      media="(min-width: 800px)" />        
  <Image 
      src={data.src} 
      aspectRatio="2/3" 
      sizes="100vw" 
      media="(min-width: 1200px)" />
</Picture>
```


When inside <Picture /> the <Image /> component should render a <source> element, the last <Image /> component should render an <img> element. Ideally we'd somehow do that automatically — looking at the nodes of children, and then setting the `as` prop for you. Alternatively, our component could re-export the Image component but as a `<Source />` component — which would be in keeping with HTML semantics.