### PR TITLE
fix(next-release): remove artifact storing from next-release workflow

### DIFF
--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -71,11 +71,3 @@ jobs:
       - name: 🚀 Publish
         if: steps.version.outputs.NEXT_VERSION
         run: npm run changeset -- publish --tag next
-
-      - name: Archive npm failure logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: npm-logs
-          path: ~/.npm/_logs
-


### PR DESCRIPTION
We did not find so useful to store the npm logs errors artifact in workflows. We can reintroduce it in the future if needed.
