### PR TITLE
Discount route query params support

### DIFF
--- a/.changeset/great-lamps-tell.md
+++ b/.changeset/great-lamps-tell.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': minor
+'@shopify/create-hydrogen': minor
+---
+
+Forwards search params of `/discount/<code>` route to a redirect route.

--- a/templates/demo-store/app/routes/($lang)/discount.$code.tsx
+++ b/templates/demo-store/app/routes/($lang)/discount.$code.tsx
@@ -22,9 +22,13 @@ export async function loader({request, context, params}: LoaderArgs) {
 
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.search);
-  const redirectUrl =
+  const redirectParam =
     searchParams.get('redirect') || searchParams.get('return_to') || '/';
 
+  searchParams.delete('redirect');
+  searchParams.delete('return_to');
+
+  const redirectUrl = `${redirectParam}?${searchParams}`;
   const headers = new Headers();
 
   if (!code) {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Current example of discount path is not backwards compatible with discount route of regular liquid storefront because it drops all the query params and does not forward any of them to the redirect location. This introduces breaking changes for shops that want to migrate from liquid storefronts to custom storefronts powered by Hydrogen. 

### WHAT is this pull request doing?

Drops `redirect` and `redirect_to` query params and forwards the rest to the redirect location.

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
