### PR TITLE
Add dist folder to eslintignore to fix npx lint script

### DIFF
--- a/templates/demo-store/.eslintignore
+++ b/templates/demo-store/.eslintignore
@@ -2,3 +2,4 @@ build
 node_modules
 bin
 *.d.ts
+dist


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

When running the lint script it caused a problem where the script would ran stuck and took forever to complete. This was caused by the worker and client folders inside the dist folder.


### WHAT is this pull request doing?

I have added the dist folder to the .eslintignore file to solve this problem.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
