### PR TITLE
[demo-store] Add support for Checkout Links to the demo-store template

### DIFF
--- a/templates/demo-store/app/routes/($lang)/cart.$lines.tsx
+++ b/templates/demo-store/app/routes/($lang)/cart.$lines.tsx
@@ -1,0 +1,75 @@
+import {redirect} from '@shopify/remix-oxygen';
+import {cartCreate} from './cart';
+
+/**
+ * Automatically creates a cart based on the URL and redirects straight to checkout.
+ * URL structure:
+ *  * ```ts
+ * /cart/<variant_id>:<quantity>,<variant_id>:<quantity>?discount=<discount_code>
+ *
+ * ```
+ *
+ * @param `?discount` an optional discount code to apply to the cart
+ * @example
+ * Example path creating a cart with a discount code and redirecting straight to checkout
+ * ```ts
+ * /cart/41007289663544:1,41007289696312:2?discount=HYDROBOARD
+ *
+ * ```
+ * @preserve
+ */
+export async function loader({request, context, params}) {
+  const {storefront} = context;
+
+  const session = context.session;
+
+  const {lines} = params;
+  const linesArray = lines.split(',');
+  const linesMap = linesArray.map((line) => {
+    line = line.split(':');
+    const variantId = line[0];
+    const quantity = parseInt(line[1], 10);
+
+    return {
+      merchandiseId: `gid://shopify/ProductVariant/${variantId}`,
+      quantity,
+    };
+  });
+
+  const url = new URL(request.url);
+  const searchParams = new URLSearchParams(url.search);
+  const discount = searchParams.get('discount');
+
+  const headers = new Headers();
+
+  //! create a cart
+  const {cart, errors: graphqlCartErrors} = await cartCreate({
+    input: {
+      lines: linesMap,
+      discountCodes: discount,
+    },
+    storefront,
+  });
+
+  if (graphqlCartErrors?.length || !cart) {
+    throw new Response('Link may be expired. Try checking the URL.', {
+      status: 410,
+    });
+  }
+
+  //! cart created - set and replace the session cart if there is one
+  session.unset('cartId');
+  session.set('cartId', cart.id);
+  headers.set('Set-Cookie', await session.commit());
+
+  //! redirect to checkout
+  if (cart.checkoutUrl) {
+    return redirect(cart.checkoutUrl, {headers});
+  } else {
+    throw new Error('No checkout URL found');
+  }
+}
+
+export default function Component() {
+  return null;
+}

--- a/templates/demo-store/app/routes/($lang)/cart.tsx
+++ b/templates/demo-store/app/routes/($lang)/cart.tsx
@@ -213,6 +213,7 @@ const CREATE_CART_MUTATION = `#graphql
     cartCreate(input: $input) {
       cart {
         ...CartLinesFragment
+        checkoutUrl
       }
       errors: userErrors {
         ...ErrorFragment


### PR DESCRIPTION
### WHY are these changes introduced?

To support merchants migrating to Hydrogen from the Online Store who use **[Checkout Links](https://help.shopify.com/en/manual/products/details/checkout-link)**, this PR adds basic support for these Checkout Links to the demo store template, to serve as a working example.

Checkout Links have the URL structure `https://[my_store]/cart/[variant_id]:[quantity]?discount=[discount_code]`

They might also contain more than one `[variant_id]:[quantity]` separated by a comma, for checkouts with more than one product variant.

Seperate PR here https://github.com/Shopify/shopify-dev/pull/32522 for adding a link to this example, in the Hydrogen migration docs.

### WHAT is this pull request doing?

* Adds a route - `($lang).cart.$lines.tsx`
* Adds `checkoutUrl` as a field in the `cartCreate` mutation

With this PR, the demo store should support Checkout Links, for example:
`https://hydrogen.shop/cart/41007289663544:1,41007289696312:2?discount=HYDROBOARD`

Using this Checkout Link should result in a new cart being created with the merchandise and discount code from the URL, and then you should be redirected straight to the checkout - video example below.

<details>
    <summary>Video example 📹 (click me!) </summary>

https://user-images.githubusercontent.com/48892838/229340253-466dd233-a491-461a-965c-d42a25e94bf8.mp4
</details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

1. Apply the changes to a **[demo store template](https://github.com/Shopify/hydrogen/tree/2023-01/templates/demo-store)**
2. Test different variations of Checkout Links to make sure they work as expected on the demo store and don't break anything 😅 

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
