### PR TITLE
Demo store collection page pagination fix

### DIFF
--- a/templates/demo-store/app/routes/($lang)/collections/$collectionHandle.tsx
+++ b/templates/demo-store/app/routes/($lang)/collections/$collectionHandle.tsx
@@ -63,12 +63,13 @@ export async function loader({params, request, context}: LoaderArgs) {
   invariant(collectionHandle, 'Missing collectionHandle param');
 
   const searchParams = new URL(request.url).searchParams;
-  const knownFilters = ['cursor', 'productVendor', 'productType'];
+  const knownFilters = ['productVendor', 'productType'];
   const available = 'available';
   const variantOption = 'variantOption';
   const {sortKey, reverse} = getSortValuesFromParam(
     searchParams.get('sort') as SortParam,
   );
+  const cursor = searchParams.get('cursor');
   const filters: FiltersQueryParams = [];
   const appliedFilters: AppliedFilter[] = [];
 
@@ -123,6 +124,7 @@ export async function loader({params, request, context}: LoaderArgs) {
     variables: {
       handle: collectionHandle,
       pageBy: PAGINATION_SIZE,
+      cursor,
       filters,
       sortKey,
       reverse,


### PR DESCRIPTION
Pagination is broken in the Demo Store (drop the `PAGINATION_SIZE` to `4` and hit 'Load more products'):

![image](https://user-images.githubusercontent.com/59898611/215675102-8e3de698-6f6c-4413-9001-c69bfecd2c07.png)

It looks like it's because `cursor` got thrown into the filters and our default `PAGINATION_SIZE` is larger than the total products, so the issue never pops up.

Let me know if I'm missing something!

<hr>

<details>
<summary>Result</summary>

![31-34-1huwt-jh5dh](https://user-images.githubusercontent.com/59898611/215674606-378c7bff-4b58-4467-b4ac-5b782fe31fa8.gif)
</details>




