### PR TITLE
chore: adds import/order eslint rule to demo-store template

### DIFF
--- a/.changeset/tricky-rocks-perform.md
+++ b/.changeset/tricky-rocks-perform.md
@@ -1,0 +1,5 @@
+---
+'demo-store': patch
+---
+
+Added import/order ESLint rule and @remix-run/eslint plugin to demo-store template eslint configuration.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,4 +10,38 @@ module.exports = {
     'no-useless-escape': 'off',
     'no-case-declarations': 'off',
   },
+  overrides: [
+    {
+      files: ['./templates/demo-store/*'],
+      rules: {
+        'import/order': [
+          'error',
+          {
+            /**
+             * @description
+             *
+             * This keeps imports separate from one another, ensuring that imports are separated
+             * by their relative groups. As you move through the groups, imports become closer
+             * to the current file.
+             *
+             * @example
+             * ```
+             * import fs from 'fs';
+             *
+             * import package from 'npm-package';
+             *
+             * import xyz from '~/project-file';
+             *
+             * import index from '../';
+             *
+             * import sibling from './foo';
+             * ```
+             */
+            groups: ['builtin', 'external', 'internal', 'parent', 'sibling'],
+            'newlines-between': 'always',
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -29513,7 +29513,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@oclif/core": "2.1.4",
@@ -29547,8 +29547,8 @@
       },
       "peerDependencies": {
         "@remix-run/react": "^1.15.0",
-        "@shopify/hydrogen-react": "^2023.4.0",
-        "@shopify/remix-oxygen": "^1.0.5"
+        "@shopify/hydrogen-react": "^2023.4.1",
+        "@shopify/remix-oxygen": "^1.0.6"
       }
     },
     "packages/cli/node_modules/@oclif/core": {
@@ -31720,7 +31720,7 @@
       "version": "4.1.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@shopify/cli-hydrogen": "^4.1.1"
+        "@shopify/cli-hydrogen": "^4.1.2"
       },
       "bin": {
         "create-hydrogen": "dist/create-app.js"
@@ -31728,10 +31728,10 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2023.4.0",
+      "version": "2023.4.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@shopify/hydrogen-react": "2023.4.0",
+        "@shopify/hydrogen-react": "2023.4.1",
         "react": "^18.2.0"
       },
       "devDependencies": {
@@ -31748,7 +31748,7 @@
     },
     "packages/hydrogen-react": {
       "name": "@shopify/hydrogen-react",
-      "version": "2023.4.0",
+      "version": "2023.4.1",
       "license": "MIT",
       "dependencies": {
         "@google/model-viewer": "^1.12.1",
@@ -32035,7 +32035,7 @@
     },
     "packages/remix-oxygen": {
       "name": "@shopify/remix-oxygen",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@remix-run/server-runtime": "1.15.0"
@@ -32048,14 +32048,14 @@
       }
     },
     "templates/demo-store": {
-      "version": "0.2.1",
+      "version": "1.0.0",
       "dependencies": {
         "@headlessui/react": "^1.7.2",
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.1",
-        "@shopify/hydrogen": "^2023.4.0",
-        "@shopify/remix-oxygen": "^1.0.5",
+        "@shopify/cli-hydrogen": "^4.1.2",
+        "@shopify/hydrogen": "^2023.4.1",
+        "@shopify/remix-oxygen": "^1.0.6",
         "clsx": "^1.2.1",
         "cross-env": "^7.0.3",
         "graphql": "^16.6.0",
@@ -32101,9 +32101,9 @@
       "dependencies": {
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.1",
-        "@shopify/hydrogen": "^2023.4.0",
-        "@shopify/remix-oxygen": "^1.0.5",
+        "@shopify/cli-hydrogen": "^4.1.2",
+        "@shopify/hydrogen": "^2023.4.1",
+        "@shopify/remix-oxygen": "^1.0.6",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^3.6.6",
@@ -32131,9 +32131,9 @@
       "dependencies": {
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.1",
-        "@shopify/hydrogen": "^2023.4.0",
-        "@shopify/remix-oxygen": "^1.0.5",
+        "@shopify/cli-hydrogen": "^4.1.2",
+        "@shopify/hydrogen": "^2023.4.1",
+        "@shopify/remix-oxygen": "^1.0.6",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^3.6.6",
@@ -38569,7 +38569,7 @@
     "@shopify/create-hydrogen": {
       "version": "file:packages/create-hydrogen",
       "requires": {
-        "@shopify/cli-hydrogen": "^4.1.1"
+        "@shopify/cli-hydrogen": "^4.1.2"
       }
     },
     "@shopify/eslint-plugin": {
@@ -38637,7 +38637,7 @@
       "version": "file:packages/hydrogen",
       "requires": {
         "@shopify/generate-docs": "0.10.7",
-        "@shopify/hydrogen-react": "2023.4.0",
+        "@shopify/hydrogen-react": "2023.4.1",
         "@testing-library/react": "^14.0.0",
         "happy-dom": "^8.9.0",
         "react": "^18.2.0",
@@ -42143,12 +42143,12 @@
         "@remix-run/eslint-config": "1.15.0",
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.1",
+        "@shopify/cli-hydrogen": "^4.1.2",
         "@shopify/eslint-plugin": "^42.0.1",
-        "@shopify/hydrogen": "^2023.4.0",
+        "@shopify/hydrogen": "^2023.4.1",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.0.5",
+        "@shopify/remix-oxygen": "^1.0.6",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/typography": "^0.5.9",
         "@types/eslint": "^8.4.10",
@@ -44552,11 +44552,11 @@
         "@remix-run/dev": "1.15.0",
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.1",
-        "@shopify/hydrogen": "^2023.4.0",
+        "@shopify/cli-hydrogen": "^4.1.2",
+        "@shopify/hydrogen": "^2023.4.1",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.0.5",
+        "@shopify/remix-oxygen": "^1.0.6",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.0.20",
         "@types/react-dom": "^18.0.6",
@@ -50686,11 +50686,11 @@
         "@remix-run/dev": "1.15.0",
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.1",
-        "@shopify/hydrogen": "^2023.4.0",
+        "@shopify/cli-hydrogen": "^4.1.2",
+        "@shopify/hydrogen": "^2023.4.1",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.0.5",
+        "@shopify/remix-oxygen": "^1.0.6",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.0.20",
         "@types/react-dom": "^18.0.6",

--- a/templates/demo-store/.eslintrc.js
+++ b/templates/demo-store/.eslintrc.js
@@ -2,7 +2,11 @@
  * @type {import("@types/eslint").Linter.BaseConfig}
  */
 module.exports = {
-  extends: ['plugin:hydrogen/recommended', 'plugin:hydrogen/typescript'],
+  extends: [
+    '@remix-run/eslint-config',
+    'plugin:hydrogen/recommended',
+    'plugin:hydrogen/typescript',
+  ],
   rules: {
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/naming-convention': 'off',
@@ -12,5 +16,32 @@ module.exports = {
     'no-case-declarations': 'off',
     // TODO: Remove jest plugin from hydrogen/eslint-plugin
     'jest/no-deprecated-functions': 'off',
+    'import/order': [
+      'error',
+      {
+        /**
+         * @description
+         *
+         * This keeps imports separate from one another, ensuring that imports are separated
+         * by their relative groups. As you move through the groups, imports become closer
+         * to the current file.
+         *
+         * @example
+         * ```
+         * import fs from 'fs';
+         *
+         * import package from 'npm-package';
+         *
+         * import xyz from '~/project-file';
+         *
+         * import index from '../';
+         *
+         * import sibling from './foo';
+         * ```
+         */
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling'],
+        'newlines-between': 'always',
+      },
+    ],
   },
 };

--- a/templates/demo-store/app/components/AccountAddressBook.tsx
+++ b/templates/demo-store/app/components/AccountAddressBook.tsx
@@ -3,6 +3,7 @@ import type {
   Customer,
   MailingAddress,
 } from '@shopify/hydrogen/storefront-api-types';
+
 import {Button, Link, Text} from '~/components';
 
 export function AccountAddressBook({

--- a/templates/demo-store/app/components/AccountDetails.tsx
+++ b/templates/demo-store/app/components/AccountDetails.tsx
@@ -1,4 +1,5 @@
 import type {Customer} from '@shopify/hydrogen/storefront-api-types';
+
 import {Link} from '~/components';
 
 export function AccountDetails({customer}: {customer: Customer}) {

--- a/templates/demo-store/app/components/AddToCartButton.tsx
+++ b/templates/demo-store/app/components/AddToCartButton.tsx
@@ -1,5 +1,6 @@
 import type {CartLineInput} from '@shopify/hydrogen/storefront-api-types';
 import {useFetcher, useMatches, useNavigation} from '@remix-run/react';
+
 import {Button} from '~/components';
 import {CartAction} from '~/lib/type';
 

--- a/templates/demo-store/app/components/Cart.tsx
+++ b/templates/demo-store/app/components/Cart.tsx
@@ -2,6 +2,14 @@ import clsx from 'clsx';
 import {useRef} from 'react';
 import {useScroll} from 'react-use';
 import {flattenConnection, Image, Money} from '@shopify/hydrogen';
+import type {
+  Cart as CartType,
+  CartCost,
+  CartLine,
+  CartLineUpdateInput,
+} from '@shopify/hydrogen/storefront-api-types';
+import {useFetcher} from '@remix-run/react';
+
 import {
   Button,
   Heading,
@@ -11,13 +19,6 @@ import {
   FeaturedProducts,
 } from '~/components';
 import {getInputStyleClasses} from '~/lib/utils';
-import type {
-  Cart as CartType,
-  CartCost,
-  CartLine,
-  CartLineUpdateInput,
-} from '@shopify/hydrogen/storefront-api-types';
-import {useFetcher} from '@remix-run/react';
 import {CartAction} from '~/lib/type';
 
 type Layouts = 'page' | 'drawer';

--- a/templates/demo-store/app/components/CountrySelector.tsx
+++ b/templates/demo-store/app/components/CountrySelector.tsx
@@ -1,11 +1,13 @@
 import {useFetcher, useLocation, useMatches} from '@remix-run/react';
-import {Heading, Button, IconCheck} from '~/components';
 import {useCallback, useEffect, useRef} from 'react';
 import {useInView} from 'react-intersection-observer';
-import {Localizations, Locale, CartAction} from '~/lib/type';
-import {DEFAULT_LOCALE} from '~/lib/utils';
 import clsx from 'clsx';
-import {CartBuyerIdentityInput} from '@shopify/hydrogen/storefront-api-types';
+import type {CartBuyerIdentityInput} from '@shopify/hydrogen/storefront-api-types';
+
+import {Heading, Button, IconCheck} from '~/components';
+import type {Localizations, Locale} from '~/lib/type';
+import {CartAction} from '~/lib/type';
+import {DEFAULT_LOCALE} from '~/lib/utils';
 
 export function CountrySelector() {
   const [root] = useMatches();

--- a/templates/demo-store/app/components/FeaturedCollections.tsx
+++ b/templates/demo-store/app/components/FeaturedCollections.tsx
@@ -1,5 +1,6 @@
 import {Image} from '@shopify/hydrogen';
 import type {Collection} from '@shopify/hydrogen/storefront-api-types';
+
 import {Heading, Section, Grid, Link} from '~/components';
 
 export function FeaturedCollections({

--- a/templates/demo-store/app/components/FeaturedProducts.tsx
+++ b/templates/demo-store/app/components/FeaturedProducts.tsx
@@ -1,11 +1,12 @@
 import clsx from 'clsx';
 import {useEffect, useId, useMemo} from 'react';
 import {useFetcher} from '@remix-run/react';
-import {Heading, ProductCard, Skeleton, Text} from '~/components';
 import type {
   Product,
   ProductSortKeys,
 } from '@shopify/hydrogen/storefront-api-types';
+
+import {Heading, ProductCard, Skeleton, Text} from '~/components';
 import {usePrefixPathWithLocale} from '~/lib/utils';
 
 interface FeaturedProductsProps {

--- a/templates/demo-store/app/components/FeaturedSection.tsx
+++ b/templates/demo-store/app/components/FeaturedSection.tsx
@@ -1,9 +1,11 @@
 import {useEffect} from 'react';
 import {useFetcher} from '@remix-run/react';
 import type {Collection, Product} from '@shopify/hydrogen/storefront-api-types';
+
+import {usePrefixPathWithLocale} from '~/lib/utils';
+
 import {FeaturedCollections} from './FeaturedCollections';
 import {ProductSwimlane} from './ProductSwimlane';
-import {usePrefixPathWithLocale} from '~/lib/utils';
 
 export interface FeaturedData {
   featuredCollections: Collection[];

--- a/templates/demo-store/app/components/Hero.tsx
+++ b/templates/demo-store/app/components/Hero.tsx
@@ -7,6 +7,7 @@ import type {
   Metafield,
   Video as MediaVideo,
 } from '@shopify/hydrogen/storefront-api-types';
+
 import {Heading, Text, Link} from '~/components';
 
 export interface CollectionHero {

--- a/templates/demo-store/app/components/Layout.tsx
+++ b/templates/demo-store/app/components/Layout.tsx
@@ -1,8 +1,8 @@
-import {
-  type EnhancedMenu,
-  type EnhancedMenuItem,
-  useIsHomePath,
-} from '~/lib/utils';
+import {useParams, Form, Await, useMatches} from '@remix-run/react';
+import {useWindowScroll} from 'react-use';
+import {Disclosure} from '@headlessui/react';
+import {Suspense, useEffect, useMemo} from 'react';
+
 import {
   Drawer,
   useDrawer,
@@ -21,12 +21,14 @@ import {
   CartLoading,
   Link,
 } from '~/components';
-import {useParams, Form, Await, useMatches} from '@remix-run/react';
-import {useWindowScroll} from 'react-use';
-import {Disclosure} from '@headlessui/react';
-import {Suspense, useEffect, useMemo} from 'react';
+import {
+  type EnhancedMenu,
+  type EnhancedMenuItem,
+  useIsHomePath,
+} from '~/lib/utils';
 import {useIsHydrated} from '~/hooks/useIsHydrated';
 import {useCartFetchers} from '~/hooks/useCartFetchers';
+
 import type {LayoutData} from '../root';
 
 export function Layout({

--- a/templates/demo-store/app/components/OrderCard.tsx
+++ b/templates/demo-store/app/components/OrderCard.tsx
@@ -1,5 +1,6 @@
 import {flattenConnection, Image} from '@shopify/hydrogen';
 import type {Order} from '@shopify/hydrogen/storefront-api-types';
+
 import {Heading, Text, Link} from '~/components';
 import {statusMessage} from '~/lib/utils';
 

--- a/templates/demo-store/app/components/Pagination.tsx
+++ b/templates/demo-store/app/components/Pagination.tsx
@@ -4,7 +4,6 @@ import type {
   PageInfo,
   ProductConnection,
 } from '@shopify/hydrogen/storefront-api-types';
-
 import {useInView, type IntersectionOptions} from 'react-intersection-observer';
 import {useNavigation, useLocation, useNavigate} from '@remix-run/react';
 

--- a/templates/demo-store/app/components/ProductCard.tsx
+++ b/templates/demo-store/app/components/ProductCard.tsx
@@ -1,15 +1,11 @@
 import clsx from 'clsx';
-import {
-  flattenConnection,
-  Image,
-  Money,
-  ShopifyAnalyticsProduct,
-  useMoney,
-} from '@shopify/hydrogen';
+import type {ShopifyAnalyticsProduct} from '@shopify/hydrogen';
+import {flattenConnection, Image, Money, useMoney} from '@shopify/hydrogen';
+import type {MoneyV2, Product} from '@shopify/hydrogen/storefront-api-types';
+
 import {Text, Link, AddToCartButton} from '~/components';
 import {isDiscounted, isNewArrival} from '~/lib/utils';
 import {getProductPlaceholder} from '~/lib/placeholders';
-import type {MoneyV2, Product} from '@shopify/hydrogen/storefront-api-types';
 
 export function ProductCard({
   product,

--- a/templates/demo-store/app/components/ProductGrid.tsx
+++ b/templates/demo-store/app/components/ProductGrid.tsx
@@ -1,8 +1,9 @@
-import {Button, Grid, ProductCard, Link} from '~/components';
-import {getImageLoadingPriority} from '~/lib/const';
 import type {Collection, Product} from '@shopify/hydrogen/storefront-api-types';
 import {useFetcher} from '@remix-run/react';
 import {useEffect, useState} from 'react';
+
+import {getImageLoadingPriority} from '~/lib/const';
+import {Button, Grid, ProductCard, Link} from '~/components';
 
 export function ProductGrid({
   url,

--- a/templates/demo-store/app/components/ProductSwimlane.tsx
+++ b/templates/demo-store/app/components/ProductSwimlane.tsx
@@ -1,4 +1,5 @@
 import type {Product} from '@shopify/hydrogen/storefront-api-types';
+
 import {ProductCard, Section} from '~/components';
 
 const mockProducts = new Array(12).fill('');

--- a/templates/demo-store/app/components/SortFilter.tsx
+++ b/templates/demo-store/app/components/SortFilter.tsx
@@ -1,22 +1,22 @@
-import {SyntheticEvent, useMemo, useState} from 'react';
+import type {SyntheticEvent} from 'react';
+import {useMemo, useState} from 'react';
 import {Menu} from '@headlessui/react';
-
-import {Heading, IconFilters, IconCaret, IconXMark, Text} from '~/components';
+import type {Location} from '@remix-run/react';
 import {
   Link,
   useLocation,
   useSearchParams,
-  Location,
   useNavigate,
 } from '@remix-run/react';
 import {useDebounce} from 'react-use';
 import {Disclosure} from '@headlessui/react';
-
 import type {
   FilterType,
   Filter,
   Collection,
 } from '@shopify/hydrogen/storefront-api-types';
+
+import {Heading, IconFilters, IconCaret, IconXMark, Text} from '~/components';
 
 export type AppliedFilter = {
   label: string;

--- a/templates/demo-store/app/data/countries.ts
+++ b/templates/demo-store/app/data/countries.ts
@@ -1,4 +1,4 @@
-import {Localizations} from '~/lib/type';
+import type {Localizations} from '~/lib/type';
 
 export const countries: Localizations = {
   default: {

--- a/templates/demo-store/app/hooks/useAnalytics.tsx
+++ b/templates/demo-store/app/hooks/useAnalytics.tsx
@@ -1,14 +1,18 @@
 import {useLocation, useFetchers, useMatches} from '@remix-run/react';
+import type {
+  ShopifyAddToCartPayload,
+  ShopifyPageViewPayload,
+} from '@shopify/hydrogen';
 import {
   AnalyticsEventName,
   getClientBrowserParameters,
   sendShopifyAnalytics,
-  ShopifyAddToCartPayload,
-  ShopifyPageViewPayload,
   useShopifyCookies,
 } from '@shopify/hydrogen';
 import {useEffect} from 'react';
-import {CartAction, I18nLocale} from '../lib/type';
+
+import type {I18nLocale} from '../lib/type';
+import {CartAction} from '../lib/type';
 
 export function useAnalytics(hasUserConsent: boolean, locale: I18nLocale) {
   useShopifyCookies({hasUserConsent});

--- a/templates/demo-store/app/lib/placeholders.ts
+++ b/templates/demo-store/app/lib/placeholders.ts
@@ -1,4 +1,4 @@
-import {Product} from '@shopify/hydrogen/storefront-api-types';
+import type {Product} from '@shopify/hydrogen/storefront-api-types';
 
 // Demo store placeholders
 const PLACEHOLDERS = {

--- a/templates/demo-store/app/lib/utils.ts
+++ b/templates/demo-store/app/lib/utils.ts
@@ -5,11 +5,12 @@ import type {
   Menu,
   MoneyV2,
 } from '@shopify/hydrogen/storefront-api-types';
-
-// @ts-expect-error types not available
 import typographicBase from 'typographic-base';
+
 import {countries} from '~/data/countries';
-import {I18nLocale, Locale} from './type';
+
+import type {I18nLocale} from './type';
+import {Locale} from './type';
 
 export interface EnhancedMenuItem extends MenuItem {
   to: string;

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -16,20 +16,23 @@ import {
   useRouteError,
 } from '@remix-run/react';
 import {ShopifySalesChannel, Seo} from '@shopify/hydrogen';
+import invariant from 'tiny-invariant';
+import type {Shop, Cart} from '@shopify/hydrogen/storefront-api-types';
+
 import {Layout} from '~/components';
+import {seoPayload} from '~/lib/seo.server';
+
+import favicon from '../public/favicon.svg';
+
 import {GenericError} from './components/GenericError';
 import {NotFound} from './components/NotFound';
 import styles from './styles/app.css';
-import favicon from '../public/favicon.svg';
-import {seoPayload} from '~/lib/seo.server';
 import {
   DEFAULT_LOCALE,
   parseMenu,
   getCartId,
   type EnhancedMenu,
 } from './lib/utils';
-import invariant from 'tiny-invariant';
-import {Shop, Cart} from '@shopify/hydrogen/storefront-api-types';
 import {useAnalytics} from './hooks/useAnalytics';
 
 export const links: LinksFunction = () => {

--- a/templates/demo-store/app/routes/($locale).$shopid.orders.$token.authenticate.tsx
+++ b/templates/demo-store/app/routes/($locale).$shopid.orders.$token.authenticate.tsx
@@ -1,6 +1,7 @@
-import {Shop} from '@shopify/hydrogen/storefront-api-types';
+import type {Shop} from '@shopify/hydrogen/storefront-api-types';
 import {redirect, type LoaderArgs} from '@shopify/remix-oxygen';
 import invariant from 'tiny-invariant';
+
 import {Button, PageHeader} from '~/components';
 
 /*

--- a/templates/demo-store/app/routes/($locale)._index.tsx
+++ b/templates/demo-store/app/routes/($locale)._index.tsx
@@ -1,15 +1,16 @@
 import {defer, type LoaderArgs} from '@shopify/remix-oxygen';
 import {Suspense} from 'react';
 import {Await, useLoaderData} from '@remix-run/react';
-import {ProductSwimlane, FeaturedCollections, Hero} from '~/components';
-import {MEDIA_FRAGMENT, PRODUCT_CARD_FRAGMENT} from '~/data/fragments';
-import {getHeroPlaceholder} from '~/lib/placeholders';
-import {seoPayload} from '~/lib/seo.server';
 import type {
   CollectionConnection,
   ProductConnection,
 } from '@shopify/hydrogen/storefront-api-types';
 import {AnalyticsPageType} from '@shopify/hydrogen';
+
+import {ProductSwimlane, FeaturedCollections, Hero} from '~/components';
+import {MEDIA_FRAGMENT, PRODUCT_CARD_FRAGMENT} from '~/data/fragments';
+import {getHeroPlaceholder} from '~/lib/placeholders';
+import {seoPayload} from '~/lib/seo.server';
 import {routeHeaders, CACHE_SHORT} from '~/data/cache';
 import {type CollectionHero} from '~/components/Hero';
 

--- a/templates/demo-store/app/routes/($locale).account.activate.$id.$activationToken.tsx
+++ b/templates/demo-store/app/routes/($locale).account.activate.$id.$activationToken.tsx
@@ -1,8 +1,9 @@
 import {json, redirect, type ActionFunction} from '@shopify/remix-oxygen';
 import {Form, useActionData, type V2_MetaFunction} from '@remix-run/react';
 import {useRef, useState} from 'react';
-import {getInputStyleClasses} from '~/lib/utils';
 import type {CustomerActivatePayload} from '@shopify/hydrogen/storefront-api-types';
+
+import {getInputStyleClasses} from '~/lib/utils';
 
 type ActionData = {
   formError?: string;

--- a/templates/demo-store/app/routes/($locale).account.address.$id.tsx
+++ b/templates/demo-store/app/routes/($locale).account.address.$id.tsx
@@ -15,8 +15,10 @@ import type {
   CustomerAddressCreatePayload,
 } from '@shopify/hydrogen/storefront-api-types';
 import invariant from 'tiny-invariant';
+
 import {Button, Text} from '~/components';
 import {assertApiErrors, getInputStyleClasses} from '~/lib/utils';
+
 import type {AccountOutletContext} from './($locale).account.edit';
 
 interface ActionData {

--- a/templates/demo-store/app/routes/($locale).account.edit.tsx
+++ b/templates/demo-store/app/routes/($locale).account.edit.tsx
@@ -12,8 +12,10 @@ import type {
 } from '@shopify/hydrogen/storefront-api-types';
 import clsx from 'clsx';
 import invariant from 'tiny-invariant';
+
 import {Button, Text} from '~/components';
 import {getInputStyleClasses, assertApiErrors} from '~/lib/utils';
+
 import {getCustomer} from './($locale).account';
 
 export interface AccountOutletContext {

--- a/templates/demo-store/app/routes/($locale).account.login.tsx
+++ b/templates/demo-store/app/routes/($locale).account.login.tsx
@@ -12,9 +12,10 @@ import {
   type V2_MetaFunction,
 } from '@remix-run/react';
 import {useState} from 'react';
+import type {CustomerAccessTokenCreatePayload} from '@shopify/hydrogen/storefront-api-types';
+
 import {getInputStyleClasses} from '~/lib/utils';
 import {Link} from '~/components';
-import type {CustomerAccessTokenCreatePayload} from '@shopify/hydrogen/storefront-api-types';
 
 export const handle = {
   isPublic: true,

--- a/templates/demo-store/app/routes/($locale).account.orders.$id.tsx
+++ b/templates/demo-store/app/routes/($locale).account.orders.$id.tsx
@@ -3,12 +3,13 @@ import clsx from 'clsx';
 import {json, redirect, type LoaderArgs} from '@shopify/remix-oxygen';
 import {useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 import {Money, Image, flattenConnection} from '@shopify/hydrogen';
-import {statusMessage} from '~/lib/utils';
 import type {
   Order,
   OrderLineItem,
   DiscountApplicationConnection,
 } from '@shopify/hydrogen/storefront-api-types';
+
+import {statusMessage} from '~/lib/utils';
 import {Link, Heading, PageHeader, Text} from '~/components';
 
 export const meta: V2_MetaFunction<typeof loader> = ({data}) => {

--- a/templates/demo-store/app/routes/($locale).account.recover.tsx
+++ b/templates/demo-store/app/routes/($locale).account.recover.tsx
@@ -6,9 +6,10 @@ import {
 } from '@shopify/remix-oxygen';
 import {Form, useActionData, type V2_MetaFunction} from '@remix-run/react';
 import {useState} from 'react';
+import type {CustomerRecoverPayload} from '@shopify/hydrogen/storefront-api-types';
+
 import {Link} from '~/components';
 import {getInputStyleClasses} from '~/lib/utils';
-import type {CustomerRecoverPayload} from '@shopify/hydrogen/storefront-api-types';
 
 export async function loader({context, params}: LoaderArgs) {
   const customerAccessToken = await context.session.get('customerAccessToken');

--- a/templates/demo-store/app/routes/($locale).account.register.tsx
+++ b/templates/demo-store/app/routes/($locale).account.register.tsx
@@ -6,10 +6,12 @@ import {
 } from '@shopify/remix-oxygen';
 import {Form, useActionData, type V2_MetaFunction} from '@remix-run/react';
 import {useState} from 'react';
-import {getInputStyleClasses} from '~/lib/utils';
-import {doLogin} from './($locale).account.login';
 import type {CustomerCreatePayload} from '@shopify/hydrogen/storefront-api-types';
+
+import {getInputStyleClasses} from '~/lib/utils';
 import {Link} from '~/components';
+
+import {doLogin} from './($locale).account.login';
 
 export async function loader({context, params}: LoaderArgs) {
   const customerAccessToken = await context.session.get('customerAccessToken');

--- a/templates/demo-store/app/routes/($locale).account.reset.$id.$resetToken.tsx
+++ b/templates/demo-store/app/routes/($locale).account.reset.$id.$resetToken.tsx
@@ -1,8 +1,9 @@
 import {json, redirect, type ActionFunction} from '@shopify/remix-oxygen';
 import {Form, useActionData, type V2_MetaFunction} from '@remix-run/react';
 import {useRef, useState} from 'react';
-import {getInputStyleClasses} from '~/lib/utils';
 import type {CustomerResetPayload} from '@shopify/hydrogen/storefront-api-types';
+
+import {getInputStyleClasses} from '~/lib/utils';
 
 type ActionData = {
   formError?: string;

--- a/templates/demo-store/app/routes/($locale).account.tsx
+++ b/templates/demo-store/app/routes/($locale).account.tsx
@@ -14,6 +14,15 @@ import type {
 } from '@shopify/hydrogen/storefront-api-types';
 import {Suspense} from 'react';
 import {
+  json,
+  defer,
+  redirect,
+  type LoaderArgs,
+  type AppLoadContext,
+} from '@shopify/remix-oxygen';
+import {flattenConnection} from '@shopify/hydrogen';
+
+import {
   Button,
   OrderCard,
   PageHeader,
@@ -24,18 +33,11 @@ import {
   ProductSwimlane,
 } from '~/components';
 import {FeaturedCollections} from '~/components/FeaturedCollections';
-import {
-  json,
-  defer,
-  redirect,
-  type LoaderArgs,
-  type AppLoadContext,
-} from '@shopify/remix-oxygen';
-import {flattenConnection} from '@shopify/hydrogen';
-import {getFeaturedData} from './($locale).featured-products';
-import {doLogout} from './($locale).account.logout';
 import {usePrefixPathWithLocale} from '~/lib/utils';
 import {CACHE_NONE, routeHeaders} from '~/data/cache';
+
+import {getFeaturedData} from './($locale).featured-products';
+import {doLogout} from './($locale).account.logout';
 
 // Combining json + Response + defer in a loader breaks the
 // types returned by useLoaderData. This is a temporary fix.
@@ -109,7 +111,7 @@ export default function Authenticated() {
           <Modal cancelLink="/account">
             <Outlet context={{customer: data.customer}} />
           </Modal>
-          <Account {...(data as Account)} />
+          <Account {...(data as AccountType)} />
         </>
       );
     } else {
@@ -117,10 +119,10 @@ export default function Authenticated() {
     }
   }
 
-  return <Account {...(data as Account)} />;
+  return <Account {...(data as AccountType)} />;
 }
 
-interface Account {
+interface AccountType {
   customer: Customer;
   orders: Order[];
   heading: string;
@@ -134,7 +136,7 @@ function Account({
   heading,
   addresses,
   featuredData,
-}: Account) {
+}: AccountType) {
   return (
     <>
       <PageHeader heading={heading}>

--- a/templates/demo-store/app/routes/($locale).api.countries.tsx
+++ b/templates/demo-store/app/routes/($locale).api.countries.tsx
@@ -1,4 +1,5 @@
 import {json} from '@shopify/remix-oxygen';
+
 import {CACHE_LONG} from '~/data/cache';
 import {countries} from '~/data/countries';
 

--- a/templates/demo-store/app/routes/($locale).api.products.tsx
+++ b/templates/demo-store/app/routes/($locale).api.products.tsx
@@ -1,7 +1,8 @@
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
 import {flattenConnection} from '@shopify/hydrogen';
-import {ProductConnection} from '@shopify/hydrogen/storefront-api-types';
+import type {ProductConnection} from '@shopify/hydrogen/storefront-api-types';
 import invariant from 'tiny-invariant';
+
 import {PRODUCT_CARD_FRAGMENT} from '~/data/fragments';
 
 /**

--- a/templates/demo-store/app/routes/($locale).cart.$lines.tsx
+++ b/templates/demo-store/app/routes/($locale).cart.$lines.tsx
@@ -1,4 +1,5 @@
 import {redirect, type LoaderArgs} from '@shopify/remix-oxygen';
+
 import {cartCreate} from './($locale).cart';
 
 /**

--- a/templates/demo-store/app/routes/($locale).cart.tsx
+++ b/templates/demo-store/app/routes/($locale).cart.tsx
@@ -1,4 +1,3 @@
-import {CartLoading, Cart} from '~/components';
 import {Await, useMatches} from '@remix-run/react';
 import {Suspense} from 'react';
 import invariant from 'tiny-invariant';
@@ -16,6 +15,8 @@ import type {
   UserError,
   CartBuyerIdentityInput,
 } from '@shopify/hydrogen/storefront-api-types';
+
+import {CartLoading, Cart} from '~/components';
 import {isLocalPath, getCartId} from '~/lib/utils';
 import {CartAction, type CartActions} from '~/lib/type';
 

--- a/templates/demo-store/app/routes/($locale).collections.$collectionHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).collections.$collectionHandle.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@shopify/hydrogen/storefront-api-types';
 import {flattenConnection, AnalyticsPageType} from '@shopify/hydrogen';
 import invariant from 'tiny-invariant';
+
 import {PageHeader, Section, Text, SortFilter} from '~/components';
 import {ProductGrid} from '~/components/ProductGrid';
 import {PRODUCT_CARD_FRAGMENT} from '~/data/fragments';

--- a/templates/demo-store/app/routes/($locale).collections._index.tsx
+++ b/templates/demo-store/app/routes/($locale).collections._index.tsx
@@ -4,6 +4,8 @@ import type {
   Collection,
   CollectionConnection,
 } from '@shopify/hydrogen/storefront-api-types';
+import {Image} from '@shopify/hydrogen';
+
 import {
   Grid,
   Heading,
@@ -17,7 +19,6 @@ import {
 import {getImageLoadingPriority} from '~/lib/const';
 import {seoPayload} from '~/lib/seo.server';
 import {CACHE_SHORT, routeHeaders} from '~/data/cache';
-import {Image} from '@shopify/hydrogen';
 
 const PAGINATION_SIZE = 8;
 

--- a/templates/demo-store/app/routes/($locale).discount.$code.tsx
+++ b/templates/demo-store/app/routes/($locale).discount.$code.tsx
@@ -1,5 +1,7 @@
 import {redirect, type LoaderArgs} from '@shopify/remix-oxygen';
+
 import {getCartId} from '~/lib/utils';
+
 import {cartCreate, cartDiscountCodesUpdate} from './($locale).cart';
 
 /**

--- a/templates/demo-store/app/routes/($locale).featured-products.tsx
+++ b/templates/demo-store/app/routes/($locale).featured-products.tsx
@@ -5,6 +5,7 @@ import type {
   ProductConnection,
 } from '@shopify/hydrogen/storefront-api-types';
 import invariant from 'tiny-invariant';
+
 import {PRODUCT_CARD_FRAGMENT} from '~/data/fragments';
 
 export async function loader({context: {storefront}}: LoaderArgs) {

--- a/templates/demo-store/app/routes/($locale).journal.$journalHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).journal.$journalHandle.tsx
@@ -1,12 +1,14 @@
 import {json, type LinksFunction, type LoaderArgs} from '@shopify/remix-oxygen';
 import {useLoaderData} from '@remix-run/react';
 import {Image} from '@shopify/hydrogen';
-import {Blog} from '@shopify/hydrogen/storefront-api-types';
+import type {Blog} from '@shopify/hydrogen/storefront-api-types';
 import invariant from 'tiny-invariant';
+
 import {PageHeader, Section} from '~/components';
 import {seoPayload} from '~/lib/seo.server';
-import styles from '../styles/custom-font.css';
 import {routeHeaders, CACHE_LONG} from '~/data/cache';
+
+import styles from '../styles/custom-font.css';
 
 const BLOG_HANDLE = 'journal';
 

--- a/templates/demo-store/app/routes/($locale).journal._index.tsx
+++ b/templates/demo-store/app/routes/($locale).journal._index.tsx
@@ -2,6 +2,7 @@ import {json, type LoaderArgs} from '@shopify/remix-oxygen';
 import {useLoaderData} from '@remix-run/react';
 import {flattenConnection, Image} from '@shopify/hydrogen';
 import type {Article, Blog} from '@shopify/hydrogen/storefront-api-types';
+
 import {Grid, PageHeader, Section, Link} from '~/components';
 import {getImageLoadingPriority, PAGINATION_SIZE} from '~/lib/const';
 import {seoPayload} from '~/lib/seo.server';

--- a/templates/demo-store/app/routes/($locale).pages.$pageHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).pages.$pageHandle.tsx
@@ -2,6 +2,7 @@ import {json, type LoaderArgs} from '@shopify/remix-oxygen';
 import type {Page as PageType} from '@shopify/hydrogen/storefront-api-types';
 import {useLoaderData} from '@remix-run/react';
 import invariant from 'tiny-invariant';
+
 import {PageHeader} from '~/components';
 import {CACHE_LONG, routeHeaders} from '~/data/cache';
 import {seoPayload} from '~/lib/seo.server';

--- a/templates/demo-store/app/routes/($locale).policies.$policyHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).policies.$policyHandle.tsx
@@ -1,8 +1,9 @@
 import {json, type MetaFunction, type LoaderArgs} from '@shopify/remix-oxygen';
 import {useLoaderData} from '@remix-run/react';
-import {PageHeader, Section, Button} from '~/components';
 import invariant from 'tiny-invariant';
-import {ShopPolicy} from '@shopify/hydrogen/storefront-api-types';
+import type {ShopPolicy} from '@shopify/hydrogen/storefront-api-types';
+
+import {PageHeader, Section, Button} from '~/components';
 import {routeHeaders, CACHE_LONG} from '~/data/cache';
 import {seoPayload} from '~/lib/seo.server';
 

--- a/templates/demo-store/app/routes/($locale).policies._index.tsx
+++ b/templates/demo-store/app/routes/($locale).policies._index.tsx
@@ -2,6 +2,7 @@ import {json, type LoaderArgs} from '@shopify/remix-oxygen';
 import {useLoaderData} from '@remix-run/react';
 import type {ShopPolicy} from '@shopify/hydrogen/storefront-api-types';
 import invariant from 'tiny-invariant';
+
 import {PageHeader, Section, Heading, Link} from '~/components';
 import {routeHeaders, CACHE_LONG} from '~/data/cache';
 import {seoPayload} from '~/lib/seo.server';

--- a/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
@@ -8,13 +8,18 @@ import {
   useLocation,
   useNavigation,
 } from '@remix-run/react';
+import type {ShopifyAnalyticsProduct} from '@shopify/hydrogen';
+import {AnalyticsPageType, Money, ShopPayButton} from '@shopify/hydrogen';
+import invariant from 'tiny-invariant';
+import clsx from 'clsx';
+import type {
+  ProductVariant,
+  SelectedOptionInput,
+  Product as ProductType,
+  Shop,
+  ProductConnection,
+} from '@shopify/hydrogen/storefront-api-types';
 
-import {
-  AnalyticsPageType,
-  Money,
-  ShopifyAnalyticsProduct,
-  ShopPayButton,
-} from '@shopify/hydrogen';
 import {
   Heading,
   IconCaret,
@@ -31,18 +36,8 @@ import {
 } from '~/components';
 import {getExcerpt} from '~/lib/utils';
 import {seoPayload} from '~/lib/seo.server';
-import invariant from 'tiny-invariant';
-import clsx from 'clsx';
-import type {
-  ProductVariant,
-  SelectedOptionInput,
-  Product as ProductType,
-  Shop,
-  ProductConnection,
-} from '@shopify/hydrogen/storefront-api-types';
 import {MEDIA_FRAGMENT, PRODUCT_CARD_FRAGMENT} from '~/data/fragments';
 import type {Storefront} from '~/lib/type';
-import type {Product} from 'schema-dts';
 import {routeHeaders, CACHE_SHORT} from '~/data/cache';
 
 export const headers = routeHeaders;

--- a/templates/demo-store/app/routes/($locale).products._index.tsx
+++ b/templates/demo-store/app/routes/($locale).products._index.tsx
@@ -5,6 +5,7 @@ import type {
   Collection,
 } from '@shopify/hydrogen/storefront-api-types';
 import invariant from 'tiny-invariant';
+
 import {
   PageHeader,
   Section,

--- a/templates/demo-store/app/routes/($locale).search.tsx
+++ b/templates/demo-store/app/routes/($locale).search.tsx
@@ -13,6 +13,7 @@ import type {
 } from '@shopify/hydrogen/storefront-api-types';
 import {Suspense} from 'react';
 import invariant from 'tiny-invariant';
+
 import {
   Heading,
   Input,

--- a/templates/demo-store/app/routes/[sitemap.xml].tsx
+++ b/templates/demo-store/app/routes/[sitemap.xml].tsx
@@ -1,6 +1,6 @@
 import {flattenConnection} from '@shopify/hydrogen';
 import type {LoaderArgs} from '@shopify/remix-oxygen';
-import {
+import type {
   CollectionConnection,
   PageConnection,
   ProductConnection,

--- a/templates/demo-store/server.ts
+++ b/templates/demo-store/server.ts
@@ -5,6 +5,7 @@ import {
   getStorefrontHeaders,
 } from '@shopify/remix-oxygen';
 import {createStorefrontClient, storefrontRedirect} from '@shopify/hydrogen';
+
 import {HydrogenSession} from '~/lib/session.server';
 import {getLocaleFromRequest} from '~/lib/utils';
 

--- a/templates/demo-store/typographic-base.d.ts
+++ b/templates/demo-store/typographic-base.d.ts
@@ -1,0 +1,1 @@
+declare module 'typographic-base';


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

For the demo-store:
- The current linting configuration deviates from Remix in that it does not utilize the `@typescript-eslint/consistent-type-imports` rule.
- The `@remix-run/eslint-config` package is installed in `package.json`, but was not being used in the eslint configuration.

Regarding `import/order` additions:
- `import/order` is considered a Shopify best practice and is introduced here to reiterate and lean on that. [shopify/web-configs/esnext](https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/lib/config/esnext.js#L254)

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This pull request adds import/order eslint rules for the demo-store as a start. Instead of adding it for the entire repository in one pull request, it makes the most sense to import this in smaller chunks.

To address the lint violations, a simple `npm run lint --fix` was used. There were only three additional issues which remained:

```log
➜  demo-store git:(chore/demo-store-lint-configuration) ✗ npm run lint
npm WARN ignoring workspace config at /Users/quintonchester/Repos/hydrogen/templates/demo-store/.npmrc

> demo-store@1.0.0 lint
> eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .

/Users/quintonchester/Repos/hydrogen/templates/demo-store/app/lib/utils.ts
  3:1  error  There should be no empty line within import group  import/order

/Users/quintonchester/Repos/hydrogen/templates/demo-store/app/routes/($locale).account.tsx
  133:10  error  'Account' is already defined  @typescript-eslint/no-redeclare

/Users/quintonchester/Repos/hydrogen/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
  114:25  error  'Product' is already defined  @typescript-eslint/no-redeclare

✖ 3 problems (3 errors, 0 warnings)
```

Addressing those violations saw the following changes:
- `utils.ts 3:1`
  - Removed the empty line within the import group.
- `($locale).account.tsx`
  - `interface Account` was updated to `interface AccountType`. Casted types were updated to reflect this change.
- `($locale).products.$productHandle.tsx`
  - The additional Product definition was an imported module which was seemingly unused -- please do check me on this as I was unable to determine the relevance of the import seen here. [Diff](https://github.com/Shopify/hydrogen/pull/895/files#diff-8be0f7e46cb0627df173635c2d9e1c3372728910f3b1ab7dc186a1e1381b001fL45)

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

- This should be tested primarily via green CI ✅ 
- Do a test with the demo-store template from this branch.

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] ~I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes~
- [ ] ~I've added [tests](CONTRIBUTING.md#testing) to cover my changes~
- [ ] ~I've added or updated the documentation~

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
