### PR TITLE
Add push event to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@
 
 name: Oxygen Deployment
 
-on: [pull_request, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   deploy:


### PR DESCRIPTION
cc @juanpprieto @frehner 

It looks like we are not deploying changes to the demo-store prod (https://hydrogen.shop) since the changes in https://github.com/Shopify/hydrogen/pull/762

Trying to revert here the change to `deploy.yml` to see if we can get a new deployment.