### PR TITLE
Add `getRequestGroupId` utility

### DIFF
--- a/.changeset/sour-jars-judge.md
+++ b/.changeset/sour-jars-judge.md
@@ -1,0 +1,5 @@
+---
+'@shopify/remix-oxygen': patch
+---
+
+Add a new `getRequestGroupId` utility that extract the Oxygen request ID to improve logs.

--- a/packages/remix-oxygen/src/index.ts
+++ b/packages/remix-oxygen/src/index.ts
@@ -5,7 +5,7 @@ export {
   createSessionStorage,
 } from './implementations';
 
-export {createRequestHandler, getBuyerIp} from './server';
+export {createRequestHandler, getBuyerIp, getRequestGroupId} from './server';
 
 export {
   createSession,

--- a/packages/remix-oxygen/src/server.ts
+++ b/packages/remix-oxygen/src/server.ts
@@ -26,3 +26,10 @@ export function createRequestHandler<Context = unknown>({
 export function getBuyerIp(request: Request) {
   return request.headers.get('oxygen-buyer-ip') ?? undefined;
 }
+
+/**
+ * Extracts the group ID from the current request in Oxygen to improve logs.
+ */
+export function getRequestGroupId(request: Request) {
+  return request.headers.get('request-id') ?? undefined;
+}

--- a/packages/remix-oxygen/src/server.ts
+++ b/packages/remix-oxygen/src/server.ts
@@ -4,6 +4,10 @@ import {
   type ServerBuild,
 } from '@remix-run/server-runtime';
 
+/**
+ * Returns a request handler for the Oxygen runtime that serves the
+ * Remix SSR response.
+ */
 export function createRequestHandler<Context = unknown>({
   build,
   mode,
@@ -23,6 +27,10 @@ export function createRequestHandler<Context = unknown>({
   };
 }
 
+/**
+ * Extracts the buyer IP address (browser client) from the current request in Oxygen
+ * to avoid API rate limits.
+ */
 export function getBuyerIp(request: Request) {
   return request.headers.get('oxygen-buyer-ip') ?? undefined;
 }

--- a/templates/demo-store/server.ts
+++ b/templates/demo-store/server.ts
@@ -1,6 +1,10 @@
 // Virtual entry point for the app
 import * as remixBuild from '@remix-run/dev/server-build';
-import {createRequestHandler, getBuyerIp} from '@shopify/remix-oxygen';
+import {
+  createRequestHandler,
+  getBuyerIp,
+  getRequestGroupId,
+} from '@shopify/remix-oxygen';
 import {createStorefrontClient, storefrontRedirect} from '@shopify/hydrogen';
 import {HydrogenSession} from '~/lib/session.server';
 import {getLocaleFromRequest} from '~/lib/utils';
@@ -36,12 +40,12 @@ export default {
         waitUntil,
         buyerIp: getBuyerIp(request),
         i18n: getLocaleFromRequest(request),
+        requestGroupId: getRequestGroupId(request),
         publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: `https://${env.PUBLIC_STORE_DOMAIN}`,
         storefrontApiVersion: env.PUBLIC_STOREFRONT_API_VERSION || '2023-01',
         storefrontId: env.PUBLIC_STOREFRONT_ID,
-        requestGroupId: request.headers.get('request-id'),
       });
 
       /**

--- a/templates/hello-world/server.ts
+++ b/templates/hello-world/server.ts
@@ -4,6 +4,7 @@ import {createStorefrontClient, storefrontRedirect} from '@shopify/hydrogen';
 import {
   createRequestHandler,
   getBuyerIp,
+  getRequestGroupId,
   createCookieSessionStorage,
   type SessionStorage,
   type Session,
@@ -40,12 +41,12 @@ export default {
         waitUntil,
         buyerIp: getBuyerIp(request),
         i18n: {language: 'EN', country: 'US'},
+        requestGroupId: getRequestGroupId(request),
         publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: `https://${env.PUBLIC_STORE_DOMAIN}`,
         storefrontApiVersion: env.PUBLIC_STOREFRONT_API_VERSION || '2023-01',
         storefrontId: env.PUBLIC_STOREFRONT_ID,
-        requestGroupId: request.headers.get('request-id'),
       });
 
       /**

--- a/templates/skeleton/server.ts
+++ b/templates/skeleton/server.ts
@@ -4,6 +4,7 @@ import {createStorefrontClient, storefrontRedirect} from '@shopify/hydrogen';
 import {
   createRequestHandler,
   getBuyerIp,
+  getRequestGroupId,
   createCookieSessionStorage,
   type SessionStorage,
   type Session,
@@ -40,12 +41,12 @@ export default {
         waitUntil,
         buyerIp: getBuyerIp(request),
         i18n: {language: 'EN', country: 'US'},
+        requestGroupId: getRequestGroupId(request),
         publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: `https://${env.PUBLIC_STORE_DOMAIN}`,
         storefrontApiVersion: env.PUBLIC_STOREFRONT_API_VERSION || '2023-01',
         storefrontId: env.PUBLIC_STOREFRONT_ID,
-        requestGroupId: request.headers.get('request-id'),
       });
 
       /**


### PR DESCRIPTION
I think knowing the header `'request-id'` should be a concern of Oxygen, just like we have `getBuyerIp` for the `'oxygen-buyer-ip'` header.

Thoughts?