### PR TITLE
Add missing isbot dep for hello-world and skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15897,8 +15897,9 @@
       }
     },
     "node_modules/isbot": {
-      "version": "3.6.5",
-      "license": "Unlicense",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.6.tgz",
+      "integrity": "sha512-98aGl1Spbx1led422YFrusDJ4ZutSNOymb2avZ2V4BCCjF3MqAF2k+J2zoaLYahubaFkb+3UyvbVDVlk/Ngrew==",
       "engines": {
         "node": ">=12"
       }
@@ -27429,6 +27430,7 @@
         "@shopify/remix-oxygen": "^1.0.3",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
+        "isbot": "^3.6.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -27458,6 +27460,7 @@
         "@shopify/remix-oxygen": "^1.0.3",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
+        "isbot": "^3.6.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },

--- a/templates/hello-world/package.json
+++ b/templates/hello-world/package.json
@@ -20,6 +20,7 @@
     "@shopify/remix-oxygen": "^1.0.3",
     "graphql": "^16.6.0",
     "graphql-tag": "^2.12.6",
+    "isbot": "^3.6.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -19,6 +19,7 @@
     "@shopify/remix-oxygen": "^1.0.3",
     "graphql": "^16.6.0",
     "graphql-tag": "^2.12.6",
+    "isbot": "^3.6.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

We're depending on `isbot` inside `entry.server` for both `hello-world` and `skeleton`, but we haven't listed these in our dependencies.

I _think_ Remix automatically saves our butt by installing it when necessary, but this breaks down if you attempt to use the hello-world template as a Remix stack, for example.
