### PR TITLE
Fix dev watch in hydrogen package

### DIFF
--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsup --clean --config ../../tsup.config.ts && npm run copy-hydrogen-react",
     "copy-hydrogen-react": "node ../../scripts/copy-hydrogen-react.mjs",
-    "dev": "tsup --watch --config ../../tsup.config.ts --watch ../../node_modules/@shopify/hydrogen-react/dist/browser-prod/index.mjs",
+    "dev": "tsup --config ../../tsup.config.ts --watch ./src --watch ../../node_modules/@shopify/hydrogen-react/dist/browser-prod/index.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "prepack": "npm run build",


### PR DESCRIPTION
Running `npm run dev` at the top was building the `hydrogen` package correctly but not refreshing its JS bundle after modifying source files (only DTS was updated).

It looks related to some inconsistency when using multiple `--watch` flags in the TSUP CLI. The docs say that `.` is assumed when not providing a path to the watch flag. However, this might be only true when there's a single watch flag. Also, when using `.` in this situation, it does not ignore `./dist` so it goes in an infinite loop. `./src` seems to fix the issue.