### PR TITLE
Remove prepack hook from CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7065,7 +7065,7 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9602,7 +9602,6 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9611,7 +9610,6 @@
     },
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9642,7 +9640,7 @@
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1"
@@ -9782,7 +9780,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.15.15",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9821,7 +9818,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20398,7 +20394,6 @@
     },
     "node_modules/tslib": {
       "version": "1.14.1",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsup": {
@@ -22648,7 +22643,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "4.0.6",
+      "version": "4.0.7",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@oclif/core": "^1.20.4",
@@ -22739,7 +22734,7 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2023.1.4",
+      "version": "2023.1.5",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@shopify/hydrogen-react": "2023.1.5"
@@ -22872,8 +22867,8 @@
         "@headlessui/react": "^1.7.2",
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.6",
-        "@shopify/hydrogen": "^2023.1.4",
+        "@shopify/cli-hydrogen": "^4.0.7",
+        "@shopify/hydrogen": "^2023.1.5",
         "@shopify/remix-oxygen": "^1.0.3",
         "clsx": "^1.2.1",
         "concurrently": "^7.5.0",
@@ -22922,8 +22917,8 @@
       "dependencies": {
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.6",
-        "@shopify/hydrogen": "^2023.1.4",
+        "@shopify/cli-hydrogen": "^4.0.7",
+        "@shopify/hydrogen": "^2023.1.5",
         "@shopify/remix-oxygen": "^1.0.3",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
@@ -22951,8 +22946,8 @@
       "dependencies": {
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.6",
-        "@shopify/hydrogen": "^2023.1.4",
+        "@shopify/cli-hydrogen": "^4.0.7",
+        "@shopify/hydrogen": "^2023.1.5",
         "@shopify/remix-oxygen": "^1.0.3",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
@@ -24956,11 +24951,13 @@
     },
     "@csstools/postcss-unset-value": {
       "version": "1.0.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/selector-specificity": {
       "version": "2.0.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@emotion/hash": {
       "version": "0.9.0"
@@ -25015,7 +25012,8 @@
       }
     },
     "@headlessui/react": {
-      "version": "1.7.2"
+      "version": "1.7.2",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.10.4",
@@ -25326,7 +25324,8 @@
           "version": "10.0.0"
         },
         "ws": {
-          "version": "8.10.0"
+          "version": "8.10.0",
+          "requires": {}
         }
       }
     },
@@ -25775,7 +25774,8 @@
     },
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.16.2",
@@ -27683,7 +27683,8 @@
       "version": "8.8.2"
     },
     "acorn-jsx": {
-      "version": "5.3.2"
+      "version": "5.3.2",
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -27773,7 +27774,7 @@
     },
     "ansi-colors": {
       "version": "4.1.3",
-      "dev": true
+      "devOptional": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -28912,7 +28913,8 @@
     },
     "css-prefers-color-scheme": {
       "version": "6.0.3",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-tree": {
       "version": "1.1.3",
@@ -29177,9 +29179,9 @@
         "@remix-run/eslint-config": "1.12.0",
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.6",
+        "@shopify/cli-hydrogen": "^4.0.7",
         "@shopify/eslint-plugin": "^42.0.1",
-        "@shopify/hydrogen": "^2023.1.4",
+        "@shopify/hydrogen": "^2023.1.5",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^1.0.3",
@@ -29372,7 +29374,6 @@
     },
     "encoding": {
       "version": "0.1.13",
-      "dev": true,
       "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -29380,7 +29381,6 @@
       "dependencies": {
         "iconv-lite": {
           "version": "0.6.3",
-          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -29404,7 +29404,7 @@
     },
     "enquirer": {
       "version": "2.3.6",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }
@@ -29502,7 +29502,6 @@
     },
     "esbuild": {
       "version": "0.15.15",
-      "dev": true,
       "requires": {
         "@esbuild/android-arm": "0.15.15",
         "@esbuild/linux-loong64": "0.15.15",
@@ -29530,7 +29529,6 @@
     },
     "esbuild-darwin-arm64": {
       "version": "0.15.15",
-      "dev": true,
       "optional": true
     },
     "escalade": {
@@ -29667,7 +29665,8 @@
     },
     "eslint-config-prettier": {
       "version": "8.5.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -29861,7 +29860,8 @@
     },
     "eslint-plugin-jest-formatting": {
       "version": "3.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.6.1",
@@ -29934,7 +29934,8 @@
     },
     "eslint-plugin-promise": {
       "version": "6.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.31.8",
@@ -29980,11 +29981,13 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-sort-class-members": {
       "version": "1.15.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "5.9.1",
@@ -31003,8 +31006,8 @@
         "@remix-run/dev": "1.12.0",
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.6",
-        "@shopify/hydrogen": "^2023.1.4",
+        "@shopify/cli-hydrogen": "^4.0.7",
+        "@shopify/hydrogen": "^2023.1.5",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^1.0.3",
@@ -31113,7 +31116,8 @@
       }
     },
     "icss-utils": {
-      "version": "5.1.0"
+      "version": "5.1.0",
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1"
@@ -33981,7 +33985,8 @@
       }
     },
     "postcss-discard-duplicates": {
-      "version": "5.1.0"
+      "version": "5.1.0",
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "3.1.2",
@@ -34014,11 +34019,13 @@
     },
     "postcss-font-variant": {
       "version": "5.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-gap-properties": {
       "version": "3.0.5",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-image-set-function": {
       "version": "4.0.7",
@@ -34038,7 +34045,8 @@
     },
     "postcss-initial": {
       "version": "4.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -34065,11 +34073,13 @@
     },
     "postcss-logical": {
       "version": "5.0.4",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules": {
       "version": "6.0.0",
@@ -34085,7 +34095,8 @@
       }
     },
     "postcss-modules-extract-imports": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -34135,7 +34146,8 @@
     },
     "postcss-page-break": {
       "version": "3.0.4",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-place": {
       "version": "7.0.5",
@@ -34208,7 +34220,8 @@
     },
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-reporter": {
       "version": "7.0.5",
