### PR TITLE
Lazy import and split SEO logger

### DIFF
--- a/packages/hydrogen/src/seo/log-seo-tags.ts
+++ b/packages/hydrogen/src/seo/log-seo-tags.ts
@@ -1,5 +1,11 @@
 import {HeadTag} from './generate-seo-tags';
 
+export default function Logger({headTags}: {headTags: HeadTag[]}) {
+  logSeoTags(headTags);
+
+  return null;
+}
+
 export function logSeoTags(headTags: HeadTag[]) {
   const style = 'text-transform: uppercase;';
   const style2 =

--- a/packages/hydrogen/src/seo/seo.ts
+++ b/packages/hydrogen/src/seo/seo.ts
@@ -1,5 +1,10 @@
 import React from 'react';
-import {useMatches, useLocation, type Params, type Location} from '@remix-run/react';
+import {
+  useMatches,
+  useLocation,
+  type Params,
+  type Location,
+} from '@remix-run/react';
 import {generateSeoTags, type Seo as SeoType} from './generate-seo-tags';
 import {logSeoTags} from './log-seo-tags';
 
@@ -8,6 +13,8 @@ import type {
   SerializeFrom,
   AppData,
 } from '@remix-run/server-runtime';
+
+const SeoLogger = React.lazy(() => import('./log-seo-tags'));
 
 export interface SeoHandleFunction<
   Loader extends LoaderFunction | unknown = unknown,
@@ -70,7 +77,13 @@ export function Seo({debug}: SeoProps) {
     );
   });
 
-  return React.createElement(React.Fragment, null, html);
+  const loggerMarkup = React.createElement(
+    React.Suspense,
+    {fallback: null},
+    React.createElement(SeoLogger, {headTags}),
+  );
+
+  return React.createElement(React.Fragment, null, html, debug && loggerMarkup);
 }
 
 export function recursivelyInvokeOrReturn<T, R extends any[]>(

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -65,6 +65,7 @@ export async function loader({context}: LoaderArgs) {
 
   return defer({
     layout,
+    seoDebug: process.env.NODE_ENV === 'development',
     selectedLocale: context.storefront.i18n,
     cart: cartId ? getCart(context, cartId) : undefined,
   });
@@ -77,7 +78,7 @@ export default function App() {
   return (
     <html lang={locale.language}>
       <head>
-        <Seo debug />
+        <Seo debug={data.seoDebug} />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
This PR splits the SEO logging added in https://github.com/Shopify/h2/pull/400 to a lazily imported component. This allows for code-splitting and for it to be auto-disabled in production and auto-enabled in development (though this lives in user-land so it is easy to change this functionality if, for example, users wanted to enable via a query string).

For tophatting, you can run the demo-store via `dev`, you should see the logs. Then run the demo-store via `preview` and you should not see the logs. You can also filter the network requests to see the additional JS request for the logger code. See screenshot below:

<img width="717" alt="Screenshot 2023-01-31 at 05 59 31" src="https://user-images.githubusercontent.com/462077/215669814-e85ebfc3-0388-4d4a-ab5b-b7a028abf193.png">

cc @gfscott 

