### PR TITLE
calver with changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,13 @@
   "baseBranch": "2023-04",
   "updateInternalDependencies": "patch",
   "ignore": ["hello-world", "skeleton"],
-  "privatePackages": {"version": true, "tag": true}
+  "privatePackages": {"version": true, "tag": true},
+  "incrementVersions": {
+    "@shopify/hydrogen": {
+      "path": "./hydrogen-increase-version.js"
+    },
+    "@shopify/hydrogen-react": {
+      "path": "./hydrogen-increase-version.js"
+    }
+  }
 }

--- a/.changeset/hydrogen-increase-version.js
+++ b/.changeset/hydrogen-increase-version.js
@@ -1,0 +1,21 @@
+const incrementVersion = (oldVersion, type, defaultIncreaseVersion) => {
+  const versions = oldVersion.split('.');
+  if (type === 'major') {
+    const minor = parseInt(versions[1]);
+    const newMinor = (minor + 3) % 12;
+
+    const major = parseInt(versions[0]);
+    const newMajor = newMinor === 1 ? major + 1 : major;
+    return `${newMajor}.${newMinor}.0`;
+  }
+
+  if (type === 'minor') {
+    return defaultIncreaseVersion();
+  }
+
+  return defaultIncreaseVersion();
+};
+
+module.exports = {
+  incrementVersion,
+};

--- a/.changeset/hydrogen-increase-version.js
+++ b/.changeset/hydrogen-increase-version.js
@@ -1,5 +1,9 @@
+// This file is used to increase the version number of the package using calver matching shopify's versioning scheme
+// For example, 2023-1, 2023-4, 2023-7, 2023-10 are all valid versions
 const incrementVersion = (oldVersion, type, defaultIncreaseVersion) => {
   const versions = oldVersion.split('.');
+
+  // we manually update major to match years, and minor to match month
   if (type === 'major') {
     const minor = parseInt(versions[1]);
     const newMinor = (minor + 3) % 12;
@@ -7,10 +11,6 @@ const incrementVersion = (oldVersion, type, defaultIncreaseVersion) => {
     const major = parseInt(versions[0]);
     const newMajor = newMinor === 1 ? major + 1 : major;
     return `${newMajor}.${newMinor}.0`;
-  }
-
-  if (type === 'minor') {
-    return defaultIncreaseVersion();
   }
 
   return defaultIncreaseVersion();

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.20.0",
         "lint-staged": "^10.5.4",
+        "patch-package": "^6.5.1",
         "prettier": "^2.8.4",
         "rimraf": "^3.0.2",
         "tsup": "^6.5.0",
@@ -8995,6 +8996,12 @@
         }
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "license": "MIT",
@@ -17701,6 +17708,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "license": "MIT",
@@ -22097,6 +22113,181 @@
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^1.10.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "node_modules/patch-package/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/path-case": {
@@ -40020,6 +40211,12 @@
         "use-sync-external-store": "^1.0.0"
       }
     },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true
