### PR TITLE
Fix discount route

### DIFF
--- a/.changeset/tall-falcons-punch.md
+++ b/.changeset/tall-falcons-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix `check routes` command to correctly check the standard route `/discount/<code>` instead of `/discounts/<code>`.

--- a/packages/cli/src/utils/missing-routes.ts
+++ b/packages/cli/src/utils/missing-routes.ts
@@ -26,7 +26,7 @@ const REQUIRED_ROUTES = [
   //   'variants/:variantId',
   'search',
   //   'gift_cards/:storeId/:cardId',
-  'discounts/:discountCode',
+  'discount/:discountCode',
 
   'account',
   'account/login',

--- a/packages/hydrogen/src/seo/generate-seo-tags.test.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.test.ts
@@ -656,7 +656,7 @@ describe('generateSeoTags', () => {
             offers: [
               {
                 '@type': 'Offer',
-                url: 'hydrogen.shop/discounts/1234',
+                url: 'hydrogen.shop/discount/1234',
               },
             ],
           },

--- a/templates/demo-store/app/routes/($lang)/discount.$code.tsx
+++ b/templates/demo-store/app/routes/($lang)/discount.$code.tsx
@@ -8,7 +8,7 @@ import {cartCreate, cartDiscountCodesUpdate} from './cart';
  * @example
  * Example path applying a discount and redirecting
  * ```ts
- * /discounts/FREESHIPPING?redirect=/products
+ * /discount/FREESHIPPING?redirect=/products
  *
  * ```
  * @preserve


### PR DESCRIPTION
The standard route is supposed to be `/discount/<code>` instead of the existing `/discounts/<code>`.
The deployed version is now redirecting correctly: [deployed-PR/discount/SHIPPING](https://b3rmj9ke6-f1f4fa724b7467f41f07.myshopify.dev/discount/SHIPPING)

What's the best way to inform of these changes in the demo-store to existing users?
