### PR TITLE
Render success banner when generating routes

### DIFF
--- a/packages/cli/src/commands/hydrogen/generate/route.ts
+++ b/packages/cli/src/commands/hydrogen/generate/route.ts
@@ -79,13 +79,27 @@ export default class GenerateRoute extends Command {
     const extension = isTypescript ? '.tsx' : '.jsx';
 
     renderSuccess({
+      // TODO update to `customSection` when available
+      // customSections: [
+      //   {
+      //     title: `${routesArray.length} route${
+      //       routesArray.length > 1 ? 's' : ''
+      //     } generated`,
+      //     body: {
+      //       list: {
+      //         items: routesArray.map(
+      //           (route) => `app/routes${route}${extension}`,
+      //         ),
+      //       },
+      //     },
+      //   },
+      // ],
       headline: `${routesArray.length} route${
         routesArray.length > 1 ? 's' : ''
       } generated`,
       body: routesArray
         .map((route) => `• app/routes${route}${extension}`)
         .join('\n'),
-      nextSteps: ['Restart the MiniOxygen server with `npm run dev`'],
     });
   }
 }


### PR DESCRIPTION
### Before

<img width="546" alt="Screenshot 2023-01-24 at 02 41 19" src="https://user-images.githubusercontent.com/462077/214195728-7bd5b46f-2265-48f9-9e64-6d120b068f22.png">

### After
<img width="581" alt="Screenshot 2023-01-24 at 02 44 58" src="https://user-images.githubusercontent.com/462077/214196067-aaa2455e-8133-4089-ab2a-a62f79f4ca49.png">
