### PR TITLE
return typed data from product and collection SEO utilities

### DIFF
--- a/.changeset/small-elephants-jam.md
+++ b/.changeset/small-elephants-jam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Improve type safety in SEO data generators.

--- a/templates/demo-store/app/lib/seo.server.ts
+++ b/templates/demo-store/app/lib/seo.server.ts
@@ -85,7 +85,7 @@ function productJsonLd({
   product: Product;
   selectedVariant: ProductVariant;
   url: Request['url'];
-}): SeoConfig<SeoProduct | BreadcrumbList>['jsonLd'][] {
+}): SeoConfig<SeoProduct | BreadcrumbList>['jsonLd'] {
   const origin = new URL(url).origin;
   const variants = product.variants.nodes;
   const description = truncate(
@@ -152,7 +152,7 @@ function product({
   product: Product;
   selectedVariant: ProductVariant;
   url: Request['url'];
-}) {
+}): SeoConfig<SeoProduct | BreadcrumbList> {
   const description = truncate(
     product?.seo?.description ?? product?.description ?? '',
   );
@@ -170,7 +170,7 @@ function collectionJsonLd({
 }: {
   url: Request['url'];
   collection: Collection;
-}): SeoConfig<CollectionPage | BreadcrumbList>['jsonLd'][] {
+}): SeoConfig<CollectionPage | BreadcrumbList>['jsonLd'] {
   const siteUrl = new URL(url);
   const itemListElement: CollectionPage['mainEntity'] =
     collection.products.nodes.map((product, index) => {
@@ -222,7 +222,7 @@ function collection({
 }: {
   collection: Collection;
   url: Request['url'];
-}) {
+}): SeoConfig<CollectionPage | BreadcrumbList> {
   return {
     title: collection?.seo?.title,
     description: truncate(


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

This PR brings more consistency to the typing of the seo data utilities. This preserves internal consistency within the module and will hopefully help folks in userland who bring the seo data utility module into their own repos.

### WHAT is this pull request doing?


Previously, the `collection` and `product` seo data utilities in the demo store inferred the types of the data they returned. In contrast, other seo data utililties annotated the return type with the `SeoConfig` generic.

I realized that the `product` and `collection` utilities were using extracted functions for creating the `jsonLd` values, but those functions returned the incorrect type. I removed the unnecessary array typing and was then able to add the return typing to `collection` and `product`.

Continuation of https://github.com/Shopify/hydrogen/pull/757

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
