### PR TITLE
Send Hydrogen version in requests to Storefront API

### DIFF
--- a/.changeset/nice-zebras-exercise.md
+++ b/.changeset/nice-zebras-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Send Hydrogen version in Storefront API requests.

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -24,6 +24,7 @@ import {
   LanguageCode,
 } from '@shopify/hydrogen-react/storefront-api-types';
 import {warnOnce} from './utils/warning';
+import {LIB_VERSION} from './version';
 
 type StorefrontApiResponse<T> = StorefrontApiResponseOk<T>;
 
@@ -150,6 +151,7 @@ export function createStorefrontClient<TI18n extends I18nBase>({
     requestGroupId || generateUUID();
   if (buyerIp) defaultHeaders[STOREFRONT_API_BUYER_IP_HEADER] = buyerIp;
   if (storefrontId) defaultHeaders[STOREFRONT_ID_HEADER] = storefrontId;
+  if (LIB_VERSION) defaultHeaders['user-agent'] = `Hydrogen ${LIB_VERSION}`;
 
   async function fetchStorefrontApi<T>({
     query,


### PR DESCRIPTION
We do this [in H1](https://github.com/Shopify/hydrogen-v1/blob/v1.x-2022-07/packages/hydrogen/src/utilities/fetch.ts#L1) so I'm adding the same behavior here.

However, a somewhat related problem is that this `LIB_VERSION` is updated **after** the package is built. Therefore, I think a newly released package always contains the version from the previous release.
It's been like this [since H1](https://github.com/Shopify/hydrogen-v1/blob/v1.x-2022-07/package.json#L29), where we modified the "source" instead of the "dist".

Any ideas on how to fix that? We could modify the generated bundle but it doesn't feel right. [Could we run `changeset version` before `npm run build`](https://github.com/Shopify/hydrogen/blob/2023-01/.github/workflows/changesets.yml#L54)? Or would that problematic?