### PR TITLE
修改window本地运行报错

### DIFF
--- a/packages/cli/src/utils/virtual-routes.ts
+++ b/packages/cli/src/utils/virtual-routes.ts
@@ -8,7 +8,7 @@ const INDEX_SUFFIX = '/index';
 
 export async function addVirtualRoutes(config: RemixConfig) {
   const userRouteList = Object.values(config.routes);
-  const distPath = new URL('..', import.meta.url).pathname;
+  const distPath = new URL("..",import.meta.url.replace('file:///','')).pathname;
   const virtualRoutesPath = path.join(distPath, VIRTUAL_ROUTES_DIR);
 
   for (const absoluteFilePath of await recursiveReaddir(virtualRoutesPath)) {


### PR DESCRIPTION
─ error ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                    │
│  ENOENT: no such file or directory, scandir 'D:\work\hydrogen\demo-store\node_modules\@shopify\cli-hydrogen\dist\utils\virtual-routes.js\virtual-routes\routes'    │
│                                                                                                                                                                    │
│  To investigate the issue, examine this stack trace:                                                                                                               │
│  at Error: ENOENT: no such file or directory, scandir 'D:\work\hydrogen\demo-store\node_modules\