### PR TITLE
PoC `withCache` utility

### DIFF
--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -2,16 +2,25 @@ import {hashKey} from '../utils/hash.js';
 import {CacheShort, CachingStrategy} from './strategies';
 import {getItemFromCache, setItemInCache, isStale} from './sub-request';
 
+type CacheKey = string | readonly unknown[];
+
+export type WithCacheOptions = {
+  strategy?: CachingStrategy | null;
+  cacheInstance?: Cache;
+  shouldCacheResult?: (value: any) => boolean;
+  waitUntil?: ExecutionContext['waitUntil'];
+};
+
 export type FetchCacheOptions = {
   cache?: CachingStrategy;
   cacheInstance?: Cache;
-  cacheKey?: string | readonly unknown[];
+  cacheKey?: CacheKey;
   shouldCacheResponse?: (body: any, response: Response) => boolean;
   waitUntil?: ExecutionContext['waitUntil'];
   returnType?: 'json' | 'text' | 'arrayBuffer' | 'blob';
 };
 
-function serializeResponse(body: any, response: Response) {
+function toSerializableResponse(body: any, response: Response) {
   return [
     body,
     {
@@ -19,7 +28,11 @@ function serializeResponse(body: any, response: Response) {
       statusText: response.statusText,
       headers: Array.from(response.headers.entries()),
     },
-  ];
+  ] satisfies [any, ResponseInit];
+}
+
+function fromSerializableResponse([body, init]: [any, ResponseInit]) {
+  return [body, new Response(body, init)] as const;
 }
 
 // Check if the response body has GraphQL errors
@@ -32,6 +45,77 @@ export const checkGraphQLErrors = (body: any) => !body?.errors;
 // since this is only an in-memory lock.
 // https://github.com/Shopify/oxygen-platform/issues/625
 const swrLock = new Set<string>();
+
+export async function withCache<T = any>(
+  cacheKey: CacheKey,
+  actionFn: () => Promise<T>,
+  {
+    strategy = CacheShort(),
+    cacheInstance,
+    shouldCacheResult = () => true,
+    waitUntil,
+  }: WithCacheOptions,
+): Promise<T> {
+  if (!cacheInstance || !strategy) return actionFn();
+
+  const key = hashKey([
+    // '__HYDROGEN_CACHE_ID__', // TODO purgeQueryCacheOnBuild
+    ...(typeof cacheKey === 'string' ? [cacheKey] : cacheKey),
+  ]);
+
+  const cachedItem = await getItemFromCache(cacheInstance, key);
+  // console.log('--- Cache', cachedItem ? 'HIT' : 'MISS');
+
+  if (cachedItem) {
+    const [cachedResult, cacheInfo] = cachedItem;
+
+    if (!swrLock.has(key) && isStale(key, cacheInfo)) {
+      swrLock.add(key);
+
+      // Important: Run revalidation asynchronously.
+      const revalidatingPromise = Promise.resolve().then(async () => {
+        try {
+          const result = await actionFn();
+
+          if (shouldCacheResult(result)) {
+            await setItemInCache(cacheInstance, key, result, strategy);
+          }
+        } catch (error: any) {
+          if (error.message) {
+            error.message = 'SWR in sub-request failed: ' + error.message;
+          }
+
+          console.error(error);
+        } finally {
+          swrLock.delete(key);
+        }
+      });
+
+      // Asynchronously wait for it in workers
+      waitUntil?.(revalidatingPromise);
+    }
+
+    return cachedResult;
+  }
+
+  const result = await actionFn();
+
+  /**
+   * Important: Do this async
+   */
+  if (shouldCacheResult(result)) {
+    const setItemInCachePromise = setItemInCache(
+      cacheInstance,
+      key,
+      result,
+      strategy,
+    );
+
+    waitUntil?.(setItemInCachePromise);
+  }
+
+  return result;
+}
 
 /**
  * `fetch` equivalent that stores responses in cache.
@@ -54,82 +138,26 @@ export async function fetchWithServerCache(
     cacheOptions = CacheShort();
   }
 
-  const doFetch = async () => {
-    const response = await fetch(url, requestInit);
-    let data;
+  return withCache(
+    cacheKey,
+    async () => {
+      const response = await fetch(url, requestInit);
+      let data;
 
-    try {
-      data = await response[returnType]();
-    } catch {
-      data = await response.text();
-    }
+      try {
+        data = await response[returnType]();
+      } catch {
+        data = await response.text();
+      }
 
-    return [data, response] as const;
-  };
-
-  if (!cacheInstance || !cacheKey || !cacheOptions) return doFetch();
-
-  const key = hashKey([
-    // '__HYDROGEN_CACHE_ID__', // TODO purgeQueryCacheOnBuild
-    ...(typeof cacheKey === 'string' ? [cacheKey] : cacheKey),
-  ]);
-
-  const cachedItem = await getItemFromCache(cacheInstance, key);
-  // console.log('--- Cache', cachedItem ? 'HIT' : 'MISS');
-
-  if (cachedItem) {
-    const [cachedValue, cacheInfo] = cachedItem;
-
-    if (!swrLock.has(key) && isStale(key, cacheInfo)) {
-      swrLock.add(key);
-
-      // Important: Run revalidation asynchronously.
-      const revalidatingPromise = Promise.resolve().then(async () => {
-        try {
-          const [body, response] = await doFetch();
-
-          if (shouldCacheResponse(body, response)) {
-            await setItemInCache(
-              cacheInstance,
-              key,
-              serializeResponse(body, response),
-              cacheOptions,
-            );
-          }
-        } catch (error: any) {
-          if (error.message) {
-            error.message = 'SWR in sub-request failed: ' + error.message;
-          }
-
-          console.error(error);
-        } finally {
-          swrLock.delete(key);
-        }
-      });
-
-      // Asynchronously wait for it in workers
-      waitUntil?.(revalidatingPromise);
-    }
-
-    const [body, init] = cachedValue;
-    return [body, new Response(body, init)];
-  }
-
-  const [body, response] = await doFetch();
-
-  /**
-   * Important: Do this async
-   */
-  if (shouldCacheResponse(body, response)) {
-    const setItemInCachePromise = setItemInCache(
+      return toSerializableResponse(data, response);
+    },
+    {
       cacheInstance,
-      key,
-      serializeResponse(body, response),
-      cacheOptions,
-    );
-
-    waitUntil?.(setItemInCachePromise);
-  }
-
-  return [body, response];
+      waitUntil,
+      strategy: cacheOptions ?? null,
+      shouldCacheResult: (result) =>
+        shouldCacheResponse(...fromSerializableResponse(result)),
+    },
+  ).then(fromSerializableResponse);
 }

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -4,10 +4,10 @@ import {getItemFromCache, setItemInCache, isStale} from './sub-request';
 
 export type CacheKey = string | readonly unknown[];
 
