### PR TITLE
Use package to parse cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32043,7 +32043,8 @@
         "react-use": "^17.4.0",
         "schema-dts": "^1.1.0",
         "tiny-invariant": "^1.2.0",
-        "typographic-base": "^1.0.4"
+        "typographic-base": "^1.0.4",
+        "worktop": "^0.7.3"
       },
       "devDependencies": {
         "@remix-run/dev": "1.15.0",
@@ -42118,7 +42119,8 @@
         "tailwindcss": "^3.3.0",
         "tiny-invariant": "^1.2.0",
         "typescript": "^4.9.5",
-        "typographic-base": "^1.0.4"
+        "typographic-base": "^1.0.4",
+        "worktop": "^0.7.3"
       }
     },
     "depd": {

--- a/templates/demo-store/app/lib/utils.ts
+++ b/templates/demo-store/app/lib/utils.ts
@@ -1,4 +1,5 @@
 import {useLocation, useMatches} from '@remix-run/react';
+import {parse as parseCookie} from 'worktop/cookie';
 import type {
   MenuItem,
   Menu,
@@ -313,15 +314,6 @@ export function isLocalPath(url: string) {
  * without customers losing carts.
  */
 export function getCartId(request: Request) {
-  const cookies = request.headers.get('Cookie');
-
-  let cart = cookies
-    ?.split(';')
-    .find((cookie) => cookie.trim().startsWith('cart='))
-    ?.substring(6);
-
-  if (cart) {
-    cart = `gid://shopify/Cart/${cart}`;
-  }
-  return cart;
+  const cookies = parseCookie(request.headers.get('Cookie') || '');
+  return cookies.cart ? `gid://shopify/Cart/${cookies.cart}` : undefined;
 }

--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -34,7 +34,8 @@
     "react-use": "^17.4.0",
     "schema-dts": "^1.1.0",
     "tiny-invariant": "^1.2.0",
-    "typographic-base": "^1.0.4"
+    "typographic-base": "^1.0.4",
+    "worktop": "^0.7.3"
   },
   "devDependencies": {
     "@remix-run/dev": "1.15.0",


### PR DESCRIPTION
### WHY are these changes introduced?

Fix cart id parsing by using a cookie library.

The previous code will break when `cart` cookie is the only cookie in the request header. (Confirmed this issue in hello-world project)

Example:

`a=1; b=2; cart=c1-12345` => this will result in correct cart id `c1-12345`
`cart=c1-12345` => this will result in incorrect cart it `1-12345`

### WHAT is this pull request doing?

Instead of relying on some regex / string functions .. use a cookie library

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
