### PR TITLE
Generate SEO tags refactor for better types

### DIFF
--- a/packages/hydrogen/README.md
+++ b/packages/hydrogen/README.md
@@ -1,18 +1,18 @@
 <div align="center">
 
 # Hydrogen
-  
+
 [![MIT License](https://img.shields.io/github/license/shopify/hydrogen)](LICENSE.md)
 [![npm downloads](https://img.shields.io/npm/dm/@shopify/hydrogen.svg?sanitize=true)](https://npmcharts.com/compare/@shopify/hydrogen?minimal=true)
 
 Hydrogen is Shopify’s stack for headless commerce. It provides a set of tools, utilities, and best-in-class examples for building dynamic and performant commerce applications. Hydrogen is designed to dovetail with [Remix](https://remix.run/), Shopify’s full stack web framework, but it also provides a React library portable to other supporting frameworks.
 
-
 **Create a Hydrogen app**
 
- ```bash
- npm create @shopify/hydrogen@latest
- ```
+```bash
+npm create @shopify/hydrogen@latest
+```
+
  </div>
 
 - Interested in contributing to Hydrogen? [Read our contributing guide](../../CONTRIBUTING.md)

--- a/packages/hydrogen/src/seo/generate-seo-tags.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.ts
@@ -8,7 +8,11 @@ const ERROR_PREFIX = 'Error in SEO input: ';
 // other places. @cartogram
 export const schema = {
   title: {
-    validate: (value: unknown) => {
+    validate: <T>(value: Maybe<T>): NonNullable<T> => {
+      if (typeof value !== 'string') {
+        throw new Error(ERROR_PREFIX.concat('`title` should be a string'));
+      }
+
       if (typeof value === 'string' && value.length > 120) {
         throw new Error(
           ERROR_PREFIX.concat(
@@ -16,11 +20,18 @@ export const schema = {
           ),
         );
       }
+
       return value;
     },
   },
   description: {
-    validate: (value: unknown) => {
+    validate: <T>(value: Maybe<T>): NonNullable<T> => {
+      if (typeof value !== 'string') {
+        throw new Error(
+          ERROR_PREFIX.concat('`description` should be a string'),
+        );
+      }
+
       if (typeof value === 'string' && value.length > 155) {
         throw new Error(
           ERROR_PREFIX.concat(
@@ -28,19 +39,29 @@ export const schema = {
           ),
         );
       }
+
       return value;
     },
   },
   url: {
-    validate: (value: unknown) => {
+    validate: <T>(value: Maybe<T>): NonNullable<T> => {
+      if (typeof value !== 'string') {
+        throw new Error(ERROR_PREFIX.concat('`url` should be a string'));
+      }
+
       if (typeof value === 'string' && !value.startsWith('http')) {
         throw new Error(ERROR_PREFIX.concat('`url` should be a valid URL'));
       }
+
       return value;
     },
   },
   handle: {
-    validate: (value: unknown) => {
+    validate: <T>(value: Maybe<T>): NonNullable<T> => {
+      if (typeof value !== 'string') {
+        throw new Error(ERROR_PREFIX.concat('`handle` should be a string'));
+      }
+
       if (typeof value === 'string' && !value.startsWith('@')) {
         throw new Error(ERROR_PREFIX.concat('`handle` should start with `@`'));
       }
@@ -91,6 +112,7 @@ export interface SeoConfig<Schema extends Thing = Thing> {
    *   ]
    * }
    * ```
+   *
    */
   media?:
     | Maybe<string>
@@ -175,6 +197,7 @@ export interface SeoConfig<Schema extends Thing = Thing> {
    * @see https://schema.org/docs/schemas.html
    * @see https://developers.google.com/search/docs/guides/intro-structured-data
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
+   *
    */
   jsonLd?: WithContext<Schema> | WithContext<Schema>[];
   /**
@@ -334,275 +357,237 @@ export function generateSeoTags<
   Schema extends Thing,
   T extends SeoConfig<Schema> = SeoConfig<Schema>,
 >(seoInput: T): CustomHeadTagObject[] {
-  const output: CustomHeadTagObject[] = [];
+  const tagResults: CustomHeadTagObject[] = [];
 
   for (const seoKey of Object.keys(seoInput)) {
-    const keyValue = seoInput[seoKey as keyof T];
-    const values = ensureArray(keyValue);
-    let content;
+    switch (seoKey) {
+      case 'title': {
+        const content = validate(schema.title, seoInput.title);
+        const title = renderTitle(seoInput?.titleTemplate, content);
 
-    if (!values) {
-      return [];
-    }
-
-    const tags = values.map((value) => {
-      const tagResults: CustomHeadTagObject[] = [];
-
-      if (!value) {
-        return tagResults;
-      }
-
-      switch (seoKey) {
-        case 'title': {
-          content = validate(schema.title, value) as string;
-
-          const title = renderTitle(seoInput?.titleTemplate, content);
-
-          tagResults.push(
-            generateTag('title', {title}),
-            generateTag('meta', {property: 'og:title', content: title}),
-            generateTag('meta', {name: 'twitter:title', content: title}),
-          );
-
+        if (!title) {
           break;
         }
 
-        case 'description':
-          content = validate(schema.description, value) as string;
+        tagResults.push(
+          generateTag('title', {title}),
+          generateTag('meta', {property: 'og:title', content: title}),
+          generateTag('meta', {name: 'twitter:title', content: title}),
+        );
 
-          tagResults.push(
-            generateTag('meta', {
-              name: 'description',
-              content,
-            }),
-            generateTag('meta', {
-              property: 'og:description',
-              content,
-            }),
-            generateTag('meta', {
-              name: 'twitter:description',
-              content,
-            }),
-          );
+        break;
+      }
 
+      case 'description': {
+        const content = validate(schema.description, seoInput.description);
+
+        if (!content) {
           break;
+        }
 
-        case 'url':
-          content = validate(schema.url, value) as string;
+        tagResults.push(
+          generateTag('meta', {
+            name: 'description',
+            content,
+          }),
+          generateTag('meta', {
+            property: 'og:description',
+            content,
+          }),
+          generateTag('meta', {
+            name: 'twitter:description',
+            content,
+          }),
+        );
 
-          tagResults.push(
-            generateTag('meta', {property: 'og:url', content}),
-            generateTag('link', {rel: 'canonical', href: content}),
-          );
+        break;
+      }
 
+      case 'url': {
+        const content = validate(schema.url, seoInput.url);
+
+        if (!content) {
           break;
+        }
 
-        case 'handle':
-          content = validate(schema.handle, value) as string;
+        tagResults.push(
+          generateTag('link', {
+            rel: 'canonical',
+            href: content,
+          }),
+          generateTag('meta', {
+            property: 'og:url',
+            content,
+          }),
+        );
 
-          tagResults.push(
-            generateTag('meta', {name: 'twitter:site', content}),
-            generateTag('meta', {name: 'twitter:creator', content}),
-          );
+        break;
+      }
 
+      case 'handle': {
+        const content = validate(schema.handle, seoInput.handle);
+
+        if (!content) {
           break;
+        }
 
-        case 'media': {
-          const values = ensureArray(value as unknown as SeoConfig['media']);
+        tagResults.push(
+          generateTag('meta', {name: 'twitter:site', content}),
+          generateTag('meta', {name: 'twitter:creator', content}),
+        );
 
-          for (const media of values) {
-            if (typeof media === 'string') {
-              tagResults.push(
-                generateTag('meta', {name: 'og:image', content: media}),
-              );
-            }
+        break;
+      }
 
-            if (media && typeof media === 'object') {
-              const type = media.type || 'image';
+      case 'media': {
+        let content;
+        const values = ensureArray(seoInput.media);
 
-              // Order matters here when adding multiple media tags @see https://ogp.me/#array
-              const normalizedMedia = media
-                ? {
-                    url: media?.url,
-                    secure_url: media?.url,
-                    type: inferMimeType(media.url),
-                    width: media?.width,
-                    height: media?.height,
-                    alt: media?.altText,
-                  }
-                : {};
+        for (const media of values) {
+          if (typeof media === 'string') {
+            tagResults.push(
+              generateTag('meta', {name: 'og:image', content: media}),
+            );
+          }
 
-              for (const key of Object.keys(normalizedMedia)) {
-                if (normalizedMedia[key as keyof typeof normalizedMedia]) {
-                  content = normalizedMedia[
-                    key as keyof typeof normalizedMedia
-                  ] as string;
+          if (media && typeof media === 'object') {
+            const type = media.type || 'image';
 
-                  tagResults.push(
-                    generateTag(
-                      'meta',
-                      {
-                        property: `og:${type}:${key}`,
-                        content,
-                      },
-                      normalizedMedia.url as string,
-                    ),
-                  );
+            // Order matters here when adding multiple media tags @see https://ogp.me/#array
+            const normalizedMedia = media
+              ? {
+                  url: media?.url,
+                  secure_url: media?.url,
+                  type: inferMimeType(media.url),
+                  width: media?.width,
+                  height: media?.height,
+                  alt: media?.altText,
                 }
+              : {};
+
+            for (const key of Object.keys(normalizedMedia)) {
+              if (normalizedMedia[key as keyof typeof normalizedMedia]) {
+                content = normalizedMedia[
+                  key as keyof typeof normalizedMedia
+                ] as string;
+
+                tagResults.push(
+                  generateTag(
+                    'meta',
+                    {
+                      property: `og:${type}:${key}`,
+                      content,
+                    },
+                    normalizedMedia.url as string,
+                  ),
+                );
               }
             }
           }
-          break;
         }
+        break;
+      }
 
-        case 'jsonLd': {
+      case 'jsonLd': {
+        const jsonLdBlocks = ensureArray(seoInput.jsonLd);
+        let index = 0;
+        for (const block of jsonLdBlocks) {
+          if (typeof block !== 'object') {
+            continue;
+          }
+
           const tag = generateTag(
             'script',
             {
               type: 'application/ld+json',
-              children: JSON.stringify(value),
+              children: JSON.stringify(block),
             },
             // @ts-expect-error
-            `json-ld-${value?.['@type'] || value?.name || ''}`,
+            `json-ld-${block?.['@type'] || block?.name || index++}`,
           );
 
           tagResults.push(tag);
-
-          break;
         }
 
-        case 'alternates': {
-          const alternates = ensureArray(
-            value as unknown as SeoConfig['alternates'],
-          );
-
-          for (const alternate of alternates) {
-            if (!alternate) {
-              continue;
-            }
-
-            const {language, url, default: defaultLang} = alternate;
-
-            const hrefLang = language
-              ? `${language}${defaultLang ? '-default' : ''}`
-              : undefined;
-
-            tagResults.push(
-              generateTag('link', {
-                rel: 'alternate',
-                hrefLang,
-                href: url,
-              }),
-            );
-          }
-
-          break;
-        }
-
-        case 'robots':
-          // Robots
-          const {
-            maxImagePreview,
-            maxSnippet,
-            maxVideoPreview,
-            noArchive,
-            noFollow,
-            noImageIndex,
-            noIndex,
-            noSnippet,
-            noTranslate,
-            unavailableAfter,
-          } = value as RobotsOptions;
-
-          const robotsParams = [
-            noArchive && 'noarchive',
-            noImageIndex && 'noimageindex',
-            noSnippet && 'nosnippet',
-            noTranslate && `notranslate`,
-            maxImagePreview && `max-image-preview:${maxImagePreview}`,
-            maxSnippet && `max-snippet:${maxSnippet}`,
-            maxVideoPreview && `max-video-preview:${maxVideoPreview}`,
-            unavailableAfter && `unavailable_after:${unavailableAfter}`,
-          ];
-
-          let robotsParam =
-            (noIndex ? 'noindex' : 'index') +
-            ',' +
-            (noFollow ? 'nofollow' : 'follow');
-
-          for (let param of robotsParams) {
-            if (param) {
-              robotsParam += `,${param}`;
-            }
-          }
-
-          tagResults.push(
-            generateTag('meta', {name: 'robots', content: robotsParam}),
-          );
-
-          break;
+        break;
       }
 
-      return tagResults;
-    });
+      case 'alternates': {
+        const alternates = ensureArray(seoInput.alternates);
 
-    const entries: CustomHeadTagObject[] = tags
-      .flat()
-      .filter((value) => !!value);
+        for (const alternate of alternates) {
+          if (!alternate) {
+            continue;
+          }
 
-    output.push(...entries);
+          const {language, url, default: defaultLang} = alternate;
+
+          const hrefLang = language
+            ? `${language}${defaultLang ? '-default' : ''}`
+            : undefined;
+
+          tagResults.push(
+            generateTag('link', {
+              rel: 'alternate',
+              hrefLang,
+              href: url,
+            }),
+          );
+        }
+
+        break;
+      }
+
+      case 'robots': {
+        if (!seoInput.robots) {
+          break;
+        }
+
+        const {
+          maxImagePreview,
+          maxSnippet,
+          maxVideoPreview,
+          noArchive,
+          noFollow,
+          noImageIndex,
+          noIndex,
+          noSnippet,
+          noTranslate,
+          unavailableAfter,
+        } = seoInput.robots;
+
+        const robotsParams = [
+          noArchive && 'noarchive',
+          noImageIndex && 'noimageindex',
+          noSnippet && 'nosnippet',
+          noTranslate && `notranslate`,
+          maxImagePreview && `max-image-preview:${maxImagePreview}`,
+          maxSnippet && `max-snippet:${maxSnippet}`,
+          maxVideoPreview && `max-video-preview:${maxVideoPreview}`,
+          unavailableAfter && `unavailable_after:${unavailableAfter}`,
+        ];
+
+        let robotsParam =
+          (noIndex ? 'noindex' : 'index') +
+          ',' +
+          (noFollow ? 'nofollow' : 'follow');
+
+        for (let param of robotsParams) {
+          if (param) {
+            robotsParam += `,${param}`;
+          }
+        }
+
+        tagResults.push(
+          generateTag('meta', {name: 'robots', content: robotsParam}),
+        );
+
+        break;
+      }
+    }
   }
 
-  return output.sort((a, b) => a.key.localeCompare(b.key));
-}
-
-function renderTitle<T extends CustomHeadTagObject['children']>(
-  template?:
-    | string
-    | ((title?: string) => string | undefined)
-    | undefined
-    | null,
-  title?: T,
-): string | undefined {
-  if (!template) {
-    return title;
-  }
-
-  if (typeof template === 'function') {
-    return template(title);
-  }
-
-  return template.replace('%s', title ?? '');
-}
-
-function inferMimeType(url: Maybe<string> | undefined) {
-  const ext = url && url.split('.').pop();
-
-  if (ext === 'svg') {
-    return 'image/svg+xml';
-  }
-
-  if (ext === 'png') {
-    return 'image/png';
-  }
-
-  if (ext === 'jpg' || ext === 'jpeg') {
-    return 'image/jpeg';
-  }
-
-  if (ext === 'gif') {
-    return 'image/gif';
-  }
-
-  if (ext === 'swf') {
-    return 'application/x-shockwave-flash';
-  }
-
-  if (ext === 'mp3') {
-    return 'audio/mpeg';
-  }
-
-  return 'image/jpeg';
+  return tagResults.flat().sort((a, b) => a.key.localeCompare(b.key));
 }
 
 type MetaTagProps =
@@ -654,7 +639,7 @@ export function generateTag(
 
   // also move the input children to children and delete it
   if (tagName === 'script') {
-    tag.children = input.children as string;
+    tag.children = typeof input.children === 'string' ? input.children : '';
     tag.key = generateKey(tag, group);
     delete input.children;
     tag.props = input;
@@ -719,22 +704,137 @@ export function generateKey(tag: CustomHeadTagObject, group?: string) {
   return `${tagName}-${props.type}`;
 }
 
-export function ensureArray<T>(value: T | T[]): T[] {
+function renderTitle<T extends CustomHeadTagObject['children']>(
+  template?:
+    | string
+    | ((title: string) => string | undefined)
+    | undefined
+    | null,
+  title?: T | null,
+): string | undefined {
+  if (!title) {
+    return undefined;
+  }
+
+  if (!template) {
+    return title;
+  }
+
+  if (typeof template === 'function') {
+    return template(title);
+  }
+
+  return template.replace('%s', title ?? '');
+}
+
+function inferMimeType(url: Maybe<string> | undefined) {
+  const ext = url && url.split('.').pop();
+
+  if (ext === 'svg') {
+    return 'image/svg+xml';
+  }
+
+  if (ext === 'png') {
+    return 'image/png';
+  }
+
+  if (ext === 'jpg' || ext === 'jpeg') {
+    return 'image/jpeg';
+  }
+
+  if (ext === 'gif') {
+    return 'image/gif';
+  }
+
+  if (ext === 'swf') {
+    return 'application/x-shockwave-flash';
+  }
+
+  if (ext === 'mp3') {
+    return 'audio/mpeg';
+  }
+
+  return 'image/jpeg';
+}
+
+export type SchemaType =
+  | 'Product'
+  | 'ItemList'
+  | 'Organization'
+  | 'WebSite'
+  | 'WebPage'
+  | 'BlogPosting'
+  | 'Thing';
+
+function inferSchemaType(url: Maybe<string> | undefined): SchemaType {
+  const defaultType = 'Thing';
+
+  if (!url) {
+    return defaultType;
+  }
+
+  const routes: {type: SchemaType; pattern: RegExp | string}[] = [
+    {
+      type: 'WebSite',
+      pattern: '^/$',
+    },
+    {
+      type: 'Product',
+      pattern: '/products/.*',
+    },
+    {
+      type: 'ItemList',
+      pattern: /\/collections$/,
+    },
+    {
+      type: 'ItemList',
+      pattern: /\/collections\/([^/]+)/,
+    },
+    {
+      type: 'WebPage',
+      pattern: /\/pages\/([^/]+)/,
+    },
+    {
+      type: 'WebSite',
+      pattern: /\/blogs\/([^/]+)/,
+    },
+    {
+      type: 'BlogPosting',
+      pattern: /\/blogs\/([^/]+)\/([^/]+)/,
+    },
+    {
+      type: 'Organization',
+      pattern: '/policies',
+    },
+    {
+      type: 'Organization',
+      pattern: /\/policies\/([^/]+)/,
+    },
+  ];
+
+  const typeMatches = routes.filter((route) => {
+    const {pattern} = route;
+    const regex = new RegExp(pattern);
+    return regex.test(url);
+  });
+
+  return typeMatches.length > 0
+    ? typeMatches[typeMatches.length - 1].type
+    : defaultType;
+}
+
+function ensureArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value];
 }
 
-export function validate(
-  schema: {validate: (data: unknown) => unknown},
-  data: unknown,
-) {
+function validate<T>(
+  schema: {validate: <T>(data: T) => NonNullable<T>},
+  data: T,
+): T {
   try {
-    return schema.validate(data);
+    return schema.validate<T>(data);
   } catch (error: unknown) {
-    const message = (error as Error).message;
-
-    // TODO: Discuss consistency of logging run time warnings/helpers
-    console.warn(message);
-
+    console.warn((error as Error).message);
     return data;
   }
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

This PR revisits some typescript improvements I have had on the back-burner. 

### WHAT is this pull request doing?

I've been struggling to achieve the proper type inference when iterating over the object keys in the SEO config. I experimented with Array methods and using the `is` operator, but the code was harder to follow. By moving the iteration outside of the nested array, it both simplifies things and removes a handful of casts.

There is still some more work to do here, but this was a first step that we can merge without issue.

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

Everything should still work, specifically SEO information still displays when running the demo-store.

All existing tests should still pass.

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
