### PR TITLE
Re-export useMoney hook

### DIFF
--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -30,6 +30,7 @@ export {
   ShopPayButton,
   storefrontApiCustomScalars,
   useShopifyCookies,
+  useMoney,
   Video,
 } from '@shopify/storefront-kit-react';
 


### PR DESCRIPTION
The TS build is failing on main and I think it is just a missing export from the RSK merge.

<img width="546" alt="Screenshot 2023-01-31 at 05 39 05" src="https://user-images.githubusercontent.com/462077/215667317-34ec7d42-3dcd-4e1e-bf38-09e9006cc692.png">