-export type WithCacheOptions = {
+export type WithCacheOptions<T = unknown> = {
   strategy?: CachingStrategy | null;
   cacheInstance?: Cache;
-  shouldCacheResult?: (value: any) => boolean;
+  shouldCacheResult?: (value: T) => boolean;
   waitUntil?: ExecutionContext['waitUntil'];
 };
 
@@ -54,7 +54,7 @@ export async function runWithCache<T = unknown>(
     cacheInstance,
     shouldCacheResult = () => true,
     waitUntil,
-  }: WithCacheOptions,
+  }: WithCacheOptions<T>,
 ): Promise<T> {
   if (!cacheInstance || !strategy) return actionFn();
 

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -2,7 +2,7 @@ import {hashKey} from '../utils/hash.js';
 import {CacheShort, CachingStrategy} from './strategies';
 import {getItemFromCache, setItemInCache, isStale} from './sub-request';
 
-type CacheKey = string | readonly unknown[];
+export type CacheKey = string | readonly unknown[];
 
 export type WithCacheOptions = {
   strategy?: CachingStrategy | null;
@@ -46,7 +46,7 @@ export const checkGraphQLErrors = (body: any) => !body?.errors;
 // https://github.com/Shopify/oxygen-platform/issues/625
 const swrLock = new Set<string>();
 
-export async function withCache<T = any>(
+export async function runWithCache<T = unknown>(
   cacheKey: CacheKey,
   actionFn: () => Promise<T>,
   {
@@ -138,7 +138,7 @@ export async function fetchWithServerCache(
     cacheOptions = CacheShort();
   }
 
-  return withCache(
+  return runWithCache(
     cacheKey,
     async () => {
       const response = await fetch(url, requestInit);

--- a/packages/hydrogen/src/cache/sub-request.ts
+++ b/packages/hydrogen/src/cache/sub-request.ts
@@ -1,3 +1,4 @@
+import {parseJSON} from '../utils/parse-json';
 import {CacheAPI} from './api';
 import {
   CacheShort,
@@ -48,7 +49,12 @@ export async function getItemFromCache(
     return;
   }
 
-  return [await response.json(), response];
+  const text = await response.text();
+  try {
+    return [parseJSON(text), response];
+  } catch {
+    return [text, response];
+  }
 }
 
 /**

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -74,10 +74,10 @@ export type Storefront<TI18n extends I18nBase = I18nBase> = {
   >['getStorefrontApiUrl'];
   isApiError: (error: any) => boolean;
   i18n: TI18n;
-  withCache: (
+  withCache: <T = unknown>(
     cacheKey: CacheKey,
-    actionFn: () => Promise<any>,
-    options?: Pick<WithCacheOptions, 'strategy' | 'shouldCacheResult'>,
+    actionFn: () => Promise<T>,
+    options?: Pick<WithCacheOptions<T>, 'strategy' | 'shouldCacheResult'>,
   ) => Promise<any>;
 };
 

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -3,7 +3,13 @@ import {
   type StorefrontApiResponseOk,
 } from '@shopify/hydrogen-react';
 import type {ExecutionArgs} from 'graphql';
-import {fetchWithServerCache, checkGraphQLErrors} from './cache/fetch';
+import {
+  fetchWithServerCache,
+  runWithCache,
+  checkGraphQLErrors,
+  type CacheKey,
+  type WithCacheOptions,
+} from './cache/fetch';
 import {
   STOREFRONT_API_BUYER_IP_HEADER,
   STOREFRONT_ID_HEADER,
@@ -68,6 +74,11 @@ export type Storefront<TI18n extends I18nBase = I18nBase> = {
   >['getStorefrontApiUrl'];
   isApiError: (error: any) => boolean;
   i18n: TI18n;
+  withCache: (
+    cacheKey: CacheKey,
+    actionFn: () => Promise<any>,
+    options?: Pick<WithCacheOptions, 'strategy' | 'shouldCacheResult'>,
+  ) => Promise<any>;
 };
 
 export type CreateStorefrontClientOptions<TI18n extends I18nBase> = Parameters<
@@ -298,6 +309,28 @@ export function createStorefrontClient<TI18n extends I18nBase>({
        */
       isApiError: isStorefrontApiError,
       i18n: (i18n ?? defaultI18n) as TI18n,
+      /**
+       * Executes an asynchronous operation like `fetch` and caches the result
+       * according to the strategy provided. Use this to call any third-party APIs
+       * from loaders or actions. By default, it uses the `CacheShort` strategy.
+       *
+       * Example:
+       *
+       * ```js
+       * async function loader ({context: {storefront}}) {
+       *   const data = await storefront.withCache('my-unique-key', () => {
+       *     return fetch('https://example.com/api').then(res => res.json());
+       *   }, {
+       *     strategy: storefront.CacheLong(),
+       *   });
+       * ```
+       */
+      withCache: (cacheKey, actionFn, options) =>
+        runWithCache(cacheKey, actionFn, {
+          ...options,
+          cacheInstance: cache,
+          waitUntil,
+        }),
     },
   };
 }


### PR DESCRIPTION
Proof of concept for a `storefront.withCache` utility similar to `useQuery`. This comes from an internal draft doc by @blittle 

Notes:
- We already have a `storefront.cache`, so I've changed its name to `storefront.withCache` for now.
- It reuses most of the existing internal logic so it doesn't add much.

Questions:
- Should this really be inside `storefront`? It's not going to be used for storefront queries so perhaps it should be returned from `const {storefront, withCache} = createStorefrontClient(...)` instead, or a different utility?
- Just like we had `useQuery` and `fetchSync` to make cache easier with fetch, would it make sense to have both `withCache` and `fetchWithCache` exposed?
- This uses `shouldCacheResult` parameter to know if the result should be cached or not (similar to the internal `shouldCacheResponse` in `storefront.query`, useful when there are GraphQL errors in the payload). Should we allow signaling "no cache" with a return value `null` instead? Or, alternatively, allow passing the cache strategy as part of the result:
  ```js
    // Current:
    withCache('key', () => {/*... fetch data*/; return data}, {shouldCacheResult: (data) => !data.errors})
    // vs `null`
    withCache('key', () => {/*... fetch data*/; return data.errors ? null : data})
    // vs dynamic strategy decided once the result is known, not before
    withCache('key', () => {/*... fetch data*/; return { data, strategy: data.errors ? NoCache() : CacheShort() }})
  ```

How to test:
Add the following code to `root.tsx` and refresh the page several times.

```ts
export async function loader({context: {storefront}}: LoaderArgs) {
  await storefront.withCache(
    'test-with-cache',
    async () => console.log('this should only show up once every 10 secs'),
    {
      strategy: storefront.CacheCustom({
        mode: 'public',
        maxAge: 10,
      }),
    },
  );

...

}
```