### PR TITLE
add github actions access provider to our workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -57,7 +57,7 @@ jobs:
           commit: '[ci] release ${{ github.ref_name }}'
           title: '[ci] release ${{ github.ref_name }}'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # - name: Create Release Pull Request or Publish (for legacy patch release)


### PR DESCRIPTION
### WHY are these changes introduced?
Our current release PR from changeset does not run ci checks because it is expecting CLA signing.

### WHAT is this pull request doing?
Talked to the team responsible of CLA and they said to add this token which bypasses CLA signing.

### HOW to test your changes?
We'll see when a new release PR happens