### PR TITLE
Remove test globals from hydrogen-react tests

### DIFF
--- a/packages/hydrogen-react/src/AddToCartButton.test.tsx
+++ b/packages/hydrogen-react/src/AddToCartButton.test.tsx
@@ -1,4 +1,4 @@
-import {vi} from 'vitest';
+import {vi, describe, it, expect} from 'vitest';
 import {CartProvider} from './CartProvider.js';
 import {render, screen, waitFor} from '@testing-library/react';
 import {ProductProvider} from './ProductProvider.js';

--- a/packages/hydrogen-react/src/BaseButton.test.tsx
+++ b/packages/hydrogen-react/src/BaseButton.test.tsx
@@ -1,6 +1,6 @@
+import {vi, describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {BaseButton} from './BaseButton.js';
-import {vi} from 'vitest';
 import userEvent from '@testing-library/user-event';
 
 describe('<BaseButton/>', () => {

--- a/packages/hydrogen-react/src/BuyNowButton.test.tsx
+++ b/packages/hydrogen-react/src/BuyNowButton.test.tsx
@@ -1,6 +1,6 @@
+import {vi, afterEach, beforeEach, describe, it, expect} from 'vitest';
 import {CartProvider, useCart} from './CartProvider.js';
 import {render, screen} from '@testing-library/react';
-import {vi} from 'vitest';
 import userEvent from '@testing-library/user-event';
 import {BuyNowButton} from './BuyNowButton.js';
 import {getCartWithActionsMock} from './CartProvider.test.helpers.js';

--- a/packages/hydrogen-react/src/CartCheckoutButton.test.tsx
+++ b/packages/hydrogen-react/src/CartCheckoutButton.test.tsx
@@ -1,8 +1,8 @@
-import {CartCheckoutButton} from './CartCheckoutButton.js';
-
-import {vi} from 'vitest';
+import {vi, afterEach, describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+import {CartCheckoutButton} from './CartCheckoutButton.js';
 
 const checkoutUrl = 'https://shopify.com/checkout';
 

--- a/packages/hydrogen-react/src/CartCost.test.tsx
+++ b/packages/hydrogen-react/src/CartCost.test.tsx
@@ -1,3 +1,5 @@
+import {describe, it, expect} from 'vitest';
+
 import {render, screen} from '@testing-library/react';
 import {CartProvider} from './CartProvider.js';
 import {CART_WITH_LINES} from './CartProvider.test.helpers.js';

--- a/packages/hydrogen-react/src/CartLinePrice.test.tsx
+++ b/packages/hydrogen-react/src/CartLinePrice.test.tsx
@@ -1,3 +1,5 @@
+import {describe, it, expect} from 'vitest';
+
 import {render, screen} from '@testing-library/react';
 import {CartLinePrice} from './CartLinePrice.js';
 import {getCartLineMock} from './CartProvider.test.helpers.js';

--- a/packages/hydrogen-react/src/CartLineProvider.test.tsx
+++ b/packages/hydrogen-react/src/CartLineProvider.test.tsx
@@ -1,15 +1,19 @@
+import {describe, it, expect} from 'vitest';
+
 import {renderHook} from '@testing-library/react';
 import {useCartLine, CartLineProvider} from './CartLineProvider.js';
 import {getCartLineMock} from './CartProvider.test.helpers.js';
 
-it('provides a hook to access cart line data', () => {
-  const cartLine = getCartLineMock();
+describe('<CartLineProvider />', () => {
+  it('provides a hook to access cart line data', () => {
+    const cartLine = getCartLineMock();
 
-  const {result} = renderHook(() => useCartLine(), {
-    wrapper: ({children}) => (
-      <CartLineProvider line={cartLine}>{children}</CartLineProvider>
-    ),
+    const {result} = renderHook(() => useCartLine(), {
+      wrapper: ({children}) => (
+        <CartLineProvider line={cartLine}>{children}</CartLineProvider>
+      ),
+    });
+
+    expect(result.current).toEqual(cartLine);
   });
-
-  expect(result.current).toEqual(cartLine);
 });

--- a/packages/hydrogen-react/src/CartLineQuantity.test.tsx
+++ b/packages/hydrogen-react/src/CartLineQuantity.test.tsx
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {CartLineProvider} from './CartLineProvider.js';
 import {CartLineQuantity} from './CartLineQuantity.js';

--- a/packages/hydrogen-react/src/CartLineQuantityAdjustButton.test.tsx
+++ b/packages/hydrogen-react/src/CartLineQuantityAdjustButton.test.tsx
@@ -1,3 +1,5 @@
+import {vi, describe, expect, it} from 'vitest';
+
 import {render, screen} from '@testing-library/react';
 import {useCart, CartProvider} from './CartProvider.js';
 import {

--- a/packages/hydrogen-react/src/CartProvider.test.helpers.ts
+++ b/packages/hydrogen-react/src/CartProvider.test.helpers.ts
@@ -1,3 +1,4 @@
+import {vi} from 'vitest';
 import {flattenConnection} from './flatten-connection.js';
 import {getPrice} from './Money.test.helpers.js';
 import type {

--- a/packages/hydrogen-react/src/CartProvider.test.tsx
+++ b/packages/hydrogen-react/src/CartProvider.test.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable @typescript-eslint/no-empty-function */
+import {vi, beforeEach, describe, expect, it} from 'vitest';
+
 import {ComponentProps, PropsWithChildren} from 'react';
-import {vi} from 'vitest';
 import {renderHook, act} from '@testing-library/react';
 import {getCartMock, getCartLineMock} from './CartProvider.test.helpers.js';
 import {ShopifyProvider} from './ShopifyProvider.js';

--- a/packages/hydrogen-react/src/ExternalVideo.test.tsx
+++ b/packages/hydrogen-react/src/ExternalVideo.test.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import {vi, describe, expect, it} from 'vitest';
+
 import {render, screen} from '@testing-library/react';
 import {ExternalVideo} from './ExternalVideo.js';
-import {vi} from 'vitest';
 import {getExternalVideoData} from './ExternalVideo.test.helpers.js';
 
 const testId = 'video-iframe';

--- a/packages/hydrogen-react/src/Image.test.tsx
+++ b/packages/hydrogen-react/src/Image.test.tsx
@@ -1,4 +1,5 @@
-import {vi} from 'vitest';
+import {vi, describe, expect, it} from 'vitest';
+
 import {render, screen} from '@testing-library/react';
 import {Image} from './Image.js';
 import * as utilities from './image-size.js';
@@ -320,7 +321,6 @@ describe('<Image />', () => {
     expect(() => render(<Image data={{url: ''}} />)).toThrow();
   });
 
-  // eslint-disable-next-line jest/expect-expect
   it.skip(`typescript types`, () => {
     // this test is actually just using //@ts-expect-error as the assertion, and don't need to execute in order to have TS validation on them
     // I don't love this idea, but at the moment I also don't have other great ideas for how to easily test our component TS types

--- a/packages/hydrogen-react/src/MediaFile.test.tsx
+++ b/packages/hydrogen-react/src/MediaFile.test.tsx
@@ -1,7 +1,8 @@
+import {describe, it} from 'vitest';
+
 import {MediaFile} from './MediaFile.js';
 
 describe(`<MediaFile/>`, () => {
-  // eslint-disable-next-line jest/expect-expect
   it.skip(`typescript types`, () => {
     // ensure className is valid
     <MediaFile className="" data={{id: 'test'}} />;

--- a/packages/hydrogen-react/src/Money.test.tsx
+++ b/packages/hydrogen-react/src/Money.test.tsx
@@ -1,3 +1,5 @@
+import {describe, expect, it} from 'vitest';
+
 import {render, screen} from '@testing-library/react';
 import {Money} from './Money.js';
 import {ShopifyProvider} from './ShopifyProvider.js';

--- a/packages/hydrogen-react/src/ProductPrice.test.tsx
+++ b/packages/hydrogen-react/src/ProductPrice.test.tsx
@@ -1,3 +1,5 @@
+import {describe, expect, it} from 'vitest';
+
 import {render, screen} from '@testing-library/react';
 import {getProduct} from './ProductProvider.test.helpers.js';
 import {ProductPrice} from './ProductPrice.js';
@@ -108,7 +110,6 @@ describe('<ProductPrice />', () => {
     ).toHaveClass('emphasized');
   });
 
-  // eslint-disable-next-line jest/expect-expect
   it.skip(`has the correct TS types for itself and for <Money/>`, () => {
     // no errors
     render(<ProductPrice data={getProduct()} />);

--- a/packages/hydrogen-react/src/ProductProvider.test.tsx
+++ b/packages/hydrogen-react/src/ProductProvider.test.tsx
@@ -1,3 +1,5 @@
+import {describe, expect, it} from 'vitest';
+
 import {ProductProvider, useProduct} from './ProductProvider.js';
 import {
   getProduct,

--- a/packages/hydrogen-react/src/ShopPayButton.test.tsx
+++ b/packages/hydrogen-react/src/ShopPayButton.test.tsx
@@ -1,4 +1,5 @@
-import {vi} from 'vitest';
+import {vi, describe, expect, it} from 'vitest';
+
 import {render} from '@testing-library/react';
 import {ShopifyProvider} from './ShopifyProvider.js';
 import {

--- a/packages/hydrogen-react/src/ShopifyProvider.test.tsx
+++ b/packages/hydrogen-react/src/ShopifyProvider.test.tsx
@@ -1,3 +1,5 @@
+import {describe, expect, it} from 'vitest';
+
 import {render, screen, renderHook} from '@testing-library/react';
 import {
   ShopifyProvider,

--- a/packages/hydrogen-react/src/Video.test.tsx
+++ b/packages/hydrogen-react/src/Video.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {describe, expect, it} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {Video} from './Video.js';
 

--- a/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.test.ts
+++ b/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.test.ts
@@ -1,3 +1,4 @@
+import {expect, it, describe} from 'vitest';
 import {expectType} from 'ts-expect';
 import {ShopifySalesChannel} from './analytics-constants.js';
 import {

--- a/packages/hydrogen-react/src/analytics-schema-trekkie-storefront-page-view.test.ts
+++ b/packages/hydrogen-react/src/analytics-schema-trekkie-storefront-page-view.test.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {expectType} from 'ts-expect';
 import {ShopifySalesChannel} from './analytics-constants.js';
 import {pageView} from './analytics-schema-trekkie-storefront-page-view.js';

--- a/packages/hydrogen-react/src/analytics-utils.test.ts
+++ b/packages/hydrogen-react/src/analytics-utils.test.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {parseGid, addDataIf, schemaWrapper} from './analytics-utils.js';
 
 describe('analytic-utils', () => {

--- a/packages/hydrogen-react/src/analytics.test.ts
+++ b/packages/hydrogen-react/src/analytics.test.ts
@@ -1,4 +1,4 @@
-import {vi, afterEach} from 'vitest';
+import {vi, afterEach, describe, it, expect} from 'vitest';
 import {AnalyticsEventName} from './analytics-constants.js';
 import {BASE_PAYLOAD} from './analytics-schema.test.helpers.js';
 import {getClientBrowserParameters, sendShopifyAnalytics} from './analytics.js';

--- a/packages/hydrogen-react/src/cookies-utils.test.ts
+++ b/packages/hydrogen-react/src/cookies-utils.test.ts
@@ -1,3 +1,5 @@
+import {describe, expect, it} from 'vitest';
+
 import {buildUUID, hexTime, getShopifyCookies} from './cookies-utils.js';
 import {ShopifyCookies} from './analytics-types.js';
 

--- a/packages/hydrogen-react/src/flatten-connection.test.ts
+++ b/packages/hydrogen-react/src/flatten-connection.test.ts
@@ -1,7 +1,8 @@
+import {vi, describe, it, expect} from 'vitest';
+
 import {PartialDeep} from 'type-fest';
 import {ProductConnection, Product} from './storefront-api-types.js';
 import {flattenConnection} from './flatten-connection.js';
-import {vi} from 'vitest';
 import {expectType, TypeEqual} from 'ts-expect';
 
 describe('flattenConnection', () => {
@@ -74,7 +75,6 @@ describe('flattenConnection', () => {
     expect(console.warn).toHaveBeenCalled();
   });
 
-  // eslint-disable-next-line jest/expect-expect
   it.skip(`has correct typescript types`, () => {
     // works without PartialDeep
     const type1 = flattenConnection({} as ProductConnection);

--- a/packages/hydrogen-react/src/parse-metafield.test.ts
+++ b/packages/hydrogen-react/src/parse-metafield.test.ts
@@ -1,3 +1,4 @@
+import {describe, it, expect} from 'vitest';
 import {
   parseMetafield,
   type ParsedMetafields,
@@ -536,7 +537,6 @@ describe(`parseMetafield`, () => {
   });
 
   describe(`types`, () => {
-    // eslint-disable-next-line jest/expect-expect
     it.skip(`TS tests`, () => {
       // This test is to ensure that ParsedMetafields has a key for every item in 'allMetafieldsTypesArray'
       expectType<TypeEqual<keyof ParsedMetafields, MetafieldTypeTypes>>(true);

--- a/packages/hydrogen-react/src/storefront-client.test.ts
+++ b/packages/hydrogen-react/src/storefront-client.test.ts
@@ -1,6 +1,7 @@
+import {vi, beforeEach, describe, expect, it} from 'vitest';
+
 import {createStorefrontClient} from './storefront-client.js';
 import {SFAPI_VERSION} from './storefront-api-constants.js';
-import {vi} from 'vitest';
 
 describe(`createStorefrontClient`, () => {
   beforeEach(() => {

--- a/packages/hydrogen-react/src/useMoney.test.tsx
+++ b/packages/hydrogen-react/src/useMoney.test.tsx
@@ -1,3 +1,4 @@
+import {describe, expect, it} from 'vitest';
 import {renderHook} from '@testing-library/react';
 import {useMoney} from './useMoney.js';
 

--- a/packages/hydrogen-react/src/useShopifyCookies.test.tsx
+++ b/packages/hydrogen-react/src/useShopifyCookies.test.tsx
@@ -1,4 +1,4 @@
-import {afterEach} from 'vitest';
+import {vi, afterEach, describe, expect, it} from 'vitest';
 import {renderHook} from '@testing-library/react';
 import {getShopifyCookies} from './cookies-utils.js';
 import {useShopifyCookies} from './useShopifyCookies.js';

--- a/packages/hydrogen-react/tsconfig.json
+++ b/packages/hydrogen-react/tsconfig.json
@@ -12,7 +12,7 @@
     "declaration": true,
     "declarationDir": "./dist/types",
     "jsx": "react-jsx",
-    "types": ["jest", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["jest", "@testing-library/jest-dom"]
   },
   "include": ["src/**/*", "globals.d.ts"],
   "exclude": [

--- a/packages/hydrogen-react/vitest.setup.ts
+++ b/packages/hydrogen-react/vitest.setup.ts
@@ -1,1 +1,5 @@
-import '@testing-library/jest-dom';
+import matchers from '@testing-library/jest-dom/matchers';
+
+import {expect} from 'vitest';
+
+expect.extend(matchers);


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Bringing some consistency to our packages. 

### WHAT is this pull request doing?

I took a poll and discovered we prefer explicit imports of test methods such as `describe`, `it` and `expect`. This PR imports the necessary methods in the `hydrogen-react` package. 

### HOW to test your changes?

Green CI

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
