### PR TITLE
Fixes visual bug in footer

### DIFF
--- a/templates/demo-store/app/components/CountrySelector.tsx
+++ b/templates/demo-store/app/components/CountrySelector.tsx
@@ -47,7 +47,7 @@ export function CountrySelector() {
   return (
     <section
       ref={observerRef}
-      className="grid w-full gap-4 md:max-w-xs md:ml-auto"
+      className="grid w-full gap-4"
       onMouseLeave={closeDropdown}
     >
       <Heading size="lead" className="cursor-default" as="h3">


### PR DESCRIPTION
Small CSS fix to the footer, removing the margin and width rules for the country selector, which creates an odd layout on medium screens.