@@ -34492,7 +34505,8 @@
       }
     },
     "react-intersection-observer": {
-      "version": "9.4.1"
+      "version": "9.4.1",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",
@@ -34512,7 +34526,8 @@
       }
     },
     "react-universal-interface": {
-      "version": "0.6.2"
+      "version": "0.6.2",
+      "requires": {}
     },
     "react-use": {
       "version": "17.4.0",
@@ -35036,7 +35051,8 @@
       }
     },
     "schema-dts": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "requires": {}
     },
     "scoped-regex": {
       "version": "2.1.0",
@@ -35198,8 +35214,8 @@
         "@remix-run/dev": "1.12.0",
         "@remix-run/react": "1.12.0",
         "@shopify/cli": "3.29.0",
-        "@shopify/cli-hydrogen": "^4.0.6",
-        "@shopify/hydrogen": "^2023.1.4",
+        "@shopify/cli-hydrogen": "^4.0.7",
+        "@shopify/hydrogen": "^2023.1.5",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^1.0.3",
@@ -36104,8 +36120,7 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "dev": true
+      "version": "1.14.1"
     },
     "tsup": {
       "version": "6.5.0",
@@ -36581,10 +36596,12 @@
       "version": "4.0.3"
     },
     "use-isomorphic-layout-effect": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "requires": {}
     },
     "use-sync-external-store": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "requires": {}
     },
     "util": {
       "version": "0.12.5",
@@ -36935,7 +36952,8 @@
       "version": "1.0.2"
     },
     "ws": {
-      "version": "7.5.9"
+      "version": "7.5.9",
+      "requires": {}
     },
     "xdm": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "typecheck": "turbo typecheck --parallel",
     "test": "turbo run test --parallel",
     "test:watch": "turbo run test:watch",
-    "version": "changeset version && npm run version:hydrogen && npm run version:cli",
+    "version": "changeset version && npm run version:hydrogen && npm run version:cli && npm run version:create-hydrogen",
     "version:hydrogen": "node -p \"'export const LIB_VERSION = \\'' + require('./packages/hydrogen/package.json').version + '\\';'\" > packages/hydrogen/src/version.ts",
     "version:cli": "cd packages/cli && npm run generate:manifest",
+    "version:create-hydrogen": "cd packages/create-hydrogen && npm run build",
     "changeset": "changeset",
     "clean-all": "rimraf node_modules/.bin && rimraf node_modules/.cache && rimraf packages/remix-oxygen/dist && rimraf packages/hydrogen/dist && rimraf packages/cli/dist && rimraf templates/demo-store/.cache"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,6 @@
     "dev": "tsup --watch --config ./tsup.config.ts",
     "typecheck": "tsc --noEmit",
     "generate:manifest": "oclif manifest",
-    "prepack": "npm run build",
     "test": "cross-env SHOPIFY_UNIT_TEST=1 vitest run",
     "test:watch": "cross-env SHOPIFY_UNIT_TEST=1 vitest"
   },

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "build": "tsup --clean --config ./tsup.config.ts",
     "dev": "tsup --watch --config ./tsup.config.ts",
-    "prepack": "npm run build",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
Trying to fix the issue where we are missing files from the build ([cli@4.0.7](https://unpkg.com/browse/@shopify/cli-hydrogen@4.0.7/dist/virtual-routes/) vs [cli@4.0.6](https://unpkg.com/browse/@shopify/cli-hydrogen@4.0.6/dist/virtual-routes/)). This is somewhat similar to #503 .

According to the CI build logs, the files are generated correctly during build but somehow missing when published. I'm suspecting that the `prepack` hook we added might be related to the issue because it runs a new build when calling `changeset publish` and we don't have logs on what happens there. Removing it here because afaik it's not needed.