### PR TITLE
(demo-store): Fix account routing

### DIFF
--- a/templates/demo-store/app/components/Icon.tsx
+++ b/templates/demo-store/app/components/Icon.tsx
@@ -145,6 +145,25 @@ export function IconBag(props: IconProps) {
   );
 }
 
+export function IconLogin(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <title>Login</title>
+      <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+        <path
+          d="M8,10.6928545 C10.362615,10.6928545 12.4860225,11.7170237 13.9504747,13.3456144 C12.4860225,14.9758308 10.362615,16 8,16 C5.63738499,16 3.51397752,14.9758308 2.04952533,13.3472401 C3.51397752,11.7170237 5.63738499,10.6928545 8,10.6928545 Z"
+          fill="currentColor"
+        ></path>
+        <path
+          d="M8,3.5 C6.433,3.5 5.25,4.894 5.25,6.5 C5.25,8.106 6.433,9.5 8,9.5 C9.567,9.5 10.75,8.106 10.75,6.5 C10.75,4.894 9.567,3.5 8,3.5 Z"
+          fill="currentColor"
+          fillRule="nonzero"
+        ></path>
+      </g>
+    </Icon>
+  );
+}
+
 export function IconAccount(props: IconProps) {
   return (
     <Icon {...props}>

--- a/templates/demo-store/app/components/Layout.tsx
+++ b/templates/demo-store/app/components/Layout.tsx
@@ -8,6 +8,7 @@ import {
   useDrawer,
   Text,
   Input,
+  IconLogin,
   IconAccount,
   IconBag,
   IconSearch,
@@ -231,12 +232,7 @@ function MobileHeader({
       </Link>
 
       <div className="flex items-center justify-end w-full gap-4">
-        <Link
-          to="/account"
-          className="relative flex items-center justify-center w-8 h-8"
-        >
-          <IconAccount />
-        </Link>
+        <AccountLink className="relative flex items-center justify-center w-8 h-8" />
         <CartCount isHome={isHome} openCart={openCart} />
       </div>
     </header>
@@ -312,15 +308,24 @@ function DesktopHeader({
             <IconSearch />
           </button>
         </Form>
-        <Link
-          to="/account"
-          className="relative flex items-center justify-center w-8 h-8 focus:ring-primary/5"
-        >
-          <IconAccount />
-        </Link>
+        <AccountLink className="relative flex items-center justify-center w-8 h-8 focus:ring-primary/5" />
         <CartCount isHome={isHome} openCart={openCart} />
       </div>
     </header>
+  );
+}
+
+function AccountLink({className}: {className?: string}) {
+  const [root] = useMatches();
+  const isLoggedIn = root.data?.isLoggedIn;
+  return isLoggedIn ? (
+    <Link to="/account" className={className}>
+      <IconAccount />
+    </Link>
+  ) : (
+    <Link to="/account/login" className={className}>
+      <IconLogin />
+    </Link>
   );
 }
 

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -48,7 +48,8 @@ export const meta: MetaFunction = () => ({
 });
 
 export async function loader({request, context}: LoaderArgs) {
-  const [cartId, layout] = await Promise.all([
+  const [customerAccessToken, cartId, layout] = await Promise.all([
+    context.session.get('customerAccessToken'),
     context.session.get('cartId'),
     getLayoutData(context),
   ]);
@@ -56,6 +57,7 @@ export async function loader({request, context}: LoaderArgs) {
   const seo = seoPayload.root({shop: layout.shop, url: request.url});
 
   return defer({
+    isLoggedIn: Boolean(customerAccessToken),
     layout,
     selectedLocale: context.storefront.i18n,
     cart: cartId ? getCart(context, cartId) : undefined,

--- a/templates/demo-store/app/routes/($lang)/account.tsx
+++ b/templates/demo-store/app/routes/($lang)/account.tsx
@@ -49,13 +49,14 @@ export async function loader({request, context, params}: LoaderArgs) {
   const customerAccessToken = await context.session.get('customerAccessToken');
   const isAuthenticated = Boolean(customerAccessToken);
   const loginPath = lang ? `/${lang}/account/login` : '/account/login';
+  const isAccountPage = /^\/account\/?$/.test(pathname);
 
   if (!isAuthenticated) {
-    if (/\/account\/login$/.test(pathname)) {
-      return json({isAuthenticated}) as unknown as TmpRemixFix;
+    if (isAccountPage) {
+      return redirect(loginPath) as unknown as TmpRemixFix;
     }
-
-    return redirect(loginPath) as unknown as TmpRemixFix;
+    // pass through to public routes
+    return json({isAuthenticated: false}) as unknown as TmpRemixFix;
   }
 
   const customer = await getCustomer(context, customerAccessToken);

--- a/templates/skeleton/app/root.tsx
+++ b/templates/skeleton/app/root.tsx
@@ -32,13 +32,16 @@ export const links: LinksFunction = () => {
   ];
 };
 
-export const meta: MetaFunction = (data) => ({
+export const meta: MetaFunction = () => ({
   charset: 'utf-8',
   viewport: 'width=device-width,initial-scale=1',
 });
 
-export async function loader({context, request}: LoaderArgs) {
-  const cartId = await context.session.get('cartId');
+export async function loader({context}: LoaderArgs) {
+  const [customerAccessToken, cartId] = await Promise.all([
+    context.session.get('customerAccessToken'),
+    context.session.get('cartId'),
+  ]);
 
   const [cart, layout] = await Promise.all([
     cartId
@@ -62,6 +65,7 @@ export async function loader({context, request}: LoaderArgs) {
   ]);
 
   return defer({
+    isLoggedIn: Boolean(customerAccessToken),
     cart,
     layout,
   });


### PR DESCRIPTION
### WHY are these changes introduced?

The password `reset` and account `activate` flows are broken/unreachable.

### WHAT is this pull request doing?

This PR fixes a routing issue with `/account`. Currently, the `reset` and `activate` password flows are broken.

This PR also makes the account/login icon in the header to be log-in aware.

### HOW to test your changes?

- Validate the account icon changes based on the logged status. It includes an outline around the user when logged in.
- Validate the password `reset` and activate flows are reachable and working

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
