### PR TITLE
Update @typescript-eslint to support `satisfies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6331,15 +6331,18 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.51.0.tgz",
+      "integrity": "sha512-wcAwhEWm1RgNd7dxD/o+nnLW8oH+6RK1OGnmbmkj/GGoDPV1WWMVP0FXYQBivKHdwM1pwii3bt//RC62EriIUQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.38.0",
-        "@typescript-eslint/type-utils": "5.38.0",
-        "@typescript-eslint/utils": "5.38.0",
+        "@typescript-eslint/scope-manager": "5.51.0",
+        "@typescript-eslint/type-utils": "5.51.0",
+        "@typescript-eslint/utils": "5.51.0",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
@@ -6483,13 +6486,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.51.0.tgz",
+      "integrity": "sha512-fEV0R9gGmfpDeRzJXn+fGQKcl0inIeYobmmUWijZh9zA7bxJ8clPhV9up2ZQzATxAiFAECqPQyMDB4o4B81AaA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.38.0",
-        "@typescript-eslint/types": "5.38.0",
-        "@typescript-eslint/typescript-estree": "5.38.0",
+        "@typescript-eslint/scope-manager": "5.51.0",
+        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/typescript-estree": "5.51.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -6509,12 +6513,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.51.0.tgz",
+      "integrity": "sha512-gNpxRdlx5qw3yaHA0SFuTjW4rxeYhpHxt491PEcKF8Z6zpq0kMhe0Tolxt0qjlojS+/wArSDlj/LtE69xUJphQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.38.0",
-        "@typescript-eslint/visitor-keys": "5.38.0"
+        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/visitor-keys": "5.51.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6525,12 +6530,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.51.0.tgz",
+      "integrity": "sha512-QHC5KKyfV8sNSyHqfNa0UbTbJ6caB8uhcx2hYcWVvJAZYJRBo5HyyZfzMdRx8nvS+GyMg56fugMzzWnojREuQQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.38.0",
-        "@typescript-eslint/utils": "5.38.0",
+        "@typescript-eslint/typescript-estree": "5.51.0",
+        "@typescript-eslint/utils": "5.51.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -6551,9 +6557,10 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.51.0.tgz",
+      "integrity": "sha512-SqOn0ANn/v6hFn0kjvLwiDi4AzR++CBZz0NV5AnusT2/3y32jdc0G4woXPWHCumWtUXZKPAS27/9vziSsC9jnw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -6563,12 +6570,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.51.0.tgz",
+      "integrity": "sha512-TSkNupHvNRkoH9FMA3w7TazVFcBPveAAmb7Sz+kArY6sLT86PA5Vx80cKlYmd8m3Ha2SwofM1KwraF24lM9FvA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "5.38.0",
-        "@typescript-eslint/visitor-keys": "5.38.0",
+        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/visitor-keys": "5.51.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -6589,16 +6597,19 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.51.0.tgz",
+      "integrity": "sha512-76qs+5KWcaatmwtwsDJvBk4H76RJQBFe+Gext0EfJdC3Vd2kpY2Pf//OHHzHp84Ciw0/rYoGTDnIAr3uWhhJYw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.38.0",
-        "@typescript-eslint/types": "5.38.0",
-        "@typescript-eslint/typescript-estree": "5.38.0",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.51.0",
+        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/typescript-estree": "5.51.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6612,11 +6623,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.51.0.tgz",
+      "integrity": "sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/types": "5.51.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -6629,8 +6641,9 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -15195,6 +15208,12 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
     },
     "node_modules/natural-orderby": {
       "version": "2.0.3",
@@ -27446,14 +27465,18 @@
       "version": "1.9.2"
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.51.0.tgz",
+      "integrity": "sha512-wcAwhEWm1RgNd7dxD/o+nnLW8oH+6RK1OGnmbmkj/GGoDPV1WWMVP0FXYQBivKHdwM1pwii3bt//RC62EriIUQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.38.0",
-        "@typescript-eslint/type-utils": "5.38.0",
-        "@typescript-eslint/utils": "5.38.0",
+        "@typescript-eslint/scope-manager": "5.51.0",
+        "@typescript-eslint/type-utils": "5.51.0",
+        "@typescript-eslint/utils": "5.51.0",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
@@ -27520,43 +27543,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.51.0.tgz",
+      "integrity": "sha512-fEV0R9gGmfpDeRzJXn+fGQKcl0inIeYobmmUWijZh9zA7bxJ8clPhV9up2ZQzATxAiFAECqPQyMDB4o4B81AaA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.38.0",
-        "@typescript-eslint/types": "5.38.0",
-        "@typescript-eslint/typescript-estree": "5.38.0",
+        "@typescript-eslint/scope-manager": "5.51.0",
+        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/typescript-estree": "5.51.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.51.0.tgz",
+      "integrity": "sha512-gNpxRdlx5qw3yaHA0SFuTjW4rxeYhpHxt491PEcKF8Z6zpq0kMhe0Tolxt0qjlojS+/wArSDlj/LtE69xUJphQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.38.0",
-        "@typescript-eslint/visitor-keys": "5.38.0"
+        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/visitor-keys": "5.51.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.51.0.tgz",
+      "integrity": "sha512-QHC5KKyfV8sNSyHqfNa0UbTbJ6caB8uhcx2hYcWVvJAZYJRBo5HyyZfzMdRx8nvS+GyMg56fugMzzWnojREuQQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.38.0",
-        "@typescript-eslint/utils": "5.38.0",
+        "@typescript-eslint/typescript-estree": "5.51.0",
+        "@typescript-eslint/utils": "5.51.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.51.0.tgz",
+      "integrity": "sha512-SqOn0ANn/v6hFn0kjvLwiDi4AzR++CBZz0NV5AnusT2/3y32jdc0G4woXPWHCumWtUXZKPAS27/9vziSsC9jnw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.51.0.tgz",
+      "integrity": "sha512-TSkNupHvNRkoH9FMA3w7TazVFcBPveAAmb7Sz+kArY6sLT86PA5Vx80cKlYmd8m3Ha2SwofM1KwraF24lM9FvA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.38.0",
-        "@typescript-eslint/visitor-keys": "5.38.0",
+        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/visitor-keys": "5.51.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -27565,27 +27598,35 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.51.0.tgz",
+      "integrity": "sha512-76qs+5KWcaatmwtwsDJvBk4H76RJQBFe+Gext0EfJdC3Vd2kpY2Pf//OHHzHp84Ciw0/rYoGTDnIAr3uWhhJYw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.38.0",
-        "@typescript-eslint/types": "5.38.0",
-        "@typescript-eslint/typescript-estree": "5.38.0",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.51.0",
+        "@typescript-eslint/types": "5.51.0",
+        "@typescript-eslint/typescript-estree": "5.51.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.38.0",
+      "version": "5.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.51.0.tgz",
+      "integrity": "sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.38.0",
+        "@typescript-eslint/types": "5.51.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
           "dev": true
         }
       }
@@ -32937,6 +32978,12 @@
     },
     "natural-compare": {
       "version": "1.4.0",
+      "dev": true
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "natural-orderby": {


### PR DESCRIPTION
Update the `@typescript-eslint/...` dependencies to support the new `satiesfies` keyword in TS (added in [v5.45.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.45.0)).