### PR TITLE
Fix the killing of processes in monorepo

### DIFF
--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "npm run build:css && shopify hydrogen build",
     "build:css": "postcss styles --base styles --dir app/styles --env production",
-    "dev": "npm run build:css && concurrently -g -k -r npm:dev:css \"shopify hydrogen dev\"",
+    "dev": "npm run build:css && concurrently -g --kill-others-on-fail -r npm:dev:css \"shopify hydrogen dev\"",
     "dev:css": "postcss styles --base styles --dir app/styles -w",
     "preview": "npm run build && shopify hydrogen preview",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",


### PR DESCRIPTION
In #443, we added a `-k` to the `dev` script in our demo-store. @frandiox probably knows why for sure, but my guess is that we wanted to prevent stray processes from running when one of them fails.

This works fine when you're running `npm run dev` from within the demo-store template itself! BUT: when you run it as part of the `turbo` monorepo `dev` command, shit breaks with no real error. I'm guessing this is related to a false positive within `concurrently`, perhaps due to turbo or due to the preceding `&&` command.

```
demo-store:dev: > demo-store@0.0.0 dev:css
demo-store:dev: > postcss styles --base styles --dir app/styles -w
demo-store:dev:
demo-store:dev: npm ERR! Lifecycle script `dev` failed with error:
demo-store:dev: npm ERR! Error: command failed
demo-store:dev: npm ERR!   in workspace: demo-store@0.0.0
demo-store:dev: npm ERR!   at location: /Users/jasonkurian/src/github.com/Shopify/h2/templates/demo-store
```

https://github.com/open-cli-tools/concurrently#usage

Anyway, this seems to fix it.