### PR TITLE
Upgrade to Remix 1.15.0

### DIFF
--- a/.changeset/angry-months-pay.md
+++ b/.changeset/angry-months-pay.md
@@ -6,11 +6,13 @@ Adopt Remix [`v2_meta`](https://remix.run/docs/en/main/route/meta#metav2) future
 
 ### `v2_meta` migration steps
 
-1. For any routes that you used `meta` route export, convert it to the `V2_MetaFunction` equivalent.
+1. For any routes that you used `meta` route export, convert it to the `V2_MetaFunction` equivalent. Notice that the package name in the import statement has also changed to `'@remix-run/react'`:
 
    **Before** - returns an object;
 
    ```jsx
+   import {type MetaFunction} from '@shopify/remix-oxygen';
+
    export const meta: MetaFunction = () => {
      return {
        title: 'Login',
@@ -21,6 +23,8 @@ Adopt Remix [`v2_meta`](https://remix.run/docs/en/main/route/meta#metav2) future
    **After** - returns an array of object:
 
    ```jsx
+   import {type V2_MetaFunction} from '@remix-run/react';
+
    export const meta: V2_MetaFunction = () => {
      return [
        {
@@ -35,6 +39,8 @@ Adopt Remix [`v2_meta`](https://remix.run/docs/en/main/route/meta#metav2) future
    **Before** - returns an object;
 
    ```jsx
+   import {type MetaFunction} from '@shopify/remix-oxygen';
+
    export const meta: MetaFunction = ({data}) => ({
      title: `Order ${data?.order?.name}`,
    });
@@ -43,6 +49,8 @@ Adopt Remix [`v2_meta`](https://remix.run/docs/en/main/route/meta#metav2) future
    **After** - returns an array of object:
 
    ```jsx
+   import {type V2_MetaFunction} from '@remix-run/react';
+
    export const meta: V2_MetaFunction<typeof loader> = ({data}) => {
      return [
        {
@@ -67,8 +75,8 @@ Adopt Remix [`v2_meta`](https://remix.run/docs/en/main/route/meta#metav2) future
      return (
        <html lang={locale.language}>
          <head>
-   +        <meta charSet="utf-8" />
-   +        <meta name="viewport" content="width=device-width,initial-scale=1" />
+   +       <meta charSet="utf-8" />
+   +       <meta name="viewport" content="width=device-width,initial-scale=1" />
            <Seo />
            <Meta />
    ```

--- a/.changeset/angry-months-pay.md
+++ b/.changeset/angry-months-pay.md
@@ -8,56 +8,25 @@ Adopt Remix [`v2_meta`](https://remix.run/docs/en/main/route/meta#metav2) future
 
 1. For any routes that you used `meta` route export, convert it to the `V2_MetaFunction` equivalent. Notice that the package name in the import statement has also changed to `'@remix-run/react'`:
 
-   **Before** - returns an object;
+   ```diff
+   - import {type MetaFunction} from '@shopify/remix-oxygen';
+   + import {type V2_MetaFunction} from '@remix-run/react';
 
-   ```jsx
-   import {type MetaFunction} from '@shopify/remix-oxygen';
-
-   export const meta: MetaFunction = () => {
-     return {
-       title: 'Login',
+   - export const meta: MetaFunction = () => {
+   + export const meta: V2_MetaFunction = () => {
+   -   return {title: 'Login'};
+   +   return [{title: 'Login'}];
      };
-   };
    ```
 
-   **After** - returns an array of object:
+2. If you are using data from loaders, pass the loader type to the `V2_MetaFunction` generic:
 
-   ```jsx
-   import {type V2_MetaFunction} from '@remix-run/react';
-
-   export const meta: V2_MetaFunction = () => {
-     return [
-       {
-         title: 'Login',
-       },
-     ];
-   };
-   ```
-
-2. If you are using data from loaders
-
-   **Before** - returns an object;
-
-   ```jsx
-   import {type MetaFunction} from '@shopify/remix-oxygen';
-
-   export const meta: MetaFunction = ({data}) => ({
-     title: `Order ${data?.order?.name}`,
-   });
-   ```
-
-   **After** - returns an array of object:
-
-   ```jsx
-   import {type V2_MetaFunction} from '@remix-run/react';
-
-   export const meta: V2_MetaFunction<typeof loader> = ({data}) => {
-     return [
-       {
-         title: `Order ${data?.order?.name}`,
-       },
-     ];
-   };
+   ```diff
+   - export const meta: MetaFunction = ({data}) => {
+   + export const meta: V2_MetaFunction<typeof loader> = ({data}) => {
+   -   return {title: `Order ${data?.order?.name}`};
+   +   return [{title: `Order ${data?.order?.name}`}];
+     };
    ```
 
 3. If you are using `meta` route export in `root`, convert it to [Global Meta](https://remix.run/docs/en/main/route/meta#global-meta)

--- a/.changeset/red-wolves-brake.md
+++ b/.changeset/red-wolves-brake.md
@@ -1,5 +1,6 @@
 ---
 '@shopify/hydrogen': patch
+'@shopify/remix-oxygen': patch
 '@shopify/cli-hydrogen': patch
 ---
 

--- a/.changeset/red-wolves-brake.md
+++ b/.changeset/red-wolves-brake.md
@@ -3,4 +3,9 @@
 '@shopify/cli-hydrogen': patch
 ---
 
-Bump Remix packages to 1.14.3
+Bump internal Remix dependencies to 1.15.0.
+
+Recommendations to follow:
+
+- Upgrade all the Remix packages in your app to 1.15.0.
+- Enable Remix v2 future flags at your earliest convenience following [the official guide](https://remix.run/docs/en/1.15.0/pages/v2).

--- a/package-lock.json
+++ b/package-lock.json
@@ -3583,7 +3583,8 @@
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
     },
     "node_modules/@esbuild-plugins/node-modules-polyfill": {
       "version": "0.1.4",
@@ -3596,6 +3597,51 @@
         "esbuild": "*"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.6.tgz",
+      "integrity": "sha512-bSC9YVUjADDy1gae8RrioINU6e1lCkg3VGVwm0QQ2E1CWcC4gnMce9+B6RpxuSsrsXsk1yojn7sp1fnG8erE2g==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.6.tgz",
+      "integrity": "sha512-YnYSCceN/dUzUr5kdtUzB+wZprCafuD89Hs0Aqv9QSdwhYQybhXTaSTcrl6X/aWThn1a/j0eEpUBGOE7269REg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.6.tgz",
+      "integrity": "sha512-MVcYcgSO7pfu/x34uX9u2QIZHmXAB7dEiLQC5bBl5Ryqtpj9lT2sg3gNDEsrPEmimSJW2FXIaxqSQ501YLDsZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.16.3",
       "cpu": [
@@ -3605,6 +3651,276 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.6.tgz",
+      "integrity": "sha512-xh2A5oPrYRfMFz74QXIQTQo8uA+hYzGWJFoeTE8EvoZGHb+idyV4ATaukaUvnnxJiauhs/fPx3vYhU4wiGfosg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.6.tgz",
+      "integrity": "sha512-EnUwjRc1inT4ccZh4pB3v1cIhohE2S4YXlt1OvI7sw/+pD+dIE4smwekZlEPIwY6PhU6oDWwITrQQm5S2/iZgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.6.tgz",
+      "integrity": "sha512-Uh3HLWGzH6FwpviUcLMKPCbZUAFzv67Wj5MTwK6jn89b576SR2IbEp+tqUHTr8DIl0iDmBAf51MVaP7pw6PY5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.6.tgz",
+      "integrity": "sha512-7YdGiurNt7lqO0Bf/U9/arrPWPqdPqcV6JCZda4LZgEn+PTQ5SMEI4MGR52Bfn3+d6bNEGcWFzlIxiQdS48YUw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.6.tgz",
+      "integrity": "sha512-bUR58IFOMJX523aDVozswnlp5yry7+0cRLCXDsxnUeQYJik1DukMY+apBsLOZJblpH+K7ox7YrKrHmJoWqVR9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.6.tgz",
+      "integrity": "sha512-ujp8uoQCM9FRcbDfkqECoARsLnLfCUhKARTP56TFPog8ie9JG83D5GVKjQ6yVrEVdMie1djH86fm98eY3quQkQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.6.tgz",
+      "integrity": "sha512-y2NX1+X/Nt+izj9bLoiaYB9YXT/LoaQFYvCkVD77G/4F+/yuVXYCWz4SE9yr5CBMbOxOfBcy/xFL4LlOeNlzYQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.6.tgz",
+      "integrity": "sha512-09AXKB1HDOzXD+j3FdXCiL/MWmZP0Ex9eR8DLMBVcHorrWJxWmY8Nms2Nm41iRM64WVx7bA/JVHMv081iP2kUA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.6.tgz",
+      "integrity": "sha512-AmLhMzkM8JuqTIOhxnX4ubh0XWJIznEynRnZAVdA2mMKE6FAfwT2TWKTwdqMG+qEaeyDPtfNoZRpJbD4ZBv0Tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.6.tgz",
+      "integrity": "sha512-Y4Ri62PfavhLQhFbqucysHOmRamlTVK10zPWlqjNbj2XMea+BOs4w6ASKwQwAiqf9ZqcY9Ab7NOU4wIgpxwoSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.6.tgz",
+      "integrity": "sha512-SPUiz4fDbnNEm3JSdUW8pBJ/vkop3M1YwZAVwvdwlFLoJwKEZ9L98l3tzeyMzq27CyepDQ3Qgoba44StgbiN5Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.6.tgz",
+      "integrity": "sha512-a3yHLmOodHrzuNgdpB7peFGPx1iJ2x6m+uDvhP2CKdr2CwOaqEFMeSqYAHU7hG+RjCq8r2NFujcd/YsEsFgTGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.6.tgz",
+      "integrity": "sha512-EanJqcU/4uZIBreTrnbnre2DXgXSa+Gjap7ifRfllpmyAU7YMvaXmljdArptTHmjrkkKm9BK6GH5D5Yo+p6y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.6.tgz",
+      "integrity": "sha512-xaxeSunhQRsTNGFanoOkkLtnmMn5QbA0qBhNet/XLVsc+OVkpIWPHcr3zTW2gxVU5YOHFbIHR9ODuaUdNza2Vw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.6.tgz",
+      "integrity": "sha512-gnMnMPg5pfMkZvhHee21KbKdc6W3GR8/JuE0Da1kjwpK6oiFU3nqfHuVPgUX2rsOx9N2SadSQTIYV1CIjYG+xw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.6.tgz",
+      "integrity": "sha512-G95n7vP1UnGJPsVdKXllAJPtqjMvFYbN20e8RK8LVLhlTiSOH1sd7+Gt7rm70xiG+I5tM58nYgwWrLs6I1jHqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.6.tgz",
+      "integrity": "sha512-96yEFzLhq5bv9jJo5JhTs1gI+1cKQ83cUpyxHuGqXVwQtY5Eq54ZEsKs8veKtiKwlrNimtckHEkj4mRh4pPjsg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.6.tgz",
+      "integrity": "sha512-n6d8MOyUrNp6G4VSpRcgjs5xj4A91svJSaiwLIDWVWEsZtpN5FA9NlBbZHDmAJc2e8e6SF4tkBD3HAvPF+7igA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -5989,9 +6305,9 @@
       "license": "0BSD"
     },
     "node_modules/@remix-run/dev": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-1.14.3.tgz",
-      "integrity": "sha512-46mmwiA/k9YDkg0UrP90UB3azVVWRXw16NLHRSbZiaaYe8XgUkddEtBnH/nBp/IrVCtzUL3LObplUe5sFk5Z9Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-1.15.0.tgz",
+      "integrity": "sha512-BsE1GN6WM9PhN+agZi4TqUIuYzoHYZrufEdXLg3ZEYxWXqvtRKUNfhsYSDlEhrW+D5fyVQhJrs61wQ83sEXHLQ==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.6",
@@ -6004,8 +6320,8 @@
         "@babel/types": "^7.20.2",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "@npmcli/package-json": "^2.0.0",
-        "@remix-run/server-runtime": "1.14.3",
-        "@vanilla-extract/integration": "^6.0.2",
+        "@remix-run/server-runtime": "1.15.0",
+        "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
         "cacache": "^15.0.5",
         "chalk": "^4.1.2",
@@ -6018,14 +6334,15 @@
         "fast-glob": "3.2.11",
         "fs-extra": "^10.0.0",
         "get-port": "^5.1.1",
+        "glob-to-regexp": "0.4.1",
         "gunzip-maybe": "^1.4.2",
         "inquirer": "^8.2.1",
         "jsesc": "3.0.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "lodash": "^4.17.21",
         "lodash.debounce": "^4.0.8",
         "lru-cache": "^7.14.1",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.0.5",
         "node-fetch": "^2.6.7",
         "ora": "^5.4.1",
         "postcss": "^8.4.19",
@@ -6053,12 +6370,327 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@remix-run/serve": "^1.14.3"
+        "@remix-run/serve": "^1.15.0"
       },
       "peerDependenciesMeta": {
         "@remix-run/serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/android-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.3.tgz",
+      "integrity": "sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/android-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.3.tgz",
+      "integrity": "sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/android-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.3.tgz",
+      "integrity": "sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/darwin-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.3.tgz",
+      "integrity": "sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.3.tgz",
+      "integrity": "sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.3.tgz",
+      "integrity": "sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.3.tgz",
+      "integrity": "sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.3.tgz",
+      "integrity": "sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.3.tgz",
+      "integrity": "sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-loong64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.3.tgz",
+      "integrity": "sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.3.tgz",
+      "integrity": "sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.3.tgz",
+      "integrity": "sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.3.tgz",
+      "integrity": "sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-s390x": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.3.tgz",
+      "integrity": "sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/linux-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.3.tgz",
+      "integrity": "sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/sunos-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.3.tgz",
+      "integrity": "sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/win32-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.3.tgz",
+      "integrity": "sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/win32-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.3.tgz",
+      "integrity": "sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/@esbuild/win32-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.3.tgz",
+      "integrity": "sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@remix-run/dev/node_modules/esbuild": {
@@ -6192,9 +6824,9 @@
       }
     },
     "node_modules/@remix-run/eslint-config": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-1.14.3.tgz",
-      "integrity": "sha512-Yy4PYSvAehj31LmkDA+lS5yCPL1lR9O04gMIo0xwHT2o59pF4QU54lEAvJJH+9MI0byZUI/v9DoGz1oGIb44IA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-1.15.0.tgz",
+      "integrity": "sha512-nwCPK/4anLMDWJnBsrWL9Wfcy2eRDlKjGWZeYeozDpJnH9iG1vA5aow0OmcpblwgvAwcgSC8Gdb7P5uK4Xy5/Q==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.19.1",
@@ -6220,7 +6852,7 @@
       "peerDependencies": {
         "eslint": "^8.0.0",
         "react": "^17.0.0 || ^18.0.0",
-        "typescript": "^4.0.0"
+        "typescript": "^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -6229,12 +6861,12 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.14.3.tgz",
-      "integrity": "sha512-dvwIx+9ZdE/9LHe8Rjos9gEOdQFLvC0dojCnKlsUIwfGhyjKE4wOHfqS9mZcmKFCvOFDakcZDallLNGaj0mEYg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-1.15.0.tgz",
+      "integrity": "sha512-S0RuIeHvQTqryCZ3KVl8EsIWCqL6/ky1/kmDpN2n5Pdjew2BLC6DX7OdrY1ZQjbzOMHAROsZlyaSSVXCItunag==",
       "dependencies": {
-        "@remix-run/router": "1.3.3",
-        "react-router-dom": "6.8.2",
+        "@remix-run/router": "1.5.0",
+        "react-router-dom": "6.10.0",
         "use-sync-external-store": "1.2.0"
       },
       "engines": {
@@ -6243,6 +6875,14 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@remix-run/react/node_modules/@remix-run/router": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@remix-run/router": {
@@ -6254,11 +6894,11 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.14.3.tgz",
-      "integrity": "sha512-qh8sxfLj/XW1u6rluN7yIgbvMCoKrVacYGUiPM7g0VHk8h8MlZGAIUfsWM45Poxo3X0uLhNuqqxMaPWldKawIQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.15.0.tgz",
+      "integrity": "sha512-DL9xjHfYYrEcOq5VbhYtrjJUWo/nFQAT7Y+Np/oC55HokyU6cb2jGhl52nx96aAxKwaFCse5N90GeodFsRzX7w==",
       "dependencies": {
-        "@remix-run/router": "1.3.3",
+        "@remix-run/router": "1.5.0",
         "@types/cookie": "^0.4.0",
         "@types/react": "^18.0.15",
         "@web3-storage/multipart-parser": "^1.0.0",
@@ -6266,6 +6906,14 @@
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3"
       },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/server-runtime/node_modules/@remix-run/router": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==",
       "engines": {
         "node": ">=14"
       }
@@ -8506,15 +9154,17 @@
       }
     },
     "node_modules/@vanilla-extract/babel-plugin-debug-ids": {
-      "version": "1.0.1",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/babel-plugin-debug-ids/-/babel-plugin-debug-ids-1.0.2.tgz",
+      "integrity": "sha512-LjnbQWGeMwaydmovx8jWUR8BxLtLiPyq0xz5C8G5OvFhsuJxvavLdrBHNNizvr1dq7/3qZGlPv0znsvU4P44YA==",
       "dependencies": {
         "@babel/core": "^7.20.7"
       }
     },
     "node_modules/@vanilla-extract/css": {
-      "version": "1.9.3",
-      "license": "MIT",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.11.0.tgz",
+      "integrity": "sha512-uohj+8cGWbnrVzTfrjlJeXqdGjH3d3TcscdQxKe3h5bb5QQXTpPSq+c+SeWADIGiZybzcW0CBvZV8jsy1ywY9w==",
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.3",
@@ -8523,7 +9173,7 @@
         "css-what": "^5.0.1",
         "cssesc": "^3.0.0",
         "csstype": "^3.0.7",
-        "deep-object-diff": "^1.1.0",
+        "deep-object-diff": "^1.1.9",
         "deepmerge": "^4.2.2",
         "media-query-parser": "^2.0.2",
         "outdent": "^0.8.0"
@@ -8531,30 +9181,36 @@
     },
     "node_modules/@vanilla-extract/css/node_modules/outdent": {
       "version": "0.8.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
     },
     "node_modules/@vanilla-extract/integration": {
-      "version": "6.0.2",
-      "license": "MIT",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/integration/-/integration-6.2.1.tgz",
+      "integrity": "sha512-+xYJz07G7TFAMZGrOqArOsURG+xcYvqctujEkANjw2McCBvGEK505RxQqOuNiA9Mi9hgGdNp2JedSa94f3eoLg==",
       "dependencies": {
         "@babel/core": "^7.20.7",
         "@babel/plugin-syntax-typescript": "^7.20.0",
-        "@vanilla-extract/babel-plugin-debug-ids": "^1.0.1",
-        "@vanilla-extract/css": "^1.9.3",
-        "esbuild": "^0.16.3",
+        "@vanilla-extract/babel-plugin-debug-ids": "^1.0.2",
+        "@vanilla-extract/css": "^1.10.0",
+        "esbuild": "0.17.6",
         "eval": "0.1.6",
         "find-up": "^5.0.0",
         "javascript-stringify": "^2.0.1",
         "lodash": "^4.17.21",
-        "outdent": "^0.8.0"
+        "mlly": "^1.1.0",
+        "outdent": "^0.8.0",
+        "vite": "^4.1.4",
+        "vite-node": "^0.28.5"
       }
     },
     "node_modules/@vanilla-extract/integration/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.16.17",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.6.tgz",
+      "integrity": "sha512-bsDRvlbKMQMt6Wl08nHtFz++yoZHsyTOxnjfB2Q95gato+Yi4WnRl13oC2/PJJA9yLCoRv9gqT/EYX0/zDsyMA==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -8564,9 +9220,10 @@
       }
     },
     "node_modules/@vanilla-extract/integration/node_modules/esbuild": {
-      "version": "0.16.17",
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.6.tgz",
+      "integrity": "sha512-TKFRp9TxrJDdRWfSsSERKEovm6v30iHnrjlcGhLBOtReE28Yp1VSBRfO3GTaOFMoxsNerx4TjrhzSuma9ha83Q==",
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8574,37 +9231,39 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.16.17",
-        "@esbuild/android-arm64": "0.16.17",
-        "@esbuild/android-x64": "0.16.17",
-        "@esbuild/darwin-arm64": "0.16.17",
-        "@esbuild/darwin-x64": "0.16.17",
-        "@esbuild/freebsd-arm64": "0.16.17",
-        "@esbuild/freebsd-x64": "0.16.17",
-        "@esbuild/linux-arm": "0.16.17",
-        "@esbuild/linux-arm64": "0.16.17",
-        "@esbuild/linux-ia32": "0.16.17",
-        "@esbuild/linux-loong64": "0.16.17",
-        "@esbuild/linux-mips64el": "0.16.17",
-        "@esbuild/linux-ppc64": "0.16.17",
-        "@esbuild/linux-riscv64": "0.16.17",
-        "@esbuild/linux-s390x": "0.16.17",
-        "@esbuild/linux-x64": "0.16.17",
-        "@esbuild/netbsd-x64": "0.16.17",
-        "@esbuild/openbsd-x64": "0.16.17",
-        "@esbuild/sunos-x64": "0.16.17",
-        "@esbuild/win32-arm64": "0.16.17",
-        "@esbuild/win32-ia32": "0.16.17",
-        "@esbuild/win32-x64": "0.16.17"
+        "@esbuild/android-arm": "0.17.6",
+        "@esbuild/android-arm64": "0.17.6",
+        "@esbuild/android-x64": "0.17.6",
+        "@esbuild/darwin-arm64": "0.17.6",
+        "@esbuild/darwin-x64": "0.17.6",
+        "@esbuild/freebsd-arm64": "0.17.6",
+        "@esbuild/freebsd-x64": "0.17.6",
+        "@esbuild/linux-arm": "0.17.6",
+        "@esbuild/linux-arm64": "0.17.6",
+        "@esbuild/linux-ia32": "0.17.6",
+        "@esbuild/linux-loong64": "0.17.6",
+        "@esbuild/linux-mips64el": "0.17.6",
+        "@esbuild/linux-ppc64": "0.17.6",
+        "@esbuild/linux-riscv64": "0.17.6",
+        "@esbuild/linux-s390x": "0.17.6",
+        "@esbuild/linux-x64": "0.17.6",
+        "@esbuild/netbsd-x64": "0.17.6",
+        "@esbuild/openbsd-x64": "0.17.6",
+        "@esbuild/sunos-x64": "0.17.6",
+        "@esbuild/win32-arm64": "0.17.6",
+        "@esbuild/win32-ia32": "0.17.6",
+        "@esbuild/win32-x64": "0.17.6"
       }
     },
     "node_modules/@vanilla-extract/integration/node_modules/outdent": {
       "version": "0.8.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
     },
     "node_modules/@vanilla-extract/private": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@vanilla-extract/private/-/private-1.0.3.tgz",
+      "integrity": "sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "3.1.0",
@@ -8989,7 +9648,8 @@
     },
     "node_modules/ahocorasick": {
       "version": "1.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ahocorasick/-/ahocorasick-1.0.2.tgz",
+      "integrity": "sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -10075,7 +10735,6 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11466,7 +12125,8 @@
     },
     "node_modules/css-what": {
       "version": "5.1.0",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
       "engines": {
         "node": ">= 6"
       },
@@ -11761,7 +12421,8 @@
     },
     "node_modules/deep-object-diff": {
       "version": "1.1.9",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
+      "integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA=="
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -12353,6 +13014,51 @@
         "esbuild-windows-arm64": "0.15.15"
       }
     },
+    "node_modules/esbuild-android-64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.15.tgz",
+      "integrity": "sha512-F+WjjQxO+JQOva3tJWNdVjouFMLK6R6i5gjDvgUthLYJnIZJsp1HlF523k73hELY20WPyEO8xcz7aaYBVkeg5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.15.tgz",
+      "integrity": "sha512-attlyhD6Y22jNyQ0fIIQ7mnPvDWKw7k6FKnsXlBvQE6s3z6s6cuEHcSgoirquQc7TmZgVCK5fD/2uxmRN+ZpcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.15.tgz",
+      "integrity": "sha512-ohZtF8W1SHJ4JWldsPVdk8st0r9ExbAOSrBOh5L+Mq47i696GVwv1ab/KlmbUoikSTNoXEhDzVpxUR/WIO19FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/esbuild-darwin-arm64": {
       "version": "0.15.15",
       "cpu": [
@@ -12362,6 +13068,276 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.15.tgz",
+      "integrity": "sha512-KkTg+AmDXz1IvA9S1gt8dE24C8Thx0X5oM0KGF322DuP+P3evwTL9YyusHAWNsh4qLsR80nvBr/EIYs29VSwuA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.15.tgz",
+      "integrity": "sha512-FUcML0DRsuyqCMfAC+HoeAqvWxMeq0qXvclZZ/lt2kLU6XBnDA5uKTLUd379WYEyVD4KKFctqWd9tTuk8C/96g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.15.tgz",
+      "integrity": "sha512-q28Qn5pZgHNqug02aTkzw5sW9OklSo96b5nm17Mq0pDXrdTBcQ+M6Q9A1B+dalFeynunwh/pvfrNucjzwDXj+Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.15.tgz",
+      "integrity": "sha512-217KPmWMirkf8liO+fj2qrPwbIbhNTGNVtvqI1TnOWJgcMjUWvd677Gq3fTzXEjilkx2yWypVnTswM2KbXgoAg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.15.tgz",
+      "integrity": "sha512-RYVW9o2yN8yM7SB1yaWr378CwrjvGCyGybX3SdzPHpikUHkME2AP55Ma20uNwkNyY2eSYFX9D55kDrfQmQBR4w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.15.tgz",
+      "integrity": "sha512-/ltmNFs0FivZkYsTzAsXIfLQX38lFnwJTWCJts0IbCqWZQe+jjj0vYBNbI0kmXLb3y5NljiM5USVAO1NVkdh2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.15.tgz",
+      "integrity": "sha512-PksEPb321/28GFFxtvL33yVPfnMZihxkEv5zME2zapXGp7fA1X2jYeiTUK+9tJ/EGgcNWuwvtawPxJG7Mmn86A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.15.tgz",
+      "integrity": "sha512-ek8gJBEIhcpGI327eAZigBOHl58QqrJrYYIZBWQCnH3UnXoeWMrMZLeeZL8BI2XMBhP+sQ6ERctD5X+ajL/AIA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.15.tgz",
+      "integrity": "sha512-H5ilTZb33/GnUBrZMNJtBk7/OXzDHDXjIzoLXHSutwwsLxSNaLxzAaMoDGDd/keZoS+GDBqNVxdCkpuiRW4OSw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.15.tgz",
+      "integrity": "sha512-jKaLUg78mua3rrtrkpv4Or2dNTJU7bgHN4bEjT4OX4GR7nLBSA9dfJezQouTxMmIW7opwEC5/iR9mpC18utnxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.15.tgz",
+      "integrity": "sha512-aOvmF/UkjFuW6F36HbIlImJTTx45KUCHJndtKo+KdP8Dhq3mgLRKW9+6Ircpm8bX/RcS3zZMMmaBLkvGY06Gvw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.15.tgz",
+      "integrity": "sha512-HFFX+WYedx1w2yJ1VyR1Dfo8zyYGQZf1cA69bLdrHzu9svj6KH6ZLK0k3A1/LFPhcEY9idSOhsB2UyU0tHPxgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.15.tgz",
+      "integrity": "sha512-jOPBudffG4HN8yJXcK9rib/ZTFoTA5pvIKbRrt3IKAGMq1EpBi4xoVoSRrq/0d4OgZLaQbmkHp8RO9eZIn5atA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.15.tgz",
+      "integrity": "sha512-MDkJ3QkjnCetKF0fKxCyYNBnOq6dmidcwstBVeMtXSgGYTy8XSwBeIE4+HuKiSsG6I/mXEb++px3IGSmTN0XiA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.15.tgz",
+      "integrity": "sha512-xaAUIB2qllE888SsMU3j9nrqyLbkqqkpQyWVkfwSil6BBPgcPk3zOFitTTncEKCLTQy3XV9RuH7PDj3aJDljWA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.15.tgz",
+      "integrity": "sha512-ttuoCYCIJAFx4UUKKWYnFdrVpoXa3+3WWkXVI6s09U+YjhnyM5h96ewTq/WgQj9LFSIlABQvadHSOQyAVjW5xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.15.tgz",
+      "integrity": "sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.15.tgz",
+      "integrity": "sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">=12"
@@ -13392,6 +14368,8 @@
     },
     "node_modules/eval": {
       "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/eval/-/eval-0.1.6.tgz",
+      "integrity": "sha512-o0XUw+5OGkXw4pJZzQoXUk+H87DHuC+7ZE//oSrRGtatTmr12oTnLfg6QOq9DyTt0c/p4TwzgmkKrBzWTSizyQ==",
       "dependencies": {
         "require-like": ">= 0.1.1"
       },
@@ -14487,6 +15465,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -16239,7 +17222,8 @@
     },
     "node_modules/javascript-stringify": {
       "version": "2.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.1.0.tgz",
+      "integrity": "sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg=="
     },
     "node_modules/jest-diff": {
       "version": "29.4.3",
@@ -16545,7 +17529,6 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -17751,7 +18734,8 @@
     },
     "node_modules/media-query-parser": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/media-query-parser/-/media-query-parser-2.0.2.tgz",
+      "integrity": "sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       }
@@ -18819,7 +19803,6 @@
     },
     "node_modules/mlly": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.8.1",
@@ -18830,12 +19813,10 @@
     },
     "node_modules/mlly/node_modules/pathe": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mlly/node_modules/ufo": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mri": {
@@ -20726,7 +21707,6 @@
     },
     "node_modules/pkg-types": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.2.0",
@@ -20736,7 +21716,6 @@
     },
     "node_modules/pkg-types/node_modules/pathe": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pkg-up": {
@@ -22044,11 +23023,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.2.tgz",
-      "integrity": "sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.10.0.tgz",
+      "integrity": "sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==",
       "dependencies": {
-        "@remix-run/router": "1.3.3"
+        "@remix-run/router": "1.5.0"
       },
       "engines": {
         "node": ">=14"
@@ -22058,12 +23037,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.2.tgz",
-      "integrity": "sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.10.0.tgz",
+      "integrity": "sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==",
       "dependencies": {
-        "@remix-run/router": "1.3.3",
-        "react-router": "6.8.2"
+        "@remix-run/router": "1.5.0",
+        "react-router": "6.10.0"
       },
       "engines": {
         "node": ">=14"
@@ -22071,6 +23050,22 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/@remix-run/router": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/react-router/node_modules/@remix-run/router": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/react-universal-interface": {
@@ -22752,6 +23747,8 @@
     },
     "node_modules/require-like": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
+      "integrity": "sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==",
       "engines": {
         "node": "*"
       }
@@ -22876,7 +23873,6 @@
     },
     "node_modules/rollup": {
       "version": "3.12.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -25902,7 +26898,6 @@
     },
     "node_modules/vite": {
       "version": "4.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.16.14",
@@ -25950,7 +26945,6 @@
     },
     "node_modules/vite-node": {
       "version": "0.28.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
@@ -25974,12 +26968,10 @@
     },
     "node_modules/vite-node/node_modules/pathe": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite-node/node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -25995,12 +26987,56 @@
         "tsconfck": "^2.0.1"
       }
     },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+      "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+      "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+      "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
       "version": "0.16.17",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -26010,9 +27046,278 @@
         "node": ">=12"
       }
     },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+      "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+      "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+      "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+      "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+      "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+      "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+      "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+      "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+      "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+      "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+      "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+      "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+      "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+      "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+      "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+      "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vite/node_modules/esbuild": {
       "version": "0.16.17",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -27274,7 +28579,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@oclif/core": "^1.20.4",
-        "@remix-run/dev": "^1.14.3",
+        "@remix-run/dev": "1.15.0",
         "@shopify/cli-kit": "3.29.0",
         "@shopify/mini-oxygen": "^1.3.1",
         "fast-glob": "^3.2.12",
@@ -27302,7 +28607,7 @@
         "node": ">=16.13"
       },
       "peerDependencies": {
-        "@remix-run/react": "^1.14.3",
+        "@remix-run/react": "^1.15.0",
         "@shopify/hydrogen-react": "^2023.1.7",
         "@shopify/remix-oxygen": "^1.0.4"
       }
@@ -27347,8 +28652,8 @@
         "vitest": "^0.27.2"
       },
       "peerDependencies": {
-        "@remix-run/react": "1.14.3",
-        "@remix-run/server-runtime": "1.14.3"
+        "@remix-run/react": "^1.15.0",
+        "@remix-run/server-runtime": "^1.15.0"
       }
     },
     "packages/hydrogen-react": {
@@ -27654,7 +28959,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@headlessui/react": "^1.7.2",
-        "@remix-run/react": "1.14.3",
+        "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.29.0",
         "@shopify/cli-hydrogen": "^4.0.9",
         "@shopify/hydrogen": "^2023.1.6",
@@ -27673,8 +28978,8 @@
         "typographic-base": "^1.0.4"
       },
       "devDependencies": {
-        "@remix-run/dev": "1.14.3",
-        "@remix-run/eslint-config": "1.14.3",
+        "@remix-run/dev": "1.15.0",
+        "@remix-run/eslint-config": "1.15.0",
         "@shopify/eslint-plugin": "^42.0.1",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
@@ -27701,7 +29006,7 @@
     "templates/hello-world": {
       "version": "0.0.0",
       "dependencies": {
-        "@remix-run/react": "1.14.3",
+        "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.29.0",
         "@shopify/cli-hydrogen": "^4.0.9",
         "@shopify/hydrogen": "^2023.1.6",
@@ -27713,7 +29018,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@remix-run/dev": "1.14.3",
+        "@remix-run/dev": "1.15.0",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
         "@types/eslint": "^8.4.10",
@@ -27731,7 +29036,7 @@
     "templates/skeleton": {
       "version": "0.0.0",
       "dependencies": {
-        "@remix-run/react": "1.14.3",
+        "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.29.0",
         "@shopify/cli-hydrogen": "^4.0.9",
         "@shopify/hydrogen": "^2023.1.6",
@@ -27743,7 +29048,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@remix-run/dev": "1.14.3",
+        "@remix-run/dev": "1.15.0",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
         "@types/eslint": "^8.4.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6885,14 +6885,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.3.tgz",
-      "integrity": "sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@remix-run/server-runtime": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.15.0.tgz",
@@ -28929,30 +28921,13 @@
       "version": "1.0.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@remix-run/server-runtime": "1.14.0"
+        "@remix-run/server-runtime": "1.15.0"
       },
       "devDependencies": {
         "@shopify/oxygen-workers-types": "^3.17.2"
       },
       "peerDependencies": {
         "@shopify/oxygen-workers-types": "^3.17.2"
-      }
-    },
-    "packages/remix-oxygen/node_modules/@remix-run/server-runtime": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-1.14.0.tgz",
-      "integrity": "sha512-qkqfT7DDwVzLICtJxMGthIU4T7DVtLy+oxKAzOi9eiCFlr3aWqV30YJ5Kq6r/kP8tighlnHbj1uEo41+WbD8uA==",
-      "dependencies": {
-        "@remix-run/router": "1.3.3",
-        "@types/cookie": "^0.4.0",
-        "@types/react": "^18.0.15",
-        "@web3-storage/multipart-parser": "^1.0.0",
-        "cookie": "^0.4.1",
-        "set-cookie-parser": "^2.4.8",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "templates/demo-store": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,13 +26,13 @@
     "tempy": "^3.0.0"
   },
   "peerDependencies": {
-    "@remix-run/react": "^1.14.3",
+    "@remix-run/react": "^1.15.0",
     "@shopify/hydrogen-react": "^2023.1.7",
     "@shopify/remix-oxygen": "^1.0.4"
   },
   "dependencies": {
     "@oclif/core": "^1.20.4",
-    "@remix-run/dev": "^1.14.3",
+    "@remix-run/dev": "1.15.0",
     "@shopify/cli-kit": "3.29.0",
     "@shopify/mini-oxygen": "^1.3.1",
     "fast-glob": "^3.2.12",

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -2,7 +2,6 @@ import type {ServerMode} from '@remix-run/dev/dist/config/serverModes.js';
 import type {RemixConfig} from '@remix-run/dev/dist/config.js';
 import {renderFatalError} from '@shopify/cli-kit/node/ui';
 import {output, file} from '@shopify/cli-kit';
-import {createRequire} from 'module';
 import {fileURLToPath} from 'url';
 import path from 'path';
 import fs from 'fs/promises';
@@ -37,15 +36,6 @@ export async function getRemixConfig(
     serverMainFields?: string[];
     serverDependenciesToBundle?: string;
   };
-
-  // TODO: Remove when updating Remix
-  if (!config.serverConditions) {
-    const require = createRequire(import.meta.url);
-    const actualConfigFile = require(path.join(root, 'remix.config'));
-    config.serverBuildTarget = 'cloudflare-workers';
-    config.serverConditions = actualConfigFile.serverConditions;
-    config.serverMainFields = actualConfigFile.serverMainFields;
-  }
 
   if (!config.serverEntryPoint) {
     throwConfigError(

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -56,8 +56,8 @@
     "react": "^18.2.0"
   },
   "peerDependencies": {
-    "@remix-run/react": "1.14.3",
-    "@remix-run/server-runtime": "1.14.3"
+    "@remix-run/react": "^1.15.0",
+    "@remix-run/server-runtime": "^1.15.0"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/packages/remix-oxygen/package.json
+++ b/packages/remix-oxygen/package.json
@@ -40,7 +40,7 @@
     "dist"
   ],
   "dependencies": {
-    "@remix-run/server-runtime": "1.14.0"
+    "@remix-run/server-runtime": "1.15.0"
   },
   "devDependencies": {
     "@shopify/oxygen-workers-types": "^3.17.2"

--- a/packages/remix-oxygen/src/index.ts
+++ b/packages/remix-oxygen/src/index.ts
@@ -62,5 +62,9 @@ export type {
   UnsignFunction,
   UploadHandler,
   UploadHandlerPart,
-  V2_MetaFunction,
+  V2_ServerRuntimeMetaArgs as V2_MetaArgs,
+  V2_ServerRuntimeMetaDescriptor as V2_MetaDescriptor,
+  // TODO: Remove in Remix v2
+  V2_ServerRuntimeMetaDescriptor as V2_HtmlMetaDescriptor,
+  V2_ServerRuntimeMetaFunction as V2_MetaFunction,
 } from '@remix-run/server-runtime';

--- a/templates/demo-store/app/components/Pagination.tsx
+++ b/templates/demo-store/app/components/Pagination.tsx
@@ -6,7 +6,7 @@ import type {
 } from '@shopify/hydrogen/storefront-api-types';
 
 import {useInView, type IntersectionOptions} from 'react-intersection-observer';
-import {useTransition, useLocation, useNavigate} from '@remix-run/react';
+import {useNavigation, useLocation, useNavigate} from '@remix-run/react';
 
 type Connection = {
   nodes: ProductConnection['nodes'] | any[];
@@ -51,8 +51,8 @@ export function Pagination<Resource extends Connection>({
     startCursor,
   }: PaginationInfo) => JSX.Element | null;
 }) {
-  const transition = useTransition();
-  const isLoading = transition.state === 'loading';
+  const {state} = useNavigation();
+  const isLoading = state === 'loading';
   const autoScrollEnabled = Boolean(autoLoadOnScroll);
   const autoScrollConfig = (
     autoScrollEnabled

--- a/templates/demo-store/app/routes/($lang)/account/__private/address/$id.tsx
+++ b/templates/demo-store/app/routes/($lang)/account/__private/address/$id.tsx
@@ -4,7 +4,7 @@ import {
   useActionData,
   useOutletContext,
   useParams,
-  useTransition,
+  useNavigation,
 } from '@remix-run/react';
 import {flattenConnection} from '@shopify/hydrogen';
 import type {
@@ -144,7 +144,7 @@ export default function EditAddress() {
   const {id: addressId} = useParams();
   const isNewAddress = addressId === 'add';
   const actionData = useActionData<ActionData>();
-  const transition = useTransition();
+  const {state} = useNavigation();
   const {customer} = useOutletContext<AccountOutletContext>();
   const addresses = flattenConnection(customer.addresses);
   const defaultAddress = customer.defaultAddress;
@@ -324,9 +324,9 @@ export default function EditAddress() {
               className="w-full rounded focus:shadow-outline"
               type="submit"
               variant="primary"
-              disabled={transition.state !== 'idle'}
+              disabled={state !== 'idle'}
             >
-              {transition.state !== 'idle' ? 'Saving' : 'Save'}
+              {state !== 'idle' ? 'Saving' : 'Save'}
             </Button>
           </div>
           <div>

--- a/templates/demo-store/app/routes/($lang)/account/__private/edit.tsx
+++ b/templates/demo-store/app/routes/($lang)/account/__private/edit.tsx
@@ -3,7 +3,7 @@ import {
   useActionData,
   Form,
   useOutletContext,
-  useTransition,
+  useNavigation,
 } from '@remix-run/react';
 import type {
   Customer,
@@ -128,7 +128,7 @@ export const action: ActionFunction = async ({request, context, params}) => {
 export default function AccountDetailsEdit() {
   const actionData = useActionData<ActionData>();
   const {customer} = useOutletContext<AccountOutletContext>();
-  const transition = useTransition();
+  const {state} = useNavigation();
 
   return (
     <>
@@ -240,9 +240,9 @@ export default function AccountDetailsEdit() {
             variant="primary"
             width="full"
             type="submit"
-            disabled={transition.state !== 'idle'}
+            disabled={state !== 'idle'}
           >
-            {transition.state !== 'idle' ? 'Saving' : 'Save'}
+            {state !== 'idle' ? 'Saving' : 'Save'}
           </Button>
         </div>
         <div className="mb-4">

--- a/templates/demo-store/app/routes/($lang)/account/__private/orders.$id.tsx
+++ b/templates/demo-store/app/routes/($lang)/account/__private/orders.$id.tsx
@@ -1,12 +1,7 @@
 import invariant from 'tiny-invariant';
 import clsx from 'clsx';
-import {
-  json,
-  redirect,
-  type V2_MetaFunction,
-  type LoaderArgs,
-} from '@shopify/remix-oxygen';
-import {useLoaderData} from '@remix-run/react';
+import {json, redirect, type LoaderArgs} from '@shopify/remix-oxygen';
+import {useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 import {Money, Image, flattenConnection} from '@shopify/hydrogen';
 import {statusMessage} from '~/lib/utils';
 import type {

--- a/templates/demo-store/app/routes/($lang)/account/__public/activate.$id.$activationToken.tsx
+++ b/templates/demo-store/app/routes/($lang)/account/__public/activate.$id.$activationToken.tsx
@@ -1,10 +1,5 @@
-import {
-  json,
-  redirect,
-  type V2_MetaFunction,
-  type ActionFunction,
-} from '@shopify/remix-oxygen';
-import {Form, useActionData} from '@remix-run/react';
+import {json, redirect, type ActionFunction} from '@shopify/remix-oxygen';
+import {Form, useActionData, type V2_MetaFunction} from '@remix-run/react';
 import {useRef, useState} from 'react';
 import {getInputStyleClasses} from '~/lib/utils';
 import type {CustomerActivatePayload} from '@shopify/hydrogen/storefront-api-types';

--- a/templates/demo-store/app/routes/($lang)/account/__public/login.tsx
+++ b/templates/demo-store/app/routes/($lang)/account/__public/login.tsx
@@ -1,12 +1,16 @@
 import {
   json,
   redirect,
-  type V2_MetaFunction,
   type ActionFunction,
   type AppLoadContext,
   type LoaderArgs,
 } from '@shopify/remix-oxygen';
-import {Form, useActionData, useLoaderData} from '@remix-run/react';
+import {
+  Form,
+  useActionData,
+  useLoaderData,
+  type V2_MetaFunction,
+} from '@remix-run/react';
 import {useState} from 'react';
 import {getInputStyleClasses} from '~/lib/utils';
 import {Link} from '~/components';

--- a/templates/demo-store/app/routes/($lang)/account/__public/recover.tsx
+++ b/templates/demo-store/app/routes/($lang)/account/__public/recover.tsx
@@ -1,11 +1,10 @@
 import {
   json,
   redirect,
-  type V2_MetaFunction,
   type ActionFunction,
   type LoaderArgs,
 } from '@shopify/remix-oxygen';
-import {Form, useActionData} from '@remix-run/react';
+import {Form, useActionData, type V2_MetaFunction} from '@remix-run/react';
 import {useState} from 'react';
 import {Link} from '~/components';
 import {getInputStyleClasses} from '~/lib/utils';

--- a/templates/demo-store/app/routes/($lang)/account/__public/register.tsx
+++ b/templates/demo-store/app/routes/($lang)/account/__public/register.tsx
@@ -1,11 +1,10 @@
 import {
-  type V2_MetaFunction,
   redirect,
   json,
   type ActionFunction,
   type LoaderArgs,
 } from '@shopify/remix-oxygen';
-import {Form, useActionData} from '@remix-run/react';
+import {Form, useActionData, type V2_MetaFunction} from '@remix-run/react';
 import {useState} from 'react';
 import {getInputStyleClasses} from '~/lib/utils';
 import {doLogin} from './login';

--- a/templates/demo-store/app/routes/($lang)/account/__public/reset.$id.$resetToken.tsx
+++ b/templates/demo-store/app/routes/($lang)/account/__public/reset.$id.$resetToken.tsx
@@ -1,10 +1,5 @@
-import {
-  json,
-  redirect,
-  type V2_MetaFunction,
-  type ActionFunction,
-} from '@shopify/remix-oxygen';
-import {Form, useActionData} from '@remix-run/react';
+import {json, redirect, type ActionFunction} from '@shopify/remix-oxygen';
+import {Form, useActionData, type V2_MetaFunction} from '@remix-run/react';
 import {useRef, useState} from 'react';
 import {getInputStyleClasses} from '~/lib/utils';
 import type {CustomerResetPayload} from '@shopify/hydrogen/storefront-api-types';

--- a/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
+++ b/templates/demo-store/app/routes/($lang)/products/$productHandle.tsx
@@ -6,7 +6,7 @@ import {
   Await,
   useSearchParams,
   useLocation,
-  useTransition,
+  useNavigation,
 } from '@remix-run/react';
 
 import {
@@ -183,18 +183,18 @@ export function ProductForm() {
   const {product, analytics, storeDomain} = useLoaderData<typeof loader>();
 
   const [currentSearchParams] = useSearchParams();
-  const transition = useTransition();
+  const {location} = useNavigation();
 
   /**
-   * We update `searchParams` with in-flight request data from `transition` (if available)
+   * We update `searchParams` with in-flight request data from `location` (if available)
    * to create an optimistic UI, e.g. check the product option before the
    * request has completed.
    */
   const searchParams = useMemo(() => {
-    return transition.location
-      ? new URLSearchParams(transition.location.search)
+    return location
+      ? new URLSearchParams(location.search)
       : currentSearchParams;
-  }, [currentSearchParams, transition]);
+  }, [currentSearchParams, location]);
 
   const firstVariant = product.variants.nodes[0];
 

--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -18,7 +18,7 @@
   "prettier": "@shopify/prettier-config",
   "dependencies": {
     "@headlessui/react": "^1.7.2",
-    "@remix-run/react": "1.14.3",
+    "@remix-run/react": "1.15.0",
     "@shopify/cli": "3.29.0",
     "@shopify/cli-hydrogen": "^4.0.9",
     "@shopify/hydrogen": "^2023.1.6",
@@ -37,8 +37,8 @@
     "typographic-base": "^1.0.4"
   },
   "devDependencies": {
-    "@remix-run/dev": "1.14.3",
-    "@remix-run/eslint-config": "1.14.3",
+    "@remix-run/dev": "1.15.0",
+    "@remix-run/eslint-config": "1.15.0",
     "@shopify/eslint-plugin": "^42.0.1",
     "@shopify/oxygen-workers-types": "^3.17.2",
     "@shopify/prettier-config": "^1.1.2",

--- a/templates/demo-store/remix.config.js
+++ b/templates/demo-store/remix.config.js
@@ -19,7 +19,8 @@ module.exports = {
   future: {
     unstable_postcss: true,
     unstable_tailwind: true,
-    v2_errorBoundary: true,
     v2_meta: true,
+    v2_errorBoundary: true,
+    v2_normalizeFormMethod: true,
   },
 };

--- a/templates/hello-world/package.json
+++ b/templates/hello-world/package.json
@@ -13,7 +13,7 @@
   },
   "prettier": "@shopify/prettier-config",
   "dependencies": {
-    "@remix-run/react": "1.14.3",
+    "@remix-run/react": "1.15.0",
     "@shopify/cli": "3.29.0",
     "@shopify/cli-hydrogen": "^4.0.9",
     "@shopify/hydrogen": "^2023.1.6",
@@ -25,7 +25,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "1.14.3",
+    "@remix-run/dev": "1.15.0",
     "@shopify/oxygen-workers-types": "^3.17.2",
     "@shopify/prettier-config": "^1.1.2",
     "@types/eslint": "^8.4.10",

--- a/templates/hello-world/remix.config.js
+++ b/templates/hello-world/remix.config.js
@@ -16,4 +16,7 @@ module.exports = {
   serverModuleFormat: 'esm',
   serverPlatform: 'neutral',
   serverMinify: process.env.NODE_ENV === 'production',
+  future: {
+    v2_normalizeFormMethod: true,
+  },
 };

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -12,7 +12,7 @@
   },
   "prettier": "@shopify/prettier-config",
   "dependencies": {
-    "@remix-run/react": "1.14.3",
+    "@remix-run/react": "1.15.0",
     "@shopify/cli": "3.29.0",
     "@shopify/cli-hydrogen": "^4.0.9",
     "@shopify/hydrogen": "^2023.1.6",
@@ -24,7 +24,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "1.14.3",
+    "@remix-run/dev": "1.15.0",
     "@shopify/oxygen-workers-types": "^3.17.2",
     "@shopify/prettier-config": "^1.1.2",
     "@types/eslint": "^8.4.10",

--- a/templates/skeleton/remix.config.js
+++ b/templates/skeleton/remix.config.js
@@ -16,4 +16,7 @@ module.exports = {
   serverModuleFormat: 'esm',
   serverPlatform: 'neutral',
   serverMinify: process.env.NODE_ENV === 'production',
+  future: {
+    v2_normalizeFormMethod: true,
+  },
 };


### PR DESCRIPTION
- Upgrade all dependencies of Remix to the latest 1.15.0.
- Enable the new `v2_normalizeFormMethod` flag in all templates.
- Replace calls to the deprecated `useTransition` with the new `useNavigation` in demo-store.
- Change `type V2_MetaFunction` imports to `'@remix-run/react'` in demo-store -- it can still be imported from adapter packages but this [will be deprecated in V2](https://github.com/remix-run/remix/pull/5785).

Users in this version will start getting warnings about enabling v2 flags:

```
⚠️ REMIX FUTURE CHANGE: The route file convention is changing in v2. You can prepare for this change at your convenience with the `v2_routeConvention` future flag. For instructions on making this change see https://remix.run/docs/en/v1.15.0/pages/v2#file-system-route-convention
```

We are enabling all the flags in our starter templates in other existing PRs. This will ease migration to Remix 2 when released.