### PR TITLE
Fix Storefront and i18n types

### DIFF
--- a/.changeset/weak-bags-swim.md
+++ b/.changeset/weak-bags-swim.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix default Storefront type in LoaderArgs.

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -37,7 +37,7 @@ export type StorefrontClient<TI18n extends I18nBase> = {
   storefront: Storefront<TI18n>;
 };
 
-export type Storefront<TI18n extends I18nBase> = {
+export type Storefront<TI18n extends I18nBase = I18nBase> = {
   query: <T>(
     query: string,
     payload?: StorefrontCommonOptions & {

--- a/templates/demo-store/app/lib/type.ts
+++ b/templates/demo-store/app/lib/type.ts
@@ -1,6 +1,5 @@
-import type {LoaderArgs} from '@shopify/remix-oxygen';
-import {Storefront as HydrogenStorefront} from '@shopify/hydrogen';
-import {
+import type {Storefront as HydrogenStorefront} from '@shopify/hydrogen';
+import type {
   CountryCode,
   CurrencyCode,
   LanguageCode,
@@ -20,12 +19,6 @@ export type I18nLocale = Locale & {
 };
 
 export type Storefront = HydrogenStorefront<I18nLocale>;
-export type StorefrontContext = {
-  storefront: Storefront;
-};
-export type StorefrontLoaderArgs = {
-  context: StorefrontContext;
-};
 
 export enum CartAction {
   ADD_TO_CART = 'ADD_TO_CART',

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -31,7 +31,6 @@ import {DEFAULT_LOCALE, parseMenu, type EnhancedMenu} from './lib/utils';
 import invariant from 'tiny-invariant';
 import {Shop, Cart} from '@shopify/hydrogen/storefront-api-types';
 import {useAnalytics} from './hooks/useAnalytics';
-import type {StorefrontContext} from './lib/type';
 
 const seo: SeoHandleFunction<typeof loader> = ({data, pathname}) => ({
   title: data?.layout?.shop?.name,
@@ -359,7 +358,7 @@ const CART_QUERY = `#graphql
   }
 `;
 
-export async function getCart({storefront}: StorefrontContext, cartId: string) {
+export async function getCart({storefront}: AppLoadContext, cartId: string) {
   invariant(storefront, 'missing storefront client in cart query');
 
   const {cart} = await storefront.query<{cart?: Cart}>(CART_QUERY, {

--- a/templates/demo-store/app/routes/($lang)/journal/index.tsx
+++ b/templates/demo-store/app/routes/($lang)/journal/index.tsx
@@ -4,7 +4,6 @@ import {flattenConnection, Image} from '@shopify/hydrogen';
 import type {Article, Blog} from '@shopify/hydrogen/storefront-api-types';
 import {Grid, PageHeader, Section, Link} from '~/components';
 import {getImageLoadingPriority, PAGINATION_SIZE} from '~/lib/const';
-import {StorefrontLoaderArgs} from '~/lib/type';
 
 const BLOG_HANDLE = 'Journal';
 
@@ -14,7 +13,7 @@ export const handle = {
   },
 };
 
-export const loader = async ({context: {storefront}}: StorefrontLoaderArgs) => {
+export const loader = async ({context: {storefront}}: LoaderArgs) => {
   const {language, country} = storefront.i18n;
   const {blog} = await storefront.query<{
     blog: Blog;

--- a/templates/demo-store/app/routes/($lang)/policies/index.tsx
+++ b/templates/demo-store/app/routes/($lang)/policies/index.tsx
@@ -1,10 +1,9 @@
-import {json} from '@shopify/remix-oxygen';
+import {json, type LoaderArgs} from '@shopify/remix-oxygen';
 import {useLoaderData} from '@remix-run/react';
 import type {ShopPolicy} from '@shopify/hydrogen/storefront-api-types';
 import invariant from 'tiny-invariant';
 
 import {PageHeader, Section, Heading, Link} from '~/components';
-import {StorefrontLoaderArgs} from '~/lib/type';
 
 export const handle = {
   seo: {
@@ -12,7 +11,7 @@ export const handle = {
   },
 };
 
-export async function loader({context: {storefront}}: StorefrontLoaderArgs) {
+export async function loader({context: {storefront}}: LoaderArgs) {
   const data = await storefront.query<{
     shop: Record<string, ShopPolicy>;
   }>(POLICIES_QUERY);

--- a/templates/demo-store/remix.env.d.ts
+++ b/templates/demo-store/remix.env.d.ts
@@ -2,7 +2,7 @@
 /// <reference types="@shopify/remix-oxygen" />
 /// <reference types="@shopify/oxygen-workers-types" />
 
-import type {Storefront} from '@shopify/hydrogen';
+import type {Storefront} from '~/lib/type';
 import type {HydrogenSession} from '~/lib/session.server';
 
 declare global {

--- a/templates/hello-world/remix.env.d.ts
+++ b/templates/hello-world/remix.env.d.ts
@@ -2,7 +2,7 @@
 /// <reference types="@shopify/remix-oxygen" />
 /// <reference types="@shopify/oxygen-workers-types" />
 
-import type {StorefrontClient} from '@shopify/hydrogen';
+import type {Storefront} from '@shopify/hydrogen';
 import type {HydrogenSession} from '../server';
 
 declare global {
@@ -30,7 +30,7 @@ declare global {
 declare module '@shopify/remix-oxygen' {
   export interface AppLoadContext {
     session: HydrogenSession;
-    storefront: StorefrontClient['storefront'];
+    storefront: Storefront;
     env: Env;
   }
 }

--- a/templates/skeleton/remix.env.d.ts
+++ b/templates/skeleton/remix.env.d.ts
@@ -2,7 +2,7 @@
 /// <reference types="@shopify/remix-oxygen" />
 /// <reference types="@shopify/oxygen-workers-types" />
 
-import type {StorefrontClient} from '@shopify/hydrogen';
+import type {Storefront} from '@shopify/hydrogen';
 import type {HydrogenSession} from '../server';
 
 declare global {
@@ -30,7 +30,7 @@ declare global {
 declare module '@shopify/remix-oxygen' {
   export interface AppLoadContext {
     session: HydrogenSession;
-    storefront: StorefrontClient['storefront'];
+    storefront: Storefront;
     env: Env;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/Shopify/hydrogen/issues/486

Changes in https://github.com/Shopify/hydrogen/commit/2345b5bfcb78b007da53146e0f1ec102a889592e made `context.storefront` be `any` unless we manually specified a type for the `i18n` property.

From now, by default, [we assume the `i18n` property is `{country, locale}`](https://github.com/Shopify/hydrogen/commit/4fb486bb8cb212da12b1a3e9f8060d0a8339eec4) and it can be overwritten in user-land to provide extra properties like `currency` or `pathPrefix` (in `remix.env.d.ts` file).

Before:
<img width="744" alt="image" src="https://user-images.githubusercontent.com/1634092/218450429-81682a20-b5ce-48a3-9cc9-08160cf8c7c6.png">

After:
<img width="744" alt="image" src="https://user-images.githubusercontent.com/1634092/218450181-7968418e-c8ef-45e5-aa15-9750e1e3bab1.png">
