### PR TITLE
fix loadmore products in search grid

### DIFF
--- a/.changeset/giant-tigers-sit.md
+++ b/.changeset/giant-tigers-sit.md
@@ -1,0 +1,5 @@
+---
+'demo-store': patch
+---
+
+Fix the load more results button on the /search route

--- a/templates/demo-store/app/components/ProductGrid.tsx
+++ b/templates/demo-store/app/components/ProductGrid.tsx
@@ -16,7 +16,6 @@ export function ProductGrid({
   const [initialProducts, setInitialProducts] = useState(
     collection?.products?.nodes || [],
   );
-
   const [nextPage, setNextPage] = useState(
     collection?.products?.pageInfo?.hasNextPage,
   );
@@ -35,17 +34,23 @@ export function ProductGrid({
   const fetcher = useFetcher();
 
   function fetchMoreProducts() {
-    fetcher.load(`${url}?index&cursor=${endCursor}`);
+    if (!endCursor) return;
+    const url = new URL(window.location.href);
+    url.searchParams.set('cursor', endCursor);
+    fetcher.load(url.pathname + url.search);
   }
 
   useEffect(() => {
     if (!fetcher.data) return;
 
-    const {collection} = fetcher.data;
+    const {products, collection} = fetcher.data;
+    const pageProducts = collection?.products || products;
 
-    setProducts((prev: Product[]) => [...prev, ...collection.products.nodes]);
-    setNextPage(collection.products.pageInfo.hasNextPage);
-    setEndCursor(collection.products.pageInfo.endCursor);
+    if (!pageProducts) return;
+
+    setProducts((prev: Product[]) => [...prev, ...pageProducts.nodes]);
+    setNextPage(products.pageInfo.hasNextPage);
+    setEndCursor(products.pageInfo.endCursor);
   }, [fetcher.data]);
 
   const haveProducts = initialProducts.length > 0;

--- a/templates/demo-store/app/routes/($locale).search.tsx
+++ b/templates/demo-store/app/routes/($locale).search.tsx
@@ -39,7 +39,7 @@ export async function loader({request, context: {storefront}}: LoaderArgs) {
     variables: {
       pageBy: PAGINATION_SIZE,
       searchTerm,
-      cursor,
+      after: cursor,
       country: storefront.i18n.country,
       language: storefront.i18n.language,
     },


### PR DESCRIPTION
Ensrue the load more results button works on the demo store `/search` route

Fixes https://github.com/Shopify/hydrogen/issues/596

https://github.com/Shopify/hydrogen/assets/12080141/2a35794d-6062-4227-92e9-e30bdeb41860
