### PR TITLE
Improve errors when initial build fails

### DIFF
--- a/.changeset/plenty-donuts-guess.md
+++ b/.changeset/plenty-donuts-guess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Show better errors when initial build fails, and recover when fixing it.


### PR DESCRIPTION
Related to these PRs in Remix:
- https://github.com/remix-run/remix/pull/5441
- https://github.com/remix-run/remix/pull/5443

--

When Remix can't generate the initial build in `dist/worker/index.js`, the `onInitialBuild` hook is still called regardless and we try to start MiniOxygen. At this point, MiniOxygen obviously fails with:

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/1634092/218952263-373c0041-b1cb-41da-9de2-d2310c1afadc.png">

After these changes, we only start MiniOxygen once the server bundle is in place (it detects when the app is fixed and rebuilds):

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/1634092/218952001-82cc1da5-f936-4c61-b061-acc56237293f.png">
