### PR TITLE
Return a null Response from skeleton login/register route loaders

### DIFF
--- a/templates/skeleton/app/routes/account/login.tsx
+++ b/templates/skeleton/app/routes/account/login.tsx
@@ -14,6 +14,8 @@ export async function loader({context, params}: LoaderArgs) {
   if (customerAccessToken) {
     return redirect(params.lang ? `${params.lang}/account` : '/account');
   }
+
+  return new Response(null);
 }
 
 type ActionData = {

--- a/templates/skeleton/app/routes/account/register.tsx
+++ b/templates/skeleton/app/routes/account/register.tsx
@@ -14,6 +14,8 @@ export async function loader({context, params}: LoaderArgs) {
   if (customerAccessToken) {
     return redirect(params.lang ? `${params.lang}/account` : '/account');
   }
+
+  return new Response(null);
 }
 
 type ActionData = {


### PR DESCRIPTION
### WHY are these changes introduced?
When installing skeleton routes via `npm run g routes`, the files that get created for login/register both include a loader function that can potentially return `undefined`, causing [this error](https://github.com/remix-run/remix/blob/191d89a8cd8e51f5402678ea13d64acc2e4018ec/packages/remix-server-runtime/data.ts#L76) in Remix to be thrown.

```
Error: You defined a loader for route "routes/account/login" but didn't return anything from your `loader` function. Please return a value or `null`.
```

### WHAT is this pull request doing?
Adding a `return new Response(null)` to loader functions on skeleton loader/register routes so it will not throw.

### HOW to test your changes?
- create a new hydrogen app with `hello-world` template
- install the login/register routes with `npm run g routes`
- run the app locally with `npm run dev`
- navigate to `/account/login` and `/account/register`
- see that the application no longer throws an error


#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

