### PR TITLE
update template client entry to match remix

### DIFF
--- a/templates/demo-store/app/entry.client.tsx
+++ b/templates/demo-store/app/entry.client.tsx
@@ -1,4 +1,22 @@
 import {RemixBrowser} from '@remix-run/react';
+import {startTransition, StrictMode} from 'react';
 import {hydrateRoot} from 'react-dom/client';
 
-hydrateRoot(document, <RemixBrowser />);
+function hydrate() {
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <RemixBrowser />
+      </StrictMode>,
+    );
+  });
+}
+
+if (typeof requestIdleCallback === 'function') {
+  requestIdleCallback(hydrate);
+} else {
+  // Safari doesn't support requestIdleCallback
+  // https://caniuse.com/requestidlecallback
+  setTimeout(hydrate, 1);
+}

--- a/templates/hello-world/app/entry.client.tsx
+++ b/templates/hello-world/app/entry.client.tsx
@@ -1,4 +1,22 @@
 import {RemixBrowser} from '@remix-run/react';
+import {startTransition, StrictMode} from 'react';
 import {hydrateRoot} from 'react-dom/client';
 
-hydrateRoot(document, <RemixBrowser />);
+function hydrate() {
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <RemixBrowser />
+      </StrictMode>,
+    );
+  });
+}
+
+if (typeof requestIdleCallback === 'function') {
+  requestIdleCallback(hydrate);
+} else {
+  // Safari doesn't support requestIdleCallback
+  // https://caniuse.com/requestidlecallback
+  setTimeout(hydrate, 1);
+}

--- a/templates/skeleton/app/entry.client.tsx
+++ b/templates/skeleton/app/entry.client.tsx
@@ -1,4 +1,22 @@
 import {RemixBrowser} from '@remix-run/react';
+import {startTransition, StrictMode} from 'react';
 import {hydrateRoot} from 'react-dom/client';
 
-hydrateRoot(document, <RemixBrowser />);
+function hydrate() {
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <RemixBrowser />
+      </StrictMode>,
+    );
+  });
+}
+
+if (typeof requestIdleCallback === 'function') {
+  requestIdleCallback(hydrate);
+} else {
+  // Safari doesn't support requestIdleCallback
+  // https://caniuse.com/requestidlecallback
+  setTimeout(hydrate, 1);
+}


### PR DESCRIPTION
Enable time-slicing with `React.startTransition` to prevent hydration from blocking the main thread for too long for those users who immediately scroll.
