### PR TITLE
Support optional segments in `check routes` CLI command

### DIFF
--- a/packages/cli/src/lib/missing-routes.test.ts
+++ b/packages/cli/src/lib/missing-routes.test.ts
@@ -1,0 +1,52 @@
+import {describe, it, expect} from 'vitest';
+import {findMissingRoutes} from './missing-routes.js';
+
+const createRoute = (path: string) => ({
+  routes: {
+    'route-id': {
+      file: 'a/file',
+      id: 'route-id',
+      path,
+    },
+  },
+});
+
+describe('missing-routes', () => {
+  it('matches routes with dots', async () => {
+    const requiredRoutes = ['sitemap.xml'];
+
+    expect(findMissingRoutes({routes: {}}, requiredRoutes)).toHaveLength(1);
+    expect(
+      findMissingRoutes(createRoute('sitemap.xml'), requiredRoutes),
+    ).toHaveLength(0);
+  });
+
+  it('matches routes with different parameter names', async () => {
+    const requiredRoutes = ['collections/:collectionHandle'];
+
+    expect(findMissingRoutes({routes: {}}, requiredRoutes)).toHaveLength(1);
+    expect(
+      findMissingRoutes(createRoute('collections/:param'), requiredRoutes),
+    ).toHaveLength(0);
+  });
+
+  it('matches optional segments in different positions', async () => {
+    const requiredRoutes = ['collections/products'];
+    const validRoutes = [
+      'segment?/collections/products',
+      ':segment?/collections/products',
+      'collections/segment?/products',
+      'collections/:segment?/products',
+      'collections/products/segment?',
+      'collections/products/:segment?',
+    ];
+
+    expect(findMissingRoutes({routes: {}}, requiredRoutes)).toHaveLength(1);
+
+    for (const validRoute of validRoutes) {
+      expect(
+        findMissingRoutes(createRoute(validRoute), requiredRoutes),
+      ).toHaveLength(0);
+    }
+  });
+});

--- a/packages/cli/src/lib/missing-routes.ts
+++ b/packages/cli/src/lib/missing-routes.ts
@@ -70,12 +70,14 @@ export function findMissingRoutes(
           currentRoute.parentId = parentRoute.parentId;
         }
 
+        const optionalSegment = ':?[^\\/\\?]+\\?';
         const reString =
-          // Starts with optional params
-          '^(:[^\\/\\?]+\\?\\/)?' +
-          // Escape dots and replace params with regex
-          requiredRoute.replaceAll('.', '\\.').replace(/:[^/]+/g, ':[^\\/]+') +
-          '$';
+          `^(${optionalSegment}\\/)?` + // Starts with an optional segment
+          requiredRoute
+            .replaceAll('.', '\\.') // Escape dots
+            .replace(/\//g, `\\/(${optionalSegment}\\/)?`) // Has optional segments in the middle
+            .replace(/:[^/)?]+/g, ':[^\\/]+') + // Replace params with regex
+          `(\\/${optionalSegment})?$`; // Ends with an optional segment
 
         if (new RegExp(reString).test(currentRoute.path)) {
           missingRoutes.delete(requiredRoute);

--- a/packages/cli/src/lib/missing-routes.ts
+++ b/packages/cli/src/lib/missing-routes.ts
@@ -41,14 +41,17 @@ const REQUIRED_ROUTES = [
   //   'opening_soon',
 ];
 
-export function findMissingRoutes(config: RemixConfig) {
+export function findMissingRoutes(
+  config: {routes: RemixConfig['routes']},
+  requiredRoutes = REQUIRED_ROUTES,
+) {
   const userRoutes = Object.values(config.routes);
-  const requiredRoutes = new Set(REQUIRED_ROUTES);
+  const missingRoutes = new Set(requiredRoutes);
 
   for (const requiredRoute of requiredRoutes) {
     for (const userRoute of userRoutes) {
       if (!requiredRoute && !userRoute.path) {
-        requiredRoutes.delete(requiredRoute);
+        missingRoutes.delete(requiredRoute);
       } else if (requiredRoute && userRoute.path) {
         const currentRoute = {
           path: userRoute.path,
@@ -75,13 +78,13 @@ export function findMissingRoutes(config: RemixConfig) {
           '$';
 
         if (new RegExp(reString).test(currentRoute.path)) {
-          requiredRoutes.delete(requiredRoute);
+          missingRoutes.delete(requiredRoute);
         }
       }
     }
   }
 
-  return [...requiredRoutes];
+  return [...missingRoutes];
 }
 
 const LINE_LIMIT = 100;


### PR DESCRIPTION
Closes #749 

The `h2 check routes` command was matching `($lang)/cart` but not `(lang)/cart` (i.e. optional segment instead of optional parameter). I've added support for that and also for optional segments and parameters in any position of the URL. It will now also match `/cart/(extra)` since the extra bit is optional.