### PR TITLE
[DemoStore] Show `CartSummary` with 0$ carts

### DIFF
--- a/templates/demo-store/app/components/Cart.tsx
+++ b/templates/demo-store/app/components/Cart.tsx
@@ -49,8 +49,6 @@ export function CartDetails({
   cart: CartType | null;
 }) {
   // @todo: get optimistic cart cost
-  const isZeroCost = !cart || cart?.cost?.subtotalAmount?.amount === '0.0';
-
   const container = {
     drawer: 'grid grid-cols-1 h-screen-no-nav grid-rows-[1fr_auto]',
     page: 'w-full pb-12 grid md:grid-cols-2 md:items-start gap-8 md:gap-8 lg:gap-12',
@@ -59,7 +57,7 @@ export function CartDetails({
   return (
     <div className={container[layout]}>
       <CartLines lines={cart?.lines} layout={layout} />
-      {!isZeroCost && (
+      {cart && (
         <CartSummary cost={cart.cost} layout={layout}>
           <CartDiscounts discountCodes={cart.discountCodes} />
           <CartCheckoutActions checkoutUrl={cart.checkoutUrl} />


### PR DESCRIPTION
Update the Cart logic for the Demo store to show the `CartSummary` component even if the cart total is 0$.

### WHY are these changes introduced?
While testing with a store with free products, I could not checkout and figured we should allow checkout even with 0$ carts.

### WHAT is this pull request doing?
Remove the `cart?.cost?.subtotalAmount?.amount === '0.0'` condition.

### HOW to test your changes?
Add 0$ product in your cart and ensure you see the `Continue to checkout` button from the cart view.


#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes

