### PR TITLE
fix(next-release): download failure logs

### DIFF
--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -72,3 +72,10 @@ jobs:
         if: steps.version.outputs.NEXT_VERSION
         run: npm run changeset -- publish --tag next
 
+      - name: Archive npm failure logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: npm-logs
+          path: ~/.npm/_logs
+


### PR DESCRIPTION
We are still having issues only with `hydrogen-react`
https://github.com/Shopify/hydrogen/actions/runs/4427971043

We are trying to store logs in github artifacts to debug