### PR TITLE
Fix the creation of Hydrogen projects on Windows

### DIFF
--- a/.changeset/slimy-zoos-brake.md
+++ b/.changeset/slimy-zoos-brake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix initialization a new Hydrogen project on Windows

--- a/packages/cli/src/utils/template-downloader.ts
+++ b/packages/cli/src/utils/template-downloader.ts
@@ -3,7 +3,7 @@ import {pipeline} from 'stream/promises';
 import gunzipMaybe from 'gunzip-maybe';
 import {extract} from 'tar-fs';
 import {http, file} from '@shopify/cli-kit';
-import {fileURLToPath} from 'fs';
+import {fileURLToPath} from 'url';
 
 // Note: this skips pre-releases
 const REPO_RELEASES_URL = `https://api.github.com/repos/shopify/hydrogen/releases/latest`;

--- a/packages/cli/src/utils/template-downloader.ts
+++ b/packages/cli/src/utils/template-downloader.ts
@@ -1,9 +1,9 @@
-import fs from 'fs';
 import path from 'path';
 import {pipeline} from 'stream/promises';
 import gunzipMaybe from 'gunzip-maybe';
 import {extract} from 'tar-fs';
-import {http} from '@shopify/cli-kit';
+import {http, file} from '@shopify/cli-kit';
+import {fileURLToPath} from 'fs';
 
 // Note: this skips pre-releases
 const REPO_RELEASES_URL = `https://api.github.com/repos/shopify/hydrogen/releases/latest`;
@@ -58,15 +58,16 @@ export async function downloadTarball(url: string, storageDir: string) {
 export async function getLatestTemplates() {
   try {
     const {version, url} = await getLatestReleaseDownloadUrl();
-    const templateStoragePath = new URL('../starter-templates', import.meta.url)
-      .pathname;
+    const templateStoragePath = fileURLToPath(
+      new URL('../starter-templates', import.meta.url),
+    );
 
-    if (!fs.existsSync(templateStoragePath)) {
-      fs.mkdirSync(templateStoragePath);
+    if (!(await file.exists(templateStoragePath))) {
+      await file.mkdir(templateStoragePath);
     }
 
     const templateStorageVersionPath = path.join(templateStoragePath, version);
-    if (!fs.existsSync(templateStorageVersionPath)) {
+    if (!(await file.exists(templateStorageVersionPath))) {
       await downloadTarball(url, templateStorageVersionPath);
     }
 


### PR DESCRIPTION
Resolves: https://github.com/Shopify/hydrogen/issues/476

The approach following approach to obtain the absolute path where the templates should be downloaded leads to Windows paths (i.e. `C://`) prefixed with a forward slash:

```js
new URL('../starter-templates', import.meta.url).pathname
```

I've adjusted the implementation to use `fileURLToPath` and I've taken the opportunity to use the asynchronous IO APIs instead. Going forward, I recommend using the modules provided by `@shopify/cli-kit` when working with the file-system and paths. Node's standard library is known for its inconsistencies across OSs and hence why libraries like [pathe](https://www.npmjs.com/package/pathe), which `@shopify/cli-kit` uses internally. I'd also recommend using the asynchronous version of the APIs. It leads to more scattered `awaits` but allows to execute the logic concurrently with other promises.