+    },
     "abort-controller": {
       "version": "3.0.0",
       "requires": {
@@ -45666,6 +45863,15 @@
       "version": "6.0.3",
       "dev": true
     },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "kleur": {
       "version": "4.1.5"
     },
@@ -48576,6 +48782,137 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
+    },
+    "patch-package": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "open": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+          "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+          "dev": true,
+          "requires": {
+            "is-docker": "^2.0.0",
+            "is-wsl": "^2.1.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+          "dev": true
+        }
+      }
     },
     "path-case": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "workspaces": [
         "templates/hello-world",
         "templates/demo-store",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "version:cli": "cd packages/cli && npm run generate:manifest",
     "version:create-hydrogen": "cd packages/create-hydrogen && npm run build",
     "changeset": "changeset",
-    "clean-all": "rimraf node_modules/.bin && rimraf node_modules/.cache && rimraf packages/remix-oxygen/dist && rimraf packages/hydrogen/dist && rimraf packages/cli/dist && rimraf templates/demo-store/.cache"
+    "clean-all": "rimraf node_modules/.bin && rimraf node_modules/.cache && rimraf packages/remix-oxygen/dist && rimraf packages/hydrogen/dist && rimraf packages/cli/dist && rimraf templates/demo-store/.cache",
+    "postinstall": "patch-package"
   },
   "workspaces": [
     "templates/hello-world",
@@ -40,6 +41,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^8.20.0",
     "lint-staged": "^10.5.4",
+    "patch-package": "^6.5.1",
     "prettier": "^2.8.4",
     "rimraf": "^3.0.2",
     "tsup": "^6.5.0",

--- a/patches/@changesets+apply-release-plan+6.1.3.dev.patch
+++ b/patches/@changesets+apply-release-plan+6.1.3.dev.patch
@@ -1,0 +1,1022 @@
+diff --git a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js
+index c2e8d2f..a501930 100644
+--- a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js
++++ b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js
+@@ -24,71 +24,54 @@ var getVersionRangeType__default = /*#__PURE__*/_interopDefault(getVersionRangeT
+ var semver__default = /*#__PURE__*/_interopDefault(semver);
+ var startCase__default = /*#__PURE__*/_interopDefault(startCase);
+ 
+-function _defineProperty(obj, key, value) {
+-  if (key in obj) {
+-    Object.defineProperty(obj, key, {
+-      value: value,
+-      enumerable: true,
+-      configurable: true,
+-      writable: true
+-    });
+-  } else {
+-    obj[key] = value;
+-  }
+-
+-  return obj;
+-}
+-
+ function ownKeys(object, enumerableOnly) {
+   var keys = Object.keys(object);
+-
+   if (Object.getOwnPropertySymbols) {
+     var symbols = Object.getOwnPropertySymbols(object);
+-    if (enumerableOnly) symbols = symbols.filter(function (sym) {
++    enumerableOnly && (symbols = symbols.filter(function (sym) {
+       return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+-    });
+-    keys.push.apply(keys, symbols);
++    })), keys.push.apply(keys, symbols);
+   }
+-
+   return keys;
+ }
+-
+ function _objectSpread2(target) {
+   for (var i = 1; i < arguments.length; i++) {
+-    var source = arguments[i] != null ? arguments[i] : {};
+-
+-    if (i % 2) {
+-      ownKeys(Object(source), true).forEach(function (key) {
+-        _defineProperty(target, key, source[key]);
+-      });
+-    } else if (Object.getOwnPropertyDescriptors) {
+-      Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+-    } else {
+-      ownKeys(Object(source)).forEach(function (key) {
+-        Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+-      });
+-    }
++    var source = null != arguments[i] ? arguments[i] : {};
++    i % 2 ? ownKeys(Object(source), !0).forEach(function (key) {
++      _defineProperty(target, key, source[key]);
++    }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) {
++      Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
++    });
+   }
+-
+   return target;
+ }
++function _defineProperty(obj, key, value) {
++  if (key in obj) {
++    Object.defineProperty(obj, key, {
++      value: value,
++      enumerable: true,
++      configurable: true,
++      writable: true
++    });
++  } else {
++    obj[key] = value;
++  }
++  return obj;
++}
+ 
+ /**
+  * Shared utility functions and business logic
+  */
+ const bumpTypes = ["none", "patch", "minor", "major"];
+-/* Converts a bump type into a numeric level to indicate order */
+ 
++/* Converts a bump type into a numeric level to indicate order */
+ function getBumpLevel(type) {
+   const level = bumpTypes.indexOf(type);
+-
+   if (level < 0) {
+     throw new Error(`Unrecognised bump type ${type}`);
+   }
+-
+   return level;
+ }
+-
+ function shouldUpdateDependencyBasedOnConfig(release, {
+   depVersionRange,
+   depType
+@@ -100,14 +83,11 @@ function shouldUpdateDependencyBasedOnConfig(release, {
+     // Dependencies leaving semver range should always be updated
+     return true;
+   }
+-
+   const minLevel = getBumpLevel(minReleaseType);
+   let shouldUpdate = getBumpLevel(release.type) >= minLevel;
+-
+   if (depType === "peerDependencies") {
+     shouldUpdate = !onlyUpdatePeerDependentsWhenOutOfRange;
+   }
+-
+   return shouldUpdate;
+ }
+ 
+@@ -123,10 +103,8 @@ function versionPackage(release, versionsToUpdate, {
+     packageJson
+   } = release;
+   packageJson.version = newVersion;
+-
+   for (let depType of DEPENDENCY_TYPES) {
+     let deps = packageJson[depType];
+-
+     if (deps) {
+       for (let {
+         name,
+@@ -134,7 +112,6 @@ function versionPackage(release, versionsToUpdate, {
+         type
+       } of versionsToUpdate) {
+         let depCurrentVersion = deps[name];
+-
+         if (!depCurrentVersion || depCurrentVersion.startsWith("file:") || depCurrentVersion.startsWith("link:") || !shouldUpdateDependencyBasedOnConfig({
+           version,
+           type
+@@ -147,28 +124,24 @@ function versionPackage(release, versionsToUpdate, {
+         })) {
+           continue;
+         }
+-
+         const usesWorkspaceRange = depCurrentVersion.startsWith("workspace:");
+-
+         if (!usesWorkspaceRange && bumpVersionsWithWorkspaceProtocolOnly === true) {
+           continue;
+         }
+-
+         if (usesWorkspaceRange) {
+           const workspaceDepVersion = depCurrentVersion.replace(/^workspace:/, "");
+-
+           if (workspaceDepVersion === "*" || workspaceDepVersion === "^" || workspaceDepVersion === "~") {
+             continue;
+           }
+-
+           depCurrentVersion = workspaceDepVersion;
+         }
+-
+-        if ( // an empty string is the normalised version of x/X/*
++        if (
++        // an empty string is the normalised version of x/X/*
+         // we don't want to change these versions because they will match
+         // any version and if someone makes the range that
+         // they probably want it to stay like that...
+-        new semver__default['default'].Range(depCurrentVersion).range !== "" || // ...unless the current version of a dependency is a prerelease (which doesn't satisfy x/X/*)
++        new semver__default['default'].Range(depCurrentVersion).range !== "" ||
++        // ...unless the current version of a dependency is a prerelease (which doesn't satisfy x/X/*)
+         // leaving those as is would leave the package in a non-installable state (wrong dep versions would get installed)
+         semver__default['default'].prerelease(version) !== null) {
+           let newNewRange = snapshot ? version : `${getVersionRangeType__default['default'](depCurrentVersion)}${version}`;
+@@ -178,7 +151,6 @@ function versionPackage(release, versionsToUpdate, {
+       }
+     }
+   }
+-
+   return _objectSpread2(_objectSpread2({}, release), {}, {
+     packageJson
+   });
+@@ -187,13 +159,12 @@ function versionPackage(release, versionsToUpdate, {
+ async function generateChangesForVersionTypeMarkdown(obj, type) {
+   let releaseLines = await Promise.all(obj[type]);
+   releaseLines = releaseLines.filter(x => x);
+-
+   if (releaseLines.length) {
+     return `### ${startCase__default['default'](type)} Changes\n\n${releaseLines.join("\n")}\n`;
+   }
+-} // release is the package and version we are releasing
+-
++}
+ 
++// release is the package and version we are releasing
+ async function getChangelogEntry(release, releases, changesets, changelogFuncs, changelogOpts, {
+   updateInternalDependencies,
+   onlyUpdatePeerDependentsWhenOutOfRange
+@@ -203,21 +174,20 @@ async function getChangelogEntry(release, releases, changesets, changelogFuncs,
+     major: [],
+     minor: [],
+     patch: []
+-  }; // I sort of feel we can do better, as ComprehensiveReleases have an array
++  };
++
++  // I sort of feel we can do better, as ComprehensiveReleases have an array
+   // of the relevant changesets but since we need the version type for the
+   // release in the changeset, I don't know if we can
+   // We can filter here, but that just adds another iteration over this list
+-
+   changesets.forEach(cs => {
+     const rls = cs.releases.find(r => r.name === release.name);
+-
+     if (rls && rls.type !== "none") {
+       changelogLines[rls.type].push(changelogFuncs.getReleaseLine(cs, rls.type, changelogOpts));
+     }
+   });
+   let dependentReleases = releases.filter(rel => {
+     var _release$packageJson$, _release$packageJson$2;
+-
+     const dependencyVersionRange = (_release$packageJson$ = release.packageJson.dependencies) === null || _release$packageJson$ === void 0 ? void 0 : _release$packageJson$[rel.name];
+     const peerDependencyVersionRange = (_release$packageJson$2 = release.packageJson.peerDependencies) === null || _release$packageJson$2 === void 0 ? void 0 : _release$packageJson$2[rel.name];
+     const versionRange = dependencyVersionRange || peerDependencyVersionRange;
+@@ -252,35 +222,32 @@ function getPrettierInstance(cwd) {
+     if (!err || err.code !== "MODULE_NOT_FOUND") {
+       throw err;
+     }
+-
+     return prettier__default['default'];
+   }
+ }
+-
+ function stringDefined(s) {
+   return !!s;
+ }
+-
+ async function getCommitsThatAddChangesets(changesetIds, cwd) {
+   const paths = changesetIds.map(id => `.changeset/${id}.md`);
+   const commits = await git.getCommitsThatAddFiles(paths, {
+     cwd,
+     short: true
+   });
+-
+   if (commits.every(stringDefined)) {
+     // We have commits for all files
+     return commits;
+-  } // Some files didn't exist. Try legacy filenames instead
+-
++  }
+ 
++  // Some files didn't exist. Try legacy filenames instead
+   const missingIds = changesetIds.map((id, i) => commits[i] ? undefined : id).filter(stringDefined);
+   const legacyPaths = missingIds.map(id => `.changeset/${id}/changes.json`);
+   const commitsForLegacyPaths = await git.getCommitsThatAddFiles(legacyPaths, {
+     cwd,
+     short: true
+-  }); // Fill in the blanks in the array of commits
++  });
+ 
++  // Fill in the blanks in the array of commits
+   changesetIds.forEach((id, i) => {
+     if (!commits[i]) {
+       const missingIndex = missingIds.indexOf(id);
+@@ -289,7 +256,6 @@ async function getCommitsThatAddChangesets(changesetIds, cwd) {
+   });
+   return commits;
+ }
+-
+ async function applyReleasePlan(releasePlan, packages, config$1 = config.defaultConfig, snapshot) {
+   let cwd = packages.root.dir;
+   let touchedFiles = [];
+@@ -302,10 +268,10 @@ async function applyReleasePlan(releasePlan, packages, config$1 = config.default
+     let pkg = packagesByName.get(release.name);
+     if (!pkg) throw new Error(`Could not find matching package for release of: ${release.name}`);
+     return _objectSpread2(_objectSpread2({}, release), pkg);
+-  }); // I think this might be the wrong place to do this, but gotta do it somewhere -  add changelog entries to releases
++  });
+ 
++  // I think this might be the wrong place to do this, but gotta do it somewhere -  add changelog entries to releases
+   let releaseWithChangelogs = await getNewChangelogEntry(releasesWithPackage, changesets, config$1, cwd);
+-
+   if (releasePlan.preState !== undefined && snapshot === undefined) {
+     if (releasePlan.preState.mode === "exit") {
+       await fs__default['default'].remove(path__default['default'].join(cwd, ".changeset", "pre.json"));
+@@ -313,7 +279,6 @@ async function applyReleasePlan(releasePlan, packages, config$1 = config.default
+       await fs__default['default'].writeFile(path__default['default'].join(cwd, ".changeset", "pre.json"), JSON.stringify(releasePlan.preState, null, 2) + "\n");
+     }
+   }
+-
+   let versionsToUpdate = releases.map(({
+     name,
+     newVersion,
+@@ -322,8 +287,9 @@ async function applyReleasePlan(releasePlan, packages, config$1 = config.default
+     name,
+     version: newVersion,
+     type
+-  })); // iterate over releases updating packages
++  }));
+ 
++  // iterate over releases updating packages
+   let finalisedRelease = releaseWithChangelogs.map(release => {
+     return versionPackage(release, versionsToUpdate, {
+       updateInternalDependencies: config$1.updateInternalDependencies,
+@@ -334,7 +300,6 @@ async function applyReleasePlan(releasePlan, packages, config$1 = config.default
+   });
+   let prettierInstance = getPrettierInstance(cwd);
+   let prettierConfig = await prettierInstance.resolveConfig(cwd);
+-
+   for (let release of finalisedRelease) {
+     let {
+       changelog,
+@@ -345,20 +310,17 @@ async function applyReleasePlan(releasePlan, packages, config$1 = config.default
+     const pkgJSONPath = path__default['default'].resolve(dir, "package.json");
+     await updatePackageJson(pkgJSONPath, packageJson);
+     touchedFiles.push(pkgJSONPath);
+-
+     if (changelog && changelog.length > 0) {
+       const changelogPath = path__default['default'].resolve(dir, "CHANGELOG.md");
+       await updateChangelog(changelogPath, changelog, name, prettierInstance, prettierConfig);
+       touchedFiles.push(changelogPath);
+     }
+   }
+-
+   if (releasePlan.preState === undefined || releasePlan.preState.mode === "exit") {
+     let changesetFolder = path__default['default'].resolve(cwd, ".changeset");
+     await Promise.all(changesets.map(async changeset => {
+       let changesetPath = path__default['default'].resolve(changesetFolder, `${changeset.id}.md`);
+       let changesetFolderPath = path__default['default'].resolve(changesetFolder, changeset.id);
+-
+       if (await fs__default['default'].pathExists(changesetPath)) {
+         // DO NOT remove changeset for ignored packages
+         // Mixed changeset that contains both ignored packages and not ignored packages are disallowed
+@@ -368,26 +330,24 @@ async function applyReleasePlan(releasePlan, packages, config$1 = config.default
+         if (!changeset.releases.find(release => config$1.ignore.includes(release.name))) {
+           touchedFiles.push(changesetPath);
+           await fs__default['default'].remove(changesetPath);
+-        } // TO REMOVE LOGIC - this works to remove v1 changesets. We should be removed in the future
+-
++        }
++        // TO REMOVE LOGIC - this works to remove v1 changesets. We should be removed in the future
+       } else if (await fs__default['default'].pathExists(changesetFolderPath)) {
+         touchedFiles.push(changesetFolderPath);
+         await fs__default['default'].remove(changesetFolderPath);
+       }
+     }));
+-  } // We return the touched files to be committed in the cli
+-
++  }
+ 
++  // We return the touched files to be committed in the cli
+   return touchedFiles;
+ }
+-
+ async function getNewChangelogEntry(releasesWithPackage, changesets, config, cwd) {
+   if (!config.changelog) {
+     return Promise.resolve(releasesWithPackage.map(release => _objectSpread2(_objectSpread2({}, release), {}, {
+       changelog: null
+     })));
+   }
+-
+   let getChangelogFuncs = {
+     getReleaseLine: () => Promise.resolve(""),
+     getDependencyReleaseLine: () => Promise.resolve("")
+@@ -395,19 +355,15 @@ async function getNewChangelogEntry(releasesWithPackage, changesets, config, cwd
+   const changelogOpts = config.changelog[1];
+   let changesetPath = path__default['default'].join(cwd, ".changeset");
+   let changelogPath = resolveFrom__default['default'](changesetPath, config.changelog[0]);
+-
+   let possibleChangelogFunc = require(changelogPath);
+-
+   if (possibleChangelogFunc.default) {
+     possibleChangelogFunc = possibleChangelogFunc.default;
+   }
+-
+   if (typeof possibleChangelogFunc.getReleaseLine === "function" && typeof possibleChangelogFunc.getDependencyReleaseLine === "function") {
+     getChangelogFuncs = possibleChangelogFunc;
+   } else {
+     throw new Error("Could not resolve changelog generation functions");
+   }
+-
+   let commits = await getCommitsThatAddChangesets(changesets.map(cs => cs.id), cwd);
+   let moddedChangesets = changesets.map((cs, i) => _objectSpread2(_objectSpread2({}, cs), {}, {
+     commit: commits[i]
+@@ -426,10 +382,8 @@ async function getNewChangelogEntry(releasesWithPackage, changesets, config, cwd
+     throw e;
+   });
+ }
+-
+ async function updateChangelog(changelogPath, changelog, name, prettierInstance, prettierConfig) {
+   let templateString = `\n\n${changelog.trim()}\n`;
+-
+   try {
+     if (fs__default['default'].existsSync(changelogPath)) {
+       await prependFile(changelogPath, templateString, name, prettierInstance, prettierConfig);
+@@ -440,29 +394,26 @@ async function updateChangelog(changelogPath, changelog, name, prettierInstance,
+     console.warn(e);
+   }
+ }
+-
+ async function updatePackageJson(pkgJsonPath, pkgJson) {
+   const pkgRaw = await fs__default['default'].readFile(pkgJsonPath, "utf-8");
+   const indent = detectIndent__default['default'](pkgRaw).indent || "  ";
+   const stringified = JSON.stringify(pkgJson, null, indent) + (pkgRaw.endsWith("\n") ? "\n" : "");
+   return fs__default['default'].writeFile(pkgJsonPath, stringified);
+ }
+-
+ async function prependFile(filePath, data, name, prettierInstance, prettierConfig) {
+-  const fileData = fs__default['default'].readFileSync(filePath).toString(); // if the file exists but doesn't have the header, we'll add it in
+-
++  const fileData = fs__default['default'].readFileSync(filePath).toString();
++  // if the file exists but doesn't have the header, we'll add it in
+   if (!fileData) {
+     const completelyNewChangelog = `# ${name}${data}`;
+     await writeFormattedMarkdownFile(filePath, completelyNewChangelog, prettierInstance, prettierConfig);
+     return;
+   }
+-
+   const newChangelog = fileData.replace("\n", data);
+   await writeFormattedMarkdownFile(filePath, newChangelog, prettierInstance, prettierConfig);
+ }
+-
+ async function writeFormattedMarkdownFile(filePath, content, prettierInstance, prettierConfig) {
+-  await fs__default['default'].writeFile(filePath, // Prettier v3 returns a promise
++  await fs__default['default'].writeFile(filePath,
++  // Prettier v3 returns a promise
+   await prettierInstance.format(content, _objectSpread2(_objectSpread2({}, prettierConfig), {}, {
+     filepath: filePath,
+     parser: "markdown"
+diff --git a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.prod.js b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.prod.js
+index 846b320..5ce5d1b 100644
+--- a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.prod.js
++++ b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.prod.js
+@@ -14,15 +14,6 @@ function _interopDefault(e) {
+ 
+ var resolveFrom__default = _interopDefault(resolveFrom), detectIndent__default = _interopDefault(detectIndent), fs__default = _interopDefault(fs), path__default = _interopDefault(path), prettier__default = _interopDefault(prettier), getVersionRangeType__default = _interopDefault(getVersionRangeType), semver__default = _interopDefault(semver), startCase__default = _interopDefault(startCase);
+ 
+-function _defineProperty(obj, key, value) {
+-  return key in obj ? Object.defineProperty(obj, key, {
+-    value: value,
+-    enumerable: !0,
+-    configurable: !0,
+-    writable: !0
+-  }) : obj[key] = value, obj;
+-}
+-
+ function ownKeys(object, enumerableOnly) {
+   var keys = Object.keys(object);
+   if (Object.getOwnPropertySymbols) {
+@@ -46,6 +37,15 @@ function _objectSpread2(target) {
+   return target;
+ }
+ 
++function _defineProperty(obj, key, value) {
++  return key in obj ? Object.defineProperty(obj, key, {
++    value: value,
++    enumerable: !0,
++    configurable: !0,
++    writable: !0
++  }) : obj[key] = value, obj;
++}
++
+ const bumpTypes = [ "none", "patch", "minor", "major" ];
+ 
+ function getBumpLevel(type) {
+diff --git a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.esm.js b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.esm.js
+index 47a42c3..d5b6ab7 100644
+--- a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.esm.js
++++ b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.esm.js
+@@ -9,71 +9,54 @@ import getVersionRangeType from '@changesets/get-version-range-type';
+ import semver from 'semver';
+ import startCase from 'lodash.startcase';
+ 
+-function _defineProperty(obj, key, value) {
+-  if (key in obj) {
+-    Object.defineProperty(obj, key, {
+-      value: value,
+-      enumerable: true,
+-      configurable: true,
+-      writable: true
+-    });
+-  } else {
+-    obj[key] = value;
+-  }
+-
+-  return obj;
+-}
+-
+ function ownKeys(object, enumerableOnly) {
+   var keys = Object.keys(object);
+-
+   if (Object.getOwnPropertySymbols) {
+     var symbols = Object.getOwnPropertySymbols(object);
+-    if (enumerableOnly) symbols = symbols.filter(function (sym) {
++    enumerableOnly && (symbols = symbols.filter(function (sym) {
+       return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+-    });
+-    keys.push.apply(keys, symbols);
++    })), keys.push.apply(keys, symbols);
+   }
+-
+   return keys;
+ }
+-
+ function _objectSpread2(target) {
+   for (var i = 1; i < arguments.length; i++) {
+-    var source = arguments[i] != null ? arguments[i] : {};
+-
+-    if (i % 2) {
+-      ownKeys(Object(source), true).forEach(function (key) {
+-        _defineProperty(target, key, source[key]);
+-      });
+-    } else if (Object.getOwnPropertyDescriptors) {
+-      Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+-    } else {
+-      ownKeys(Object(source)).forEach(function (key) {
+-        Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+-      });
+-    }
++    var source = null != arguments[i] ? arguments[i] : {};
++    i % 2 ? ownKeys(Object(source), !0).forEach(function (key) {
++      _defineProperty(target, key, source[key]);
++    }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) {
++      Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
++    });
+   }
+-
+   return target;
+ }
++function _defineProperty(obj, key, value) {
++  if (key in obj) {
++    Object.defineProperty(obj, key, {
++      value: value,
++      enumerable: true,
++      configurable: true,
++      writable: true
++    });
++  } else {
++    obj[key] = value;
++  }
++  return obj;
++}
+ 
+ /**
+  * Shared utility functions and business logic
+  */
+ const bumpTypes = ["none", "patch", "minor", "major"];
+-/* Converts a bump type into a numeric level to indicate order */
+ 
++/* Converts a bump type into a numeric level to indicate order */
+ function getBumpLevel(type) {
+   const level = bumpTypes.indexOf(type);
+-
+   if (level < 0) {
+     throw new Error(`Unrecognised bump type ${type}`);
+   }
+-
+   return level;
+ }
+-
+ function shouldUpdateDependencyBasedOnConfig(release, {
+   depVersionRange,
+   depType
+@@ -85,14 +68,11 @@ function shouldUpdateDependencyBasedOnConfig(release, {
+     // Dependencies leaving semver range should always be updated
+     return true;
+   }
+-
+   const minLevel = getBumpLevel(minReleaseType);
+   let shouldUpdate = getBumpLevel(release.type) >= minLevel;
+-
+   if (depType === "peerDependencies") {
+     shouldUpdate = !onlyUpdatePeerDependentsWhenOutOfRange;
+   }
+-
+   return shouldUpdate;
+ }
+ 
+@@ -108,10 +88,8 @@ function versionPackage(release, versionsToUpdate, {
+     packageJson
+   } = release;
+   packageJson.version = newVersion;
+-
+   for (let depType of DEPENDENCY_TYPES) {
+     let deps = packageJson[depType];
+-
+     if (deps) {
+       for (let {
+         name,
+@@ -119,7 +97,6 @@ function versionPackage(release, versionsToUpdate, {
+         type
+       } of versionsToUpdate) {
+         let depCurrentVersion = deps[name];
+-
+         if (!depCurrentVersion || depCurrentVersion.startsWith("file:") || depCurrentVersion.startsWith("link:") || !shouldUpdateDependencyBasedOnConfig({
+           version,
+           type
+@@ -132,28 +109,24 @@ function versionPackage(release, versionsToUpdate, {
+         })) {
+           continue;
+         }
+-
+         const usesWorkspaceRange = depCurrentVersion.startsWith("workspace:");
+-
+         if (!usesWorkspaceRange && bumpVersionsWithWorkspaceProtocolOnly === true) {
+           continue;
+         }
+-
+         if (usesWorkspaceRange) {
+           const workspaceDepVersion = depCurrentVersion.replace(/^workspace:/, "");
+-
+           if (workspaceDepVersion === "*" || workspaceDepVersion === "^" || workspaceDepVersion === "~") {
+             continue;
+           }
+-
+           depCurrentVersion = workspaceDepVersion;
+         }
+-
+-        if ( // an empty string is the normalised version of x/X/*
++        if (
++        // an empty string is the normalised version of x/X/*
+         // we don't want to change these versions because they will match
+         // any version and if someone makes the range that
+         // they probably want it to stay like that...
+-        new semver.Range(depCurrentVersion).range !== "" || // ...unless the current version of a dependency is a prerelease (which doesn't satisfy x/X/*)
++        new semver.Range(depCurrentVersion).range !== "" ||
++        // ...unless the current version of a dependency is a prerelease (which doesn't satisfy x/X/*)
+         // leaving those as is would leave the package in a non-installable state (wrong dep versions would get installed)
+         semver.prerelease(version) !== null) {
+           let newNewRange = snapshot ? version : `${getVersionRangeType(depCurrentVersion)}${version}`;
+@@ -163,7 +136,6 @@ function versionPackage(release, versionsToUpdate, {
+       }
+     }
+   }
+-
+   return _objectSpread2(_objectSpread2({}, release), {}, {
+     packageJson
+   });
+@@ -172,13 +144,12 @@ function versionPackage(release, versionsToUpdate, {
+ async function generateChangesForVersionTypeMarkdown(obj, type) {
+   let releaseLines = await Promise.all(obj[type]);
+   releaseLines = releaseLines.filter(x => x);
+-
+   if (releaseLines.length) {
+     return `### ${startCase(type)} Changes\n\n${releaseLines.join("\n")}\n`;
+   }
+-} // release is the package and version we are releasing
+-
++}
+ 
++// release is the package and version we are releasing
+ async function getChangelogEntry(release, releases, changesets, changelogFuncs, changelogOpts, {
+   updateInternalDependencies,
+   onlyUpdatePeerDependentsWhenOutOfRange
+@@ -188,21 +159,20 @@ async function getChangelogEntry(release, releases, changesets, changelogFuncs,
+     major: [],
+     minor: [],
+     patch: []
+-  }; // I sort of feel we can do better, as ComprehensiveReleases have an array
++  };
++
++  // I sort of feel we can do better, as ComprehensiveReleases have an array
+   // of the relevant changesets but since we need the version type for the
+   // release in the changeset, I don't know if we can
+   // We can filter here, but that just adds another iteration over this list
+-
+   changesets.forEach(cs => {
+     const rls = cs.releases.find(r => r.name === release.name);
+-
+     if (rls && rls.type !== "none") {
+       changelogLines[rls.type].push(changelogFuncs.getReleaseLine(cs, rls.type, changelogOpts));
+     }
+   });
+   let dependentReleases = releases.filter(rel => {
+     var _release$packageJson$, _release$packageJson$2;
+-
+     const dependencyVersionRange = (_release$packageJson$ = release.packageJson.dependencies) === null || _release$packageJson$ === void 0 ? void 0 : _release$packageJson$[rel.name];
+     const peerDependencyVersionRange = (_release$packageJson$2 = release.packageJson.peerDependencies) === null || _release$packageJson$2 === void 0 ? void 0 : _release$packageJson$2[rel.name];
+     const versionRange = dependencyVersionRange || peerDependencyVersionRange;
+@@ -237,35 +207,32 @@ function getPrettierInstance(cwd) {
+     if (!err || err.code !== "MODULE_NOT_FOUND") {
+       throw err;
+     }
+-
+     return prettier;
+   }
+ }
+-
+ function stringDefined(s) {
+   return !!s;
+ }
+-
+ async function getCommitsThatAddChangesets(changesetIds, cwd) {
+   const paths = changesetIds.map(id => `.changeset/${id}.md`);
+   const commits = await getCommitsThatAddFiles(paths, {
+     cwd,
+     short: true
+   });
+-
+   if (commits.every(stringDefined)) {
+     // We have commits for all files
+     return commits;
+-  } // Some files didn't exist. Try legacy filenames instead
+-
++  }
+ 
++  // Some files didn't exist. Try legacy filenames instead
+   const missingIds = changesetIds.map((id, i) => commits[i] ? undefined : id).filter(stringDefined);
+   const legacyPaths = missingIds.map(id => `.changeset/${id}/changes.json`);
+   const commitsForLegacyPaths = await getCommitsThatAddFiles(legacyPaths, {
+     cwd,
+     short: true
+-  }); // Fill in the blanks in the array of commits
++  });
+ 
++  // Fill in the blanks in the array of commits
+   changesetIds.forEach((id, i) => {
+     if (!commits[i]) {
+       const missingIndex = missingIds.indexOf(id);
+@@ -274,7 +241,6 @@ async function getCommitsThatAddChangesets(changesetIds, cwd) {
+   });
+   return commits;
+ }
+-
+ async function applyReleasePlan(releasePlan, packages, config = defaultConfig, snapshot) {
+   let cwd = packages.root.dir;
+   let touchedFiles = [];
+@@ -287,10 +253,10 @@ async function applyReleasePlan(releasePlan, packages, config = defaultConfig, s
+     let pkg = packagesByName.get(release.name);
+     if (!pkg) throw new Error(`Could not find matching package for release of: ${release.name}`);
+     return _objectSpread2(_objectSpread2({}, release), pkg);
+-  }); // I think this might be the wrong place to do this, but gotta do it somewhere -  add changelog entries to releases
++  });
+ 
++  // I think this might be the wrong place to do this, but gotta do it somewhere -  add changelog entries to releases
+   let releaseWithChangelogs = await getNewChangelogEntry(releasesWithPackage, changesets, config, cwd);
+-
+   if (releasePlan.preState !== undefined && snapshot === undefined) {
+     if (releasePlan.preState.mode === "exit") {
+       await fs.remove(path.join(cwd, ".changeset", "pre.json"));
+@@ -298,7 +264,6 @@ async function applyReleasePlan(releasePlan, packages, config = defaultConfig, s
+       await fs.writeFile(path.join(cwd, ".changeset", "pre.json"), JSON.stringify(releasePlan.preState, null, 2) + "\n");
+     }
+   }
+-
+   let versionsToUpdate = releases.map(({
+     name,
+     newVersion,
+@@ -307,8 +272,9 @@ async function applyReleasePlan(releasePlan, packages, config = defaultConfig, s
+     name,
+     version: newVersion,
+     type
+-  })); // iterate over releases updating packages
++  }));
+ 
++  // iterate over releases updating packages
+   let finalisedRelease = releaseWithChangelogs.map(release => {
+     return versionPackage(release, versionsToUpdate, {
+       updateInternalDependencies: config.updateInternalDependencies,
+@@ -319,7 +285,6 @@ async function applyReleasePlan(releasePlan, packages, config = defaultConfig, s
+   });
+   let prettierInstance = getPrettierInstance(cwd);
+   let prettierConfig = await prettierInstance.resolveConfig(cwd);
+-
+   for (let release of finalisedRelease) {
+     let {
+       changelog,
+@@ -330,20 +295,17 @@ async function applyReleasePlan(releasePlan, packages, config = defaultConfig, s
+     const pkgJSONPath = path.resolve(dir, "package.json");
+     await updatePackageJson(pkgJSONPath, packageJson);
+     touchedFiles.push(pkgJSONPath);
+-
+     if (changelog && changelog.length > 0) {
+       const changelogPath = path.resolve(dir, "CHANGELOG.md");
+       await updateChangelog(changelogPath, changelog, name, prettierInstance, prettierConfig);
+       touchedFiles.push(changelogPath);
+     }
+   }
+-
+   if (releasePlan.preState === undefined || releasePlan.preState.mode === "exit") {
+     let changesetFolder = path.resolve(cwd, ".changeset");
+     await Promise.all(changesets.map(async changeset => {
+       let changesetPath = path.resolve(changesetFolder, `${changeset.id}.md`);
+       let changesetFolderPath = path.resolve(changesetFolder, changeset.id);
+-
+       if (await fs.pathExists(changesetPath)) {
+         // DO NOT remove changeset for ignored packages
+         // Mixed changeset that contains both ignored packages and not ignored packages are disallowed
+@@ -353,26 +315,24 @@ async function applyReleasePlan(releasePlan, packages, config = defaultConfig, s
+         if (!changeset.releases.find(release => config.ignore.includes(release.name))) {
+           touchedFiles.push(changesetPath);
+           await fs.remove(changesetPath);
+-        } // TO REMOVE LOGIC - this works to remove v1 changesets. We should be removed in the future
+-
++        }
++        // TO REMOVE LOGIC - this works to remove v1 changesets. We should be removed in the future
+       } else if (await fs.pathExists(changesetFolderPath)) {
+         touchedFiles.push(changesetFolderPath);
+         await fs.remove(changesetFolderPath);
+       }
+     }));
+-  } // We return the touched files to be committed in the cli
+-
++  }
+ 
++  // We return the touched files to be committed in the cli
+   return touchedFiles;
+ }
+-
+ async function getNewChangelogEntry(releasesWithPackage, changesets, config, cwd) {
+   if (!config.changelog) {
+     return Promise.resolve(releasesWithPackage.map(release => _objectSpread2(_objectSpread2({}, release), {}, {
+       changelog: null
+     })));
+   }
+-
+   let getChangelogFuncs = {
+     getReleaseLine: () => Promise.resolve(""),
+     getDependencyReleaseLine: () => Promise.resolve("")
+@@ -380,19 +340,15 @@ async function getNewChangelogEntry(releasesWithPackage, changesets, config, cwd
+   const changelogOpts = config.changelog[1];
+   let changesetPath = path.join(cwd, ".changeset");
+   let changelogPath = resolveFrom(changesetPath, config.changelog[0]);
+-
+   let possibleChangelogFunc = require(changelogPath);
+-
+   if (possibleChangelogFunc.default) {
+     possibleChangelogFunc = possibleChangelogFunc.default;
+   }
+-
+   if (typeof possibleChangelogFunc.getReleaseLine === "function" && typeof possibleChangelogFunc.getDependencyReleaseLine === "function") {
+     getChangelogFuncs = possibleChangelogFunc;
+   } else {
+     throw new Error("Could not resolve changelog generation functions");
+   }
+-
+   let commits = await getCommitsThatAddChangesets(changesets.map(cs => cs.id), cwd);
+   let moddedChangesets = changesets.map((cs, i) => _objectSpread2(_objectSpread2({}, cs), {}, {
+     commit: commits[i]
+@@ -411,10 +367,8 @@ async function getNewChangelogEntry(releasesWithPackage, changesets, config, cwd
+     throw e;
+   });
+ }
+-
+ async function updateChangelog(changelogPath, changelog, name, prettierInstance, prettierConfig) {
+   let templateString = `\n\n${changelog.trim()}\n`;
+-
+   try {
+     if (fs.existsSync(changelogPath)) {
+       await prependFile(changelogPath, templateString, name, prettierInstance, prettierConfig);
+@@ -425,29 +379,26 @@ async function updateChangelog(changelogPath, changelog, name, prettierInstance,
+     console.warn(e);
+   }
+ }
+-
+ async function updatePackageJson(pkgJsonPath, pkgJson) {
+   const pkgRaw = await fs.readFile(pkgJsonPath, "utf-8");
+   const indent = detectIndent(pkgRaw).indent || "  ";
+   const stringified = JSON.stringify(pkgJson, null, indent) + (pkgRaw.endsWith("\n") ? "\n" : "");
+   return fs.writeFile(pkgJsonPath, stringified);
+ }
+-
+ async function prependFile(filePath, data, name, prettierInstance, prettierConfig) {
+-  const fileData = fs.readFileSync(filePath).toString(); // if the file exists but doesn't have the header, we'll add it in
+-
++  const fileData = fs.readFileSync(filePath).toString();
++  // if the file exists but doesn't have the header, we'll add it in
+   if (!fileData) {
+     const completelyNewChangelog = `# ${name}${data}`;
+     await writeFormattedMarkdownFile(filePath, completelyNewChangelog, prettierInstance, prettierConfig);
+     return;
+   }
+-
+   const newChangelog = fileData.replace("\n", data);
+   await writeFormattedMarkdownFile(filePath, newChangelog, prettierInstance, prettierConfig);
+ }
+-
+ async function writeFormattedMarkdownFile(filePath, content, prettierInstance, prettierConfig) {
+-  await fs.writeFile(filePath, // Prettier v3 returns a promise
++  await fs.writeFile(filePath,
++  // Prettier v3 returns a promise
+   await prettierInstance.format(content, _objectSpread2(_objectSpread2({}, prettierConfig), {}, {
+     filepath: filePath,
+     parser: "markdown"
+diff --git a/node_modules/@changesets/apply-release-plan/src/index.test.ts b/node_modules/@changesets/apply-release-plan/src/index.test.ts
+index 8d07a81..3909bbe 100644
+--- a/node_modules/@changesets/apply-release-plan/src/index.test.ts
++++ b/node_modules/@changesets/apply-release-plan/src/index.test.ts
+@@ -60,6 +60,7 @@ class FakeReleasePlan {
+         useCalculatedVersion: false,
+         prereleaseTemplate: null,
+       },
++      incrementVersions: false,
+       ...config,
+     };
+ 
+@@ -103,6 +104,7 @@ async function testSetup(
+         onlyUpdatePeerDependentsWhenOutOfRange: false,
+         updateInternalDependents: "out-of-range",
+       },
++      incrementVersions: false,
+     };
+   }
+   let tempDir = await testdir(fixture);
+@@ -675,6 +677,7 @@ describe("apply release plan", () => {
+             useCalculatedVersion: false,
+             prereleaseTemplate: null,
+           },
++          incrementVersions: false,
+         }
+       );
+       let pkgPathA = changedFiles.find((a) =>
+@@ -751,6 +754,7 @@ describe("apply release plan", () => {
+             useCalculatedVersion: false,
+             prereleaseTemplate: null,
+           },
++          incrementVersions: false,
+         }
+       );
+ 
+@@ -1009,6 +1013,7 @@ describe("apply release plan", () => {
+                 useCalculatedVersion: false,
+                 prereleaseTemplate: null,
+               },
++              incrementVersions: false,
+             }
+           );
+           let pkgPathA = changedFiles.find((a) =>
+@@ -1125,6 +1130,7 @@ describe("apply release plan", () => {
+                 useCalculatedVersion: false,
+                 prereleaseTemplate: null,
+               },
++              incrementVersions: false,
+             }
+           );
+           let pkgPathA = changedFiles.find((a) =>
+@@ -1226,6 +1232,7 @@ describe("apply release plan", () => {
+                 useCalculatedVersion: false,
+                 prereleaseTemplate: null,
+               },
++              incrementVersions: false,
+             }
+           );
+           let pkgPathA = changedFiles.find((a) =>
+@@ -1326,6 +1333,7 @@ describe("apply release plan", () => {
+                 useCalculatedVersion: false,
+                 prereleaseTemplate: null,
+               },
++              incrementVersions: false,
+             }
+           );
+           let pkgPathA = changedFiles.find((a) =>
+@@ -1429,6 +1437,7 @@ describe("apply release plan", () => {
+                 useCalculatedVersion: false,
+                 prereleaseTemplate: null,
+               },
++              incrementVersions: false,
+             }
+           );
+           let pkgPathA = changedFiles.find((a) =>
+@@ -1545,6 +1554,7 @@ describe("apply release plan", () => {
+                 useCalculatedVersion: false,
+                 prereleaseTemplate: null,
+               },
++              incrementVersions: false,
+             }
+           );
+           let pkgPathA = changedFiles.find((a) =>
+@@ -1654,6 +1664,7 @@ describe("apply release plan", () => {
+                 useCalculatedVersion: false,
+                 prereleaseTemplate: null,
+               },
++              incrementVersions: false,
+             }
+           );
+           let pkgPathA = changedFiles.find((a) =>
+@@ -1754,6 +1765,7 @@ describe("apply release plan", () => {
+                 useCalculatedVersion: false,
+                 prereleaseTemplate: null,
+               },
++              incrementVersions: false,
+             }
+           );
+           let pkgPathA = changedFiles.find((a) =>
+@@ -1855,6 +1867,7 @@ describe("apply release plan", () => {
+               useCalculatedVersion: false,
+               prereleaseTemplate: null,
+             },
++            incrementVersions: false,
+           }
+         );
+         let pkgPathDependent = changedFiles.find((a) =>
+@@ -2087,6 +2100,7 @@ describe("apply release plan", () => {
+             useCalculatedVersion: false,
+             prereleaseTemplate: null,
+           },
++          incrementVersions: false,
+         }
+       );
+       let pkgAChangelogPath = changedFiles.find((a) =>
+@@ -2225,6 +2239,7 @@ describe("apply release plan", () => {
+             useCalculatedVersion: false,
+             prereleaseTemplate: null,
+           },
++          incrementVersions: false,
+         }
+       );
+ 
+@@ -2334,6 +2349,7 @@ describe("apply release plan", () => {
+             useCalculatedVersion: false,
+             prereleaseTemplate: null,
+           },
++          incrementVersions: false,
+         }
+       );
+ 
+@@ -2455,6 +2471,7 @@ describe("apply release plan", () => {
+             useCalculatedVersion: false,
+             prereleaseTemplate: null,
+           },
++          incrementVersions: false,
+         }
+       );
+ 
+@@ -2590,6 +2607,7 @@ describe("apply release plan", () => {
+             useCalculatedVersion: false,
+             prereleaseTemplate: null,
+           },
++          incrementVersions: false,
+         }
+       );
+ 

--- a/patches/@changesets+assemble-release-plan+5.2.3.dev.patch
+++ b/patches/@changesets+assemble-release-plan+5.2.3.dev.patch
@@ -1,0 +1,1654 @@
+diff --git a/node_modules/@changesets/assemble-release-plan/.DS_Store b/node_modules/@changesets/assemble-release-plan/.DS_Store
+new file mode 100644
+index 0000000..c88a062
+Binary files /dev/null and b/node_modules/@changesets/assemble-release-plan/.DS_Store differ
+diff --git a/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.dev.js b/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.dev.js
+index 3a37c62..dd25388 100644
+--- a/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.dev.js
++++ b/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.dev.js
+@@ -5,79 +5,64 @@ Object.defineProperty(exports, '__esModule', { value: true });
+ var semver = require('semver');
+ var errors = require('@changesets/errors');
+ var getDependentsGraph = require('@changesets/get-dependents-graph');
++var resolveFrom = require('resolve-from');
++var path = require('path');
+ 
+ function _interopDefault (e) { return e && e.__esModule ? e : { 'default': e }; }
+ 
+ var semver__default = /*#__PURE__*/_interopDefault(semver);
+-
+-function _defineProperty(obj, key, value) {
+-  if (key in obj) {
+-    Object.defineProperty(obj, key, {
+-      value: value,
+-      enumerable: true,
+-      configurable: true,
+-      writable: true
+-    });
+-  } else {
+-    obj[key] = value;
+-  }
+-
+-  return obj;
+-}
++var resolveFrom__default = /*#__PURE__*/_interopDefault(resolveFrom);
++var path__default = /*#__PURE__*/_interopDefault(path);
+ 
+ function ownKeys(object, enumerableOnly) {
+   var keys = Object.keys(object);
+-
+   if (Object.getOwnPropertySymbols) {
+     var symbols = Object.getOwnPropertySymbols(object);
+-    if (enumerableOnly) symbols = symbols.filter(function (sym) {
++    enumerableOnly && (symbols = symbols.filter(function (sym) {
+       return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+-    });
+-    keys.push.apply(keys, symbols);
++    })), keys.push.apply(keys, symbols);
+   }
+-
+   return keys;
+ }
+-
+ function _objectSpread2(target) {
+   for (var i = 1; i < arguments.length; i++) {
+-    var source = arguments[i] != null ? arguments[i] : {};
+-
+-    if (i % 2) {
+-      ownKeys(Object(source), true).forEach(function (key) {
+-        _defineProperty(target, key, source[key]);
+-      });
+-    } else if (Object.getOwnPropertyDescriptors) {
+-      Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+-    } else {
+-      ownKeys(Object(source)).forEach(function (key) {
+-        Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+-      });
+-    }
++    var source = null != arguments[i] ? arguments[i] : {};
++    i % 2 ? ownKeys(Object(source), !0).forEach(function (key) {
++      _defineProperty(target, key, source[key]);
++    }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) {
++      Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
++    });
+   }
+-
+   return target;
+ }
++function _defineProperty(obj, key, value) {
++  if (key in obj) {
++    Object.defineProperty(obj, key, {
++      value: value,
++      enumerable: true,
++      configurable: true,
++      writable: true
++    });
++  } else {
++    obj[key] = value;
++  }
++  return obj;
++}
+ 
+ function incrementVersion(release, preInfo) {
+   if (release.type === "none") {
+     return release.oldVersion;
+   }
+-
+   let version = semver.inc(release.oldVersion, release.type);
+-
+   if (preInfo !== undefined && preInfo.state.mode !== "exit") {
+     let preVersion = preInfo.preVersions.get(release.name);
+-
+     if (preVersion === undefined) {
+       throw new errors.InternalError(`preVersion for ${release.name} does not exist when preState is defined`);
+-    } // why are we adding this ourselves rather than passing 'pre' + versionType to semver.inc?
++    }
++    // why are we adding this ourselves rather than passing 'pre' + versionType to semver.inc?
+     // because semver.inc with prereleases is confusing and this seems easier
+-
+-
+     version += `-${preInfo.state.tag}.${preVersion}`;
+   }
+-
+   return version;
+ }
+ 
+@@ -93,7 +78,6 @@ function incrementVersion(release, preInfo) {
+   We could solve this by inlining this function, or by returning a deep-cloned then
+   modified array, but we decided both of those are worse than this solution.
+ */
+-
+ function determineDependents({
+   releases,
+   packagesByName,
+@@ -101,31 +85,26 @@ function determineDependents({
+   preInfo,
+   config
+ }) {
+-  let updated = false; // NOTE this is intended to be called recursively
+-
++  let updated = false;
++  // NOTE this is intended to be called recursively
+   let pkgsToSearch = [...releases.values()];
+-
+   while (pkgsToSearch.length > 0) {
+     // nextRelease is our dependency, think of it as "avatar"
+     const nextRelease = pkgsToSearch.shift();
+-    if (!nextRelease) continue; // pkgDependents will be a list of packages that depend on nextRelease ie. ['avatar-group', 'comment']
+-
++    if (!nextRelease) continue;
++    // pkgDependents will be a list of packages that depend on nextRelease ie. ['avatar-group', 'comment']
+     const pkgDependents = dependencyGraph.get(nextRelease.name);
+-
+     if (!pkgDependents) {
+       throw new Error(`Error in determining dependents - could not find package in repository: ${nextRelease.name}`);
+     }
+-
+     pkgDependents.map(dependent => {
+       let type;
+       const dependentPackage = packagesByName.get(dependent);
+       if (!dependentPackage) throw new Error("Dependency map is incorrect");
+-
+       if (config.ignore.includes(dependent)) {
+         type = "none";
+       } else {
+         const dependencyVersionRanges = getDependencyVersionRanges(dependentPackage.packageJson, nextRelease);
+-
+         for (const {
+           depType,
+           versionRange
+@@ -150,9 +129,7 @@ function determineDependents({
+                 if (type !== "major" && type !== "minor") {
+                   type = "patch";
+                 }
+-
+                 break;
+-
+               case "devDependencies":
+                 {
+                   // We don't need a version bump if the package is only in the devDependencies of the dependent package
+@@ -164,11 +141,9 @@ function determineDependents({
+           }
+         }
+       }
+-
+       if (releases.has(dependent) && releases.get(dependent).type === type) {
+         type = undefined;
+       }
+-
+       return {
+         name: dependent,
+         type,
+@@ -181,7 +156,8 @@ function determineDependents({
+     }) => {
+       // At this point, we know if we are making a change
+       updated = true;
+-      const existing = releases.get(name); // For things that are being given a major bump, we check if we have already
++      const existing = releases.get(name);
++      // For things that are being given a major bump, we check if we have already
+       // added them here. If we have, we update the existing item instead of pushing it on to search.
+       // It is safe to not add it to pkgsToSearch because it should have already been searched at the
+       // largest possible bump type.
+@@ -201,31 +177,29 @@ function determineDependents({
+       }
+     });
+   }
+-
+   return updated;
+ }
++
+ /*
+   Returns an array of objects in the shape { depType: DependencyType, versionRange: string }
+   The array can contain more than one elements in case a dependency appears in multiple
+   dependency lists. For example, a package that is both a peerDepenency and a devDependency.
+ */
+-
+ function getDependencyVersionRanges(dependentPkgJSON, dependencyRelease) {
+   const DEPENDENCY_TYPES = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+   const dependencyVersionRanges = [];
+-
+   for (const type of DEPENDENCY_TYPES) {
+     var _dependentPkgJSON$typ;
+-
+     const versionRange = (_dependentPkgJSON$typ = dependentPkgJSON[type]) === null || _dependentPkgJSON$typ === void 0 ? void 0 : _dependentPkgJSON$typ[dependencyRelease.name];
+     if (!versionRange) continue;
+-
+     if (versionRange.startsWith("workspace:")) {
+       dependencyVersionRanges.push({
+         depType: type,
+-        versionRange: // intentionally keep other workspace ranges untouched
++        versionRange:
++        // intentionally keep other workspace ranges untouched
+         // this has to be fixed but this should only be done when adding appropriate tests
+-        versionRange === "workspace:*" ? // workspace:* actually means the current exact version, and not a wildcard similar to a reguler * range
++        versionRange === "workspace:*" ?
++        // workspace:* actually means the current exact version, and not a wildcard similar to a reguler * range
+         dependencyRelease.oldVersion : versionRange.replace(/^workspace:/, "")
+       });
+     } else {
+@@ -235,10 +209,8 @@ function getDependencyVersionRanges(dependentPkgJSON, dependencyRelease) {
+       });
+     }
+   }
+-
+   return dependencyVersionRanges;
+ }
+-
+ function shouldBumpMajor({
+   dependent,
+   depType,
+@@ -249,18 +221,22 @@ function shouldBumpMajor({
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+-  return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && ( // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
++  return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
++  // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+   // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
+-  !onlyUpdatePeerDependentsWhenOutOfRange || !semver__default['default'].satisfies(incrementVersion(nextRelease, preInfo), versionRange)) && ( // bump major only if the dependent doesn't already has a major release.
++  !onlyUpdatePeerDependentsWhenOutOfRange || !semver__default['default'].satisfies(incrementVersion(nextRelease, preInfo), versionRange)) && (
++  // bump major only if the dependent doesn't already has a major release.
+   !releases.has(dependent) || releases.has(dependent) && releases.get(dependent).type !== "major");
+ }
+ 
+ // This function takes in changesets and returns one release per
+ // package listed in the changesets
++
+ function flattenReleases(changesets, packagesByName, ignoredPackages) {
+   let releases = new Map();
+   changesets.forEach(changeset => {
+-    changeset.releases // Filter out ignored packages because they should not trigger a release
++    changeset.releases
++    // Filter out ignored packages because they should not trigger a release
+     // If their dependencies need updates, they will be added to releases by `determineDependents()` with release type `none`
+     .filter(({
+       name
+@@ -270,11 +246,9 @@ function flattenReleases(changesets, packagesByName, ignoredPackages) {
+     }) => {
+       let release = releases.get(name);
+       let pkg = packagesByName.get(name);
+-
+       if (!pkg) {
+         throw new Error(`"${changeset.id}" changeset mentions a release for a package "${name}" but such a package could not be found.`);
+       }
+-
+       if (!release) {
+         release = {
+           name,
+@@ -285,14 +259,12 @@ function flattenReleases(changesets, packagesByName, ignoredPackages) {
+       } else {
+         if (type === "major" || (release.type === "patch" || release.type === "none") && (type === "minor" || type === "patch")) {
+           release.type = type;
+-        } // Check whether the bumpType will change
++        }
++        // Check whether the bumpType will change
+         // If the bumpType has changed recalc newVersion
+         // push new changeset to releases
+-
+-
+         release.changesets.push(changeset.id);
+       }
+-
+       releases.set(name, release);
+     });
+   });
+@@ -303,64 +275,52 @@ function getHighestReleaseType(releases) {
+   if (releases.length === 0) {
+     throw new Error(`Large internal Changesets error when calculating highest release type in the set of releases. Please contact the maintainers`);
+   }
+-
+   let highestReleaseType = "none";
+-
+   for (let release of releases) {
+     switch (release.type) {
+       case "major":
+         return "major";
+-
+       case "minor":
+         highestReleaseType = "minor";
+         break;
+-
+       case "patch":
+         if (highestReleaseType === "none") {
+           highestReleaseType = "patch";
+         }
+-
+         break;
+     }
+   }
+-
+   return highestReleaseType;
+ }
+ function getCurrentHighestVersion(packageGroup, packagesByName) {
+   let highestVersion;
+-
+   for (let pkgName of packageGroup) {
+     let pkg = packagesByName.get(pkgName);
+-
+     if (!pkg) {
+       console.error(`FATAL ERROR IN CHANGESETS! We were unable to version for package group: ${pkgName} in package group: ${packageGroup.toString()}`);
+       throw new Error(`fatal: could not resolve linked packages`);
+     }
+-
+     if (highestVersion === undefined || semver__default['default'].gt(pkg.packageJson.version, highestVersion)) {
+       highestVersion = pkg.packageJson.version;
+     }
+   }
+-
+   return highestVersion;
+ }
+ 
+ function matchFixedConstraint(releases, packagesByName, config) {
+   let updated = false;
+-
+   for (let fixedPackages of config.fixed) {
+     let releasingFixedPackages = [...releases.values()].filter(release => fixedPackages.includes(release.name) && release.type !== "none");
+     if (releasingFixedPackages.length === 0) continue;
+     let highestReleaseType = getHighestReleaseType(releasingFixedPackages);
+-    let highestVersion = getCurrentHighestVersion(fixedPackages, packagesByName); // Finally, we update the packages so all of them are on the highest version
++    let highestVersion = getCurrentHighestVersion(fixedPackages, packagesByName);
+ 
++    // Finally, we update the packages so all of them are on the highest version
+     for (let pkgName of fixedPackages) {
+       if (config.ignore.includes(pkgName)) {
+         continue;
+       }
+-
+       let release = releases.get(pkgName);
+-
+       if (!release) {
+         updated = true;
+         releases.set(pkgName, {
+@@ -371,19 +331,16 @@ function matchFixedConstraint(releases, packagesByName, config) {
+         });
+         continue;
+       }
+-
+       if (release.type !== highestReleaseType) {
+         updated = true;
+         release.type = highestReleaseType;
+       }
+-
+       if (release.oldVersion !== highestVersion) {
+         updated = true;
+         release.oldVersion = highestVersion;
+       }
+     }
+   }
+-
+   return updated;
+ }
+ 
+@@ -399,47 +356,44 @@ function matchFixedConstraint(releases, packagesByName, config) {
+   We could solve this by inlining this function, or by returning a deep-cloned then
+   modified array, but we decided both of those are worse than this solution.
+ */
+-
+ function applyLinks(releases, packagesByName, linked) {
+-  let updated = false; // We do this for each set of linked packages
++  let updated = false;
+ 
++  // We do this for each set of linked packages
+   for (let linkedPackages of linked) {
+     // First we filter down to all the relevant releases for one set of linked packages
+-    let releasingLinkedPackages = [...releases.values()].filter(release => linkedPackages.includes(release.name) && release.type !== "none"); // If we proceed any further we do extra work with calculating highestVersion for things that might
+-    // not need one, as they only have workspace based packages
++    let releasingLinkedPackages = [...releases.values()].filter(release => linkedPackages.includes(release.name) && release.type !== "none");
+ 
++    // If we proceed any further we do extra work with calculating highestVersion for things that might
++    // not need one, as they only have workspace based packages
+     if (releasingLinkedPackages.length === 0) continue;
+     let highestReleaseType = getHighestReleaseType(releasingLinkedPackages);
+-    let highestVersion = getCurrentHighestVersion(linkedPackages, packagesByName); // Finally, we update the packages so all of them are on the highest version
++    let highestVersion = getCurrentHighestVersion(linkedPackages, packagesByName);
+ 
++    // Finally, we update the packages so all of them are on the highest version
+     for (let linkedPackage of releasingLinkedPackages) {
+       if (linkedPackage.type !== highestReleaseType) {
+         updated = true;
+         linkedPackage.type = highestReleaseType;
+       }
+-
+       if (linkedPackage.oldVersion !== highestVersion) {
+         updated = true;
+         linkedPackage.oldVersion = highestVersion;
+       }
+     }
+   }
+-
+   return updated;
+ }
+ 
+ function getPreVersion(version) {
+   let parsed = semver.parse(version);
+   let preVersion = parsed.prerelease[1] === undefined ? -1 : parsed.prerelease[1];
+-
+   if (typeof preVersion !== "number") {
+     throw new errors.InternalError("preVersion is not a number");
+   }
+-
+   preVersion++;
+   return preVersion;
+ }
+-
+ function getSnapshotSuffix(template, snapshotParameters) {
+   let snapshotRefDate = new Date();
+   const placeholderValues = {
+@@ -447,36 +401,32 @@ function getSnapshotSuffix(template, snapshotParameters) {
+     tag: snapshotParameters.tag,
+     timestamp: snapshotRefDate.getTime().toString(),
+     datetime: snapshotRefDate.toISOString().replace(/\.\d{3}Z$/, "").replace(/[^\d]/g, "")
+-  }; // We need a special handling because we need to handle a case where `--snapshot` is used without any template,
+-  // and the resulting version needs to be composed without a tag.
++  };
+ 
++  // We need a special handling because we need to handle a case where `--snapshot` is used without any template,
++  // and the resulting version needs to be composed without a tag.
+   if (!template) {
+     return [placeholderValues.tag, placeholderValues.datetime].filter(Boolean).join("-");
+   }
+-
+   const placeholders = Object.keys(placeholderValues);
+-
+   if (!template.includes(`{tag}`) && placeholderValues.tag !== undefined) {
+     throw new Error(`Failed to compose snapshot version: "{tag}" placeholder is missing, but the snapshot parameter is defined (value: '${placeholderValues.tag}')`);
+   }
+-
+   return placeholders.reduce((prev, key) => {
+     return prev.replace(new RegExp(`\\{${key}\\}`, "g"), () => {
+       const value = placeholderValues[key];
+-
+       if (value === undefined) {
+         throw new Error(`Failed to compose snapshot version: "{${key}}" placeholder is used without having a value defined!`);
+       }
+-
+       return value;
+     });
+   }, template);
+ }
+-
+ function getSnapshotVersion(release, preInfo, useCalculatedVersion, snapshotSuffix) {
+   if (release.type === "none") {
+     return release.oldVersion;
+   }
++
+   /**
+    * Using version as 0.0.0 so that it does not hinder with other version release
+    * For example;
+@@ -486,22 +436,53 @@ function getSnapshotVersion(release, preInfo, useCalculatedVersion, snapshotSuff
+    *
+    * You can set `snapshot.useCalculatedVersion` flag to true to use calculated versions if you don't care about the above problem.
+    */
+-
+-
+   const baseVersion = useCalculatedVersion ? incrementVersion(release, preInfo) : `0.0.0`;
+   return `${baseVersion}-${snapshotSuffix}`;
+ }
+-
+-function getNewVersion(release, preInfo) {
++function getNewVersion(release, preInfo, config) {
+   if (release.type === "none") {
+     return release.oldVersion;
+   }
+ 
++  const customIncrement = getCustomIncrementVersionsFunc(release.name, config);
++  if (customIncrement) return customIncrement.incrementVersionsFuncs.incrementVersion(release.oldVersion, release.type, () => {
++    return incrementVersion(release, preInfo);
++  });
+   return incrementVersion(release, preInfo);
+ }
+-
+-function assembleReleasePlan(changesets, packages, config, // intentionally not using an optional parameter here so the result of `readPreState` has to be passed in here
+-preState, // snapshot: undefined            ->  not using snaphot
++function getCustomIncrementVersionsFunc(pkgName, config) {
++  var _config$incrementVers, _config$incrementVers2;
++  if (!config.incrementVersions) {
++    return null;
++  }
++  const cwd = process.cwd();
++  let changesetPath = path__default['default'].join(cwd, ".changeset");
++  if (!((_config$incrementVers = config.incrementVersions) !== null && _config$incrementVers !== void 0 && (_config$incrementVers2 = _config$incrementVers[pkgName]) !== null && _config$incrementVers2 !== void 0 && _config$incrementVers2.path)) {
++    return null;
++  }
++  const incrementVersionsOpts = config.incrementVersions[pkgName];
++  let incrementVersionsPath = resolveFrom__default['default'](changesetPath, incrementVersionsOpts.path);
++  let incrementVersionsFuncs;
++  let possibleIncrementVersionFunc = require(incrementVersionsPath);
++  if (possibleIncrementVersionFunc.default) {
++    possibleIncrementVersionFunc = possibleIncrementVersionFunc.default;
++  }
++  if (typeof possibleIncrementVersionFunc.incrementVersion === "function") {
++    incrementVersionsFuncs = {
++      incrementVersion: possibleIncrementVersionFunc.incrementVersion
++    };
++  } else {
++    throw new Error("Could not resolve changelog generation functions");
++  }
++  return {
++    incrementVersionsOpts,
++    incrementVersionsFuncs
++  };
++}
++function assembleReleasePlan(changesets, packages, config,
++// intentionally not using an optional parameter here so the result of `readPreState` has to be passed in here
++preState,
++// snapshot: undefined            ->  not using snaphot
+ // snapshot: { tag: undefined }   ->  --snapshot (empty tag)
+ // snapshot: { tag: "canary" }    ->  --snapshot canary
+ snapshot) {
+@@ -520,16 +501,16 @@ snapshot) {
+   } : snapshot;
+   let packagesByName = new Map(packages.packages.map(x => [x.packageJson.name, x]));
+   const relevantChangesets = getRelevantChangesets(changesets, refinedConfig.ignore, preState);
+-  const preInfo = getPreInfo(changesets, packagesByName, refinedConfig, preState); // releases is, at this point a list of all packages we are going to releases,
++  const preInfo = getPreInfo(changesets, packagesByName, refinedConfig, preState);
++
++  // releases is, at this point a list of all packages we are going to releases,
+   // flattened down to one release per package, having a reference back to their
+   // changesets, and with a calculated new versions
+-
+   let releases = flattenReleases(relevantChangesets, packagesByName, refinedConfig.ignore);
+   let dependencyGraph = getDependentsGraph.getDependentsGraph(packages, {
+     bumpVersionsWithWorkspaceProtocolOnly: refinedConfig.bumpVersionsWithWorkspaceProtocolOnly
+   });
+   let releasesValidated = false;
+-
+   while (releasesValidated === false) {
+     // The map passed in to determineDependents will be mutated
+     let dependentAdded = determineDependents({
+@@ -538,13 +519,13 @@ snapshot) {
+       dependencyGraph,
+       preInfo,
+       config: refinedConfig
+-    }); // `releases` might get mutated here
++    });
+ 
++    // `releases` might get mutated here
+     let fixedConstraintUpdated = matchFixedConstraint(releases, packagesByName, refinedConfig);
+     let linksUpdated = applyLinks(releases, packagesByName, refinedConfig.linked);
+     releasesValidated = !linksUpdated && !dependentAdded && !fixedConstraintUpdated;
+   }
+-
+   if ((preInfo === null || preInfo === void 0 ? void 0 : preInfo.state.mode) === "exit") {
+     for (let pkg of packages.packages) {
+       // If a package had a prerelease, but didn't trigger a version bump in the regular release,
+@@ -552,7 +533,6 @@ snapshot) {
+       // Detailed explanation at https://github.com/changesets/changesets/pull/382#discussion_r434434182
+       if (preInfo.preVersions.get(pkg.packageJson.name) !== 0) {
+         const existingRelease = releases.get(pkg.packageJson.name);
+-
+         if (!existingRelease) {
+           releases.set(pkg.packageJson.name, {
+             name: pkg.packageJson.name,
+@@ -565,28 +545,26 @@ snapshot) {
+         }
+       }
+     }
+-  } // Caching the snapshot version here and use this if it is snapshot release
+-
++  }
+ 
++  // Caching the snapshot version here and use this if it is snapshot release
+   const snapshotSuffix = refinedSnapshot && getSnapshotSuffix(refinedConfig.snapshot.prereleaseTemplate, refinedSnapshot);
+   return {
+     changesets: relevantChangesets,
+     releases: [...releases.values()].map(incompleteRelease => {
+       return _objectSpread2(_objectSpread2({}, incompleteRelease), {}, {
+-        newVersion: snapshotSuffix ? getSnapshotVersion(incompleteRelease, preInfo, refinedConfig.snapshot.useCalculatedVersion, snapshotSuffix) : getNewVersion(incompleteRelease, preInfo)
++        newVersion: snapshotSuffix ? getSnapshotVersion(incompleteRelease, preInfo, refinedConfig.snapshot.useCalculatedVersion, snapshotSuffix) : getNewVersion(incompleteRelease, preInfo, config)
+       });
+     }),
+     preState: preInfo === null || preInfo === void 0 ? void 0 : preInfo.state
+   };
+ }
+-
+ function getRelevantChangesets(changesets, ignored, preState) {
+   for (const changeset of changesets) {
+     // Using the following 2 arrays to decide whether a changeset
+     // contains both ignored and not ignored packages
+     const ignoredPackages = [];
+     const notIgnoredPackages = [];
+-
+     for (const release of changeset.releases) {
+       if (ignored.find(ignoredPackageName => ignoredPackageName === release.name)) {
+         ignoredPackages.push(release.name);
+@@ -594,70 +572,54 @@ function getRelevantChangesets(changesets, ignored, preState) {
+         notIgnoredPackages.push(release.name);
+       }
+     }
+-
+     if (ignoredPackages.length > 0 && notIgnoredPackages.length > 0) {
+       throw new Error(`Found mixed changeset ${changeset.id}\n` + `Found ignored packages: ${ignoredPackages.join(" ")}\n` + `Found not ignored packages: ${notIgnoredPackages.join(" ")}\n` + "Mixed changesets that contain both ignored and not ignored packages are not allowed");
+     }
+   }
+-
+   if (preState && preState.mode !== "exit") {
+     let usedChangesetIds = new Set(preState.changesets);
+     return changesets.filter(changeset => !usedChangesetIds.has(changeset.id));
+   }
+-
+   return changesets;
+ }
+-
+ function getHighestPreVersion(packageGroup, packagesByName) {
+   let highestPreVersion = 0;
+-
+   for (let pkg of packageGroup) {
+     highestPreVersion = Math.max(getPreVersion(packagesByName.get(pkg).packageJson.version), highestPreVersion);
+   }
+-
+   return highestPreVersion;
+ }
+-
+ function getPreInfo(changesets, packagesByName, config, preState) {
+   if (preState === undefined) {
+     return;
+   }
+-
+   let updatedPreState = _objectSpread2(_objectSpread2({}, preState), {}, {
+     changesets: changesets.map(changeset => changeset.id),
+     initialVersions: _objectSpread2({}, preState.initialVersions)
+   });
+-
+   for (const [, pkg] of packagesByName) {
+     if (updatedPreState.initialVersions[pkg.packageJson.name] === undefined) {
+       updatedPreState.initialVersions[pkg.packageJson.name] = pkg.packageJson.version;
+     }
+-  } // Populate preVersion
++  }
++  // Populate preVersion
+   // preVersion is the map between package name and its next pre version number.
+-
+-
+   let preVersions = new Map();
+-
+   for (const [, pkg] of packagesByName) {
+     preVersions.set(pkg.packageJson.name, getPreVersion(pkg.packageJson.version));
+   }
+-
+   for (let fixedGroup of config.fixed) {
+     let highestPreVersion = getHighestPreVersion(fixedGroup, packagesByName);
+-
+     for (let fixedPackage of fixedGroup) {
+       preVersions.set(fixedPackage, highestPreVersion);
+     }
+   }
+-
+   for (let linkedGroup of config.linked) {
+     let highestPreVersion = getHighestPreVersion(linkedGroup, packagesByName);
+-
+     for (let linkedPackage of linkedGroup) {
+       preVersions.set(linkedPackage, highestPreVersion);
+     }
+   }
+-
+   return {
+     state: updatedPreState,
+     preVersions
+diff --git a/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.prod.js b/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.prod.js
+index 87b4c10..08a2fd6 100644
+--- a/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.prod.js
++++ b/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.cjs.prod.js
+@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
+   value: !0
+ });
+ 
+-var semver = require("semver"), errors = require("@changesets/errors"), getDependentsGraph = require("@changesets/get-dependents-graph");
++var semver = require("semver"), errors = require("@changesets/errors"), getDependentsGraph = require("@changesets/get-dependents-graph"), resolveFrom = require("resolve-from"), path = require("path");
+ 
+ function _interopDefault(e) {
+   return e && e.__esModule ? e : {
+@@ -12,16 +12,7 @@ function _interopDefault(e) {
+   };
+ }
+ 
+-var semver__default = _interopDefault(semver);
+-
+-function _defineProperty(obj, key, value) {
+-  return key in obj ? Object.defineProperty(obj, key, {
+-    value: value,
+-    enumerable: !0,
+-    configurable: !0,
+-    writable: !0
+-  }) : obj[key] = value, obj;
+-}
++var semver__default = _interopDefault(semver), resolveFrom__default = _interopDefault(resolveFrom), path__default = _interopDefault(path);
+ 
+ function ownKeys(object, enumerableOnly) {
+   var keys = Object.keys(object);
+@@ -46,6 +37,15 @@ function _objectSpread2(target) {
+   return target;
+ }
+ 
++function _defineProperty(obj, key, value) {
++  return key in obj ? Object.defineProperty(obj, key, {
++    value: value,
++    enumerable: !0,
++    configurable: !0,
++    writable: !0
++  }) : obj[key] = value, obj;
++}
++
+ function incrementVersion(release, preInfo) {
+   if ("none" === release.type) return release.oldVersion;
+   let version = semver.inc(release.oldVersion, release.type);
+@@ -242,8 +242,28 @@ function getSnapshotVersion(release, preInfo, useCalculatedVersion, snapshotSuff
+   return `${useCalculatedVersion ? incrementVersion(release, preInfo) : "0.0.0"}-${snapshotSuffix}`;
+ }
+ 
+-function getNewVersion(release, preInfo) {
+-  return "none" === release.type ? release.oldVersion : incrementVersion(release, preInfo);
++function getNewVersion(release, preInfo, config) {
++  if ("none" === release.type) return release.oldVersion;
++  const customIncrement = getCustomIncrementVersionsFunc(release.name, config);
++  return customIncrement ? customIncrement.incrementVersionsFuncs.incrementVersion(release.oldVersion, release.type, (() => incrementVersion(release, preInfo))) : incrementVersion(release, preInfo);
++}
++
++function getCustomIncrementVersionsFunc(pkgName, config) {
++  var _config$incrementVers, _config$incrementVers2;
++  if (!config.incrementVersions) return null;
++  const cwd = process.cwd();
++  let changesetPath = path__default.default.join(cwd, ".changeset");
++  if (null === (_config$incrementVers = config.incrementVersions) || void 0 === _config$incrementVers || null === (_config$incrementVers2 = _config$incrementVers[pkgName]) || void 0 === _config$incrementVers2 || !_config$incrementVers2.path) return null;
++  const incrementVersionsOpts = config.incrementVersions[pkgName];
++  let incrementVersionsFuncs, incrementVersionsPath = resolveFrom__default.default(changesetPath, incrementVersionsOpts.path), possibleIncrementVersionFunc = require(incrementVersionsPath);
++  if (possibleIncrementVersionFunc.default && (possibleIncrementVersionFunc = possibleIncrementVersionFunc.default), 
++  "function" != typeof possibleIncrementVersionFunc.incrementVersion) throw new Error("Could not resolve changelog generation functions");
++  return incrementVersionsFuncs = {
++    incrementVersion: possibleIncrementVersionFunc.incrementVersion
++  }, {
++    incrementVersionsOpts: incrementVersionsOpts,
++    incrementVersionsFuncs: incrementVersionsFuncs
++  };
+ }
+ 
+ function assembleReleasePlan(changesets, packages, config, preState, snapshot) {
+@@ -285,7 +305,7 @@ function assembleReleasePlan(changesets, packages, config, preState, snapshot) {
+   return {
+     changesets: relevantChangesets,
+     releases: [ ...releases.values() ].map((incompleteRelease => _objectSpread2(_objectSpread2({}, incompleteRelease), {}, {
+-      newVersion: snapshotSuffix ? getSnapshotVersion(incompleteRelease, preInfo, refinedConfig.snapshot.useCalculatedVersion, snapshotSuffix) : getNewVersion(incompleteRelease, preInfo)
++      newVersion: snapshotSuffix ? getSnapshotVersion(incompleteRelease, preInfo, refinedConfig.snapshot.useCalculatedVersion, snapshotSuffix) : getNewVersion(incompleteRelease, preInfo, config)
+     }))),
+     preState: null == preInfo ? void 0 : preInfo.state
+   };
+diff --git a/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.esm.js b/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.esm.js
+index c29c008..a07823e 100644
+--- a/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.esm.js
++++ b/node_modules/@changesets/assemble-release-plan/dist/assemble-release-plan.esm.js
+@@ -1,75 +1,58 @@
+ import semver, { inc, parse } from 'semver';
+ import { InternalError } from '@changesets/errors';
+ import { getDependentsGraph } from '@changesets/get-dependents-graph';
+-
+-function _defineProperty(obj, key, value) {
+-  if (key in obj) {
+-    Object.defineProperty(obj, key, {
+-      value: value,
+-      enumerable: true,
+-      configurable: true,
+-      writable: true
+-    });
+-  } else {
+-    obj[key] = value;
+-  }
+-
+-  return obj;
+-}
++import resolveFrom from 'resolve-from';
++import path from 'path';
+ 
+ function ownKeys(object, enumerableOnly) {
+   var keys = Object.keys(object);
+-
+   if (Object.getOwnPropertySymbols) {
+     var symbols = Object.getOwnPropertySymbols(object);
+-    if (enumerableOnly) symbols = symbols.filter(function (sym) {
++    enumerableOnly && (symbols = symbols.filter(function (sym) {
+       return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+-    });
+-    keys.push.apply(keys, symbols);
++    })), keys.push.apply(keys, symbols);
+   }
+-
+   return keys;
+ }
+-
+ function _objectSpread2(target) {
+   for (var i = 1; i < arguments.length; i++) {
+-    var source = arguments[i] != null ? arguments[i] : {};
+-
+-    if (i % 2) {
+-      ownKeys(Object(source), true).forEach(function (key) {
+-        _defineProperty(target, key, source[key]);
+-      });
+-    } else if (Object.getOwnPropertyDescriptors) {
+-      Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+-    } else {
+-      ownKeys(Object(source)).forEach(function (key) {
+-        Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+-      });
+-    }
++    var source = null != arguments[i] ? arguments[i] : {};
++    i % 2 ? ownKeys(Object(source), !0).forEach(function (key) {
++      _defineProperty(target, key, source[key]);
++    }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) {
++      Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
++    });
+   }
+-
+   return target;
+ }
++function _defineProperty(obj, key, value) {
++  if (key in obj) {
++    Object.defineProperty(obj, key, {
++      value: value,
++      enumerable: true,
++      configurable: true,
++      writable: true
++    });
++  } else {
++    obj[key] = value;
++  }
++  return obj;
++}
+ 
+ function incrementVersion(release, preInfo) {
+   if (release.type === "none") {
+     return release.oldVersion;
+   }
+-
+   let version = inc(release.oldVersion, release.type);
+-
+   if (preInfo !== undefined && preInfo.state.mode !== "exit") {
+     let preVersion = preInfo.preVersions.get(release.name);
+-
+     if (preVersion === undefined) {
+       throw new InternalError(`preVersion for ${release.name} does not exist when preState is defined`);
+-    } // why are we adding this ourselves rather than passing 'pre' + versionType to semver.inc?
++    }
++    // why are we adding this ourselves rather than passing 'pre' + versionType to semver.inc?
+     // because semver.inc with prereleases is confusing and this seems easier
+-
+-
+     version += `-${preInfo.state.tag}.${preVersion}`;
+   }
+-
+   return version;
+ }
+ 
+@@ -85,7 +68,6 @@ function incrementVersion(release, preInfo) {
+   We could solve this by inlining this function, or by returning a deep-cloned then
+   modified array, but we decided both of those are worse than this solution.
+ */
+-
+ function determineDependents({
+   releases,
+   packagesByName,
+@@ -93,31 +75,26 @@ function determineDependents({
+   preInfo,
+   config
+ }) {
+-  let updated = false; // NOTE this is intended to be called recursively
+-
++  let updated = false;
++  // NOTE this is intended to be called recursively
+   let pkgsToSearch = [...releases.values()];
+-
+   while (pkgsToSearch.length > 0) {
+     // nextRelease is our dependency, think of it as "avatar"
+     const nextRelease = pkgsToSearch.shift();
+-    if (!nextRelease) continue; // pkgDependents will be a list of packages that depend on nextRelease ie. ['avatar-group', 'comment']
+-
++    if (!nextRelease) continue;
++    // pkgDependents will be a list of packages that depend on nextRelease ie. ['avatar-group', 'comment']
+     const pkgDependents = dependencyGraph.get(nextRelease.name);
+-
+     if (!pkgDependents) {
+       throw new Error(`Error in determining dependents - could not find package in repository: ${nextRelease.name}`);
+     }
+-
+     pkgDependents.map(dependent => {
+       let type;
+       const dependentPackage = packagesByName.get(dependent);
+       if (!dependentPackage) throw new Error("Dependency map is incorrect");
+-
+       if (config.ignore.includes(dependent)) {
+         type = "none";
+       } else {
+         const dependencyVersionRanges = getDependencyVersionRanges(dependentPackage.packageJson, nextRelease);
+-
+         for (const {
+           depType,
+           versionRange
+@@ -142,9 +119,7 @@ function determineDependents({
+                 if (type !== "major" && type !== "minor") {
+                   type = "patch";
+                 }
+-
+                 break;
+-
+               case "devDependencies":
+                 {
+                   // We don't need a version bump if the package is only in the devDependencies of the dependent package
+@@ -156,11 +131,9 @@ function determineDependents({
+           }
+         }
+       }
+-
+       if (releases.has(dependent) && releases.get(dependent).type === type) {
+         type = undefined;
+       }
+-
+       return {
+         name: dependent,
+         type,
+@@ -173,7 +146,8 @@ function determineDependents({
+     }) => {
+       // At this point, we know if we are making a change
+       updated = true;
+-      const existing = releases.get(name); // For things that are being given a major bump, we check if we have already
++      const existing = releases.get(name);
++      // For things that are being given a major bump, we check if we have already
+       // added them here. If we have, we update the existing item instead of pushing it on to search.
+       // It is safe to not add it to pkgsToSearch because it should have already been searched at the
+       // largest possible bump type.
+@@ -193,31 +167,29 @@ function determineDependents({
+       }
+     });
+   }
+-
+   return updated;
+ }
++
+ /*
+   Returns an array of objects in the shape { depType: DependencyType, versionRange: string }
+   The array can contain more than one elements in case a dependency appears in multiple
+   dependency lists. For example, a package that is both a peerDepenency and a devDependency.
+ */
+-
+ function getDependencyVersionRanges(dependentPkgJSON, dependencyRelease) {
+   const DEPENDENCY_TYPES = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+   const dependencyVersionRanges = [];
+-
+   for (const type of DEPENDENCY_TYPES) {
+     var _dependentPkgJSON$typ;
+-
+     const versionRange = (_dependentPkgJSON$typ = dependentPkgJSON[type]) === null || _dependentPkgJSON$typ === void 0 ? void 0 : _dependentPkgJSON$typ[dependencyRelease.name];
+     if (!versionRange) continue;
+-
+     if (versionRange.startsWith("workspace:")) {
+       dependencyVersionRanges.push({
+         depType: type,
+-        versionRange: // intentionally keep other workspace ranges untouched
++        versionRange:
++        // intentionally keep other workspace ranges untouched
+         // this has to be fixed but this should only be done when adding appropriate tests
+-        versionRange === "workspace:*" ? // workspace:* actually means the current exact version, and not a wildcard similar to a reguler * range
++        versionRange === "workspace:*" ?
++        // workspace:* actually means the current exact version, and not a wildcard similar to a reguler * range
+         dependencyRelease.oldVersion : versionRange.replace(/^workspace:/, "")
+       });
+     } else {
+@@ -227,10 +199,8 @@ function getDependencyVersionRanges(dependentPkgJSON, dependencyRelease) {
+       });
+     }
+   }
+-
+   return dependencyVersionRanges;
+ }
+-
+ function shouldBumpMajor({
+   dependent,
+   depType,
+@@ -241,18 +211,22 @@ function shouldBumpMajor({
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
+   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
+-  return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && ( // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
++  return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
++  // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+   // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
+-  !onlyUpdatePeerDependentsWhenOutOfRange || !semver.satisfies(incrementVersion(nextRelease, preInfo), versionRange)) && ( // bump major only if the dependent doesn't already has a major release.
++  !onlyUpdatePeerDependentsWhenOutOfRange || !semver.satisfies(incrementVersion(nextRelease, preInfo), versionRange)) && (
++  // bump major only if the dependent doesn't already has a major release.
+   !releases.has(dependent) || releases.has(dependent) && releases.get(dependent).type !== "major");
+ }
+ 
+ // This function takes in changesets and returns one release per
+ // package listed in the changesets
++
+ function flattenReleases(changesets, packagesByName, ignoredPackages) {
+   let releases = new Map();
+   changesets.forEach(changeset => {
+-    changeset.releases // Filter out ignored packages because they should not trigger a release
++    changeset.releases
++    // Filter out ignored packages because they should not trigger a release
+     // If their dependencies need updates, they will be added to releases by `determineDependents()` with release type `none`
+     .filter(({
+       name
+@@ -262,11 +236,9 @@ function flattenReleases(changesets, packagesByName, ignoredPackages) {
+     }) => {
+       let release = releases.get(name);
+       let pkg = packagesByName.get(name);
+-
+       if (!pkg) {
+         throw new Error(`"${changeset.id}" changeset mentions a release for a package "${name}" but such a package could not be found.`);
+       }
+-
+       if (!release) {
+         release = {
+           name,
+@@ -277,14 +249,12 @@ function flattenReleases(changesets, packagesByName, ignoredPackages) {
+       } else {
+         if (type === "major" || (release.type === "patch" || release.type === "none") && (type === "minor" || type === "patch")) {
+           release.type = type;
+-        } // Check whether the bumpType will change
++        }
++        // Check whether the bumpType will change
+         // If the bumpType has changed recalc newVersion
+         // push new changeset to releases
+-
+-
+         release.changesets.push(changeset.id);
+       }
+-
+       releases.set(name, release);
+     });
+   });
+@@ -295,64 +265,52 @@ function getHighestReleaseType(releases) {
+   if (releases.length === 0) {
+     throw new Error(`Large internal Changesets error when calculating highest release type in the set of releases. Please contact the maintainers`);
+   }
+-
+   let highestReleaseType = "none";
+-
+   for (let release of releases) {
+     switch (release.type) {
+       case "major":
+         return "major";
+-
+       case "minor":
+         highestReleaseType = "minor";
+         break;
+-
+       case "patch":
+         if (highestReleaseType === "none") {
+           highestReleaseType = "patch";
+         }
+-
+         break;
+     }
+   }
+-
+   return highestReleaseType;
+ }
+ function getCurrentHighestVersion(packageGroup, packagesByName) {
+   let highestVersion;
+-
+   for (let pkgName of packageGroup) {
+     let pkg = packagesByName.get(pkgName);
+-
+     if (!pkg) {
+       console.error(`FATAL ERROR IN CHANGESETS! We were unable to version for package group: ${pkgName} in package group: ${packageGroup.toString()}`);
+       throw new Error(`fatal: could not resolve linked packages`);
+     }
+-
+     if (highestVersion === undefined || semver.gt(pkg.packageJson.version, highestVersion)) {
+       highestVersion = pkg.packageJson.version;
+     }
+   }
+-
+   return highestVersion;
+ }
+ 
+ function matchFixedConstraint(releases, packagesByName, config) {
+   let updated = false;
+-
+   for (let fixedPackages of config.fixed) {
+     let releasingFixedPackages = [...releases.values()].filter(release => fixedPackages.includes(release.name) && release.type !== "none");
+     if (releasingFixedPackages.length === 0) continue;
+     let highestReleaseType = getHighestReleaseType(releasingFixedPackages);
+-    let highestVersion = getCurrentHighestVersion(fixedPackages, packagesByName); // Finally, we update the packages so all of them are on the highest version
++    let highestVersion = getCurrentHighestVersion(fixedPackages, packagesByName);
+ 
++    // Finally, we update the packages so all of them are on the highest version
+     for (let pkgName of fixedPackages) {
+       if (config.ignore.includes(pkgName)) {
+         continue;
+       }
+-
+       let release = releases.get(pkgName);
+-
+       if (!release) {
+         updated = true;
+         releases.set(pkgName, {
+@@ -363,19 +321,16 @@ function matchFixedConstraint(releases, packagesByName, config) {
+         });
+         continue;
+       }
+-
+       if (release.type !== highestReleaseType) {
+         updated = true;
+         release.type = highestReleaseType;
+       }
+-
+       if (release.oldVersion !== highestVersion) {
+         updated = true;
+         release.oldVersion = highestVersion;
+       }
+     }
+   }
+-
+   return updated;
+ }
+ 
+@@ -391,47 +346,44 @@ function matchFixedConstraint(releases, packagesByName, config) {
+   We could solve this by inlining this function, or by returning a deep-cloned then
+   modified array, but we decided both of those are worse than this solution.
+ */
+-
+ function applyLinks(releases, packagesByName, linked) {
+-  let updated = false; // We do this for each set of linked packages
++  let updated = false;
+ 
++  // We do this for each set of linked packages
+   for (let linkedPackages of linked) {
+     // First we filter down to all the relevant releases for one set of linked packages
+-    let releasingLinkedPackages = [...releases.values()].filter(release => linkedPackages.includes(release.name) && release.type !== "none"); // If we proceed any further we do extra work with calculating highestVersion for things that might
+-    // not need one, as they only have workspace based packages
++    let releasingLinkedPackages = [...releases.values()].filter(release => linkedPackages.includes(release.name) && release.type !== "none");
+ 
++    // If we proceed any further we do extra work with calculating highestVersion for things that might
++    // not need one, as they only have workspace based packages
+     if (releasingLinkedPackages.length === 0) continue;
+     let highestReleaseType = getHighestReleaseType(releasingLinkedPackages);
+-    let highestVersion = getCurrentHighestVersion(linkedPackages, packagesByName); // Finally, we update the packages so all of them are on the highest version
++    let highestVersion = getCurrentHighestVersion(linkedPackages, packagesByName);
+ 
++    // Finally, we update the packages so all of them are on the highest version
+     for (let linkedPackage of releasingLinkedPackages) {
+       if (linkedPackage.type !== highestReleaseType) {
+         updated = true;
+         linkedPackage.type = highestReleaseType;
+       }
+-
+       if (linkedPackage.oldVersion !== highestVersion) {
+         updated = true;
+         linkedPackage.oldVersion = highestVersion;
+       }
+     }
+   }
+-
+   return updated;
+ }
+ 
+ function getPreVersion(version) {
+   let parsed = parse(version);
+   let preVersion = parsed.prerelease[1] === undefined ? -1 : parsed.prerelease[1];
+-
+   if (typeof preVersion !== "number") {
+     throw new InternalError("preVersion is not a number");
+   }
+-
+   preVersion++;
+   return preVersion;
+ }
+-
+ function getSnapshotSuffix(template, snapshotParameters) {
+   let snapshotRefDate = new Date();
+   const placeholderValues = {
+@@ -439,36 +391,32 @@ function getSnapshotSuffix(template, snapshotParameters) {
+     tag: snapshotParameters.tag,
+     timestamp: snapshotRefDate.getTime().toString(),
+     datetime: snapshotRefDate.toISOString().replace(/\.\d{3}Z$/, "").replace(/[^\d]/g, "")
+-  }; // We need a special handling because we need to handle a case where `--snapshot` is used without any template,
+-  // and the resulting version needs to be composed without a tag.
++  };
+ 
++  // We need a special handling because we need to handle a case where `--snapshot` is used without any template,
++  // and the resulting version needs to be composed without a tag.
+   if (!template) {
+     return [placeholderValues.tag, placeholderValues.datetime].filter(Boolean).join("-");
+   }
+-
+   const placeholders = Object.keys(placeholderValues);
+-
+   if (!template.includes(`{tag}`) && placeholderValues.tag !== undefined) {
+     throw new Error(`Failed to compose snapshot version: "{tag}" placeholder is missing, but the snapshot parameter is defined (value: '${placeholderValues.tag}')`);
+   }
+-
+   return placeholders.reduce((prev, key) => {
+     return prev.replace(new RegExp(`\\{${key}\\}`, "g"), () => {
+       const value = placeholderValues[key];
+-
+       if (value === undefined) {
+         throw new Error(`Failed to compose snapshot version: "{${key}}" placeholder is used without having a value defined!`);
+       }
+-
+       return value;
+     });
+   }, template);
+ }
+-
+ function getSnapshotVersion(release, preInfo, useCalculatedVersion, snapshotSuffix) {
+   if (release.type === "none") {
+     return release.oldVersion;
+   }
++
+   /**
+    * Using version as 0.0.0 so that it does not hinder with other version release
+    * For example;
+@@ -478,22 +426,52 @@ function getSnapshotVersion(release, preInfo, useCalculatedVersion, snapshotSuff
+    *
+    * You can set `snapshot.useCalculatedVersion` flag to true to use calculated versions if you don't care about the above problem.
+    */
+-
+-
+   const baseVersion = useCalculatedVersion ? incrementVersion(release, preInfo) : `0.0.0`;
+   return `${baseVersion}-${snapshotSuffix}`;
+ }
+-
+-function getNewVersion(release, preInfo) {
++function getNewVersion(release, preInfo, config) {
+   if (release.type === "none") {
+     return release.oldVersion;
+   }
+-
++  const customIncrement = getCustomIncrementVersionsFunc(release.name, config);
++  if (customIncrement) return customIncrement.incrementVersionsFuncs.incrementVersion(release.oldVersion, release.type, () => {
++    return incrementVersion(release, preInfo);
++  });
+   return incrementVersion(release, preInfo);
+ }
+-
+-function assembleReleasePlan(changesets, packages, config, // intentionally not using an optional parameter here so the result of `readPreState` has to be passed in here
+-preState, // snapshot: undefined            ->  not using snaphot
++function getCustomIncrementVersionsFunc(pkgName, config) {
++  var _config$incrementVers, _config$incrementVers2;
++  if (!config.incrementVersions) {
++    return null;
++  }
++  const cwd = process.cwd();
++  let changesetPath = path.join(cwd, ".changeset");
++  if (!((_config$incrementVers = config.incrementVersions) !== null && _config$incrementVers !== void 0 && (_config$incrementVers2 = _config$incrementVers[pkgName]) !== null && _config$incrementVers2 !== void 0 && _config$incrementVers2.path)) {
++    return null;
++  }
++  const incrementVersionsOpts = config.incrementVersions[pkgName];
++  let incrementVersionsPath = resolveFrom(changesetPath, incrementVersionsOpts.path);
++  let incrementVersionsFuncs;
++  let possibleIncrementVersionFunc = require(incrementVersionsPath);
++  if (possibleIncrementVersionFunc.default) {
++    possibleIncrementVersionFunc = possibleIncrementVersionFunc.default;
++  }
++  if (typeof possibleIncrementVersionFunc.incrementVersion === "function") {
++    incrementVersionsFuncs = {
++      incrementVersion: possibleIncrementVersionFunc.incrementVersion
++    };
++  } else {
++    throw new Error("Could not resolve changelog generation functions");
++  }
++  return {
++    incrementVersionsOpts,
++    incrementVersionsFuncs
++  };
++}
++function assembleReleasePlan(changesets, packages, config,
++// intentionally not using an optional parameter here so the result of `readPreState` has to be passed in here
++preState,
++// snapshot: undefined            ->  not using snaphot
+ // snapshot: { tag: undefined }   ->  --snapshot (empty tag)
+ // snapshot: { tag: "canary" }    ->  --snapshot canary
+ snapshot) {
+@@ -512,16 +490,16 @@ snapshot) {
+   } : snapshot;
+   let packagesByName = new Map(packages.packages.map(x => [x.packageJson.name, x]));
+   const relevantChangesets = getRelevantChangesets(changesets, refinedConfig.ignore, preState);
+-  const preInfo = getPreInfo(changesets, packagesByName, refinedConfig, preState); // releases is, at this point a list of all packages we are going to releases,
++  const preInfo = getPreInfo(changesets, packagesByName, refinedConfig, preState);
++
++  // releases is, at this point a list of all packages we are going to releases,
+   // flattened down to one release per package, having a reference back to their
+   // changesets, and with a calculated new versions
+-
+   let releases = flattenReleases(relevantChangesets, packagesByName, refinedConfig.ignore);
+   let dependencyGraph = getDependentsGraph(packages, {
+     bumpVersionsWithWorkspaceProtocolOnly: refinedConfig.bumpVersionsWithWorkspaceProtocolOnly
+   });
+   let releasesValidated = false;
+-
+   while (releasesValidated === false) {
+     // The map passed in to determineDependents will be mutated
+     let dependentAdded = determineDependents({
+@@ -530,13 +508,13 @@ snapshot) {
+       dependencyGraph,
+       preInfo,
+       config: refinedConfig
+-    }); // `releases` might get mutated here
++    });
+ 
++    // `releases` might get mutated here
+     let fixedConstraintUpdated = matchFixedConstraint(releases, packagesByName, refinedConfig);
+     let linksUpdated = applyLinks(releases, packagesByName, refinedConfig.linked);
+     releasesValidated = !linksUpdated && !dependentAdded && !fixedConstraintUpdated;
+   }
+-
+   if ((preInfo === null || preInfo === void 0 ? void 0 : preInfo.state.mode) === "exit") {
+     for (let pkg of packages.packages) {
+       // If a package had a prerelease, but didn't trigger a version bump in the regular release,
+@@ -544,7 +522,6 @@ snapshot) {
+       // Detailed explanation at https://github.com/changesets/changesets/pull/382#discussion_r434434182
+       if (preInfo.preVersions.get(pkg.packageJson.name) !== 0) {
+         const existingRelease = releases.get(pkg.packageJson.name);
+-
+         if (!existingRelease) {
+           releases.set(pkg.packageJson.name, {
+             name: pkg.packageJson.name,
+@@ -557,28 +534,26 @@ snapshot) {
+         }
+       }
+     }
+-  } // Caching the snapshot version here and use this if it is snapshot release
+-
++  }
+ 
++  // Caching the snapshot version here and use this if it is snapshot release
+   const snapshotSuffix = refinedSnapshot && getSnapshotSuffix(refinedConfig.snapshot.prereleaseTemplate, refinedSnapshot);
+   return {
+     changesets: relevantChangesets,
+     releases: [...releases.values()].map(incompleteRelease => {
+       return _objectSpread2(_objectSpread2({}, incompleteRelease), {}, {
+-        newVersion: snapshotSuffix ? getSnapshotVersion(incompleteRelease, preInfo, refinedConfig.snapshot.useCalculatedVersion, snapshotSuffix) : getNewVersion(incompleteRelease, preInfo)
++        newVersion: snapshotSuffix ? getSnapshotVersion(incompleteRelease, preInfo, refinedConfig.snapshot.useCalculatedVersion, snapshotSuffix) : getNewVersion(incompleteRelease, preInfo, config)
+       });
+     }),
+     preState: preInfo === null || preInfo === void 0 ? void 0 : preInfo.state
+   };
+ }
+-
+ function getRelevantChangesets(changesets, ignored, preState) {
+   for (const changeset of changesets) {
+     // Using the following 2 arrays to decide whether a changeset
+     // contains both ignored and not ignored packages
+     const ignoredPackages = [];
+     const notIgnoredPackages = [];
+-
+     for (const release of changeset.releases) {
+       if (ignored.find(ignoredPackageName => ignoredPackageName === release.name)) {
+         ignoredPackages.push(release.name);
+@@ -586,70 +561,54 @@ function getRelevantChangesets(changesets, ignored, preState) {
+         notIgnoredPackages.push(release.name);
+       }
+     }
+-
+     if (ignoredPackages.length > 0 && notIgnoredPackages.length > 0) {
+       throw new Error(`Found mixed changeset ${changeset.id}\n` + `Found ignored packages: ${ignoredPackages.join(" ")}\n` + `Found not ignored packages: ${notIgnoredPackages.join(" ")}\n` + "Mixed changesets that contain both ignored and not ignored packages are not allowed");
+     }
+   }
+-
+   if (preState && preState.mode !== "exit") {
+     let usedChangesetIds = new Set(preState.changesets);
+     return changesets.filter(changeset => !usedChangesetIds.has(changeset.id));
+   }
+-
+   return changesets;
+ }
+-
+ function getHighestPreVersion(packageGroup, packagesByName) {
+   let highestPreVersion = 0;
+-
+   for (let pkg of packageGroup) {
+     highestPreVersion = Math.max(getPreVersion(packagesByName.get(pkg).packageJson.version), highestPreVersion);
+   }
+-
+   return highestPreVersion;
+ }
+-
+ function getPreInfo(changesets, packagesByName, config, preState) {
+   if (preState === undefined) {
+     return;
+   }
+-
+   let updatedPreState = _objectSpread2(_objectSpread2({}, preState), {}, {
+     changesets: changesets.map(changeset => changeset.id),
+     initialVersions: _objectSpread2({}, preState.initialVersions)
+   });
+-
+   for (const [, pkg] of packagesByName) {
+     if (updatedPreState.initialVersions[pkg.packageJson.name] === undefined) {
+       updatedPreState.initialVersions[pkg.packageJson.name] = pkg.packageJson.version;
+     }
+-  } // Populate preVersion
++  }
++  // Populate preVersion
+   // preVersion is the map between package name and its next pre version number.
+-
+-
+   let preVersions = new Map();
+-
+   for (const [, pkg] of packagesByName) {
+     preVersions.set(pkg.packageJson.name, getPreVersion(pkg.packageJson.version));
+   }
+-
+   for (let fixedGroup of config.fixed) {
+     let highestPreVersion = getHighestPreVersion(fixedGroup, packagesByName);
+-
+     for (let fixedPackage of fixedGroup) {
+       preVersions.set(fixedPackage, highestPreVersion);
+     }
+   }
+-
+   for (let linkedGroup of config.linked) {
+     let highestPreVersion = getHighestPreVersion(linkedGroup, packagesByName);
+-
+     for (let linkedPackage of linkedGroup) {
+       preVersions.set(linkedPackage, highestPreVersion);
+     }
+   }
+-
+   return {
+     state: updatedPreState,
+     preVersions
+diff --git a/node_modules/@changesets/assemble-release-plan/src/index.test.ts b/node_modules/@changesets/assemble-release-plan/src/index.test.ts
+index 24d9583..0d24595 100644
+--- a/node_modules/@changesets/assemble-release-plan/src/index.test.ts
++++ b/node_modules/@changesets/assemble-release-plan/src/index.test.ts
+@@ -1,6 +1,8 @@
+ import { defaultConfig } from "@changesets/config";
++import { Config } from "@changesets/types";
+ import assembleReleasePlan from "./";
+ import FakeFullState from "./test-utils";
++import path from "path";
+ 
+ describe("assemble-release-plan", () => {
+   let setup: FakeFullState;
+@@ -13,6 +15,57 @@ describe("assemble-release-plan", () => {
+     setup.addPackage("pkg-d", "1.0.0");
+   });
+ 
++  it("should run func", () => {
++    setup = new FakeFullState();
++
++    setup.addPackage("pkg-b", "2023.1.0");
++    setup.addPackage("pkg-c", "2023.10.0");
++    setup.addPackage("pkg-d", "2023.10.0");
++
++    setup.addChangeset({
++      id: "big-cats-delight",
++      releases: [
++        { name: "pkg-a", type: "major" },
++        { name: "pkg-b", type: "major" },
++        { name: "pkg-c", type: "major" },
++        { name: "pkg-d", type: "major" },
++      ],
++    });
++
++    const newConfig: Config = {
++      ...defaultConfig,
++      incrementVersions: {
++        "pkg-b": {
++          path: path.resolve(__dirname, "test-utils/version-file.ts"),
++        },
++        "pkg-c": {
++          path: path.resolve(__dirname, "test-utils/version-file.ts"),
++        },
++      },
++    };
++
++    let { releases } = assembleReleasePlan(
++      setup.changesets,
++      setup.packages,
++      newConfig,
++      undefined
++    );
++
++    expect(releases.length).toBe(4);
++    expect(releases[0].name).toBe("pkg-a");
++    expect(releases[0].newVersion).toBe("2.0.0");
++
++    expect(releases[1].name).toBe("pkg-b");
++    expect(releases[1].newVersion).toBe("2023.4.0");
++
++    expect(releases[2].name).toBe("pkg-c");
++    expect(releases[2].newVersion).toBe("2024.1.0");
++
++    // no custom calver control
++    expect(releases[3].name).toBe("pkg-d");
++    expect(releases[3].newVersion).toBe("2024.0.0");
++  });
++
+   it("should assemble release plan for basic setup", () => {
+     let { releases } = assembleReleasePlan(
+       setup.changesets,
+diff --git a/node_modules/@changesets/assemble-release-plan/src/index.ts b/node_modules/@changesets/assemble-release-plan/src/index.ts
+index 3ffb6fa..5882569 100644
+--- a/node_modules/@changesets/assemble-release-plan/src/index.ts
++++ b/node_modules/@changesets/assemble-release-plan/src/index.ts
+@@ -4,6 +4,7 @@ import {
+   NewChangeset,
+   PreState,
+   PackageGroup,
++  IncrementVersionsFunctions,
+ } from "@changesets/types";
+ import determineDependents from "./determine-dependents";
+ import flattenReleases from "./flatten-releases";
+@@ -15,6 +16,8 @@ import { InternalError } from "@changesets/errors";
+ import { Packages, Package } from "@manypkg/get-packages";
+ import { getDependentsGraph } from "@changesets/get-dependents-graph";
+ import { PreInfo, InternalRelease } from "./types";
++import resolveFrom from "resolve-from";
++import path from "path";
+ 
+ type SnapshotReleaseParameters = {
+   tag?: string | undefined;
+@@ -108,15 +111,69 @@ function getSnapshotVersion(
+ 
+ function getNewVersion(
+   release: InternalRelease,
+-  preInfo: PreInfo | undefined
++  preInfo: PreInfo | undefined,
++  config: OptionalProp<Config, "snapshot">
+ ): string {
+   if (release.type === "none") {
+     return release.oldVersion;
+   }
+ 
++  const customIncrement = getCustomIncrementVersionsFunc(release.name, config);
++
++  if (customIncrement)
++    return customIncrement.incrementVersionsFuncs.incrementVersion(
++      release.oldVersion,
++      release.type,
++      () => {
++        return incrementVersion(release, preInfo);
++      }
++    );
++
+   return incrementVersion(release, preInfo);
+ }
+ 
++function getCustomIncrementVersionsFunc(
++  pkgName: string,
++  config: OptionalProp<Config, "snapshot">
++): {
++  incrementVersionsOpts: any;
++  incrementVersionsFuncs: IncrementVersionsFunctions;
++} | null {
++  if (!config.incrementVersions) {
++    return null;
++  }
++
++  const cwd = process.cwd();
++  let changesetPath = path.join(cwd, ".changeset");
++
++  if (!config.incrementVersions?.[pkgName]?.path) {
++    return null;
++  }
++
++  const incrementVersionsOpts = config.incrementVersions[pkgName];
++
++  let incrementVersionsPath = resolveFrom(
++    changesetPath,
++    incrementVersionsOpts.path
++  );
++
++  let incrementVersionsFuncs: IncrementVersionsFunctions;
++  let possibleIncrementVersionFunc = require(incrementVersionsPath);
++  if (possibleIncrementVersionFunc.default) {
++    possibleIncrementVersionFunc = possibleIncrementVersionFunc.default;
++  }
++
++  if (typeof possibleIncrementVersionFunc.incrementVersion === "function") {
++    incrementVersionsFuncs = {
++      incrementVersion: possibleIncrementVersionFunc.incrementVersion,
++    };
++  } else {
++    throw new Error("Could not resolve changelog generation functions");
++  }
++
++  return { incrementVersionsOpts, incrementVersionsFuncs };
++}
++
+ type OptionalProp<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+ 
+ function assembleReleasePlan(
+@@ -252,7 +309,7 @@ function assembleReleasePlan(
+               refinedConfig.snapshot.useCalculatedVersion,
+               snapshotSuffix
+             )
+-          : getNewVersion(incompleteRelease, preInfo),
++          : getNewVersion(incompleteRelease, preInfo, config),
+       };
+     }),
+     preState: preInfo?.state,
+diff --git a/node_modules/@changesets/assemble-release-plan/src/test-utils/version-file.ts b/node_modules/@changesets/assemble-release-plan/src/test-utils/version-file.ts
+new file mode 100644
+index 0000000..6e25676
+--- /dev/null
++++ b/node_modules/@changesets/assemble-release-plan/src/test-utils/version-file.ts
+@@ -0,0 +1,25 @@
++const incrementVersion = (
++  oldVersion: string,
++  type: string,
++  defaultIncreaseVersion: () => string
++) => {
++  const versions = oldVersion.split(".");
++  if (type === "major") {
++    const minor = parseInt(versions[1]);
++    const newMinor = (minor + 3) % 12;
++
++    const major = parseInt(versions[0]);
++    const newMajor = newMinor === 1 ? major + 1 : major;
++    return `${newMajor}.${newMinor}.0`;
++  }
++
++  if (type === "minor") {
++    return defaultIncreaseVersion();
++  }
++
++  return defaultIncreaseVersion();
++};
++
++export default {
++  incrementVersion,
++};

--- a/patches/@changesets+config+2.3.0.dev.patch
+++ b/patches/@changesets+config+2.3.0.dev.patch
@@ -1,0 +1,2139 @@
+diff --git a/node_modules/@changesets/config/CHANGELOG.md b/node_modules/@changesets/config/CHANGELOG.md
+new file mode 100644
+index 0000000..0540615
+--- /dev/null
++++ b/node_modules/@changesets/config/CHANGELOG.md
+@@ -0,0 +1,328 @@
++# @changesets/config
++
++## 2.3.0
++
++### Minor Changes
++
++- [#1033](https://github.com/changesets/changesets/pull/1033) [`521205d`](https://github.com/changesets/changesets/commit/521205dc8c70fe71b181bd3c4bb7c9c6d2e721d2) Thanks [@Andarist](https://github.com/Andarist)! - Support and validation for the new `changedFilePatterns` option has been added.
++
++### Patch Changes
++
++- Updated dependencies [[`521205d`](https://github.com/changesets/changesets/commit/521205dc8c70fe71b181bd3c4bb7c9c6d2e721d2)]:
++  - @changesets/types@5.2.1
++  - @changesets/get-dependents-graph@1.3.5
++
++## 2.2.0
++
++### Minor Changes
++
++- [#662](https://github.com/changesets/changesets/pull/662) [`8c08469`](https://github.com/changesets/changesets/commit/8c0846977597ddaf51aaeb35f1f0f9428bf8ba14) Thanks [@JakeGinnivan](https://github.com/JakeGinnivan)! - Added support for the `privatePackages` property in the config.
++
++### Patch Changes
++
++- Updated dependencies [[`8c08469`](https://github.com/changesets/changesets/commit/8c0846977597ddaf51aaeb35f1f0f9428bf8ba14)]:
++  - @changesets/types@5.2.0
++  - @changesets/get-dependents-graph@1.3.4
++
++## 2.1.1
++
++### Patch Changes
++
++- [#900](https://github.com/changesets/changesets/pull/900) [`7d998ee`](https://github.com/changesets/changesets/commit/7d998eeb16064b5442ebc49ad31dec7b841d504e) Thanks [@sdirosa](https://github.com/sdirosa)! - Include the information about `false` being a valid value for the `changelog` option in the validation message for the `changelog` option.
++
++## 2.1.0
++
++### Minor Changes
++
++- [#858](https://github.com/changesets/changesets/pull/858) [`dd9b76f`](https://github.com/changesets/changesets/commit/dd9b76f162a546ae8b412e0cb10277f971f3585e) Thanks [@dotansimha](https://github.com/dotansimha)! - Added a new config option: `snapshot.prereleaseTemplate` for customizing the way snapshot release numbers are being composed.
++
++### Patch Changes
++
++- [#858](https://github.com/changesets/changesets/pull/858) [`dd9b76f`](https://github.com/changesets/changesets/commit/dd9b76f162a546ae8b412e0cb10277f971f3585e) Thanks [@dotansimha](https://github.com/dotansimha)! - A possibility to use the calculated version for snapshot releases is now stable 🥳 All snapshot-related config parameters are now grouped under a single config property called `snapshot`.
++
++  To migrate, make sure to update your `config.json`.
++
++  Old usage (still works, but comes with a deprecated warning):
++
++  ```json
++  {
++    "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
++      "useCalculatedVersionForSnapshots": true
++    }
++  }
++  ```
++
++  New usage:
++
++  ```json
++  {
++    "snapshot": {
++      "useCalculatedVersion": true
++    }
++  }
++  ```
++
++- Updated dependencies [[`dd9b76f`](https://github.com/changesets/changesets/commit/dd9b76f162a546ae8b412e0cb10277f971f3585e)]:
++  - @changesets/types@5.1.0
++  - @changesets/get-dependents-graph@1.3.3
++
++## 2.0.1
++
++### Patch Changes
++
++- [#854](https://github.com/changesets/changesets/pull/854) [`2827c7a`](https://github.com/changesets/changesets/commit/2827c7ab33af30065fafe72ede1a2a6ac88d5276) Thanks [@Andarist](https://github.com/Andarist)! - Fixed the declared JSON schema type for the `changelog` config option.
++
++- [#852](https://github.com/changesets/changesets/pull/852) [`7b1c0c1`](https://github.com/changesets/changesets/commit/7b1c0c1b73a19b50fe3a104acb440c604eab108f) Thanks [@caohuilin](https://github.com/caohuilin)! - Fixed the declared JSON schema type for the `commit` config option.
++
++## 2.0.0
++
++### Major Changes
++
++- [#768](https://github.com/changesets/changesets/pull/768) [`c87eba6`](https://github.com/changesets/changesets/commit/c87eba6f80a34563b7382f87472c29f6dafb546c) Thanks [@rohit-gohri](https://github.com/rohit-gohri)! - The parsed config now normalzied the commit option to either `false` or a tuple describing what module should be loaded to resolve commit functions.
++
++### Patch Changes
++
++- Updated dependencies [[`c87eba6`](https://github.com/changesets/changesets/commit/c87eba6f80a34563b7382f87472c29f6dafb546c)]:
++  - @changesets/types@5.0.0
++  - @changesets/get-dependents-graph@1.3.2
++
++## 1.7.0
++
++### Minor Changes
++
++- [#690](https://github.com/changesets/changesets/pull/690) [`27a5a82`](https://github.com/changesets/changesets/commit/27a5a82188914570d192162f9d045dfd082a3c15) Thanks [@Andarist](https://github.com/Andarist)! - Added parsing and validating of the new `fixed` option. The description for this option has also been added to the JSON schema.
++
++### Patch Changes
++
++- Updated dependencies [[`27a5a82`](https://github.com/changesets/changesets/commit/27a5a82188914570d192162f9d045dfd082a3c15)]:
++  - @changesets/types@4.1.0
++  - @changesets/get-dependents-graph@1.3.1
++
++## 1.6.4
++
++### Patch Changes
++
++- Updated dependencies [[`6f9c9d6`](https://github.com/changesets/changesets/commit/6f9c9d60c0e02c79d555c48deb01559057f1d252)]:
++  - @changesets/get-dependents-graph@1.3.0
++
++## 1.6.3
++
++### Patch Changes
++
++- [#667](https://github.com/changesets/changesets/pull/667) [`fe8db75`](https://github.com/changesets/changesets/commit/fe8db7500f81caea9064f8bec02bcb77e0fd8fce) Thanks [@fz6m](https://github.com/fz6m)! - Upgraded `@manypkg/get-packages` dependency to fix getting correct packages in pnpm workspaces with exclude rules.
++
++- Updated dependencies [[`fe8db75`](https://github.com/changesets/changesets/commit/fe8db7500f81caea9064f8bec02bcb77e0fd8fce), [`9a993ba`](https://github.com/changesets/changesets/commit/9a993ba09629c1620d749432520470cec49d3a96)]:
++  - @changesets/get-dependents-graph@1.2.4
++  - @changesets/types@4.0.2
++
++## 1.6.2
++
++### Patch Changes
++
++- Updated dependencies [[`74dda8c`](https://github.com/changesets/changesets/commit/74dda8c0d8bd1741ca7b19f0ccb37b2330dc9549)]:
++  - @changesets/get-dependents-graph@1.2.3
++
++## 1.6.1
++
++### Patch Changes
++
++- Updated dependencies [[`e89e28a`](https://github.com/changesets/changesets/commit/e89e28a05f5fa43307db73812a6bcd269b62ddee)]:
++  - @changesets/types@4.0.1
++  - @changesets/get-dependents-graph@1.2.2
++
++## 1.6.0
++
++### Minor Changes
++
++- [#542](https://github.com/changesets/changesets/pull/542) [`de2b4a5`](https://github.com/changesets/changesets/commit/de2b4a5a7b244a37d94625bcb70ecde9dde5b612) Thanks [@Andarist](https://github.com/Andarist)! - A new `updateInternalDependents` experimental option has been added. It can be used to add dependent packages to the release (if they are not already a part of it) with patch bumps. To use it you can add this to your config:
++
++  ```json
++  {
++    "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
++      "updateInternalDependents": "always"
++    }
++  }
++  ```
++
++  This option accepts two values - `"always"` and `"out-of-range"` (the latter matches the current default behavior).
++
++### Patch Changes
++
++- Updated dependencies [[`de2b4a5`](https://github.com/changesets/changesets/commit/de2b4a5a7b244a37d94625bcb70ecde9dde5b612)]:
++  - @changesets/types@4.0.0
++  - @changesets/get-dependents-graph@1.2.1
++
++## 1.5.0
++
++### Minor Changes
++
++- [`12f9a43`](https://github.com/changesets/changesets/commit/12f9a433a6c3ac38f9405fcd77c9108c423d7101) [#507](https://github.com/changesets/changesets/pull/507) Thanks [@zkochan](https://github.com/zkochan)! - New setting added: bumpVersionsWithWorkspaceProtocolOnly. When it is set to `true`, versions are bumped in `dependencies`, only if those versions are prefixed by the workspace protocol. For instance, `"foo": "workspace:^1.0.0"`.
++
++### Patch Changes
++
++- Updated dependencies [[`12f9a43`](https://github.com/changesets/changesets/commit/12f9a433a6c3ac38f9405fcd77c9108c423d7101)]:
++  - @changesets/get-dependents-graph@1.2.0
++  - @changesets/types@3.3.0
++
++## 1.4.0
++
++### Minor Changes
++
++- [`e33e4ca`](https://github.com/changesets/changesets/commit/e33e4ca7e71ba7747e21af5011057f11ddfab939) [#458](https://github.com/changesets/changesets/pull/458) Thanks [@emmenko](https://github.com/emmenko)! - Allow glob expressions to be provided for the `linked` and `ignore` options
++
++### Patch Changes
++
++- Updated dependencies [[`f4973a2`](https://github.com/changesets/changesets/commit/f4973a25ec6a837f36d64c1fb4b108ace3bc1f9d)]:
++  - @changesets/types@3.2.0
++
++## 1.3.0
++
++### Minor Changes
++
++- [`377f5c3`](https://github.com/changesets/changesets/commit/377f5c385ad9db4ff8458f159e2d452c39828567) [#393](https://github.com/changesets/changesets/pull/393) Thanks [@Andarist](https://github.com/Andarist)! - Added `updateInternalDependencies` and `ignore` options to the JSON schema.
++
++### Patch Changes
++
++- [`377f5c3`](https://github.com/changesets/changesets/commit/377f5c385ad9db4ff8458f159e2d452c39828567) [#393](https://github.com/changesets/changesets/pull/393) Thanks [@Andarist](https://github.com/Andarist)! - Removed experimental flags from `defaultWrittenConfig`. They were added there by mistake.
++
++## 1.2.0
++
++### Minor Changes
++
++- [`9dcc364`](https://github.com/changesets/changesets/commit/9dcc364bf19e48f8f2824ebaf967d9ef41b6fc04) [#371](https://github.com/changesets/changesets/pull/371) Thanks [@Feiyang1](https://github.com/Feiyang1)! - Add `ignore` config option to configure ignored packages. The versions of ignored packages will not be bumped during a release, but their dependencies will still be bumped normally.
++
++### Patch Changes
++
++- [`addd725`](https://github.com/changesets/changesets/commit/addd7256d9251d999251a7c16c0a0b068d557b5d) [#383](https://github.com/changesets/changesets/pull/383) Thanks [@Feiyang1](https://github.com/Feiyang1)! - Added an experimental flag `onlyUpdatePeerDependentsWhenOutOfRange`. When set to `true`, we only bump peer dependents when peerDependencies are leaving range.
++
++- Updated dependencies [[`addd725`](https://github.com/changesets/changesets/commit/addd7256d9251d999251a7c16c0a0b068d557b5d), [`9dcc364`](https://github.com/changesets/changesets/commit/9dcc364bf19e48f8f2824ebaf967d9ef41b6fc04)]:
++  - @changesets/types@3.1.0
++
++## 1.1.0
++
++### Minor Changes
++
++- [`2b49d66`](https://github.com/changesets/changesets/commit/2b49d668ecaa1333bc5c7c5be4648dda1b11528d) [#358](https://github.com/changesets/changesets/pull/358) Thanks [@Blasz](https://github.com/Blasz)! - Add new updateInternalDependencies config option to disable auto bumping of internal dependencies in the same release if the dependency was only patch bumped
++
++### Patch Changes
++
++- Updated dependencies [[`2b49d66`](https://github.com/changesets/changesets/commit/2b49d668ecaa1333bc5c7c5be4648dda1b11528d)]:
++  - @changesets/types@3.0.0
++
++## 1.0.3
++
++### Patch Changes
++
++- [`1706fb7`](https://github.com/changesets/changesets/commit/1706fb751ecc2f5a792c42f467b2063078d58716) [#321](https://github.com/changesets/changesets/pull/321) Thanks [@mitchellhamilton](https://github.com/mitchellhamilton)! - Fix TypeScript declarations
++
++- Updated dependencies [[`1706fb7`](https://github.com/changesets/changesets/commit/1706fb751ecc2f5a792c42f467b2063078d58716)]:
++  - @changesets/errors@0.1.4
++  - @changesets/logger@0.0.5
++  - @changesets/types@2.0.1
++
++## 1.0.2
++
++### Patch Changes
++
++- Updated dependencies [[`011d57f`](https://github.com/changesets/changesets/commit/011d57f1edf9e37f75a8bef4f918e72166af096e)]:
++  - @changesets/types@2.0.0
++
++## 1.0.1
++
++### Patch Changes
++
++- [`04ddfd7`](https://github.com/changesets/changesets/commit/04ddfd7c3acbfb84ef9c92873fe7f9dea1f5145c) [#305](https://github.com/changesets/changesets/pull/305) Thanks [@Noviny](https://github.com/Noviny)! - Add link to changelog in readme
++
++- [`b49e1cf`](https://github.com/changesets/changesets/commit/b49e1cff65dca7fe9e341a35aa91704aa0e51cb3) [#306](https://github.com/changesets/changesets/pull/306) Thanks [@Andarist](https://github.com/Andarist)! - Ignore `node_modules` when glob searching for packages. This fixes an issue with package cycles.
++
++- Updated dependencies [[`04ddfd7`](https://github.com/changesets/changesets/commit/04ddfd7c3acbfb84ef9c92873fe7f9dea1f5145c), [`e56928b`](https://github.com/changesets/changesets/commit/e56928bbd6f9096def06ac37487bdbf28efec9d1)]:
++  - @changesets/errors@0.1.3
++  - @changesets/logger@0.0.4
++  - @changesets/types@1.0.1
++
++## 1.0.0
++
++### Major Changes
++
++- [`cc8c921`](https://github.com/changesets/changesets/commit/cc8c92143d4c4b7cca8b9917dfc830a40b5cda20) [#290](https://github.com/changesets/changesets/pull/290) Thanks [@mitchellhamilton](https://github.com/mitchellhamilton)! - Accept `Packages` object from `@manypkg/get-workspaces` instead of `Workspace[]` from `get-workspaces`
++
++### Patch Changes
++
++- Updated dependencies [[`41e2e3d`](https://github.com/changesets/changesets/commit/41e2e3dd1053ff2f35a1a07e60793c9099f26997), [`cc8c921`](https://github.com/changesets/changesets/commit/cc8c92143d4c4b7cca8b9917dfc830a40b5cda20), [`cc8c921`](https://github.com/changesets/changesets/commit/cc8c92143d4c4b7cca8b9917dfc830a40b5cda20), [`2363366`](https://github.com/changesets/changesets/commit/2363366756d1b15bddf6d803911baccfca03cbdf)]:
++  - @changesets/types@1.0.0
++
++## 0.3.0
++
++### Minor Changes
++
++- [`bca8865`](https://github.com/changesets/changesets/commit/bca88652d38caa31e789c4564230ba0b49562ad2) [#221](https://github.com/changesets/changesets/pull/221) Thanks [@mitchellhamilton](https://github.com/mitchellhamilton)! - Added support for `baseBranch` option which specifies what branch Changesets should use when determining what packages have changed
++
++## 0.2.4
++
++### Patch Changes
++
++- Updated dependencies [[`9cd1eaf`](https://github.com/changesets/changesets/commit/9cd1eafc1620894a39fe10d3e393ad8f812df53a)]:
++  - @changesets/logger@0.0.3
++
++## 0.2.3
++
++### Patch Changes
++
++- Updated dependencies [[`8f0a1ef`](https://github.com/changesets/changesets/commit/8f0a1ef327563512f471677ef0ca99d30da009c0), [`8f0a1ef`](https://github.com/changesets/changesets/commit/8f0a1ef327563512f471677ef0ca99d30da009c0), [`8f0a1ef`](https://github.com/changesets/changesets/commit/8f0a1ef327563512f471677ef0ca99d30da009c0)]:
++  - @changesets/types@0.4.0
++  - @changesets/errors@0.1.2
++  - @changesets/logger@0.0.2
++
++## 0.2.2
++
++### Patch Changes
++
++- [`5ababa0`](https://github.com/changesets/changesets/commit/5ababa08c8ea5ee3b4ff92253e2e752a5976cd27) [#201](https://github.com/changesets/changesets/pull/201) Thanks [@ajaymathur](https://github.com/ajaymathur)! - Updated to use the Error classes from the @changesets/errors package
++
++- [`a679b1d`](https://github.com/changesets/changesets/commit/a679b1dcdcb56652d31536e2d6326ba02a9dfe62) [#204](https://github.com/changesets/changesets/pull/204) Thanks [@Andarist](https://github.com/Andarist)! - Correctly handle the 'access' flag for packages
++
++  Previously, we had access as "public" or "private", access "private" isn't valid. This was a confusing because there are three states for publishing a package:
++
++  - `private: true` - the package will not be published to npm (worked)
++  - `access: public` - the package will be publicly published to npm (even if it uses a scope) (worked)
++  - `access: restricted` - the package will be published to npm, but only visible/accessible by those who are part of the scope. This technically worked, but we were passing the wrong bit of information in.
++
++  Now, we pass the correct access options `public` or `restricted`.
++
++- Updated dependencies [[`51a0d76`](https://github.com/changesets/changesets/commit/51a0d766c7064b4c6a9d1490593522c6fcd02929), [`a679b1d`](https://github.com/changesets/changesets/commit/a679b1dcdcb56652d31536e2d6326ba02a9dfe62), [`5ababa0`](https://github.com/changesets/changesets/commit/5ababa08c8ea5ee3b4ff92253e2e752a5976cd27)]:
++  - @changesets/logger@0.0.1
++  - @changesets/types@0.3.1
++  - @changesets/errors@0.1.1
++
++## 0.2.1
++
++### Patch Changes
++
++- Updated dependencies [8c43fa0, 1ff73b7]:
++  - @changesets/types@0.3.0
++
++## 0.2.0
++
++### Minor Changes
++
++- [296a6731](https://github.com/changesets/changesets/commit/296a6731) - Safety bump: Towards the end of preparing changesets v2, there was a lot of chaos - this bump is to ensure every package on npm matches what is found in the repository.
++
++### Patch Changes
++
++- Updated dependencies [296a6731]:
++  - @changesets/types@0.2.0
++
++## 0.1.2
++
++### Patch Changes
++
++- [a15abbf9](https://github.com/changesets/changesets/commit/a15abbf9) - Previous release shipped unbuilt code - fixing that
++
++## 0.1.0
++
++### Minor Changes
++
++- [519b4218](https://github.com/changesets/changesets/commit/519b4218) - Initial release with parse and read functions along with defaultConfig and defaultWrittenConfig
++
++- Updated dependencies [519b4218]:
++  - @changesets/types@0.1.0
+diff --git a/node_modules/@changesets/config/dist/config.cjs.dev.js b/node_modules/@changesets/config/dist/config.cjs.dev.js
+index 4cdfd0c..42eaa55 100644
+--- a/node_modules/@changesets/config/dist/config.cjs.dev.js
++++ b/node_modules/@changesets/config/dist/config.cjs.dev.js
+@@ -51,119 +51,95 @@ let defaultWrittenConfig = {
+   access: "restricted",
+   baseBranch: "master",
+   updateInternalDependencies: "patch",
+-  ignore: []
++  ignore: [],
++  incrementVersions: false
+ };
+-
+ function flatten(arr) {
+   return [].concat(...arr);
+ }
+-
+ function getNormalizedChangelogOption(thing) {
+   if (thing === false) {
+     return false;
+   }
+-
+   if (typeof thing === "string") {
+     return [thing, null];
+   }
+-
+   return thing;
+ }
+-
+ function getNormalizedCommitOption(thing) {
+   if (thing === false) {
+     return false;
+   }
+-
+   if (thing === true) {
+     return ["@changesets/cli/commit", {
+       skipCI: "version"
+     }];
+   }
+-
+   if (typeof thing === "string") {
+     return [thing, null];
+   }
+-
+   return thing;
+ }
+-
+ function getUnmatchedPatterns(listOfPackageNamesOrGlob, pkgNames) {
+   return listOfPackageNamesOrGlob.filter(pkgNameOrGlob => !pkgNames.some(pkgName => micromatch__default['default'].isMatch(pkgName, pkgNameOrGlob)));
+ }
+-
+ const havePackageGroupsCorrectShape = pkgGroups => {
+   return isArray(pkgGroups) && pkgGroups.every(arr => isArray(arr) && arr.every(pkgName => typeof pkgName === "string"));
+-}; // TODO: it might be possible to remove this if improvements to `Array.isArray` ever land
+-// related thread: github.com/microsoft/TypeScript/issues/36554
+-
++};
+ 
++// TODO: it might be possible to remove this if improvements to `Array.isArray` ever land
++// related thread: github.com/microsoft/TypeScript/issues/36554
+ function isArray(arg) {
+   return Array.isArray(arg);
+ }
+-
+ let read = async (cwd, packages) => {
+   let json = await fs.readJSON(path__default['default'].join(cwd, ".changeset", "config.json"));
+   return parse(json, packages);
+ };
+ let parse = (json, packages) => {
+   var _json$changedFilePatt, _json$snapshot$prerel, _json$snapshot, _json$snapshot2, _json$___experimental, _json$___experimental2, _json$___experimental3, _json$___experimental4, _json$privatePackages, _json$privatePackages2;
+-
+   let messages = [];
+   let pkgNames = packages.packages.map(({
+     packageJson
+   }) => packageJson.name);
+-
+   if (json.changelog !== undefined && json.changelog !== false && typeof json.changelog !== "string" && !(isArray(json.changelog) && json.changelog.length === 2 && typeof json.changelog[0] === "string")) {
+     messages.push(`The \`changelog\` option is set as ${JSON.stringify(json.changelog, null, 2)} when the only valid values are undefined, false, a module path(e.g. "@changesets/cli/changelog" or "./some-module") or a tuple with a module path and config for the changelog generator(e.g. ["@changesets/cli/changelog", { someOption: true }])`);
+   }
+-
+   let normalizedAccess = json.access;
+-
+   if (json.access === "private") {
+     normalizedAccess = "restricted";
+     logger.warn('The `access` option is set as "private", but this is actually not a valid value - the correct form is "restricted".');
+   }
+-
+   if (normalizedAccess !== undefined && normalizedAccess !== "restricted" && normalizedAccess !== "public") {
+     messages.push(`The \`access\` option is set as ${JSON.stringify(normalizedAccess, null, 2)} when the only valid values are undefined, "public" or "restricted"`);
+   }
+-
+   if (json.commit !== undefined && typeof json.commit !== "boolean" && typeof json.commit !== "string" && !(isArray(json.commit) && json.commit.length === 2 && typeof json.commit[0] === "string")) {
+     messages.push(`The \`commit\` option is set as ${JSON.stringify(json.commit, null, 2)} when the only valid values are undefined or a boolean or a module path (e.g. "@changesets/cli/commit" or "./some-module") or a tuple with a module path and config for the commit message generator (e.g. ["@changesets/cli/commit", { "skipCI": "version" }])`);
+   }
+-
+   if (json.baseBranch !== undefined && typeof json.baseBranch !== "string") {
+     messages.push(`The \`baseBranch\` option is set as ${JSON.stringify(json.baseBranch, null, 2)} but the \`baseBranch\` option can only be set as a string`);
+   }
+-
+   if (json.changedFilePatterns !== undefined && (!isArray(json.changedFilePatterns) || !json.changedFilePatterns.every(pattern => typeof pattern === "string"))) {
+     messages.push(`The \`changedFilePatterns\` option is set as ${JSON.stringify(json.changedFilePatterns, null, 2)} but the \`changedFilePatterns\` option can only be set as an array of strings`);
+   }
+-
+   let fixed = [];
+-
+   if (json.fixed !== undefined) {
+     if (!havePackageGroupsCorrectShape(json.fixed)) {
+       messages.push(`The \`fixed\` option is set as ${JSON.stringify(json.fixed, null, 2)} when the only valid values are undefined or an array of arrays of package names`);
+     } else {
+       let foundPkgNames = new Set();
+       let duplicatedPkgNames = new Set();
+-
+       for (let fixedGroup of json.fixed) {
+         messages.push(...getUnmatchedPatterns(fixedGroup, pkgNames).map(pkgOrGlob => `The package or glob expression "${pkgOrGlob}" specified in the \`fixed\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`));
+         let expandedFixedGroup = micromatch__default['default'](pkgNames, fixedGroup);
+         fixed.push(expandedFixedGroup);
+-
+         for (let fixedPkgName of expandedFixedGroup) {
+           if (foundPkgNames.has(fixedPkgName)) {
+             duplicatedPkgNames.add(fixedPkgName);
+           }
+-
+           foundPkgNames.add(fixedPkgName);
+         }
+       }
+-
+       if (duplicatedPkgNames.size) {
+         duplicatedPkgNames.forEach(pkgName => {
+           messages.push(`The package "${pkgName}" is defined in multiple sets of fixed packages. Packages can only be defined in a single set of fixed packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch.`);
+@@ -171,30 +147,24 @@ let parse = (json, packages) => {
+       }
+     }
+   }
+-
+   let linked = [];
+-
+   if (json.linked !== undefined) {
+     if (!havePackageGroupsCorrectShape(json.linked)) {
+       messages.push(`The \`linked\` option is set as ${JSON.stringify(json.linked, null, 2)} when the only valid values are undefined or an array of arrays of package names`);
+     } else {
+       let foundPkgNames = new Set();
+       let duplicatedPkgNames = new Set();
+-
+       for (let linkedGroup of json.linked) {
+         messages.push(...getUnmatchedPatterns(linkedGroup, pkgNames).map(pkgOrGlob => `The package or glob expression "${pkgOrGlob}" specified in the \`linked\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`));
+         let expandedLinkedGroup = micromatch__default['default'](pkgNames, linkedGroup);
+         linked.push(expandedLinkedGroup);
+-
+         for (let linkedPkgName of expandedLinkedGroup) {
+           if (foundPkgNames.has(linkedPkgName)) {
+             duplicatedPkgNames.add(linkedPkgName);
+           }
+-
+           foundPkgNames.add(linkedPkgName);
+         }
+       }
+-
+       if (duplicatedPkgNames.size) {
+         duplicatedPkgNames.forEach(pkgName => {
+           messages.push(`The package "${pkgName}" is defined in multiple sets of linked packages. Packages can only be defined in a single set of linked packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch.`);
+@@ -202,7 +172,6 @@ let parse = (json, packages) => {
+       }
+     }
+   }
+-
+   const allFixedPackages = new Set(flatten(fixed));
+   const allLinkedPackages = new Set(flatten(linked));
+   allFixedPackages.forEach(pkgName => {
+@@ -210,22 +179,19 @@ let parse = (json, packages) => {
+       messages.push(`The package "${pkgName}" can be found in both fixed and linked groups. A package can only be either fixed or linked.`);
+     }
+   });
+-
+   if (json.updateInternalDependencies !== undefined && !["patch", "minor"].includes(json.updateInternalDependencies)) {
+     messages.push(`The \`updateInternalDependencies\` option is set as ${JSON.stringify(json.updateInternalDependencies, null, 2)} but can only be 'patch' or 'minor'`);
+   }
+-
+   if (json.ignore) {
+     if (!(isArray(json.ignore) && json.ignore.every(pkgName => typeof pkgName === "string"))) {
+       messages.push(`The \`ignore\` option is set as ${JSON.stringify(json.ignore, null, 2)} when the only valid values are undefined or an array of package names`);
+     } else {
+-      messages.push(...getUnmatchedPatterns(json.ignore, pkgNames).map(pkgOrGlob => `The package or glob expression "${pkgOrGlob}" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`)); // Validate that all dependents of ignored packages are listed in the ignore list
++      messages.push(...getUnmatchedPatterns(json.ignore, pkgNames).map(pkgOrGlob => `The package or glob expression "${pkgOrGlob}" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`));
+ 
++      // Validate that all dependents of ignored packages are listed in the ignore list
+       const dependentsGraph = getDependentsGraph.getDependentsGraph(packages);
+-
+       for (const ignoredPackage of json.ignore) {
+         const dependents = dependentsGraph.get(ignoredPackage) || [];
+-
+         for (const dependent of dependents) {
+           if (!json.ignore.includes(dependent)) {
+             messages.push(`The package "${dependent}" depends on the ignored package "${ignoredPackage}", but "${dependent}" is not being ignored. Please add "${dependent}" to the \`ignore\` option.`);
+@@ -234,49 +200,39 @@ let parse = (json, packages) => {
+       }
+     }
+   }
+-
+   const {
+     snapshot
+   } = json;
+-
+   if (snapshot !== undefined) {
+     if (snapshot.useCalculatedVersion !== undefined && typeof snapshot.useCalculatedVersion !== "boolean") {
+       messages.push(`The \`snapshot.useCalculatedVersion\` option is set as ${JSON.stringify(snapshot.useCalculatedVersion, null, 2)} when the only valid values are undefined or a boolean`);
+     }
+-
+     if (snapshot.prereleaseTemplate !== undefined && typeof snapshot.prereleaseTemplate !== "string") {
+       messages.push(`The \`snapshot.prereleaseTemplate\` option is set as ${JSON.stringify(snapshot.prereleaseTemplate, null, 2)} when the only valid values are undefined, or a template string.`);
+     }
+   }
+-
+   if (json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH !== undefined) {
+     const {
+       onlyUpdatePeerDependentsWhenOutOfRange,
+       updateInternalDependents,
+       useCalculatedVersionForSnapshots
+     } = json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH;
+-
+     if (onlyUpdatePeerDependentsWhenOutOfRange !== undefined && typeof onlyUpdatePeerDependentsWhenOutOfRange !== "boolean") {
+       messages.push(`The \`onlyUpdatePeerDependentsWhenOutOfRange\` option is set as ${JSON.stringify(onlyUpdatePeerDependentsWhenOutOfRange, null, 2)} when the only valid values are undefined or a boolean`);
+     }
+-
+     if (updateInternalDependents !== undefined && !["always", "out-of-range"].includes(updateInternalDependents)) {
+       messages.push(`The \`updateInternalDependents\` option is set as ${JSON.stringify(updateInternalDependents, null, 2)} but can only be 'always' or 'out-of-range'`);
+     }
+-
+     if (useCalculatedVersionForSnapshots && useCalculatedVersionForSnapshots !== undefined) {
+       console.warn(`Experimental flag "useCalculatedVersionForSnapshots" is deprecated since snapshot feature became stable. Please use "snapshot.useCalculatedVersion" instead.`);
+-
+       if (typeof useCalculatedVersionForSnapshots !== "boolean") {
+         messages.push(`The \`useCalculatedVersionForSnapshots\` option is set as ${JSON.stringify(useCalculatedVersionForSnapshots, null, 2)} when the only valid values are undefined or a boolean`);
+       }
+     }
+   }
+-
+   if (messages.length) {
+     throw new errors.ValidationError(`Some errors occurred when validating the changesets config:\n` + messages.join("\n"));
+   }
+-
+   let config = {
+     changelog: getNormalizedChangelogOption(json.changelog === undefined ? defaultWrittenConfig.changelog : json.changelog),
+     access: normalizedAccess === undefined ? defaultWrittenConfig.access : normalizedAccess,
+@@ -306,13 +262,12 @@ let parse = (json, packages) => {
+     } : {
+       version: true,
+       tag: false
+-    }
++    },
++    incrementVersions: (json === null || json === void 0 ? void 0 : json.incrementVersions) || defaultWrittenConfig.incrementVersions
+   };
+-
+   if (config.privatePackages.version === false && config.privatePackages.tag === true) {
+     throw new errors.ValidationError(`The \`privatePackages.tag\` option is set to \`true\` but \`privatePackages.version\` is set to \`false\`. This is not allowed.`);
+   }
+-
+   return config;
+ };
+ let fakePackage = {
+diff --git a/node_modules/@changesets/config/dist/config.cjs.prod.js b/node_modules/@changesets/config/dist/config.cjs.prod.js
+index fa25528..6a02bb4 100644
+--- a/node_modules/@changesets/config/dist/config.cjs.prod.js
++++ b/node_modules/@changesets/config/dist/config.cjs.prod.js
+@@ -46,7 +46,8 @@ let defaultWrittenConfig = {
+   access: "restricted",
+   baseBranch: "master",
+   updateInternalDependencies: "patch",
+-  ignore: []
++  ignore: [],
++  incrementVersions: !1
+ };
+ 
+ function flatten(arr) {
+@@ -165,7 +166,8 @@ let read = async (cwd, packages) => {
+     } : {
+       version: !0,
+       tag: !1
+-    }
++    },
++    incrementVersions: (null == json ? void 0 : json.incrementVersions) || defaultWrittenConfig.incrementVersions
+   };
+   if (!1 === config.privatePackages.version && !0 === config.privatePackages.tag) throw new errors.ValidationError("The `privatePackages.tag` option is set to `true` but `privatePackages.version` is set to `false`. This is not allowed.");
+   return config;
+diff --git a/node_modules/@changesets/config/dist/config.esm.js b/node_modules/@changesets/config/dist/config.esm.js
+index 32ffcca..c8da787 100644
+--- a/node_modules/@changesets/config/dist/config.esm.js
++++ b/node_modules/@changesets/config/dist/config.esm.js
+@@ -42,119 +42,95 @@ let defaultWrittenConfig = {
+   access: "restricted",
+   baseBranch: "master",
+   updateInternalDependencies: "patch",
+-  ignore: []
++  ignore: [],
++  incrementVersions: false
+ };
+-
+ function flatten(arr) {
+   return [].concat(...arr);
+ }
+-
+ function getNormalizedChangelogOption(thing) {
+   if (thing === false) {
+     return false;
+   }
+-
+   if (typeof thing === "string") {
+     return [thing, null];
+   }
+-
+   return thing;
+ }
+-
+ function getNormalizedCommitOption(thing) {
+   if (thing === false) {
+     return false;
+   }
+-
+   if (thing === true) {
+     return ["@changesets/cli/commit", {
+       skipCI: "version"
+     }];
+   }
+-
+   if (typeof thing === "string") {
+     return [thing, null];
+   }
+-
+   return thing;
+ }
+-
+ function getUnmatchedPatterns(listOfPackageNamesOrGlob, pkgNames) {
+   return listOfPackageNamesOrGlob.filter(pkgNameOrGlob => !pkgNames.some(pkgName => micromatch.isMatch(pkgName, pkgNameOrGlob)));
+ }
+-
+ const havePackageGroupsCorrectShape = pkgGroups => {
+   return isArray(pkgGroups) && pkgGroups.every(arr => isArray(arr) && arr.every(pkgName => typeof pkgName === "string"));
+-}; // TODO: it might be possible to remove this if improvements to `Array.isArray` ever land
+-// related thread: github.com/microsoft/TypeScript/issues/36554
+-
++};
+ 
++// TODO: it might be possible to remove this if improvements to `Array.isArray` ever land
++// related thread: github.com/microsoft/TypeScript/issues/36554
+ function isArray(arg) {
+   return Array.isArray(arg);
+ }
+-
+ let read = async (cwd, packages) => {
+   let json = await readJSON(path.join(cwd, ".changeset", "config.json"));
+   return parse(json, packages);
+ };
+ let parse = (json, packages) => {
+   var _json$changedFilePatt, _json$snapshot$prerel, _json$snapshot, _json$snapshot2, _json$___experimental, _json$___experimental2, _json$___experimental3, _json$___experimental4, _json$privatePackages, _json$privatePackages2;
+-
+   let messages = [];
+   let pkgNames = packages.packages.map(({
+     packageJson
+   }) => packageJson.name);
+-
+   if (json.changelog !== undefined && json.changelog !== false && typeof json.changelog !== "string" && !(isArray(json.changelog) && json.changelog.length === 2 && typeof json.changelog[0] === "string")) {
+     messages.push(`The \`changelog\` option is set as ${JSON.stringify(json.changelog, null, 2)} when the only valid values are undefined, false, a module path(e.g. "@changesets/cli/changelog" or "./some-module") or a tuple with a module path and config for the changelog generator(e.g. ["@changesets/cli/changelog", { someOption: true }])`);
+   }
+-
+   let normalizedAccess = json.access;
+-
+   if (json.access === "private") {
+     normalizedAccess = "restricted";
+     warn('The `access` option is set as "private", but this is actually not a valid value - the correct form is "restricted".');
+   }
+-
+   if (normalizedAccess !== undefined && normalizedAccess !== "restricted" && normalizedAccess !== "public") {
+     messages.push(`The \`access\` option is set as ${JSON.stringify(normalizedAccess, null, 2)} when the only valid values are undefined, "public" or "restricted"`);
+   }
+-
+   if (json.commit !== undefined && typeof json.commit !== "boolean" && typeof json.commit !== "string" && !(isArray(json.commit) && json.commit.length === 2 && typeof json.commit[0] === "string")) {
+     messages.push(`The \`commit\` option is set as ${JSON.stringify(json.commit, null, 2)} when the only valid values are undefined or a boolean or a module path (e.g. "@changesets/cli/commit" or "./some-module") or a tuple with a module path and config for the commit message generator (e.g. ["@changesets/cli/commit", { "skipCI": "version" }])`);
+   }
+-
+   if (json.baseBranch !== undefined && typeof json.baseBranch !== "string") {
+     messages.push(`The \`baseBranch\` option is set as ${JSON.stringify(json.baseBranch, null, 2)} but the \`baseBranch\` option can only be set as a string`);
+   }
+-
+   if (json.changedFilePatterns !== undefined && (!isArray(json.changedFilePatterns) || !json.changedFilePatterns.every(pattern => typeof pattern === "string"))) {
+     messages.push(`The \`changedFilePatterns\` option is set as ${JSON.stringify(json.changedFilePatterns, null, 2)} but the \`changedFilePatterns\` option can only be set as an array of strings`);
+   }
+-
+   let fixed = [];
+-
+   if (json.fixed !== undefined) {
+     if (!havePackageGroupsCorrectShape(json.fixed)) {
+       messages.push(`The \`fixed\` option is set as ${JSON.stringify(json.fixed, null, 2)} when the only valid values are undefined or an array of arrays of package names`);
+     } else {
+       let foundPkgNames = new Set();
+       let duplicatedPkgNames = new Set();
+-
+       for (let fixedGroup of json.fixed) {
+         messages.push(...getUnmatchedPatterns(fixedGroup, pkgNames).map(pkgOrGlob => `The package or glob expression "${pkgOrGlob}" specified in the \`fixed\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`));
+         let expandedFixedGroup = micromatch(pkgNames, fixedGroup);
+         fixed.push(expandedFixedGroup);
+-
+         for (let fixedPkgName of expandedFixedGroup) {
+           if (foundPkgNames.has(fixedPkgName)) {
+             duplicatedPkgNames.add(fixedPkgName);
+           }
+-
+           foundPkgNames.add(fixedPkgName);
+         }
+       }
+-
+       if (duplicatedPkgNames.size) {
+         duplicatedPkgNames.forEach(pkgName => {
+           messages.push(`The package "${pkgName}" is defined in multiple sets of fixed packages. Packages can only be defined in a single set of fixed packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch.`);
+@@ -162,30 +138,24 @@ let parse = (json, packages) => {
+       }
+     }
+   }
+-
+   let linked = [];
+-
+   if (json.linked !== undefined) {
+     if (!havePackageGroupsCorrectShape(json.linked)) {
+       messages.push(`The \`linked\` option is set as ${JSON.stringify(json.linked, null, 2)} when the only valid values are undefined or an array of arrays of package names`);
+     } else {
+       let foundPkgNames = new Set();
+       let duplicatedPkgNames = new Set();
+-
+       for (let linkedGroup of json.linked) {
+         messages.push(...getUnmatchedPatterns(linkedGroup, pkgNames).map(pkgOrGlob => `The package or glob expression "${pkgOrGlob}" specified in the \`linked\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`));
+         let expandedLinkedGroup = micromatch(pkgNames, linkedGroup);
+         linked.push(expandedLinkedGroup);
+-
+         for (let linkedPkgName of expandedLinkedGroup) {
+           if (foundPkgNames.has(linkedPkgName)) {
+             duplicatedPkgNames.add(linkedPkgName);
+           }
+-
+           foundPkgNames.add(linkedPkgName);
+         }
+       }
+-
+       if (duplicatedPkgNames.size) {
+         duplicatedPkgNames.forEach(pkgName => {
+           messages.push(`The package "${pkgName}" is defined in multiple sets of linked packages. Packages can only be defined in a single set of linked packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch.`);
+@@ -193,7 +163,6 @@ let parse = (json, packages) => {
+       }
+     }
+   }
+-
+   const allFixedPackages = new Set(flatten(fixed));
+   const allLinkedPackages = new Set(flatten(linked));
+   allFixedPackages.forEach(pkgName => {
+@@ -201,22 +170,19 @@ let parse = (json, packages) => {
+       messages.push(`The package "${pkgName}" can be found in both fixed and linked groups. A package can only be either fixed or linked.`);
+     }
+   });
+-
+   if (json.updateInternalDependencies !== undefined && !["patch", "minor"].includes(json.updateInternalDependencies)) {
+     messages.push(`The \`updateInternalDependencies\` option is set as ${JSON.stringify(json.updateInternalDependencies, null, 2)} but can only be 'patch' or 'minor'`);
+   }
+-
+   if (json.ignore) {
+     if (!(isArray(json.ignore) && json.ignore.every(pkgName => typeof pkgName === "string"))) {
+       messages.push(`The \`ignore\` option is set as ${JSON.stringify(json.ignore, null, 2)} when the only valid values are undefined or an array of package names`);
+     } else {
+-      messages.push(...getUnmatchedPatterns(json.ignore, pkgNames).map(pkgOrGlob => `The package or glob expression "${pkgOrGlob}" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`)); // Validate that all dependents of ignored packages are listed in the ignore list
++      messages.push(...getUnmatchedPatterns(json.ignore, pkgNames).map(pkgOrGlob => `The package or glob expression "${pkgOrGlob}" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`));
+ 
++      // Validate that all dependents of ignored packages are listed in the ignore list
+       const dependentsGraph = getDependentsGraph(packages);
+-
+       for (const ignoredPackage of json.ignore) {
+         const dependents = dependentsGraph.get(ignoredPackage) || [];
+-
+         for (const dependent of dependents) {
+           if (!json.ignore.includes(dependent)) {
+             messages.push(`The package "${dependent}" depends on the ignored package "${ignoredPackage}", but "${dependent}" is not being ignored. Please add "${dependent}" to the \`ignore\` option.`);
+@@ -225,49 +191,39 @@ let parse = (json, packages) => {
+       }
+     }
+   }
+-
+   const {
+     snapshot
+   } = json;
+-
+   if (snapshot !== undefined) {
+     if (snapshot.useCalculatedVersion !== undefined && typeof snapshot.useCalculatedVersion !== "boolean") {
+       messages.push(`The \`snapshot.useCalculatedVersion\` option is set as ${JSON.stringify(snapshot.useCalculatedVersion, null, 2)} when the only valid values are undefined or a boolean`);
+     }
+-
+     if (snapshot.prereleaseTemplate !== undefined && typeof snapshot.prereleaseTemplate !== "string") {
+       messages.push(`The \`snapshot.prereleaseTemplate\` option is set as ${JSON.stringify(snapshot.prereleaseTemplate, null, 2)} when the only valid values are undefined, or a template string.`);
+     }
+   }
+-
+   if (json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH !== undefined) {
+     const {
+       onlyUpdatePeerDependentsWhenOutOfRange,
+       updateInternalDependents,
+       useCalculatedVersionForSnapshots
+     } = json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH;
+-
+     if (onlyUpdatePeerDependentsWhenOutOfRange !== undefined && typeof onlyUpdatePeerDependentsWhenOutOfRange !== "boolean") {
+       messages.push(`The \`onlyUpdatePeerDependentsWhenOutOfRange\` option is set as ${JSON.stringify(onlyUpdatePeerDependentsWhenOutOfRange, null, 2)} when the only valid values are undefined or a boolean`);
+     }
+-
+     if (updateInternalDependents !== undefined && !["always", "out-of-range"].includes(updateInternalDependents)) {
+       messages.push(`The \`updateInternalDependents\` option is set as ${JSON.stringify(updateInternalDependents, null, 2)} but can only be 'always' or 'out-of-range'`);
+     }
+-
+     if (useCalculatedVersionForSnapshots && useCalculatedVersionForSnapshots !== undefined) {
+       console.warn(`Experimental flag "useCalculatedVersionForSnapshots" is deprecated since snapshot feature became stable. Please use "snapshot.useCalculatedVersion" instead.`);
+-
+       if (typeof useCalculatedVersionForSnapshots !== "boolean") {
+         messages.push(`The \`useCalculatedVersionForSnapshots\` option is set as ${JSON.stringify(useCalculatedVersionForSnapshots, null, 2)} when the only valid values are undefined or a boolean`);
+       }
+     }
+   }
+-
+   if (messages.length) {
+     throw new ValidationError(`Some errors occurred when validating the changesets config:\n` + messages.join("\n"));
+   }
+-
+   let config = {
+     changelog: getNormalizedChangelogOption(json.changelog === undefined ? defaultWrittenConfig.changelog : json.changelog),
+     access: normalizedAccess === undefined ? defaultWrittenConfig.access : normalizedAccess,
+@@ -297,13 +253,12 @@ let parse = (json, packages) => {
+     } : {
+       version: true,
+       tag: false
+-    }
++    },
++    incrementVersions: (json === null || json === void 0 ? void 0 : json.incrementVersions) || defaultWrittenConfig.incrementVersions
+   };
+-
+   if (config.privatePackages.version === false && config.privatePackages.tag === true) {
+     throw new ValidationError(`The \`privatePackages.tag\` option is set to \`true\` but \`privatePackages.version\` is set to \`false\`. This is not allowed.`);
+   }
+-
+   return config;
+ };
+ let fakePackage = {
+diff --git a/node_modules/@changesets/config/dist/declarations/src/index.d.ts b/node_modules/@changesets/config/dist/declarations/src/index.d.ts
+index 5e7d7d9..a543554 100644
+--- a/node_modules/@changesets/config/dist/declarations/src/index.d.ts
++++ b/node_modules/@changesets/config/dist/declarations/src/index.d.ts
+@@ -10,6 +10,7 @@ export declare let defaultWrittenConfig: {
+     readonly baseBranch: "master";
+     readonly updateInternalDependencies: "patch";
+     readonly ignore: readonly string[];
++    readonly incrementVersions: false;
+ };
+ export declare let read: (cwd: string, packages: Packages) => Promise<Config>;
+ export declare let parse: (json: WrittenConfig, packages: Packages) => Config;
+diff --git a/node_modules/@changesets/config/schema.json b/node_modules/@changesets/config/schema.json
+index 459e451..5d28b6e 100644
+--- a/node_modules/@changesets/config/schema.json
++++ b/node_modules/@changesets/config/schema.json
+@@ -2,6 +2,17 @@
+   "$schema": "http://json-schema.org/draft-07/schema#",
+   "type": "object",
+   "properties": {
++    "increaseVersion": {
++      "anyOf": [
++        {
++          "type": "object"
++        },
++        {
++          "enum": [false],
++          "type": "boolean"
++        }
++      ]
++    },
+     "changelog": {
+       "anyOf": [
+         {
+diff --git a/node_modules/@changesets/config/src/index.test.ts b/node_modules/@changesets/config/src/index.test.ts
+new file mode 100644
+index 0000000..ccff6d9
+--- /dev/null
++++ b/node_modules/@changesets/config/src/index.test.ts
+@@ -0,0 +1,696 @@
++import { read, parse } from "./";
++import jestInCase from "jest-in-case";
++import * as logger from "@changesets/logger";
++import { Config, WrittenConfig } from "@changesets/types";
++import { Packages } from "@manypkg/get-packages";
++import { testdir } from "@changesets/test-utils";
++
++jest.mock("@changesets/logger");
++
++type CorrectCase = {
++  packages?: string[];
++  input: WrittenConfig;
++  output: Config;
++};
++
++let defaultPackages: Packages = {
++  root: {
++    packageJson: { name: "", version: "" },
++    dir: "/",
++  },
++  packages: [],
++  tool: "yarn",
++};
++
++const withPackages = (pkgNames: string[]) => ({
++  ...defaultPackages,
++  packages: pkgNames.map((pkgName) => ({
++    packageJson: { name: pkgName, version: "" },
++    dir: "dir",
++  })),
++});
++
++test("read reads the config", async () => {
++  let cwd = await testdir({
++    ".changeset/config.json": JSON.stringify({
++      changelog: false,
++      commit: true,
++    }),
++  });
++  let config = await read(cwd, defaultPackages);
++  expect(config).toEqual({
++    fixed: [],
++    linked: [],
++    changelog: false,
++    commit: ["@changesets/cli/commit", { skipCI: "version" }],
++    access: "restricted",
++    baseBranch: "master",
++    changedFilePatterns: ["**"],
++    updateInternalDependencies: "patch",
++    ignore: [],
++    bumpVersionsWithWorkspaceProtocolOnly: false,
++    privatePackages: {
++      tag: false,
++      version: true,
++    },
++    ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
++      onlyUpdatePeerDependentsWhenOutOfRange: false,
++      updateInternalDependents: "out-of-range",
++    },
++    snapshot: {
++      useCalculatedVersion: false,
++      prereleaseTemplate: null,
++    },
++    incrementVersions: false,
++  });
++});
++
++let defaults: Config = {
++  fixed: [],
++  linked: [],
++  changelog: ["@changesets/cli/changelog", null],
++  commit: false,
++  access: "restricted",
++  baseBranch: "master",
++  changedFilePatterns: ["**"],
++  updateInternalDependencies: "patch",
++  ignore: [],
++  privatePackages: { version: true, tag: false },
++  ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
++    onlyUpdatePeerDependentsWhenOutOfRange: false,
++    updateInternalDependents: "out-of-range",
++  },
++  snapshot: {
++    useCalculatedVersion: false,
++    prereleaseTemplate: null,
++  },
++  bumpVersionsWithWorkspaceProtocolOnly: false,
++  incrementVersions: false,
++};
++
++let correctCases: Record<string, CorrectCase> = {
++  defaults: {
++    input: {},
++    output: defaults,
++  },
++  "changelog string": {
++    input: {
++      changelog: "some-module",
++    },
++    output: {
++      ...defaults,
++      changelog: ["some-module", null],
++    },
++  },
++  "changelog false": {
++    input: {
++      changelog: false,
++    },
++    output: {
++      ...defaults,
++      changelog: false,
++    },
++  },
++  "changelog tuple": {
++    input: {
++      changelog: ["some-module", { something: true }],
++    },
++    output: {
++      ...defaults,
++      changelog: ["some-module", { something: true }],
++    },
++  },
++  "commit false": {
++    input: {
++      commit: false,
++    },
++    output: {
++      ...defaults,
++      commit: false,
++    },
++  },
++  "commit true": {
++    input: {
++      commit: true,
++    },
++    output: {
++      ...defaults,
++      commit: ["@changesets/cli/commit", { skipCI: "version" }],
++    },
++  },
++  "commit custom": {
++    input: {
++      commit: ["./some-module", { customOption: true }],
++    },
++    output: {
++      ...defaults,
++      commit: ["./some-module", { customOption: true }],
++    },
++  },
++  "access private": {
++    input: {
++      access: "restricted",
++    },
++    output: {
++      ...defaults,
++      access: "restricted",
++    },
++  },
++  "access public": {
++    input: {
++      access: "public",
++    },
++    output: {
++      ...defaults,
++      access: "public",
++    },
++  },
++  changedFilePatterns: {
++    input: {
++      changedFilePatterns: ["src/**"],
++    },
++    output: {
++      ...defaults,
++      changedFilePatterns: ["src/**"],
++    },
++  },
++  fixed: {
++    input: {
++      fixed: [["pkg-a", "pkg-b"]],
++    },
++    output: {
++      ...defaults,
++      fixed: [["pkg-a", "pkg-b"]],
++    },
++  },
++  fixedWithGlobs: {
++    packages: [
++      "pkg-a",
++      "pkg-b",
++      "@pkg/a",
++      "@pkg/b",
++      "@pkg-other/a",
++      "@pkg-other/b",
++    ],
++    input: {
++      fixed: [["pkg-*", "@pkg/*"], ["@pkg-other/a"]],
++    },
++    output: {
++      ...defaults,
++      fixed: [["pkg-a", "pkg-b", "@pkg/a", "@pkg/b"], ["@pkg-other/a"]],
++    },
++  },
++  fixedWithGlobsAndExclusion: {
++    packages: [
++      "pkg-a",
++      "pkg-b",
++      "@pkg/a",
++      "@pkg/b",
++      "@pkg-other/a",
++      "@pkg-other/b",
++    ],
++    input: {
++      fixed: [["pkg-*", "!pkg-b", "@pkg/*"], ["@pkg-other/a"]],
++    },
++    output: {
++      ...defaults,
++      fixed: [["pkg-a", "@pkg/a", "@pkg/b"], ["@pkg-other/a"]],
++    },
++  },
++  linked: {
++    input: {
++      linked: [["pkg-a", "pkg-b"]],
++    },
++    output: {
++      ...defaults,
++      linked: [["pkg-a", "pkg-b"]],
++    },
++  },
++  linkedWithGlobs: {
++    packages: [
++      "pkg-a",
++      "pkg-b",
++      "@pkg/a",
++      "@pkg/b",
++      "@pkg-other/a",
++      "@pkg-other/b",
++    ],
++    input: {
++      linked: [["pkg-*", "@pkg/*"], ["@pkg-other/a"]],
++    },
++    output: {
++      ...defaults,
++      linked: [["pkg-a", "pkg-b", "@pkg/a", "@pkg/b"], ["@pkg-other/a"]],
++    },
++  },
++  linkedWithGlobsAndExclusion: {
++    packages: [
++      "pkg-a",
++      "pkg-b",
++      "@pkg/a",
++      "@pkg/b",
++      "@pkg-other/a",
++      "@pkg-other/b",
++    ],
++    input: {
++      linked: [["pkg-*", "!pkg-b", "@pkg/*"], ["@pkg-other/a"]],
++    },
++    output: {
++      ...defaults,
++      linked: [["pkg-a", "@pkg/a", "@pkg/b"], ["@pkg-other/a"]],
++    },
++  },
++  "update internal dependencies minor": {
++    input: {
++      updateInternalDependencies: "minor",
++    },
++    output: {
++      ...defaults,
++      updateInternalDependencies: "minor",
++    },
++  },
++  "update internal dependencies patch": {
++    input: {
++      updateInternalDependencies: "patch",
++    },
++    output: {
++      ...defaults,
++      updateInternalDependencies: "patch",
++    },
++  },
++  ignore: {
++    input: {
++      ignore: ["pkg-a", "pkg-b"],
++    },
++    output: {
++      ...defaults,
++      ignore: ["pkg-a", "pkg-b"],
++    },
++  },
++  ignoreWithGlobs: {
++    packages: ["pkg-a", "pkg-b", "@pkg/a", "@pkg/b"],
++    input: {
++      ignore: ["pkg-*", "@pkg/*"],
++    },
++    output: {
++      ...defaults,
++      ignore: ["pkg-a", "pkg-b", "@pkg/a", "@pkg/b"],
++    },
++  },
++  ignoreWithGlobsAndExclusions: {
++    packages: ["pkg-a", "pkg-b", "@pkg/a", "@pkg/b"],
++    input: {
++      ignore: ["pkg-*", "!pkg-b", "@pkg/*"],
++    },
++    output: {
++      ...defaults,
++      ignore: ["pkg-a", "@pkg/a", "@pkg/b"],
++    },
++  },
++  privatePackagesFalseDisablesAll: {
++    input: {
++      privatePackages: false,
++    },
++    output: {
++      ...defaults,
++      privatePackages: {
++        version: false,
++        tag: false,
++      },
++    },
++  },
++  updateInternalDependents: {
++    input: {
++      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
++        updateInternalDependents: "always",
++      },
++    },
++    output: {
++      ...defaults,
++      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
++        ...defaults.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH,
++        updateInternalDependents: "always",
++      },
++    },
++  },
++  experimental_deprecated_useCalculatedVersionInSnapshot: {
++    input: {
++      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
++        useCalculatedVersionForSnapshots: true,
++      },
++    },
++    output: {
++      ...defaults,
++      snapshot: {
++        useCalculatedVersion: true,
++        prereleaseTemplate: null,
++      },
++    },
++  },
++};
++
++jestInCase(
++  "parse",
++  (testCase) => {
++    expect(
++      parse(
++        testCase.input,
++        withPackages(testCase.packages || ["pkg-a", "pkg-b"])
++      )
++    ).toEqual(testCase.output);
++  },
++  correctCases
++);
++
++let unsafeParse = parse as any;
++
++describe("parser errors", () => {
++  test("changelog invalid value", () => {
++    expect(() => {
++      unsafeParse({ changelog: {} }, defaultPackages);
++    }).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`changelog\` option is set as {} when the only valid values are undefined, false, a module path(e.g. "@changesets/cli/changelog" or "./some-module") or a tuple with a module path and config for the changelog generator(e.g. ["@changesets/cli/changelog", { someOption: true }])"
++    `);
++  });
++  test("changelog array with 3 values", () => {
++    expect(() => {
++      unsafeParse(
++        { changelog: ["some-module", "something", "other"] },
++        defaultPackages
++      );
++    }).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`changelog\` option is set as [
++        "some-module",
++        "something",
++        "other"
++      ] when the only valid values are undefined, false, a module path(e.g. "@changesets/cli/changelog" or "./some-module") or a tuple with a module path and config for the changelog generator(e.g. ["@changesets/cli/changelog", { someOption: true }])"
++    `);
++  });
++  test("changelog array with first value not string", () => {
++    expect(() => {
++      unsafeParse({ changelog: [false, "something"] }, defaultPackages);
++    }).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`changelog\` option is set as [
++        false,
++        "something"
++      ] when the only valid values are undefined, false, a module path(e.g. "@changesets/cli/changelog" or "./some-module") or a tuple with a module path and config for the changelog generator(e.g. ["@changesets/cli/changelog", { someOption: true }])"
++    `);
++  });
++  test("access other string", () => {
++    expect(() => {
++      unsafeParse({ access: "something" }, defaultPackages);
++    }).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`access\` option is set as "something" when the only valid values are undefined, "public" or "restricted""
++    `);
++  });
++  test("commit invalid value", () => {
++    expect(() => {
++      unsafeParse({ commit: {} }, defaultPackages);
++    }).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`commit\` option is set as {} when the only valid values are undefined or a boolean or a module path (e.g. "@changesets/cli/commit" or "./some-module") or a tuple with a module path and config for the commit message generator (e.g. ["@changesets/cli/commit", { "skipCI": "version" }])"
++    `);
++  });
++  describe("fixed", () => {
++    test("non-array", () => {
++      expect(() => {
++        unsafeParse({ fixed: {} }, defaultPackages);
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The \`fixed\` option is set as {} when the only valid values are undefined or an array of arrays of package names"
++      `);
++    });
++    test("array of non array", () => {
++      expect(() => {
++        unsafeParse({ fixed: [{}] }, defaultPackages);
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The \`fixed\` option is set as [
++          {}
++        ] when the only valid values are undefined or an array of arrays of package names"
++      `);
++    });
++    test("array of array of non-string", () => {
++      expect(() => {
++        unsafeParse({ fixed: [[{}]] }, defaultPackages);
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The \`fixed\` option is set as [
++          [
++            {}
++          ]
++        ] when the only valid values are undefined or an array of arrays of package names"
++      `);
++    });
++    test("package that does not exist", () => {
++      expect(() => {
++        parse({ fixed: [["not-existing"]] }, defaultPackages);
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The package or glob expression "not-existing" specified in the \`fixed\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch."
++      `);
++    });
++    test("package that does not exist (using glob expressions)", () => {
++      expect(() => {
++        parse({ fixed: [["pkg-a", "foo/*"]] }, withPackages(["pkg-a"]));
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The package or glob expression "foo/*" specified in the \`fixed\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch."
++      `);
++    });
++    test("package in two fixed groups", () => {
++      expect(() => {
++        parse({ fixed: [["pkg-a"], ["pkg-a"]] }, withPackages(["pkg-a"]));
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The package "pkg-a" is defined in multiple sets of fixed packages. Packages can only be defined in a single set of fixed packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch."
++      `);
++    });
++    test("package in two fixed groups (using glob expressions)", () => {
++      expect(() => {
++        parse(
++          { fixed: [["pkg-*"], ["pkg-*"]] },
++          withPackages(["pkg-a", "pkg-b"])
++        );
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The package "pkg-a" is defined in multiple sets of fixed packages. Packages can only be defined in a single set of fixed packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch.
++        The package "pkg-b" is defined in multiple sets of fixed packages. Packages can only be defined in a single set of fixed packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch."
++      `);
++    });
++  });
++
++  describe("linked", () => {
++    test("non-array", () => {
++      expect(() => {
++        unsafeParse({ linked: {} }, defaultPackages);
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The \`linked\` option is set as {} when the only valid values are undefined or an array of arrays of package names"
++      `);
++    });
++    test("array of non array", () => {
++      expect(() => {
++        unsafeParse({ linked: [{}] }, defaultPackages);
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The \`linked\` option is set as [
++          {}
++        ] when the only valid values are undefined or an array of arrays of package names"
++      `);
++    });
++    test("array of array of non-string", () => {
++      expect(() => {
++        unsafeParse({ linked: [[{}]] }, defaultPackages);
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The \`linked\` option is set as [
++          [
++            {}
++          ]
++        ] when the only valid values are undefined or an array of arrays of package names"
++      `);
++    });
++    test("package that does not exist", () => {
++      expect(() => {
++        parse({ linked: [["not-existing"]] }, defaultPackages);
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The package or glob expression "not-existing" specified in the \`linked\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch."
++      `);
++    });
++    test("package that does not exist (using glob expressions)", () => {
++      expect(() => {
++        parse({ linked: [["pkg-a", "foo/*"]] }, withPackages(["pkg-a"]));
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The package or glob expression "foo/*" specified in the \`linked\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch."
++      `);
++    });
++    test("package in two linked groups", () => {
++      expect(() => {
++        parse({ linked: [["pkg-a"], ["pkg-a"]] }, withPackages(["pkg-a"]));
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The package "pkg-a" is defined in multiple sets of linked packages. Packages can only be defined in a single set of linked packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch."
++      `);
++    });
++    test("package in two linked groups (using glob expressions)", () => {
++      expect(() => {
++        parse(
++          { linked: [["pkg-*"], ["pkg-*"]] },
++          withPackages(["pkg-a", "pkg-b"])
++        );
++      }).toThrowErrorMatchingInlineSnapshot(`
++        "Some errors occurred when validating the changesets config:
++        The package "pkg-a" is defined in multiple sets of linked packages. Packages can only be defined in a single set of linked packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch.
++        The package "pkg-b" is defined in multiple sets of linked packages. Packages can only be defined in a single set of linked packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch."
++      `);
++    });
++  });
++  test("access private warns and sets to restricted", () => {
++    let config = unsafeParse({ access: "private" }, defaultPackages);
++    expect(config).toEqual(defaults);
++    expect(logger.warn).toBeCalledWith(
++      'The `access` option is set as "private", but this is actually not a valid value - the correct form is "restricted".'
++    );
++  });
++  test("updateInternalDependencies not patch or minor", () => {
++    expect(() => {
++      unsafeParse({ updateInternalDependencies: "major" }, defaultPackages);
++    }).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`updateInternalDependencies\` option is set as "major" but can only be 'patch' or 'minor'"
++    `);
++  });
++  test("ignore non-array", () => {
++    expect(() => unsafeParse({ ignore: "string value" }, defaultPackages))
++      .toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`ignore\` option is set as "string value" when the only valid values are undefined or an array of package names"
++    `);
++  });
++  test("ignore array of non-string", () => {
++    expect(() => unsafeParse({ ignore: [123, "pkg-a"] }, defaultPackages))
++      .toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`ignore\` option is set as [
++        123,
++        "pkg-a"
++      ] when the only valid values are undefined or an array of package names"
++    `);
++  });
++  test("ignore package that does not exist", () => {
++    expect(() => unsafeParse({ ignore: ["pkg-a"] }, defaultPackages))
++      .toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The package or glob expression "pkg-a" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch."
++    `);
++  });
++  test("ignore package that does not exist (using glob expressions)", () => {
++    expect(() => unsafeParse({ ignore: ["pkg-*"] }, defaultPackages))
++      .toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The package or glob expression "pkg-*" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch."
++    `);
++  });
++  test("ignore missing dependent packages", async () => {
++    expect(() =>
++      unsafeParse(
++        { ignore: ["pkg-b"] },
++        {
++          ...defaultPackages,
++          packages: [
++            {
++              packageJson: {
++                name: "pkg-a",
++                version: "1.0.0",
++                dependencies: { "pkg-b": "1.0.0" },
++              },
++              dir: "dir",
++            },
++            {
++              packageJson: { name: "pkg-b", version: "1.0.0" },
++              dir: "dir",
++            },
++          ],
++        }
++      )
++    ).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The package "pkg-a" depends on the ignored package "pkg-b", but "pkg-a" is not being ignored. Please add "pkg-a" to the \`ignore\` option."
++    `);
++  });
++
++  test("onlyUpdatePeerDependentsWhenOutOfRange non-boolean", () => {
++    expect(() => {
++      unsafeParse(
++        {
++          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
++            onlyUpdatePeerDependentsWhenOutOfRange: "not true",
++          },
++        },
++        defaultPackages
++      );
++    }).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`onlyUpdatePeerDependentsWhenOutOfRange\` option is set as "not true" when the only valid values are undefined or a boolean"
++    `);
++  });
++
++  test("snapshot.useCalculatedVersion non-boolean", () => {
++    expect(() => {
++      unsafeParse(
++        {
++          snapshot: {
++            useCalculatedVersion: "not true",
++          },
++        },
++        defaultPackages
++      );
++    }).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`snapshot.useCalculatedVersion\` option is set as "not true" when the only valid values are undefined or a boolean"
++    `);
++  });
++
++  test("Experimental useCalculatedVersionForSnapshots non-boolean", () => {
++    expect(() => {
++      unsafeParse(
++        {
++          ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
++            useCalculatedVersionForSnapshots: "not true",
++          },
++        },
++        defaultPackages
++      );
++    }).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`useCalculatedVersionForSnapshots\` option is set as "not true" when the only valid values are undefined or a boolean"
++    `);
++  });
++
++  test("changed files patterns - non-array", () => {
++    expect(() => unsafeParse({ changedFilePatterns: false }, defaultPackages))
++      .toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`changedFilePatterns\` option is set as false but the \`changedFilePatterns\` option can only be set as an array of strings"
++    `);
++  });
++
++  test("changed files patterns - non-string element", () => {
++    expect(() =>
++      unsafeParse({ changedFilePatterns: ["src/**", 100] }, defaultPackages)
++    ).toThrowErrorMatchingInlineSnapshot(`
++      "Some errors occurred when validating the changesets config:
++      The \`changedFilePatterns\` option is set as [
++        "src/**",
++        100
++      ] but the \`changedFilePatterns\` option can only be set as an array of strings"
++    `);
++  });
++});
+diff --git a/node_modules/@changesets/config/src/index.ts b/node_modules/@changesets/config/src/index.ts
+new file mode 100644
+index 0000000..5f28822
+--- /dev/null
++++ b/node_modules/@changesets/config/src/index.ts
+@@ -0,0 +1,521 @@
++import * as fs from "fs-extra";
++import path from "path";
++import micromatch from "micromatch";
++import { ValidationError } from "@changesets/errors";
++import { warn } from "@changesets/logger";
++import { Packages } from "@manypkg/get-packages";
++import {
++  Config,
++  WrittenConfig,
++  Fixed,
++  Linked,
++  PackageGroup,
++} from "@changesets/types";
++import packageJson from "../package.json";
++import { getDependentsGraph } from "@changesets/get-dependents-graph";
++
++export let defaultWrittenConfig = {
++  $schema: `https://unpkg.com/@changesets/config@${packageJson.version}/schema.json`,
++  changelog: "@changesets/cli/changelog",
++  commit: false,
++  fixed: [] as Fixed,
++  linked: [] as Linked,
++  access: "restricted",
++  baseBranch: "master",
++  updateInternalDependencies: "patch",
++  ignore: [] as ReadonlyArray<string>,
++  incrementVersions: false,
++} as const;
++
++function flatten<T>(arr: Array<T[]>): T[] {
++  return ([] as T[]).concat(...arr);
++}
++
++function getNormalizedChangelogOption(
++  thing: false | readonly [string, any] | string
++): Config["changelog"] {
++  if (thing === false) {
++    return false;
++  }
++  if (typeof thing === "string") {
++    return [thing, null];
++  }
++  return thing;
++}
++
++function getNormalizedCommitOption(
++  thing: boolean | readonly [string, any] | string
++): Config["commit"] {
++  if (thing === false) {
++    return false;
++  }
++  if (thing === true) {
++    return ["@changesets/cli/commit", { skipCI: "version" }];
++  }
++  if (typeof thing === "string") {
++    return [thing, null];
++  }
++  return thing;
++}
++
++function getUnmatchedPatterns(
++  listOfPackageNamesOrGlob: readonly string[],
++  pkgNames: readonly string[]
++): string[] {
++  return listOfPackageNamesOrGlob.filter(
++    (pkgNameOrGlob) =>
++      !pkgNames.some((pkgName) => micromatch.isMatch(pkgName, pkgNameOrGlob))
++  );
++}
++
++const havePackageGroupsCorrectShape = (
++  pkgGroups: ReadonlyArray<PackageGroup>
++) => {
++  return (
++    isArray(pkgGroups) &&
++    pkgGroups.every(
++      (arr) =>
++        isArray(arr) && arr.every((pkgName) => typeof pkgName === "string")
++    )
++  );
++};
++
++// TODO: it might be possible to remove this if improvements to `Array.isArray` ever land
++// related thread: github.com/microsoft/TypeScript/issues/36554
++function isArray<T>(
++  arg: T | {}
++): arg is T extends readonly any[]
++  ? unknown extends T
++    ? never
++    : readonly any[]
++  : any[] {
++  return Array.isArray(arg);
++}
++
++export let read = async (cwd: string, packages: Packages) => {
++  let json = await fs.readJSON(path.join(cwd, ".changeset", "config.json"));
++  return parse(json, packages);
++};
++
++export let parse = (json: WrittenConfig, packages: Packages): Config => {
++  let messages = [];
++  let pkgNames: readonly string[] = packages.packages.map(
++    ({ packageJson }) => packageJson.name
++  );
++
++  if (
++    json.changelog !== undefined &&
++    json.changelog !== false &&
++    typeof json.changelog !== "string" &&
++    !(
++      isArray(json.changelog) &&
++      json.changelog.length === 2 &&
++      typeof json.changelog[0] === "string"
++    )
++  ) {
++    messages.push(
++      `The \`changelog\` option is set as ${JSON.stringify(
++        json.changelog,
++        null,
++        2
++      )} when the only valid values are undefined, false, a module path(e.g. "@changesets/cli/changelog" or "./some-module") or a tuple with a module path and config for the changelog generator(e.g. ["@changesets/cli/changelog", { someOption: true }])`
++    );
++  }
++
++  let normalizedAccess: WrittenConfig["access"] = json.access;
++  if ((json.access as string) === "private") {
++    normalizedAccess = "restricted";
++    warn(
++      'The `access` option is set as "private", but this is actually not a valid value - the correct form is "restricted".'
++    );
++  }
++  if (
++    normalizedAccess !== undefined &&
++    normalizedAccess !== "restricted" &&
++    normalizedAccess !== "public"
++  ) {
++    messages.push(
++      `The \`access\` option is set as ${JSON.stringify(
++        normalizedAccess,
++        null,
++        2
++      )} when the only valid values are undefined, "public" or "restricted"`
++    );
++  }
++
++  if (
++    json.commit !== undefined &&
++    typeof json.commit !== "boolean" &&
++    typeof json.commit !== "string" &&
++    !(
++      isArray(json.commit) &&
++      json.commit.length === 2 &&
++      typeof json.commit[0] === "string"
++    )
++  ) {
++    messages.push(
++      `The \`commit\` option is set as ${JSON.stringify(
++        json.commit,
++        null,
++        2
++      )} when the only valid values are undefined or a boolean or a module path (e.g. "@changesets/cli/commit" or "./some-module") or a tuple with a module path and config for the commit message generator (e.g. ["@changesets/cli/commit", { "skipCI": "version" }])`
++    );
++  }
++  if (json.baseBranch !== undefined && typeof json.baseBranch !== "string") {
++    messages.push(
++      `The \`baseBranch\` option is set as ${JSON.stringify(
++        json.baseBranch,
++        null,
++        2
++      )} but the \`baseBranch\` option can only be set as a string`
++    );
++  }
++
++  if (
++    json.changedFilePatterns !== undefined &&
++    (!isArray(json.changedFilePatterns) ||
++      !json.changedFilePatterns.every((pattern) => typeof pattern === "string"))
++  ) {
++    messages.push(
++      `The \`changedFilePatterns\` option is set as ${JSON.stringify(
++        json.changedFilePatterns,
++        null,
++        2
++      )} but the \`changedFilePatterns\` option can only be set as an array of strings`
++    );
++  }
++
++  let fixed: string[][] = [];
++  if (json.fixed !== undefined) {
++    if (!havePackageGroupsCorrectShape(json.fixed)) {
++      messages.push(
++        `The \`fixed\` option is set as ${JSON.stringify(
++          json.fixed,
++          null,
++          2
++        )} when the only valid values are undefined or an array of arrays of package names`
++      );
++    } else {
++      let foundPkgNames = new Set<string>();
++      let duplicatedPkgNames = new Set<string>();
++
++      for (let fixedGroup of json.fixed) {
++        messages.push(
++          ...getUnmatchedPatterns(fixedGroup, pkgNames).map(
++            (pkgOrGlob) =>
++              `The package or glob expression "${pkgOrGlob}" specified in the \`fixed\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`
++          )
++        );
++
++        let expandedFixedGroup = micromatch(pkgNames, fixedGroup);
++        fixed.push(expandedFixedGroup);
++
++        for (let fixedPkgName of expandedFixedGroup) {
++          if (foundPkgNames.has(fixedPkgName)) {
++            duplicatedPkgNames.add(fixedPkgName);
++          }
++          foundPkgNames.add(fixedPkgName);
++        }
++      }
++
++      if (duplicatedPkgNames.size) {
++        duplicatedPkgNames.forEach((pkgName) => {
++          messages.push(
++            `The package "${pkgName}" is defined in multiple sets of fixed packages. Packages can only be defined in a single set of fixed packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch.`
++          );
++        });
++      }
++    }
++  }
++
++  let linked: string[][] = [];
++  if (json.linked !== undefined) {
++    if (!havePackageGroupsCorrectShape(json.linked)) {
++      messages.push(
++        `The \`linked\` option is set as ${JSON.stringify(
++          json.linked,
++          null,
++          2
++        )} when the only valid values are undefined or an array of arrays of package names`
++      );
++    } else {
++      let foundPkgNames = new Set<string>();
++      let duplicatedPkgNames = new Set<string>();
++
++      for (let linkedGroup of json.linked) {
++        messages.push(
++          ...getUnmatchedPatterns(linkedGroup, pkgNames).map(
++            (pkgOrGlob) =>
++              `The package or glob expression "${pkgOrGlob}" specified in the \`linked\` option does not match any package in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`
++          )
++        );
++
++        let expandedLinkedGroup = micromatch(pkgNames, linkedGroup);
++        linked.push(expandedLinkedGroup);
++
++        for (let linkedPkgName of expandedLinkedGroup) {
++          if (foundPkgNames.has(linkedPkgName)) {
++            duplicatedPkgNames.add(linkedPkgName);
++          }
++          foundPkgNames.add(linkedPkgName);
++        }
++      }
++
++      if (duplicatedPkgNames.size) {
++        duplicatedPkgNames.forEach((pkgName) => {
++          messages.push(
++            `The package "${pkgName}" is defined in multiple sets of linked packages. Packages can only be defined in a single set of linked packages. If you are using glob expressions, make sure that they are valid according to https://www.npmjs.com/package/micromatch.`
++          );
++        });
++      }
++    }
++  }
++
++  const allFixedPackages = new Set(flatten(fixed));
++  const allLinkedPackages = new Set(flatten(linked));
++
++  allFixedPackages.forEach((pkgName) => {
++    if (allLinkedPackages.has(pkgName)) {
++      messages.push(
++        `The package "${pkgName}" can be found in both fixed and linked groups. A package can only be either fixed or linked.`
++      );
++    }
++  });
++
++  if (
++    json.updateInternalDependencies !== undefined &&
++    !["patch", "minor"].includes(json.updateInternalDependencies)
++  ) {
++    messages.push(
++      `The \`updateInternalDependencies\` option is set as ${JSON.stringify(
++        json.updateInternalDependencies,
++        null,
++        2
++      )} but can only be 'patch' or 'minor'`
++    );
++  }
++  if (json.ignore) {
++    if (
++      !(
++        isArray(json.ignore) &&
++        json.ignore.every((pkgName) => typeof pkgName === "string")
++      )
++    ) {
++      messages.push(
++        `The \`ignore\` option is set as ${JSON.stringify(
++          json.ignore,
++          null,
++          2
++        )} when the only valid values are undefined or an array of package names`
++      );
++    } else {
++      messages.push(
++        ...getUnmatchedPatterns(json.ignore, pkgNames).map(
++          (pkgOrGlob) =>
++            `The package or glob expression "${pkgOrGlob}" is specified in the \`ignore\` option but it is not found in the project. You may have misspelled the package name or provided an invalid glob expression. Note that glob expressions must be defined according to https://www.npmjs.com/package/micromatch.`
++        )
++      );
++
++      // Validate that all dependents of ignored packages are listed in the ignore list
++      const dependentsGraph = getDependentsGraph(packages);
++      for (const ignoredPackage of json.ignore) {
++        const dependents = dependentsGraph.get(ignoredPackage) || [];
++        for (const dependent of dependents) {
++          if (!json.ignore.includes(dependent)) {
++            messages.push(
++              `The package "${dependent}" depends on the ignored package "${ignoredPackage}", but "${dependent}" is not being ignored. Please add "${dependent}" to the \`ignore\` option.`
++            );
++          }
++        }
++      }
++    }
++  }
++
++  const { snapshot } = json;
++
++  if (snapshot !== undefined) {
++    if (
++      snapshot.useCalculatedVersion !== undefined &&
++      typeof snapshot.useCalculatedVersion !== "boolean"
++    ) {
++      messages.push(
++        `The \`snapshot.useCalculatedVersion\` option is set as ${JSON.stringify(
++          snapshot.useCalculatedVersion,
++          null,
++          2
++        )} when the only valid values are undefined or a boolean`
++      );
++    }
++    if (
++      snapshot.prereleaseTemplate !== undefined &&
++      typeof snapshot.prereleaseTemplate !== "string"
++    ) {
++      messages.push(
++        `The \`snapshot.prereleaseTemplate\` option is set as ${JSON.stringify(
++          snapshot.prereleaseTemplate,
++          null,
++          2
++        )} when the only valid values are undefined, or a template string.`
++      );
++    }
++  }
++
++  if (json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH !== undefined) {
++    const {
++      onlyUpdatePeerDependentsWhenOutOfRange,
++      updateInternalDependents,
++      useCalculatedVersionForSnapshots,
++    } = json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH;
++
++    if (
++      onlyUpdatePeerDependentsWhenOutOfRange !== undefined &&
++      typeof onlyUpdatePeerDependentsWhenOutOfRange !== "boolean"
++    ) {
++      messages.push(
++        `The \`onlyUpdatePeerDependentsWhenOutOfRange\` option is set as ${JSON.stringify(
++          onlyUpdatePeerDependentsWhenOutOfRange,
++          null,
++          2
++        )} when the only valid values are undefined or a boolean`
++      );
++    }
++
++    if (
++      updateInternalDependents !== undefined &&
++      !["always", "out-of-range"].includes(updateInternalDependents)
++    ) {
++      messages.push(
++        `The \`updateInternalDependents\` option is set as ${JSON.stringify(
++          updateInternalDependents,
++          null,
++          2
++        )} but can only be 'always' or 'out-of-range'`
++      );
++    }
++    if (
++      useCalculatedVersionForSnapshots &&
++      useCalculatedVersionForSnapshots !== undefined
++    ) {
++      console.warn(
++        `Experimental flag "useCalculatedVersionForSnapshots" is deprecated since snapshot feature became stable. Please use "snapshot.useCalculatedVersion" instead.`
++      );
++
++      if (typeof useCalculatedVersionForSnapshots !== "boolean") {
++        messages.push(
++          `The \`useCalculatedVersionForSnapshots\` option is set as ${JSON.stringify(
++            useCalculatedVersionForSnapshots,
++            null,
++            2
++          )} when the only valid values are undefined or a boolean`
++        );
++      }
++    }
++  }
++
++  if (messages.length) {
++    throw new ValidationError(
++      `Some errors occurred when validating the changesets config:\n` +
++        messages.join("\n")
++    );
++  }
++
++  let config: Config = {
++    changelog: getNormalizedChangelogOption(
++      json.changelog === undefined
++        ? defaultWrittenConfig.changelog
++        : json.changelog
++    ),
++    access:
++      normalizedAccess === undefined
++        ? defaultWrittenConfig.access
++        : normalizedAccess,
++    commit: getNormalizedCommitOption(
++      json.commit === undefined ? defaultWrittenConfig.commit : json.commit
++    ),
++    fixed,
++    linked,
++    baseBranch:
++      json.baseBranch === undefined
++        ? defaultWrittenConfig.baseBranch
++        : json.baseBranch,
++
++    changedFilePatterns: json.changedFilePatterns ?? ["**"],
++
++    updateInternalDependencies:
++      json.updateInternalDependencies === undefined
++        ? defaultWrittenConfig.updateInternalDependencies
++        : json.updateInternalDependencies,
++
++    ignore:
++      json.ignore === undefined
++        ? defaultWrittenConfig.ignore
++        : micromatch(pkgNames, json.ignore),
++
++    bumpVersionsWithWorkspaceProtocolOnly:
++      json.bumpVersionsWithWorkspaceProtocolOnly === true,
++
++    snapshot: {
++      prereleaseTemplate: json.snapshot?.prereleaseTemplate ?? null,
++      useCalculatedVersion:
++        json.snapshot?.useCalculatedVersion !== undefined
++          ? json.snapshot.useCalculatedVersion
++          : json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
++              ?.useCalculatedVersionForSnapshots !== undefined
++          ? json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
++              ?.useCalculatedVersionForSnapshots
++          : false,
++    },
++
++    ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
++      onlyUpdatePeerDependentsWhenOutOfRange:
++        json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH === undefined ||
++        json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
++          .onlyUpdatePeerDependentsWhenOutOfRange === undefined
++          ? false
++          : json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
++              .onlyUpdatePeerDependentsWhenOutOfRange,
++
++      updateInternalDependents:
++        json.___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH
++          ?.updateInternalDependents ?? "out-of-range",
++    },
++
++    // TODO consider enabling this by default in the next major version
++    privatePackages:
++      json.privatePackages === false
++        ? { tag: false, version: false }
++        : json.privatePackages
++        ? {
++            version: json.privatePackages.version ?? true,
++            tag: json.privatePackages.tag ?? false,
++          }
++        : { version: true, tag: false },
++    incrementVersions:
++      json?.incrementVersions || defaultWrittenConfig.incrementVersions,
++  };
++
++  if (
++    config.privatePackages.version === false &&
++    config.privatePackages.tag === true
++  ) {
++    throw new ValidationError(
++      `The \`privatePackages.tag\` option is set to \`true\` but \`privatePackages.version\` is set to \`false\`. This is not allowed.`
++    );
++  }
++
++  return config;
++};
++
++let fakePackage = {
++  dir: "",
++  packageJson: {
++    name: "",
++    version: "",
++  },
++};
++
++export let defaultConfig = parse(defaultWrittenConfig, {
++  root: fakePackage,
++  tool: "root",
++  packages: [fakePackage],
++});

--- a/patches/@changesets+types+5.2.1.dev.patch
+++ b/patches/@changesets+types+5.2.1.dev.patch
@@ -1,0 +1,82 @@
+diff --git a/node_modules/@changesets/types/dist/declarations/src/index.d.ts b/node_modules/@changesets/types/dist/declarations/src/index.d.ts
+index 1903f29..e9cc006 100644
+--- a/node_modules/@changesets/types/dist/declarations/src/index.d.ts
++++ b/node_modules/@changesets/types/dist/declarations/src/index.d.ts
+@@ -1,3 +1,4 @@
++import { ReleaseType } from "semver";
+ declare const DEPENDENCY_TYPES: readonly ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+ export declare type VersionType = "major" | "minor" | "patch" | "none";
+ export declare type DependencyType = typeof DEPENDENCY_TYPES[number];
+@@ -77,6 +78,9 @@ export declare type Config = {
+         useCalculatedVersion: boolean;
+         prereleaseTemplate: string | null;
+     };
++    incrementVersions: false | Record<string, {
++        path: string;
++    }>;
+ };
+ export declare type WrittenConfig = {
+     changelog?: false | readonly [string, any] | string;
+@@ -100,6 +104,9 @@ export declare type WrittenConfig = {
+         prereleaseTemplate?: string;
+     };
+     ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH?: ExperimentalOptions;
++    incrementVersions?: false | Record<string, {
++        path: string;
++    }>;
+ };
+ export declare type ExperimentalOptions = {
+     onlyUpdatePeerDependentsWhenOutOfRange?: boolean;
+@@ -120,6 +127,9 @@ export declare type ChangelogFunctions = {
+     getReleaseLine: GetReleaseLine;
+     getDependencyReleaseLine: GetDependencyReleaseLine;
+ };
++export declare type IncrementVersionsFunctions = {
++    incrementVersion: (oldVersion: string, type: ReleaseType, defaultIncreaseVersion: () => string) => string;
++};
+ export declare type GetAddMessage = (changeset: Changeset, commitOptions: any) => Promise<string>;
+ export declare type GetVersionMessage = (releasePlan: ReleasePlan, commitOptions: any) => Promise<string>;
+ export declare type CommitFunctions = {
+diff --git a/node_modules/@changesets/types/src/index.ts b/node_modules/@changesets/types/src/index.ts
+index 17bb849..ad51f22 100644
+--- a/node_modules/@changesets/types/src/index.ts
++++ b/node_modules/@changesets/types/src/index.ts
+@@ -1,4 +1,7 @@
+ // NB: Bolt check uses a different dependnecy set to every other package.
++
++import { ReleaseType } from "semver";
++
+ // You need think before you use this.
+ const DEPENDENCY_TYPES = [
+   "dependencies",
+@@ -89,6 +92,7 @@ export type Config = {
+     useCalculatedVersion: boolean;
+     prereleaseTemplate: string | null;
+   };
++  incrementVersions: false | Record<string, { path: string }>;
+ };
+ 
+ export type WrittenConfig = {
+@@ -115,6 +119,7 @@ export type WrittenConfig = {
+     prereleaseTemplate?: string;
+   };
+   ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH?: ExperimentalOptions;
++  incrementVersions?: false | Record<string, { path: string }>;
+ };
+ 
+ export type ExperimentalOptions = {
+@@ -148,6 +153,14 @@ export type ChangelogFunctions = {
+   getDependencyReleaseLine: GetDependencyReleaseLine;
+ };
+ 
++export type IncrementVersionsFunctions = {
++  incrementVersion: (
++    oldVersion: string,
++    type: ReleaseType,
++    defaultIncreaseVersion: () => string
++  ) => string;
++};
++
+ export type GetAddMessage = (
+   changeset: Changeset,
+   commitOptions: any


### PR DESCRIPTION
### WHY are these changes introduced?
Whenever we apply a major version of `hydrogen` or `hydrogen-react`, changesets applies semver which results in incorrect package updates. For example, `2023.1` with a major update, results in `2024.0`. Then we have to end up doing a lot of manual work updating packages which is incredibly risky when dealing with publishing packages.

### WHAT is this pull request doing?
This PR patches changesets to allow us to set custom version functions per package. This will allow us to add a function that will do calver instead of semver to specific packages.

### HOW to test your changes?
1. get this branch
2. `npm run clean-all` to clean your node_modules
3. `npm install`
4. `npm run changeset` and create a changeset file for `hydrogen` and/or `hydrogen-react`
5. `npm run changeset versioning`

check that the versions are updated correctly in `package.json`, etc. For example for `2023-04` check that it updates to `2023-07`

