### PR TITLE
POC of graphiql integration with bad queries

### DIFF
--- a/packages/hydrogen/src/routing/graphiql.ts
+++ b/packages/hydrogen/src/routing/graphiql.ts
@@ -56,6 +56,19 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
       type="application/javascript"
     ></script>
     <script>
+
+      const windowUrl = new URL(document.URL);
+
+      let query = '';
+      if (windowUrl.searchParams.has('query')) {
+        query = decodeURIComponent(windowUrl.searchParams.get('query') ?? '');
+      }
+
+      let variables = '';
+      if (windowUrl.searchParams.has('variables')) {
+        variables = decodeURIComponent(windowUrl.searchParams.get('variables') ?? '');
+      }
+
       ReactDOM.render(
         React.createElement(GraphiQL, {
           fetcher: GraphiQL.createFetcher({
@@ -65,7 +78,9 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
             }
           }),
           defaultEditorToolsVisibility: true,
-          initialTabs: [{query: '{\\n  shop {\\n    name\\n  }\\n}'}]
+          initialTabs: [{query: '{\\n  shop {\\n    name\\n  }\\n}'}],
+          query: query,
+          variables: variables
         }),
         document.getElementById('graphiql'),
       );


### PR DESCRIPTION
POC of how the `storefront.query` and `storefront.mutate` could potentially provide a link to your local GraphiQL instance with the full query pre-filled, so you can maybe more easily see the error and play around with the query? 


https://github.com/Shopify/hydrogen/assets/3054066/6dce8fda-d8db-4ab1-bc83-5720f8153e59

