### PR TITLE
[hackdays] - Dynamic OG Image Base branch

### DIFF
--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -14,6 +14,9 @@ export {useDataFromMatches, useDataFromFetchers} from './hooks/utils';
 export {Seo} from './seo/seo';
 export type {SeoHandleFunction} from './seo/seo';
 
+export {OgImage} from './og-image/og-image';
+export type {OgImageHandleFunction} from './og-image/og-image';
+
 export {
   AnalyticsEventName,
   AnalyticsPageType,

--- a/packages/hydrogen/src/og-image/og-image.tsx
+++ b/packages/hydrogen/src/og-image/og-image.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {useMatches, useLocation} from '@remix-run/react';
+
+import type {
+  LoaderFunction,
+  SerializeFrom,
+  AppData,
+} from '@remix-run/server-runtime';
+
+export interface OgImageHandleFunction<
+  Loader extends LoaderFunction | unknown = unknown,
+> {
+  (args: {
+    data: Loader extends LoaderFunction ? SerializeFrom<Loader> : AppData;
+  }): React.ReactNode;
+}
+
+export function OgImage() {
+  const matches = useMatches();
+  const location = useLocation();
+  const lastMatch = matches.at(-1);
+
+  if (lastMatch === undefined) {
+    return null;
+  }
+
+  const {handle, data} = lastMatch;
+
+  if (handle === undefined || handle.ogImage === undefined) {
+    return null;
+  }
+
+  const searchParams = new URLSearchParams({
+    component: encodeURIComponent(handle.ogImage({data})),
+  });
+
+  const params = searchParams.toString();
+
+  const ogImage = `http://localhost:3000/og-image.svg?${params}`;
+
+  return React.createElement('meta', {
+    property: 'og:image',
+    content: ogImage,
+  });
+}

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -18,6 +18,7 @@ import {
 import {
   ShopifySalesChannel,
   Seo,
+  OgImage,
   type SeoHandleFunction,
 } from '@shopify/hydrogen';
 import {Layout} from '~/components';
@@ -93,6 +94,7 @@ export default function App() {
     <html lang={locale.language}>
       <head>
         <Seo debug={data.seoDebug} />
+        <OgImage />
         <Meta />
         <Links />
       </head>

--- a/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
@@ -14,6 +14,7 @@ import {
   ShopifyAnalyticsProduct,
   ShopPayButton,
   type SeoHandleFunction,
+  type OgImageHandleFunction,
 } from '@shopify/hydrogen';
 import {
   Heading,
@@ -46,8 +47,12 @@ const seo: SeoHandleFunction<typeof loader> = ({data}) => ({
   description: data?.product?.seo?.description,
 });
 
+const ogImage: OgImageHandleFunction<typeof loader> = ({data}) =>
+  `${data?.product?.title}`;
+
 export const handle = {
   seo,
+  ogImage,
 };
 
 export async function loader({params, request, context}: LoaderArgs) {

--- a/templates/demo-store/app/routes/[og-image.svg].tsx
+++ b/templates/demo-store/app/routes/[og-image.svg].tsx
@@ -1,0 +1,62 @@
+import {LoaderArgs} from '@shopify/remix-oxygen';
+import React from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+import parse from 'html-react-parser';
+
+export async function loader({request}: LoaderArgs) {
+  const searchParams = new URL(request.url).searchParams;
+  const {component, ...props} = Object.fromEntries(searchParams.entries());
+  const Component = decodeURIComponent(component);
+  const svg = React.createElement(
+    'svg',
+    {
+      xmlns: 'http://www.w3.org/2000/svg',
+      viewBox: '0 0 1200 630',
+      width: 1200,
+      height: 630,
+    },
+    <>
+      <rect width="100%" height="100%" fill="#000" />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        style={{fontFamily: 'sans-serif', fontSize: '30px', fill: 'white'}}
+      >
+        {Component}
+      </text>
+    </>,
+  );
+
+  return render(svg);
+}
+
+export async function render(component: React.ReactSVGElement) {
+  try {
+    const svg = renderToStaticMarkup(component);
+    return new Response(svg, {
+      headers: {
+        'Content-Type': 'image/svg+xml',
+        'Cache-Control': 'public, s-maxage=60',
+      },
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to render Share Image:', component, error);
+
+    return new Response(
+      renderToStaticMarkup(
+        <svg>
+          <text>Default share image</text>
+        </svg>,
+      ),
+      {
+        headers: {
+          'Content-Type': 'image/svg+xml',
+          'Cache-Control': 'public, s-maxage=60',
+        },
+      },
+    );
+  }
+}


### PR DESCRIPTION
So far this branch includes

- Basic set up of the remix resource route to return an `svg`
- React component rendered in the root to collect `handle.ogImage` from a route
- Library code to create a metatag with an encoded URL that makes a request to a resource route.

https://user-images.githubusercontent.com/462077/217196365-0ab54787-1341-414f-b071-e9d7c62b9291.mov

Todo

- Figure how serialize/deserialize JSX in a route URL. Do we need to send it as a string and parse it (maybe look into what mdx does?)
- Experiment with using [satori](https://github.com/vercel/satori) to handle the rendering. Does this just work? What does it support in terms of fonts, css, etc...
- Caching and splitting things out into a global oxygen worker, and figure out how to handle the infra side.
