### PR TITLE
Refresh app when hydrogen-react changes

### DIFF
--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -140,7 +140,9 @@ export async function getRemixConfig(
 
     config.watchPaths.push(
       ...(await fs.readdir(packagesPath)).map((pkg) =>
-        path.resolve(packagesPath, pkg, 'dist', 'development', 'index.js'),
+        pkg === 'hydrogen-react'
+          ? path.resolve(packagesPath, pkg, 'dist', 'browser-dev', 'index.mjs')
+          : path.resolve(packagesPath, pkg, 'dist', 'development', 'index.js'),
       ),
     );
 


### PR DESCRIPTION
@frehner I was checking [your branch](https://github.com/Shopify/hydrogen/tree/integrate-hydrogen-react) and I think this will be necessary to reload the templates during local development 🙌 