### PR TITLE
Run prettier in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,30 @@ jobs:
       - name: 🔬 Lint
         run: npm run lint
 
+  format:
+    name: ⬣ Prettier
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: ci-format-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v3
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: 📥 Install dependencies
+        run: npm ci
+
+      - name: 🔬 Lint
+        run: npm run format:check
+
   typecheck:
     name: Typescript
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "turbo build --filter=./packages/* && npm run preview -w demo-store",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx ./packages && npm run lint -w demo-store",
     "format": "prettier --write --ignore-unknown ./packages && npm run format -w demo-store",
+    "format:check": "prettier --check --ignore-unknown ./packages && npm run format:check -w demo-store",
     "typecheck": "turbo typecheck --parallel",
     "test": "turbo run test --parallel",
     "test:watch": "turbo run test:watch",

--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -10,6 +10,7 @@
     "preview": "npm run build && shopify hydrogen preview",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "format": "prettier --write --ignore-unknown .",
+    "format:check": "prettier --check --ignore-unknown .",
     "typecheck": "tsc --noEmit"
   },
   "prettier": "@shopify/prettier-config",

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,8 @@
       "outputs": [],
       "dependsOn": ["build"]
     },
+    "//#format": {},
+    "//#format:check": {},
     "test": {},
     "test:watch": {
       "cache": false


### PR DESCRIPTION
~**NOTE: This PR is meant to fail in CI.**~ 

~This is because we currently have an unformatted `css` file in the repo. This PR adds an additional prettier run in CI to augment the local run added in https://github.com/Shopify/hydrogen/pull/543. Once _that_ PR is merged, the CI checks in _this_ PR will pass (when rebased).~

EDIT: I rebased after merging the #543 and it should pass now.

I also added some turbo commands to format the code. This isn't needed, but figured they should exist for consistency with the other orchestration tasks and general convenience.