### PR TITLE
fix template download check on windows

### DIFF
--- a/packages/cli/src/utils/template-downloader.ts
+++ b/packages/cli/src/utils/template-downloader.ts
@@ -47,8 +47,8 @@ export async function downloadTarball(url: string, storageDir: string) {
       filter: (name) => {
         name = name.replace(storageDir, '');
         return (
-          !name.startsWith('/templates/') ||
-          name.startsWith('/templates/skeleton/')
+          !name.startsWith(path.normalize('/templates/')) ||
+          name.startsWith(path.normalize('/templates/skeleton/'))
         );
       },
     }),


### PR DESCRIPTION
following up on #520
@frandiox  i am having the same issue and sadly your PR didn't solve it for me,
so i looked into the issue on my own and found this

![image](https://user-images.githubusercontent.com/39623643/219150243-314d9035-2a6f-4fb1-a239-a649ef853bff.png)

after wrapping the check with `path.normalize` i was able to execute the command without any issue.

![image](https://user-images.githubusercontent.com/39623643/219150788-616f63e0-083e-4a7b-88be-df2403e5012f.png)

i made a PR in the hope to help others that have the same issue :slightly_smiling_face:

if you need any additional info/help with testing debugging please feel free to ping me

best regards