### PR TITLE
(templates): Stop hydrating with requestIdleCallback

### DIFF
--- a/.changeset/witty-goats-tap.md
+++ b/.changeset/witty-goats-tap.md
@@ -1,0 +1,6 @@
+---
+'@shopify/create-hydrogen': patch
+'@shopify/cli-hydrogen': patch
+---
+
+Stop hydrating with `requestIdleCallback`

--- a/templates/demo-store/app/entry.client.tsx
+++ b/templates/demo-store/app/entry.client.tsx
@@ -2,21 +2,11 @@ import {RemixBrowser} from '@remix-run/react';
 import {startTransition, StrictMode} from 'react';
 import {hydrateRoot} from 'react-dom/client';
 
-function hydrate() {
-  startTransition(() => {
-    hydrateRoot(
-      document,
-      <StrictMode>
-        <RemixBrowser />
-      </StrictMode>,
-    );
-  });
-}
-
-if (typeof requestIdleCallback === 'function') {
-  requestIdleCallback(hydrate);
-} else {
-  // Safari doesn't support requestIdleCallback
-  // https://caniuse.com/requestidlecallback
-  setTimeout(hydrate, 1);
-}
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>,
+  );
+});

--- a/templates/hello-world/app/entry.client.tsx
+++ b/templates/hello-world/app/entry.client.tsx
@@ -2,21 +2,11 @@ import {RemixBrowser} from '@remix-run/react';
 import {startTransition, StrictMode} from 'react';
 import {hydrateRoot} from 'react-dom/client';
 
-function hydrate() {
-  startTransition(() => {
-    hydrateRoot(
-      document,
-      <StrictMode>
-        <RemixBrowser />
-      </StrictMode>,
-    );
-  });
-}
-
-if (typeof requestIdleCallback === 'function') {
-  requestIdleCallback(hydrate);
-} else {
-  // Safari doesn't support requestIdleCallback
-  // https://caniuse.com/requestidlecallback
-  setTimeout(hydrate, 1);
-}
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>,
+  );
+});

--- a/templates/skeleton/app/entry.client.tsx
+++ b/templates/skeleton/app/entry.client.tsx
@@ -2,21 +2,11 @@ import {RemixBrowser} from '@remix-run/react';
 import {startTransition, StrictMode} from 'react';
 import {hydrateRoot} from 'react-dom/client';
 
-function hydrate() {
-  startTransition(() => {
-    hydrateRoot(
-      document,
-      <StrictMode>
-        <RemixBrowser />
-      </StrictMode>,
-    );
-  });
-}
-
-if (typeof requestIdleCallback === 'function') {
-  requestIdleCallback(hydrate);
-} else {
-  // Safari doesn't support requestIdleCallback
-  // https://caniuse.com/requestidlecallback
-  setTimeout(hydrate, 1);
-}
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>,
+  );
+});


### PR DESCRIPTION
### WHY are these changes introduced?

Hydrating with `requestIdleCallback` can cause the following issues
- If a site is loaded within a cross-origin iframe it will cause the site to wait until the user clicks into the iframe to perform hydration.
- It will defer hydration when a page is loaded in a new tab.
- It will defer hydration for a really long time when Chrome's Battery Saver mode is on.

Thanks to @developit for highlighting all the above 🙏🏼 

TLDR;
https://shopify.slack.com/archives/C04SRS2C10A/p1678401031037239

### WHAT is this pull request doing?

Avoid waiting for an idle frame to hydrate the app.

### HOW to test your changes?

Demo store should be interactive after this change.

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
