### PR TITLE
Format staged `css`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     ],
     "*.md": [
       "prettier --write"
+    ],
+    "*.css": [
+      "prettier --write"
     ]
   },
   "dependencies": {

--- a/packages/cli/src/virtual-routes/assets/styles.css
+++ b/packages/cli/src/virtual-routes/assets/styles.css
@@ -1,10 +1,11 @@
 @font-face {
   font-family: 'Inter';
-  src: url('../assets/inter-variable-font.woff2') format("woff2-variations");
+  src: url('../assets/inter-variable-font.woff2') format('woff2-variations');
 }
 @font-face {
   font-family: 'JetBrains Mono';
-  src: url('../assets/jetbrainsmono-variable-font.woff2') format("woff2-variations");
+  src: url('../assets/jetbrainsmono-variable-font.woff2')
+    format('woff2-variations');
 }
 
 * {
@@ -35,13 +36,12 @@ p {
   font-weight: 500;
 }
 
-
 body {
   padding: 0;
   margin: 0;
-  background: #FFFFFF;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background: #fff;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   min-height: 100vh;
   display: flex;
@@ -61,9 +61,9 @@ header {
   padding: 14px 20px;
   width: 100%;
   height: 48px;
-  background: #FFFFFF;
+  background: #ffffff;
   align-items: center;
-  color: #5C5F62;
+  color: #5c5f62;
 }
 
 header nav {
@@ -82,7 +82,7 @@ header p {
   font-family: 'JetBrains Mono';
   font-weight: 700;
   font-size: 0.875rem;
-  border: 1.5px solid #D2D5D8;
+  border: 1.5px solid #d2d5d8;
   border-radius: 4px;
   padding: 1px;
   white-space: nowrap;
@@ -95,7 +95,7 @@ main {
 }
 
 footer {
-  background: #F6F6F7;
+  background: #f6f6f7;
 }
 
 footer div {
@@ -116,7 +116,6 @@ main > h1 {
   margin-bottom: 24px;
 }
 
-
 main > p {
   margin-bottom: 16px;
 }
@@ -125,14 +124,12 @@ main > section {
   margin-bottom: 40px;
 }
 
-
 main a {
-  color: #475F91;
+  color: #475f91;
   font-size: 1rem;
   position: relative;
   font-weight: 500;
 }
-
 
 main a::after {
   content: url("data:image/svg+xml,%3Csvg width='18' height='24' viewBox='0 0 18 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.45312 19.3828H13.9297C15.5703 19.3828 16.3828 18.5703 16.3828 16.9609V7.42188C16.3828 5.8125 15.5703 5 13.9297 5H4.45312C2.82031 5 2 5.80469 2 7.42188V16.9609C2 18.5781 2.82031 19.3828 4.45312 19.3828ZM4.46875 18.125C3.6875 18.125 3.25781 17.7109 3.25781 16.8984V7.48438C3.25781 6.67188 3.6875 6.25781 4.46875 6.25781H13.9141C14.6875 6.25781 15.125 6.67188 15.125 7.48438V16.8984C15.125 17.7109 14.6875 18.125 13.9141 18.125H4.46875ZM11.6406 14.1172C11.9844 14.1172 12.2188 13.8516 12.2188 13.4922V9.80469C12.2188 9.34375 11.9609 9.16406 11.5625 9.16406H7.85938C7.49219 9.16406 7.25781 9.39062 7.25781 9.73438C7.25781 10.0781 7.5 10.3047 7.875 10.3047H9.29688L10.4531 10.1797L9.23438 11.3125L6.35156 14.1953C6.24219 14.3047 6.17188 14.4609 6.17188 14.6172C6.17188 14.9688 6.39844 15.1953 6.74219 15.1953C6.92969 15.1953 7.07812 15.125 7.1875 15.0156L10.0625 12.1406L11.1875 10.9375L11.0703 12.1562V13.5078C11.0703 13.875 11.2969 14.1172 11.6406 14.1172Z' fill='%23475F91'/%3E%3C/svg%3E%0A");
@@ -146,7 +143,7 @@ main {
 
 .Links ul {
   margin: 0;
-  padding: 0 .5rem;
+  padding: 0 0.5rem;
   list-style: none;
 }
 
@@ -155,7 +152,7 @@ main {
 }
 
 .Links li::before {
-  content: "\25fc";
+  content: '\25fc';
   color: #5c5f62;
   display: inline-block;
   vertical-align: text-bottom;
@@ -164,12 +161,11 @@ main {
 }
 
 .Links h2 {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   font-size: 1.5rem;
-  color: #44474A;
+  color: #44474a;
   font-weight: 700;
 }
-
 
 .Banner {
   box-sizing: border-box;
@@ -183,9 +179,9 @@ main {
   font-style: normal;
   font-size: 1rem;
   line-height: 24px;
-  color: #5C5F62;
-  border: 1px solid #D2D5D8;
-  background: #FAFBFB;
+  color: #5c5f62;
+  border: 1px solid #d2d5d8;
+  background: #fafbfb;
 }
 
 .Banner div {
@@ -199,10 +195,9 @@ main {
   padding-left: 48px;
 }
 
-
 .Banner code {
-  background: #F6F6F7;
-  border: 1px solid #D2D5D8;
+  background: #f6f6f7;
+  border: 1px solid #d2d5d8;
   font-family: monospace;
   border-radius: 4px;
   padding: 2px;
@@ -214,23 +209,22 @@ main {
 }
 
 .Banner.ErrorBanner {
-  color: #981C06;
-  border: 1px solid #FDA9A5;
-  background: #FEE9E8;
+  color: #981c06;
+  border: 1px solid #fda9a5;
+  background: #fee9e8;
 }
 
 .Banner.ErrorBanner code {
-  background: #FEF4F4;
-  border: 1px solid #FDA9A5;
+  background: #fef4f4;
+  border: 1px solid #fda9a5;
   border-radius: 4px;
   padding: 2px;
-  color: #74180C;
+  color: #74180c;
 }
 
 .Banner.ErrorBanner a {
-  color: #B92409;
+  color: #b92409;
 }
-
 
 .Banner.ErrorBanner a::after {
   content: url("data:image/svg+xml,%3Csvg width='18' height='24' viewBox='0 0 18 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.45312 19.3828H13.9297C15.5703 19.3828 16.3828 18.5703 16.3828 16.9609V7.42188C16.3828 5.8125 15.5703 5 13.9297 5H4.45312C2.82031 5 2 5.80469 2 7.42188V16.9609C2 18.5781 2.82031 19.3828 4.45312 19.3828ZM4.46875 18.125C3.6875 18.125 3.25781 17.7109 3.25781 16.8984V7.48438C3.25781 6.67188 3.6875 6.25781 4.46875 6.25781H13.9141C14.6875 6.25781 15.125 6.67188 15.125 7.48438V16.8984C15.125 17.7109 14.6875 18.125 13.9141 18.125H4.46875ZM11.6406 14.1172C11.9844 14.1172 12.2188 13.8516 12.2188 13.4922V9.80469C12.2188 9.34375 11.9609 9.16406 11.5625 9.16406H7.85938C7.49219 9.16406 7.25781 9.39062 7.25781 9.73438C7.25781 10.0781 7.5 10.3047 7.875 10.3047H9.29688L10.4531 10.1797L9.23438 11.3125L6.35156 14.1953C6.24219 14.3047 6.17188 14.4609 6.17188 14.6172C6.17188 14.9688 6.39844 15.1953 6.74219 15.1953C6.92969 15.1953 7.07812 15.125 7.1875 15.0156L10.0625 12.1406L11.1875 10.9375L11.0703 12.1562V13.5078C11.0703 13.875 11.2969 14.1172 11.6406 14.1172Z' fill='%23B92409'/%3E%3C/svg%3E%0A");
@@ -240,5 +234,5 @@ main {
 
 .Banner.ErrorBanner > h2 {
   font-size: 1rem;
-  color: #74180C;
+  color: #74180c;
 }


### PR DESCRIPTION
I noticed that running `npm run format` locally created changes in my working tree, this PR should prevent that from happening again.

I've added an additional action for the Yorkie `lint-staged` command to run prettier on staged files with the `.css` extension. This file was a recent addition to the repo and made it in without being `prettier-fied`.