### PR TITLE
Support Remix HMR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27029,6 +27029,7 @@
         "@types/prettier": "^2.7.2",
         "@types/recursive-readdir": "^2.2.1",
         "@types/tar-fs": "^2.0.1",
+        "get-port": "^6.1.2",
         "oclif": "^3.4.2",
         "tempy": "^3.0.0",
         "vitest": "^0.28.1"
@@ -27056,6 +27057,18 @@
         "node": ">=8.6.0"
       }
     },
+    "packages/cli/node_modules/get-port": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/create-hydrogen": {
       "name": "@shopify/create-hydrogen",
       "version": "4.0.4",
@@ -27072,7 +27085,8 @@
       "version": "2023.1.5",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@shopify/hydrogen-react": "2023.1.6"
+        "@shopify/hydrogen-react": "2023.1.6",
+        "react": "^18.2.0"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,9 +21,10 @@
     "@types/prettier": "^2.7.2",
     "@types/recursive-readdir": "^2.2.1",
     "@types/tar-fs": "^2.0.1",
+    "get-port": "^6.1.2",
     "oclif": "^3.4.2",
-    "vitest": "^0.28.1",
-    "tempy": "^3.0.0"
+    "tempy": "^3.0.0",
+    "vitest": "^0.28.1"
   },
   "peerDependencies": {
     "@remix-run/react": "^1.14.0",

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -7,6 +7,7 @@ import {muteDevLogs} from '../../utils/log.js';
 import {
   deprecated,
   commonFlags,
+  DEFAULT_PORT,
   flagsToCamelObject,
 } from '../../utils/flags.js';
 import Command from '@shopify/cli-kit/node/base-command';
@@ -14,6 +15,7 @@ import Flags from '@oclif/core/lib/flags.js';
 import {startMiniOxygen} from '../../utils/mini-oxygen.js';
 import {checkHydrogenVersion} from '../../utils/check-version.js';
 import {addVirtualRoutes} from '../../utils/virtual-routes.js';
+import {findPort} from '../../utils/find-port.js';
 
 const LOG_INITIAL_BUILD = '\n🏁 Initial build';
 const LOG_REBUILDING = '🧱 Rebuilding...';
@@ -44,7 +46,7 @@ export default class Dev extends Command {
 }
 
 async function runDev({
-  port,
+  port: portReference = DEFAULT_PORT,
   path: appPath,
   disableVirtualRoutes,
 }: {
@@ -75,6 +77,8 @@ async function runDev({
   };
 
   const serverBundleExists = () => file.exists(buildPathWorkerFile);
+
+  const port = await findPort(portReference);
 
   let miniOxygenStarted = false;
   async function safeStartMiniOxygen() {

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -1,8 +1,9 @@
 import Command from '@shopify/cli-kit/node/base-command';
 import {muteDevLogs} from '../../utils/log.js';
 import {getProjectPaths} from '../../utils/config.js';
-import {commonFlags} from '../../utils/flags.js';
+import {commonFlags, DEFAULT_PORT} from '../../utils/flags.js';
 import {startMiniOxygen} from '../../utils/mini-oxygen.js';
+import {findPort} from '../../utils/find-port.js';
 
 export default class Preview extends Command {
   static description =
@@ -21,7 +22,7 @@ export default class Preview extends Command {
 }
 
 export async function runPreview({
-  port,
+  port = DEFAULT_PORT,
   path: appPath,
 }: {
   port?: number;
@@ -35,7 +36,7 @@ export async function runPreview({
 
   await startMiniOxygen({
     root,
-    port,
+    port: await findPort(port),
     buildPathClient,
     buildPathWorkerFile,
   });

--- a/packages/cli/src/utils/find-port.ts
+++ b/packages/cli/src/utils/find-port.ts
@@ -1,0 +1,7 @@
+import getPort, {portNumbers} from 'get-port';
+
+export function findPort(portPreference: number, range = 100) {
+  return getPort({
+    port: portNumbers(portPreference, portPreference + range),
+  });
+}

--- a/packages/cli/src/utils/flags.ts
+++ b/packages/cli/src/utils/flags.ts
@@ -3,6 +3,8 @@ import {string as stringUtils} from '@shopify/cli-kit';
 import {renderInfo} from '@shopify/cli-kit/node/ui';
 import colors from '@shopify/cli-kit/node/colors';
 
+export const DEFAULT_PORT = 3000;
+
 export const commonFlags = {
   path: Flags.string({
     description:
@@ -12,7 +14,7 @@ export const commonFlags = {
   port: Flags.integer({
     description: 'Port to run the server on.',
     env: 'SHOPIFY_HYDROGEN_FLAG_PORT',
-    default: 3000,
+    default: DEFAULT_PORT,
   }),
   force: Flags.boolean({
     description:

--- a/packages/cli/src/utils/live-reload.ts
+++ b/packages/cli/src/utils/live-reload.ts
@@ -1,0 +1,106 @@
+// Support Remix 0.14 HMR and HDR.
+// Most of this file is copied from Remix 0.14's `@remix-run/dev` package.
+// https://github.com/remix-run/remix/blob/%40remix-run/dev%401.14.0/packages/remix-dev/devServer2.ts
+// Requirements:
+// - Enable `future.unstable_dev` in `remix.config.js`
+// - Add <LiveReload /> to the root of your app
+
+import type {AssetsManifest, ResolvedRemixConfig} from '@remix-run/dev';
+import type {updates as HMRUpdates} from '@remix-run/dev/dist/hmr.js';
+import type {serve as LiveReloadServe} from '@remix-run/dev/dist/liveReload.js';
+import type {CompileResult} from '@remix-run/dev/dist/compiler/index.js';
+
+type LiveReload = {
+  hmrUpdates: typeof HMRUpdates;
+  socket: ReturnType<typeof LiveReloadServe>;
+  onInitialBuild: (build?: CompileResult) => void;
+  hotUpdate: (build?: CompileResult) => void;
+  previousBuild?: CompileResult;
+};
+
+export async function setupLiveReload(
+  config: ResolvedRemixConfig,
+  appPort: number,
+) {
+  let liveReload: LiveReload | undefined;
+
+  if (config.future?.unstable_dev) {
+    try {
+      const {updates} = await import('@remix-run/dev/dist/hmr.js');
+      const {serve} = await import('@remix-run/dev/dist/liveReload.js');
+      liveReload = {
+        hmrUpdates: updates,
+        socket: await serve({port: config.devServerPort}),
+        onInitialBuild: (build?: CompileResult) => {
+          liveReload!.previousBuild = build;
+        },
+        hotUpdate: (build?: CompileResult) =>
+          hotUpdate(config, liveReload!, appPort, build),
+      };
+    } catch (error) {
+      console.warn(
+        'Could not start HMR server. Please make sure you are using the latest version of Remix.' +
+          ' Defaulting to regular live reload.',
+        (error as Error).stack,
+      );
+    }
+  }
+
+  return liveReload;
+}
+
+async function hotUpdate(
+  config: ResolvedRemixConfig,
+  liveReload: LiveReload,
+  appPort: number,
+  build?: CompileResult,
+) {
+  if (build) {
+    const {assetsManifest} = build;
+
+    await waitForAppServer(
+      assetsManifest.version,
+      config.future.unstable_dev,
+      appPort,
+    );
+
+    if (assetsManifest.hmr && liveReload.previousBuild) {
+      liveReload.socket.hmr(
+        assetsManifest,
+        liveReload.hmrUpdates(config, build, liveReload.previousBuild),
+      );
+    } else {
+      liveReload.socket.reload();
+    }
+  }
+
+  liveReload.previousBuild = build;
+}
+
+// Copied from Remix:
+async function waitForAppServer(
+  buildHash: string,
+  unstableDev: ResolvedRemixConfig['future']['unstable_dev'],
+  appPort: number,
+) {
+  const dev = typeof unstableDev === 'boolean' ? {} : unstableDev;
+  const url = `http://localhost:${dev.appServerPort ?? appPort}${
+    dev.remixRequestHandlerPath ?? ''
+  }/__REMIX_ASSETS_MANIFEST`;
+
+  while (true) {
+    try {
+      let res = await fetch(url);
+      let assetsManifest = (await res.json()) as AssetsManifest;
+      if (assetsManifest?.version === buildHash) break;
+    } catch {
+      //
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, dev.rebuildPollIntervalMs ?? 50),
+    );
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, -1));
+}


### PR DESCRIPTION
Related: #582

I'm trying to understand what we need to support Remix HMR in MiniOxygen. Not sure if we should merge this since part of the Remix internals is currently copied (`live-reload.ts` file) and it could break in Remix@0.15.

Requirements:

1. Ensure it's running Remix 0.14
2. Add `<LiveReload />` to `root.tsx`
3. Add `future: {unstable_dev: true}` to `remix.config.js`

A way to test this is writing something in the search input at the top, then modify anything in the page and save. The typed text should not be removed when updating.