### PR TITLE
Update links to docs after successful project creation via CLI

### DIFF
--- a/.changeset/funny-comics-lay.md
+++ b/.changeset/funny-comics-lay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Update docs links on successful project creation

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -234,7 +234,9 @@ export async function runInit(
       )} to start your local development server and start building`.value,
     ].filter((step): step is string => Boolean(step)),
     reference: [
-      'Building with Hydrogen: https://shopify.dev/docs/custom-storefronts/hydrogen/building/begin-development',
+      'Getting started with Hydrogen: https://shopify.dev/docs/custom-storefronts/hydrogen/building/begin-development',
+      'Hydrogen project structure: https://shopify.dev/docs/custom-storefronts/hydrogen/project-structure',
+      'Setting up Hydrogen environment variables: https://shopify.dev/docs/custom-storefronts/hydrogen/environment-variables',
     ],
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #524

This PR adds a couple more links to documentation when scaffolding out a new project via CLI.

Before | After
---|---
<img width="988" alt="before" src="https://user-images.githubusercontent.com/547470/233723231-803323c6-d840-406e-8330-a24d4c6f414e.png"> | ![image](https://user-images.githubusercontent.com/547470/234098302-d432fbca-96c7-4a6b-ab0d-82c729085454.png)

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- ~[ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes~
- ~[ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes~
- ~[ ] I've added or updated the documentation~
