### PR TITLE
Fix flakey SEO test for `unavailableAfter` robots tag

### DIFF
--- a/packages/hydrogen/src/seo/generate-seo-tags.test.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.test.ts
@@ -1,4 +1,4 @@
-import {expect, describe, it, vi} from 'vitest';
+import {expect, describe, afterAll, it, vi} from 'vitest';
 import {generateSeoTags, type Seo} from './generate-seo-tags';
 import type {Product} from 'schema-dts';
 
@@ -8,6 +8,10 @@ describe('generateSeoTags', () => {
   };
 
   vi.stubGlobal('console', consoleMock);
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
 
   it('removes undefined values', () => {
     // Given
@@ -794,7 +798,7 @@ describe('generateSeoTags', () => {
         maxImagePreview: 'large' as const,
         maxSnippet: 100,
         maxVideoPreview: 100,
-        unavailableAfter: new Date('2023-01-01').toLocaleDateString(),
+        unavailableAfter: '2023-01-01',
       },
     };
 
@@ -808,7 +812,7 @@ describe('generateSeoTags', () => {
           key: 'meta-robots',
           props: {
             content:
-              'noindex,nofollow,noarchive,noimageindex,nosnippet,notranslate,max-image-preview:large,max-snippet:100,max-video-preview:100,unavailable_after:1/1/2023',
+              'noindex,nofollow,noarchive,noimageindex,nosnippet,notranslate,max-image-preview:large,max-snippet:100,max-video-preview:100,unavailable_after:2023-01-01',
             name: 'robots',
           },
           tag: 'meta',


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

This test was failing locally on contributors working on Hydrogen due to different default locales in the date constructor. 

### WHAT is this pull request doing?

Let's just hardcode this right into the config. I can't think of a reason we need to construct the date in the test.

**Minor additional thing**

While debugging I noticed we should be unstubbing the `console`.

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
