### PR TITLE
Fix SEO > LDJson Hydration warning

### DIFF
--- a/packages/hydrogen/src/seo/seo.ts
+++ b/packages/hydrogen/src/seo/seo.ts
@@ -40,6 +40,14 @@ export function Seo() {
   const headTags = generateSeoTags(seoConfig);
 
   const html = headTags.map((tag) => {
+    if (tag.tag === 'script') {
+      return React.createElement(tag.tag, {
+        ...tag.props,
+        key: tag.key,
+        dangerouslySetInnerHTML: {__html: tag.children},
+      });
+    }
+
     return React.createElement(
       tag.tag,
       {...tag.props, key: tag.key},


### PR DESCRIPTION
When I moved this library to use `React.createElement` from plain jsx tags, I failed to remember that the script tag data needs to be passed in "dangerously" 💀 ... without this, the data is serialized and causes a mis-match on server/client.

Thanks @wizardlyhel for pointing this out.

### Before
<img width="765" alt="Screenshot 2023-01-25 at 18 45 33" src="https://user-images.githubusercontent.com/462077/214641732-d48963e3-4984-40a5-8d24-f98d1e2423f5.png">

### After
<img width="751" alt="Screenshot 2023-01-25 at 18 43 58" src="https://user-images.githubusercontent.com/462077/214641721-7dd9a7a4-8342-48fc-9522-f1c58c733218.png">
