### PR TITLE
Refactor SEO tests by removing InlineSnapshot testing

### DIFF
--- a/packages/hydrogen/src/seo/generate-seo-tags.test.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.test.ts
@@ -67,56 +67,33 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "children": "Snowdevil",
-            "key": "0-title",
-            "props": {},
-            "tag": "title",
+            children: 'Snowdevil',
+            key: '0-title',
+            props: {},
+            tag: 'title',
           },
           {
-            "key": "meta-og:title",
-            "props": {
-              "content": "Snowdevil",
-              "property": "og:title",
+            key: 'meta-og:title',
+            props: {
+              content: 'Snowdevil',
+              property: 'og:title',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
+
           {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
+            key: 'meta-twitter:title',
+            props: {
+              content: 'Snowdevil',
+              name: 'twitter:title',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:title",
-            "props": {
-              "content": "Snowdevil",
-              "name": "twitter:title",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\",\\"name\\":\\"Snowdevil\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
 
     it('should fill the title with a template', () => {
@@ -130,56 +107,33 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "children": "Snowdevil - A headless storefront",
-            "key": "0-title",
-            "props": {},
-            "tag": "title",
+            children: 'Snowdevil - A headless storefront',
+            key: '0-title',
+            props: {},
+            tag: 'title',
           },
           {
-            "key": "meta-og:title",
-            "props": {
-              "content": "Snowdevil - A headless storefront",
-              "property": "og:title",
+            key: 'meta-og:title',
+            props: {
+              content: 'Snowdevil - A headless storefront',
+              property: 'og:title',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
+
           {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
+            key: 'meta-twitter:title',
+            props: {
+              content: 'Snowdevil - A headless storefront',
+              name: 'twitter:title',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:title",
-            "props": {
-              "content": "Snowdevil - A headless storefront",
-              "name": "twitter:title",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\",\\"name\\":\\"Snowdevil\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
 
     it('should warn if the title is too long', () => {
@@ -210,58 +164,34 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "meta-description",
-            "props": {
-              "content": "A headless storefront",
-              "name": "description",
+            key: 'meta-description',
+            props: {
+              content: 'A headless storefront',
+              name: 'description',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-og:description",
-            "props": {
-              "content": "A headless storefront",
-              "property": "og:description",
+            key: 'meta-og:description',
+            props: {
+              content: 'A headless storefront',
+              property: 'og:description',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
+            key: 'meta-twitter:description',
+            props: {
+              content: 'A headless storefront',
+              name: 'twitter:description',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:description",
-            "props": {
-              "content": "A headless storefront",
-              "name": "twitter:description",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\",\\"description\\":\\"A headless storefront\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
 
     it('should warn if the description is too long', () => {
@@ -292,50 +222,26 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "link-canonical",
-            "props": {
-              "href": "https://hydrogen.shop/collections",
-              "rel": "canonical",
+            key: 'link-canonical',
+            props: {
+              href: 'https://hydrogen.shop/collections',
+              rel: 'canonical',
             },
-            "tag": "link",
+            tag: 'link',
           },
           {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
+            key: 'meta-og:url',
+            props: {
+              content: 'https://hydrogen.shop/collections',
+              property: 'og:url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-og:url",
-            "props": {
-              "content": "https://hydrogen.shop/collections",
-              "property": "og:url",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"ItemList\\",\\"url\\":\\"https://hydrogen.shop/collections\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
 
     it('should warn if the url is not a url', () => {
@@ -366,42 +272,18 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "meta-og:image",
-            "props": {
-              "content": "https://example.com/image.jpg",
-              "name": "og:image",
+            key: 'meta-og:image',
+            props: {
+              content: 'https://example.com/image.jpg',
+              name: 'og:image',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\",\\"image\\":\\"https://example.com/image.jpg\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
 
     it('should add media tags when given an array of strings', () => {
@@ -417,50 +299,26 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "meta-og:image",
-            "props": {
-              "content": "https://example.com/image-1.jpg",
-              "name": "og:image",
+            key: 'meta-og:image',
+            props: {
+              content: 'https://example.com/image-1.jpg',
+              name: 'og:image',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-og:image",
-            "props": {
-              "content": "https://example.com/image-2.jpg",
-              "name": "og:image",
+            key: 'meta-og:image',
+            props: {
+              content: 'https://example.com/image-2.jpg',
+              name: 'og:image',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\",\\"image\\":\\"https://example.com/image-2.jpg\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
 
     it('should add media tags when given an object', () => {
@@ -476,66 +334,42 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "meta-https://example.com/image-1.jpg-0-og:image:url",
-            "props": {
-              "content": "https://example.com/image-1.jpg",
-              "property": "og:image:url",
+            key: 'meta-https://example.com/image-1.jpg-0-og:image:url',
+            props: {
+              content: 'https://example.com/image-1.jpg',
+              property: 'og:image:url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.jpg-og:image:height",
-            "props": {
-              "content": 100,
-              "property": "og:image:height",
+            key: 'meta-https://example.com/image-1.jpg-og:image:height',
+            props: {
+              content: 100,
+              property: 'og:image:height',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.jpg-og:image:secure_url",
-            "props": {
-              "content": "https://example.com/image-1.jpg",
-              "property": "og:image:secure_url",
+            key: 'meta-https://example.com/image-1.jpg-og:image:secure_url',
+            props: {
+              content: 'https://example.com/image-1.jpg',
+              property: 'og:image:secure_url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.jpg-og:image:type",
-            "props": {
-              "content": "image/jpeg",
-              "property": "og:image:type",
+            key: 'meta-https://example.com/image-1.jpg-og:image:type',
+            props: {
+              content: 'image/jpeg',
+              property: 'og:image:type',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
 
     it('should add media tags when given an array of objects', () => {
@@ -557,98 +391,74 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "meta-https://example.com/image-1.jpg-0-og:image:url",
-            "props": {
-              "content": "https://example.com/image-1.jpg",
-              "property": "og:image:url",
+            key: 'meta-https://example.com/image-1.jpg-0-og:image:url',
+            props: {
+              content: 'https://example.com/image-1.jpg',
+              property: 'og:image:url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.jpg-og:image:height",
-            "props": {
-              "content": 100,
-              "property": "og:image:height",
+            key: 'meta-https://example.com/image-1.jpg-og:image:height',
+            props: {
+              content: 100,
+              property: 'og:image:height',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.jpg-og:image:secure_url",
-            "props": {
-              "content": "https://example.com/image-1.jpg",
-              "property": "og:image:secure_url",
+            key: 'meta-https://example.com/image-1.jpg-og:image:secure_url',
+            props: {
+              content: 'https://example.com/image-1.jpg',
+              property: 'og:image:secure_url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.jpg-og:image:type",
-            "props": {
-              "content": "image/jpeg",
-              "property": "og:image:type",
+            key: 'meta-https://example.com/image-1.jpg-og:image:type',
+            props: {
+              content: 'image/jpeg',
+              property: 'og:image:type',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-2.jpg-0-og:image:url",
-            "props": {
-              "content": "https://example.com/image-2.jpg",
-              "property": "og:image:url",
+            key: 'meta-https://example.com/image-2.jpg-0-og:image:url',
+            props: {
+              content: 'https://example.com/image-2.jpg',
+              property: 'og:image:url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-2.jpg-og:image:secure_url",
-            "props": {
-              "content": "https://example.com/image-2.jpg",
-              "property": "og:image:secure_url",
+            key: 'meta-https://example.com/image-2.jpg-og:image:secure_url',
+            props: {
+              content: 'https://example.com/image-2.jpg',
+              property: 'og:image:secure_url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-2.jpg-og:image:type",
-            "props": {
-              "content": "image/jpeg",
-              "property": "og:image:type",
+            key: 'meta-https://example.com/image-2.jpg-og:image:type',
+            props: {
+              content: 'image/jpeg',
+              property: 'og:image:type',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-2.jpg-og:image:width",
-            "props": {
-              "content": 100,
-              "property": "og:image:width",
+            key: 'meta-https://example.com/image-2.jpg-og:image:width',
+            props: {
+              content: 100,
+              property: 'og:image:width',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
 
     it('should add media tags for multiple types of media', () => {
@@ -676,122 +486,98 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "meta-https://example.com/image-1.jpg-0-og:image:url",
-            "props": {
-              "content": "https://example.com/image-1.jpg",
-              "property": "og:image:url",
+            key: 'meta-https://example.com/image-1.jpg-0-og:image:url',
+            props: {
+              content: 'https://example.com/image-1.jpg',
+              property: 'og:image:url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.jpg-og:image:height",
-            "props": {
-              "content": 100,
-              "property": "og:image:height",
+            key: 'meta-https://example.com/image-1.jpg-og:image:height',
+            props: {
+              content: 100,
+              property: 'og:image:height',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.jpg-og:image:secure_url",
-            "props": {
-              "content": "https://example.com/image-1.jpg",
-              "property": "og:image:secure_url",
+            key: 'meta-https://example.com/image-1.jpg-og:image:secure_url',
+            props: {
+              content: 'https://example.com/image-1.jpg',
+              property: 'og:image:secure_url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.jpg-og:image:type",
-            "props": {
-              "content": "image/jpeg",
-              "property": "og:image:type",
+            key: 'meta-https://example.com/image-1.jpg-og:image:type',
+            props: {
+              content: 'image/jpeg',
+              property: 'og:image:type',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.mp3-0-og:audio:url",
-            "props": {
-              "content": "https://example.com/image-1.mp3",
-              "property": "og:audio:url",
+            key: 'meta-https://example.com/image-1.mp3-0-og:audio:url',
+            props: {
+              content: 'https://example.com/image-1.mp3',
+              property: 'og:audio:url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.mp3-og:audio:secure_url",
-            "props": {
-              "content": "https://example.com/image-1.mp3",
-              "property": "og:audio:secure_url",
+            key: 'meta-https://example.com/image-1.mp3-og:audio:secure_url',
+            props: {
+              content: 'https://example.com/image-1.mp3',
+              property: 'og:audio:secure_url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.mp3-og:audio:type",
-            "props": {
-              "content": "audio/mpeg",
-              "property": "og:audio:type",
+            key: 'meta-https://example.com/image-1.mp3-og:audio:type',
+            props: {
+              content: 'audio/mpeg',
+              property: 'og:audio:type',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.swf-0-og:video:url",
-            "props": {
-              "content": "https://example.com/image-1.swf",
-              "property": "og:video:url",
+            key: 'meta-https://example.com/image-1.swf-0-og:video:url',
+            props: {
+              content: 'https://example.com/image-1.swf',
+              property: 'og:video:url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.swf-og:video:height",
-            "props": {
-              "content": 100,
-              "property": "og:video:height",
+            key: 'meta-https://example.com/image-1.swf-og:video:height',
+            props: {
+              content: 100,
+              property: 'og:video:height',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.swf-og:video:secure_url",
-            "props": {
-              "content": "https://example.com/image-1.swf",
-              "property": "og:video:secure_url",
+            key: 'meta-https://example.com/image-1.swf-og:video:secure_url',
+            props: {
+              content: 'https://example.com/image-1.swf',
+              property: 'og:video:secure_url',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-https://example.com/image-1.swf-og:video:type",
-            "props": {
-              "content": "application/x-shockwave-flash",
-              "property": "og:video:type",
+            key: 'meta-https://example.com/image-1.swf-og:video:type',
+            props: {
+              content: 'application/x-shockwave-flash',
+              property: 'og:video:type',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
   });
 
@@ -806,50 +592,26 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
+            key: 'meta-twitter:creator',
+            props: {
+              content: '@shopify',
+              name: 'twitter:creator',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
           {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
+            key: 'meta-twitter:site',
+            props: {
+              content: '@shopify',
+              name: 'twitter:site',
             },
-            "tag": "meta",
+            tag: 'meta',
           },
-          {
-            "key": "meta-twitter:creator",
-            "props": {
-              "content": "@shopify",
-              "name": "twitter:creator",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:site",
-            "props": {
-              "content": "@shopify",
-              "name": "twitter:site",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
 
     it('should warn if the handle is not a valid', () => {
@@ -900,35 +662,20 @@ describe('generateSeoTags', () => {
       // When
       const output = generateSeoTags<Product>(input);
 
+      console.warn(output);
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
+            children: JSON.stringify(input.jsonLd),
+            key: 'script-application/ld+json',
+            props: {
+              type: 'application/ld+json',
             },
-            "tag": "meta",
+            tag: 'script',
           },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Product\\",\\"aggregateRating\\":{\\"@type\\":\\"AggregateRating\\",\\"bestRating\\":\\"100\\",\\"ratingCount\\":\\"24\\",\\"ratingValue\\":\\"87\\"},\\"offers\\":{\\"@type\\":\\"AggregateOffer\\",\\"highPrice\\":\\"$1495\\",\\"lowPrice\\":\\"$1250\\",\\"offerCount\\":\\"8\\",\\"offers\\":[{\\"@type\\":\\"Offer\\",\\"url\\":\\"hydrogen.shop/discounts/1234\\"}]}}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
   });
 
@@ -953,52 +700,28 @@ describe('generateSeoTags', () => {
       const output = generateSeoTags(input);
 
       // Then
-      expect(output).toMatchInlineSnapshot(`
-        [
+      expect(output).toEqual(
+        expect.arrayContaining([
           {
-            "key": "link-alternate-de",
-            "props": {
-              "href": "https://hydrogen.shop.com/de/products/1234",
-              "hrefLang": "de",
-              "rel": "alternate",
+            key: 'link-alternate-de',
+            props: {
+              href: 'https://hydrogen.shop.com/de/products/1234',
+              hrefLang: 'de',
+              rel: 'alternate',
             },
-            "tag": "link",
+            tag: 'link',
           },
           {
-            "key": "link-alternate-fr-default",
-            "props": {
-              "href": "https://hydrogen.shop.com/fr/products/1234",
-              "hrefLang": "fr-default",
-              "rel": "alternate",
+            key: 'link-alternate-fr-default',
+            props: {
+              href: 'https://hydrogen.shop.com/fr/products/1234',
+              hrefLang: 'fr-default',
+              rel: 'alternate',
             },
-            "tag": "link",
+            tag: 'link',
           },
-          {
-            "key": "meta-og:type",
-            "props": {
-              "content": "website",
-              "property": "og:type",
-            },
-            "tag": "meta",
-          },
-          {
-            "key": "meta-twitter:card",
-            "props": {
-              "content": "summary_large_image",
-              "name": "twitter:card",
-            },
-            "tag": "meta",
-          },
-          {
-            "children": "{\\"@context\\":\\"https://schema.org\\",\\"@type\\":\\"Thing\\"}",
-            "key": "script-application/ld+json",
-            "props": {
-              "type": "application/ld+json",
-            },
-            "tag": "script",
-          },
-        ]
-      `);
+        ]),
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

In the lead up to release, I added a lot of tests using `toMatchInlineSnapshot`. This was helpful for driving the development of features and getting a lot of test coverage in quickly.

However, I don't feel snapshot tests are the right approach. They just end up looking like a mess of text. Failures are hard to understand. Test intentions are hard to understand. I think developers will find themselves updating these snapshots out of either frustration or unintentional clumsiness.

### WHAT is this pull request doing?

This PR removes the inline snapshots from the SEO tests and replaces them with more specific assertions directly on the array values we expect to exist.

### HOW to test your changes?

Passing CI should be enough.

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
