### PR TITLE
Update hello world template virtual route to use Remix V2 route name

### DIFF
--- a/.changeset/famous-eagles-rhyme.md
+++ b/.changeset/famous-eagles-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Update virtual route to use Remix V2 route name conventions

--- a/packages/cli/src/virtual-routes/routes/index.tsx
+++ b/packages/cli/src/virtual-routes/routes/index.tsx
@@ -75,7 +75,7 @@ export default function Index() {
               <br /> To get started, edit {` `}
               <code>.env</code>. Then, create your first route with the file
               {` `}
-              <code>/app/routes/index.jsx</code>. Learn more about
+              <code>/app/routes/_index.jsx</code>. Learn more about
               {` `}
               <a
                 target="_blank"


### PR DESCRIPTION
### WHY are these changes introduced?

Improve the first route creation instructions for Remix V2

### WHAT is this pull request doing?

Fixes route name in instructions for Remix V2 route name conventions.

