### PR TITLE
WIP Send requests from browser to Node.js bypassing MiniOxygen

### DIFF
--- a/packages/cli/src/virtual-routes/routes/_h2-setup.tsx
+++ b/packages/cli/src/virtual-routes/routes/_h2-setup.tsx
@@ -1,0 +1,4 @@
+export async function action() {
+  // Dummy action for project setup from virtual routes
+  return {};
+}

--- a/packages/cli/src/virtual-routes/routes/index.tsx
+++ b/packages/cli/src/virtual-routes/routes/index.tsx
@@ -70,6 +70,12 @@ export default function Index() {
 
   const configDone = shopId !== HYDROGEN_SHOP_ID;
 
+  const doStuffInNode = () =>
+    fetch('/_h2-setup', {
+      method: 'POST',
+      body: JSON.stringify({action: 'doStuffInNode'}),
+    });
+
   return (
     <>
       <Layout shopName={shopName}>
@@ -110,6 +116,9 @@ export default function Index() {
             </p>
           </section>
         )}
+        <div>
+          <button onClick={doStuffInNode}>Do Stuff In Node</button>
+        </div>
         <ResourcesLinks />
       </Layout>
     </>


### PR DESCRIPTION
WIP testing a way here to send information from browser => MiniOxygen => Node.
This would allows us to build a UI for project setup (generate routes, etc) in a virtual route `/_h2-setup`, for example. Then, when receiving requests from that route in Node, we can run commands like `npx shopify generate route xyz` or modify the project in other ways.
