### PR TITLE
Disabled add to cart button on sold out products in demo store template

### DIFF
--- a/templates/demo-store/app/components/AddToCartButton.tsx
+++ b/templates/demo-store/app/components/AddToCartButton.tsx
@@ -1,5 +1,5 @@
 import type {CartLineInput} from '@shopify/hydrogen/storefront-api-types';
-import {useFetcher, useMatches} from '@remix-run/react';
+import {useFetcher, useMatches, useNavigation} from '@remix-run/react';
 import {Button} from '~/components';
 import {CartAction} from '~/lib/type';
 
@@ -9,7 +9,7 @@ export function AddToCartButton({
   className = '',
   variant = 'primary',
   width = 'full',
-  isOutOfStock,
+  disabled,
   analytics,
   ...props
 }: {
@@ -18,13 +18,14 @@ export function AddToCartButton({
   className?: string;
   variant?: 'primary' | 'secondary' | 'inline';
   width?: 'auto' | 'full';
-  isOutOfStock?: boolean;
+  disabled?: boolean;
   analytics?: unknown;
   [key: string]: any;
 }) {
   const [root] = useMatches();
   const selectedLocale = root?.data?.selectedLocale;
   const fetcher = useFetcher();
+  const fetcherIsNotIdle = fetcher.state !== 'idle';
 
   return (
     <fetcher.Form action="/cart" method="post">
@@ -34,11 +35,11 @@ export function AddToCartButton({
       <input type="hidden" name="analytics" value={JSON.stringify(analytics)} />
       <Button
         as="button"
-        type={isOutOfStock ? 'button' : 'submit'}
+        type="submit"
         width={width}
         variant={variant}
         className={className}
-        disabled={isOutOfStock}
+        disabled={disabled ?? fetcherIsNotIdle}
         {...props}
       >
         {children}

--- a/templates/demo-store/app/components/AddToCartButton.tsx
+++ b/templates/demo-store/app/components/AddToCartButton.tsx
@@ -9,6 +9,7 @@ export function AddToCartButton({
   className = '',
   variant = 'primary',
   width = 'full',
+  isOutOfStock,
   analytics,
   ...props
 }: {
@@ -17,6 +18,7 @@ export function AddToCartButton({
   className?: string;
   variant?: 'primary' | 'secondary' | 'inline';
   width?: 'auto' | 'full';
+  isOutOfStock?: boolean;
   analytics?: unknown;
   [key: string]: any;
 }) {
@@ -32,10 +34,11 @@ export function AddToCartButton({
       <input type="hidden" name="analytics" value={JSON.stringify(analytics)} />
       <Button
         as="button"
-        type="submit"
+        type={isOutOfStock ? 'button' : 'submit'}
         width={width}
         variant={variant}
         className={className}
+        disabled={isOutOfStock}
         {...props}
       >
         {children}

--- a/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
@@ -29,6 +29,7 @@ import {
   Text,
   Link,
   AddToCartButton,
+  Button,
 } from '~/components';
 import {getExcerpt} from '~/lib/utils';
 import invariant from 'tiny-invariant';
@@ -249,24 +250,25 @@ export function ProductForm() {
         />
         {selectedVariant && (
           <div className="grid items-stretch gap-4">
-            <AddToCartButton
-              lines={[
-                {
-                  merchandiseId: selectedVariant.id,
-                  quantity: 1,
-                },
-              ]}
-              variant={isOutOfStock ? 'secondary' : 'primary'}
-              data-test="add-to-cart"
-              isOutOfStock={isOutOfStock}
-              analytics={{
-                products: [productAnalytics],
-                totalValue: parseFloat(productAnalytics.price),
-              }}
-            >
-              {isOutOfStock ? (
+            {isOutOfStock ? (
+              <Button variant="secondary" disabled>
                 <Text>Sold out</Text>
-              ) : (
+              </Button>
+            ) : (
+              <AddToCartButton
+                lines={[
+                  {
+                    merchandiseId: selectedVariant.id,
+                    quantity: 1,
+                  },
+                ]}
+                variant={isOutOfStock ? 'secondary' : 'primary'}
+                data-test="add-to-cart"
+                analytics={{
+                  products: [productAnalytics],
+                  totalValue: parseFloat(productAnalytics.price),
+                }}
+              >
                 <Text
                   as="span"
                   className="flex items-center justify-center gap-2"
@@ -286,8 +288,8 @@ export function ProductForm() {
                     />
                   )}
                 </Text>
-              )}
-            </AddToCartButton>
+              </AddToCartButton>
+            )}
             {!isOutOfStock && (
               <ShopPayButton variantIds={[selectedVariant?.id!]} />
             )}

--- a/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
@@ -262,7 +262,7 @@ export function ProductForm() {
                     quantity: 1,
                   },
                 ]}
-                variant={isOutOfStock ? 'secondary' : 'primary'}
+                variant="primary"
                 data-test="add-to-cart"
                 analytics={{
                   products: [productAnalytics],

--- a/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
@@ -258,6 +258,7 @@ export function ProductForm() {
               ]}
               variant={isOutOfStock ? 'secondary' : 'primary'}
               data-test="add-to-cart"
+              isOutOfStock={isOutOfStock}
               analytics={{
                 products: [productAnalytics],
                 totalValue: parseFloat(productAnalytics.price),


### PR DESCRIPTION
When clicking on the add to cart button on the product page, when the product was sold out, the action was still sent. It adds the line to your cart, but with zero quantity. With this solution I changed the button type to 'button' instead of 'submit' when the product `isOutOfStock` and disabled the button as well. I think it also would be nice to use the fetcher state to block the button when it's not in `idle` state.