### PR TITLE
Minor codegen fixes

### DIFF
--- a/packages/cli/src/commands/hydrogen/codegen-unstable.ts
+++ b/packages/cli/src/commands/hydrogen/codegen-unstable.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import Command from '@shopify/cli-kit/node/base-command';
 import {AbortError} from '@shopify/cli-kit/node/error';
+import {renderSuccess} from '@shopify/cli-kit/node/ui';
 import {Flags} from '@oclif/core';
 import {getProjectPaths, getRemixConfig} from '../../lib/config.js';
 import {commonFlags, flagsToCamelObject} from '../../lib/flags.js';
@@ -54,11 +55,19 @@ async function runCodegen({
   await patchGqlPluck();
 
   try {
-    await generateTypes({
+    const generatedFiles = await generateTypes({
       ...remixConfig,
       configFilePath: codegenConfigPath,
       watch,
     });
+
+    if (!watch) {
+      console.log('');
+      renderSuccess({
+        headline: 'Generated types for GraphQL:',
+        body: generatedFiles.map((file) => `- ${file}`).join('\n'),
+      });
+    }
   } catch (error) {
     const {message, details} = normalizeCodegenError(
       (error as Error).message,

--- a/packages/cli/src/lib/codegen.ts
+++ b/packages/cli/src/lib/codegen.ts
@@ -145,7 +145,10 @@ export async function generateTypes({
   return Object.keys(codegenConfig.generates);
 }
 
-function generateDefaultConfig({rootDirectory, appDirectory}: ProjectDirs) {
+function generateDefaultConfig({
+  rootDirectory,
+  appDirectory,
+}: ProjectDirs): LoadCodegenConfigResult {
   const tsDefaultGlob = '*!(*.d).{ts,tsx}'; // No d.ts files
   const appDirRelative = relativePath(rootDirectory, appDirectory);
 

--- a/packages/cli/src/lib/codegen.ts
+++ b/packages/cli/src/lib/codegen.ts
@@ -141,6 +141,8 @@ export async function generateTypes({
     },
     true,
   );
+
+  return Object.keys(codegenConfig.generates);
 }
 
 function generateDefaultConfig({rootDirectory, appDirectory}: ProjectDirs) {

--- a/packages/hydrogen-codegen/src/preset.ts
+++ b/packages/hydrogen-codegen/src/preset.ts
@@ -11,8 +11,8 @@ export const namespacedImportName = 'StorefrontAPI';
 
 export const interfaceExtensionCode = `
 declare module '@shopify/hydrogen' {
-  interface QueryTypes extends GeneratedQueryTypes {}
-  interface MutationTypes extends GeneratedMutationTypes {}
+  interface StorefrontQueries extends GeneratedQueryTypes {}
+  interface StorefrontMutations extends GeneratedMutationTypes {}
 }`;
 
 export const preset: Types.OutputPreset<GqlTagConfig> = {

--- a/packages/hydrogen-codegen/src/preset.ts
+++ b/packages/hydrogen-codegen/src/preset.ts
@@ -3,7 +3,6 @@ import * as addPlugin from '@graphql-codegen/add';
 import * as typescriptOperationPlugin from '@graphql-codegen/typescript-operations';
 import {processSources} from './sources.js';
 import {plugin as dtsPlugin} from './plugin.js';
-import {getSchema} from './schema.js';
 
 export type GqlTagConfig = {};
 
@@ -72,7 +71,7 @@ export const preset: Types.OutputPreset<GqlTagConfig> = {
         filename: options.baseOutputDir,
         plugins,
         pluginMap,
-        schema: options.schema || getSchema(),
+        schema: options.schema,
         config: {
           ...options.config,
           // This is for the operations plugin

--- a/packages/hydrogen-codegen/tests/codegen.test.ts
+++ b/packages/hydrogen-codegen/tests/codegen.test.ts
@@ -93,8 +93,8 @@ describe('Hydrogen Codegen', async () => {
       }
 
       declare module '@shopify/hydrogen' {
-        interface QueryTypes extends GeneratedQueryTypes {}
-        interface MutationTypes extends GeneratedMutationTypes {}
+        interface StorefrontQueries extends GeneratedQueryTypes {}
+        interface StorefrontMutations extends GeneratedMutationTypes {}
       }
       "
     `);
@@ -200,8 +200,8 @@ describe('Hydrogen Codegen', async () => {
       }
 
       declare module '@shopify/hydrogen' {
-        interface QueryTypes extends GeneratedQueryTypes {}
-        interface MutationTypes extends GeneratedMutationTypes {}
+        interface StorefrontQueries extends GeneratedQueryTypes {}
+        interface StorefrontMutations extends GeneratedMutationTypes {}
       }
       "
     `);

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -46,7 +46,7 @@ export type StorefrontClient<TI18n extends I18nBase> = {
 /**
  * Maps all the queries found in the project to variables and return types.
  */
-export interface QueryTypes {
+export interface StorefrontQueries {
   // Example of how a generated query type looks like:
   // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};
 }
@@ -54,7 +54,7 @@ export interface QueryTypes {
 /**
  * Maps all the mutations found in the project to variables and return types.
  */
-export interface MutationTypes {
+export interface StorefrontMutations {
   // Example of how a generated mutation type looks like:
   // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};
 }
@@ -88,15 +88,15 @@ type StorefrontCommonOptions<Variables extends GenericVariables> = {
   : {variables: Variables});
 
 type StorefrontQuerySecondParam<
-  RawGqlString extends keyof QueryTypes | string = string,
-> = (RawGqlString extends keyof QueryTypes
-  ? StorefrontCommonOptions<QueryTypes[RawGqlString]['variables']>
+  RawGqlString extends keyof StorefrontQueries | string = string,
+> = (RawGqlString extends keyof StorefrontQueries
+  ? StorefrontCommonOptions<StorefrontQueries[RawGqlString]['variables']>
   : StorefrontCommonOptions<GenericVariables>) & {cache?: CachingStrategy};
 
 type StorefrontMutateSecondParam<
-  RawGqlString extends keyof MutationTypes | string = string,
-> = RawGqlString extends keyof MutationTypes
-  ? StorefrontCommonOptions<MutationTypes[RawGqlString]['variables']>
+  RawGqlString extends keyof StorefrontMutations | string = string,
+> = RawGqlString extends keyof StorefrontMutations
+  ? StorefrontCommonOptions<StorefrontMutations[RawGqlString]['variables']>
   : StorefrontCommonOptions<GenericVariables>;
 
 /**
@@ -106,27 +106,27 @@ export type Storefront<TI18n extends I18nBase = I18nBase> = {
   /** The function to run a query on Storefront API. */
   query: <OverrideReturnType = any, RawGqlString extends string = string>(
     query: RawGqlString,
-    ...options: RawGqlString extends keyof QueryTypes // Do we have any generated query types?
-      ? IsOptionalVariables<QueryTypes[RawGqlString]> extends true
+    ...options: RawGqlString extends keyof StorefrontQueries // Do we have any generated query types?
+      ? IsOptionalVariables<StorefrontQueries[RawGqlString]> extends true
         ? [StorefrontQuerySecondParam<RawGqlString>?] // Using codegen, query has no variables
         : [StorefrontQuerySecondParam<RawGqlString>] // Using codegen, query needs variables
       : [StorefrontQuerySecondParam?] // No codegen, variables always optional
   ) => Promise<
-    RawGqlString extends keyof QueryTypes // Do we have any generated query types?
-      ? QueryTypes[RawGqlString]['return'] // Using codegen, return type is known
+    RawGqlString extends keyof StorefrontQueries // Do we have any generated query types?
+      ? StorefrontQueries[RawGqlString]['return'] // Using codegen, return type is known
       : OverrideReturnType // No codegen, let user specify return type
   >;
   /** The function to run a mutation on Storefront API. */
   mutate: <OverrideReturnType = any, RawGqlString extends string = string>(
     mutation: RawGqlString,
-    ...options: RawGqlString extends keyof MutationTypes // Do we have any generated mutation types?
-      ? IsOptionalVariables<MutationTypes[RawGqlString]> extends true
+    ...options: RawGqlString extends keyof StorefrontMutations // Do we have any generated mutation types?
+      ? IsOptionalVariables<StorefrontMutations[RawGqlString]> extends true
         ? [StorefrontMutateSecondParam<RawGqlString>?] // Using codegen, mutation has no variables
         : [StorefrontMutateSecondParam<RawGqlString>] // Using codegen, mutation needs variables
       : [StorefrontMutateSecondParam?] // No codegen, variables always optional
   ) => Promise<
-    RawGqlString extends keyof MutationTypes // Do we have any generated mutation types?
-      ? MutationTypes[RawGqlString]['return'] // Using codegen, return type is known
+    RawGqlString extends keyof StorefrontMutations // Do we have any generated mutation types?
+      ? StorefrontMutations[RawGqlString]['return'] // Using codegen, return type is known
       : OverrideReturnType // No codegen, let user specify return type
   >;
   /** The cache instance passed in from the `createStorefrontClient` argument. */


### PR DESCRIPTION
- Renamed the exposed interfaces from `QueryTypes` to `StorefrontQueries` to prevent issues in the future (e.g. we might add `CartQueries`).
- Show success banner after `h2 codegen-unstable`.

  <img width="650" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/ecbda7f6-8a10-44f5-b886-aec71765d8e7">
