### PR TITLE
update next release workflow to not run on release

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           version: npm run version
           publish: npm run changeset publish
+          # we use the commit message in next release workflow file. This avoid a next release when an actual release is happening
           commit: '[ci] release ${{ github.ref_name }}'
           title: '[ci] release ${{ github.ref_name }}'
         env:

--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -10,7 +10,8 @@ jobs:
   next-release:
     name: ⏭️ Next Release
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'shopify'
+    # don't run if a commit message with [ci] release is present. The release workflow will do the release
+    if: github.repository_owner == 'shopify' && !contains(github.event.commits.*.message, '[ci] release')
     outputs:
       NEXT_VERSION: ${{ steps.version.outputs.NEXT_VERSION }}
     steps:


### PR DESCRIPTION
Use commit name to skip a next release when a release is happening.

### WHY are these changes introduced?

We were running and publishing in both changeset and next-release workflows when we merged the changeset pull request.

Other approaches considered:
* Using the github bot
* path matching files
* chaining workflows

This one seemed the easiest without complicating the workflows