### PR TITLE
PoC: Add a logging abstraction and wrap remix build output to track errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17663,11 +17663,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/kolorist": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
-    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
       "dev": true,
@@ -31557,7 +31552,6 @@
       "license": "MIT",
       "dependencies": {
         "@shopify/hydrogen-react": "2023.4.3",
-        "kolorist": "^1.8.0",
         "react": "^18.2.0"
       },
       "devDependencies": {
@@ -38452,7 +38446,6 @@
         "@shopify/hydrogen-react": "2023.4.3",
         "@testing-library/react": "^14.0.0",
         "happy-dom": "^8.9.0",
-        "kolorist": "*",
         "react": "^18.2.0",
         "schema-dts": "^1.1.0",
         "vitest": "^0.27.2"
@@ -45547,11 +45540,6 @@
         "co": "^4.6.0",
         "koa-compose": "^4.1.0"
       }
-    },
-    "kolorist": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
     },
     "language-subtag-registry": {
       "version": "0.3.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12395,27 +12395,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "license": "MIT",
@@ -17683,6 +17662,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
@@ -29352,14 +29336,14 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "4.1.2",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "4.2.1",
+      "license": "MIT",
       "dependencies": {
         "@graphql-codegen/cli": "3.3.1",
         "@oclif/core": "2.1.4",
         "@remix-run/dev": "1.15.0",
         "@shopify/cli-kit": "3.45.0",
-        "@shopify/hydrogen-codegen": "^0.0.0-alpha.0",
+        "@shopify/hydrogen-codegen": "^0.0.1",
         "@shopify/mini-oxygen": "^1.6.0",
         "ansi-colors": "^4.1.3",
         "fast-glob": "^3.2.12",
@@ -29388,8 +29372,8 @@
       },
       "peerDependencies": {
         "@remix-run/react": "^1.15.0",
-        "@shopify/hydrogen-react": "^2023.4.1",
-        "@shopify/remix-oxygen": "^1.0.6"
+        "@shopify/hydrogen-react": "^2023.4.3",
+        "@shopify/remix-oxygen": "^1.0.7"
       }
     },
     "packages/cli/node_modules/@oclif/core": {
@@ -31558,10 +31542,10 @@
     },
     "packages/create-hydrogen": {
       "name": "@shopify/create-hydrogen",
-      "version": "4.1.1",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "4.1.2",
+      "license": "MIT",
       "dependencies": {
-        "@shopify/cli-hydrogen": "^4.1.2"
+        "@shopify/cli-hydrogen": "^4.2.1"
       },
       "bin": {
         "create-hydrogen": "dist/create-app.js"
@@ -31569,10 +31553,11 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2023.4.1",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "2023.4.3",
+      "license": "MIT",
       "dependencies": {
-        "@shopify/hydrogen-react": "2023.4.1",
+        "@shopify/hydrogen-react": "2023.4.3",
+        "kolorist": "^1.8.0",
         "react": "^18.2.0"
       },
       "devDependencies": {
@@ -31589,8 +31574,8 @@
     },
     "packages/hydrogen-codegen": {
       "name": "@shopify/hydrogen-codegen",
-      "version": "0.0.0-alpha.0",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "0.0.1",
+      "license": "MIT",
       "dependencies": {
         "@graphql-codegen/add": "^4.0.1",
         "@graphql-codegen/typescript-operations": "^3.0.1"
@@ -31606,7 +31591,7 @@
     },
     "packages/hydrogen-react": {
       "name": "@shopify/hydrogen-react",
-      "version": "2023.4.1",
+      "version": "2023.4.3",
       "license": "MIT",
       "dependencies": {
         "@google/model-viewer": "^1.12.1",
@@ -31893,8 +31878,8 @@
     },
     "packages/remix-oxygen": {
       "name": "@shopify/remix-oxygen",
-      "version": "1.0.6",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "1.0.7",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/server-runtime": "1.15.0"
       },
@@ -31906,14 +31891,14 @@
       }
     },
     "templates/demo-store": {
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@headlessui/react": "^1.7.2",
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.2",
-        "@shopify/hydrogen": "^2023.4.1",
-        "@shopify/remix-oxygen": "^1.0.6",
+        "@shopify/cli-hydrogen": "^4.2.1",
+        "@shopify/hydrogen": "^2023.4.3",
+        "@shopify/remix-oxygen": "^1.0.7",
         "clsx": "^1.2.1",
         "cross-env": "^7.0.3",
         "graphql": "^16.6.0",
@@ -31959,9 +31944,9 @@
       "dependencies": {
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.2",
-        "@shopify/hydrogen": "^2023.4.1",
-        "@shopify/remix-oxygen": "^1.0.6",
+        "@shopify/cli-hydrogen": "^4.2.1",
+        "@shopify/hydrogen": "^2023.4.3",
+        "@shopify/remix-oxygen": "^1.0.7",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^3.6.6",
@@ -31989,9 +31974,9 @@
       "dependencies": {
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.2",
-        "@shopify/hydrogen": "^2023.4.1",
-        "@shopify/remix-oxygen": "^1.0.6",
+        "@shopify/cli-hydrogen": "^4.2.1",
+        "@shopify/hydrogen": "^2023.4.3",
+        "@shopify/remix-oxygen": "^1.0.7",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^3.6.6",
@@ -36215,7 +36200,7 @@
         "@oclif/core": "2.1.4",
         "@remix-run/dev": "1.15.0",
         "@shopify/cli-kit": "3.45.0",
-        "@shopify/hydrogen-codegen": "^0.0.0-alpha.0",
+        "@shopify/hydrogen-codegen": "^0.0.1",
         "@shopify/mini-oxygen": "^1.6.0",
         "@types/fs-extra": "^9.0.13",
         "@types/gunzip-maybe": "^1.4.0",
@@ -38396,7 +38381,7 @@
     "@shopify/create-hydrogen": {
       "version": "file:packages/create-hydrogen",
       "requires": {
-        "@shopify/cli-hydrogen": "^4.1.2"
+        "@shopify/cli-hydrogen": "^4.2.1"
       }
     },
     "@shopify/eslint-plugin": {
@@ -38464,9 +38449,10 @@
       "version": "file:packages/hydrogen",
       "requires": {
         "@shopify/generate-docs": "0.10.7",
-        "@shopify/hydrogen-react": "2023.4.1",
+        "@shopify/hydrogen-react": "2023.4.3",
         "@testing-library/react": "^14.0.0",
         "happy-dom": "^8.9.0",
+        "kolorist": "*",
         "react": "^18.2.0",
         "schema-dts": "^1.1.0",
         "vitest": "^0.27.2"
@@ -41946,12 +41932,12 @@
         "@remix-run/eslint-config": "1.15.0",
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.2",
+        "@shopify/cli-hydrogen": "^4.2.1",
         "@shopify/eslint-plugin": "^42.0.1",
-        "@shopify/hydrogen": "^2023.4.1",
+        "@shopify/hydrogen": "^2023.4.3",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.0.6",
+        "@shopify/remix-oxygen": "^1.0.7",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/typography": "^0.5.9",
         "@types/eslint": "^8.4.10",
@@ -42162,24 +42148,6 @@
     },
     "encodeurl": {
       "version": "1.0.2"
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -44354,11 +44322,11 @@
         "@remix-run/dev": "1.15.0",
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.2",
-        "@shopify/hydrogen": "^2023.4.1",
+        "@shopify/cli-hydrogen": "^4.2.1",
+        "@shopify/hydrogen": "^2023.4.3",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.0.6",
+        "@shopify/remix-oxygen": "^1.0.7",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.0.20",
         "@types/react-dom": "^18.0.6",
@@ -45579,6 +45547,11 @@
         "co": "^4.6.0",
         "koa-compose": "^4.1.0"
       }
+    },
+    "kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
     },
     "language-subtag-registry": {
       "version": "0.3.22",
@@ -50433,11 +50406,11 @@
         "@remix-run/dev": "1.15.0",
         "@remix-run/react": "1.15.0",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^4.1.2",
-        "@shopify/hydrogen": "^2023.4.1",
+        "@shopify/cli-hydrogen": "^4.2.1",
+        "@shopify/hydrogen": "^2023.4.3",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.0.6",
+        "@shopify/remix-oxygen": "^1.0.7",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.0.20",
         "@types/react-dom": "^18.0.6",

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -55,6 +55,7 @@
   ],
   "dependencies": {
     "@shopify/hydrogen-react": "2023.4.3",
+    "kolorist": "^1.8.0",
     "react": "^18.2.0"
   },
   "peerDependencies": {
@@ -62,10 +63,10 @@
     "@remix-run/server-runtime": "^1.15.0"
   },
   "devDependencies": {
+    "@shopify/generate-docs": "0.10.7",
     "@testing-library/react": "^14.0.0",
     "happy-dom": "^8.9.0",
     "schema-dts": "^1.1.0",
-    "vitest": "^0.27.2",
-    "@shopify/generate-docs": "0.10.7"
+    "vitest": "^0.27.2"
   }
 }

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -55,7 +55,6 @@
   ],
   "dependencies": {
     "@shopify/hydrogen-react": "2023.4.3",
-    "kolorist": "^1.8.0",
     "react": "^18.2.0"
   },
   "peerDependencies": {

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -59,3 +59,5 @@ export type {
   StorefrontApiResponseOkPartial,
   StorefrontApiResponsePartial,
 } from '@shopify/hydrogen-react';
+
+export {Logger} from './logger';

--- a/packages/hydrogen/src/logger.ts
+++ b/packages/hydrogen/src/logger.ts
@@ -1,0 +1,103 @@
+import {yellow, red} from 'kolorist';
+
+type LoggerMethod = (
+  context: {request: Request},
+  ...args: Array<any>
+) => void | Promise<any>;
+
+interface LoggerOptions {
+  trace: LoggerMethod;
+  debug: LoggerMethod;
+  warn: LoggerMethod;
+  error: LoggerMethod;
+  fatal: LoggerMethod;
+}
+
+export class Logger {
+  #waitUntil: (p: Promise<unknown>) => void;
+  #request: Request;
+
+  constructor(
+    waitUntil: (p: Promise<unknown>) => void,
+    request: Request,
+    options: Partial<LoggerOptions> = {},
+  ) {
+    for (const [key, value] of Object.entries(options)) {
+      this.defaultLogger[key as keyof LoggerOptions] = value;
+    }
+    this.#waitUntil = waitUntil;
+    this.#request = request;
+  }
+
+  trace(...args: Array<unknown>) {
+    this.#doLog('trace', ...args);
+  }
+
+  debug(...args: Array<unknown>) {
+    this.#doLog('debug', ...args);
+  }
+
+  warn(...args: Array<unknown>) {
+    this.#doLog('warn', ...args);
+  }
+
+  error(...args: Array<unknown>) {
+    this.#doLog('error', ...args);
+  }
+
+  fatal(...args: Array<unknown>) {
+    this.#doLog('fatal', ...args);
+  }
+
+  #doLog(method: keyof LoggerOptions, ...args: Array<any>) {
+    try {
+      const maybePromise = this.defaultLogger[method](
+        {request: this.#request},
+        ...args,
+      );
+      if (maybePromise instanceof Promise) {
+        this.#waitUntil(
+          maybePromise.catch((e) => {
+            const message = e instanceof Error ? e.stack : e;
+            console.error(
+              `Promise error from the custom logging implementation for logger.${method} failed:\n${message}`,
+            );
+          }),
+        );
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.stack : e;
+      console.error(
+        `The custom logging implementation for logger.${method} failed:\n${message}`,
+      );
+    }
+  }
+
+  defaultLogger: LoggerOptions = {
+    trace: (context, ...args) => {
+      console.log(...args);
+    },
+
+    debug: (context, ...args) => {
+      console.log(...args);
+    },
+
+    warn: (context, ...args) => {
+      console.warn(yellow('WARN: '), ...args);
+    },
+
+    error: (context, error, ...extra) => {
+      const url = context ? ` ${context.request.url}` : '';
+
+      if (error instanceof Error) {
+        console.error(red(`Error processing route:${url}\n${error.stack}`));
+      } else {
+        console.error(red(`Error:${url} ${error}`));
+      }
+    },
+
+    fatal: (context, ...args) => {
+      console.error(red('FATAL: '), ...args);
+    },
+  };
+}

--- a/packages/hydrogen/src/logger.ts
+++ b/packages/hydrogen/src/logger.ts
@@ -1,5 +1,3 @@
-import {yellow, red} from 'kolorist';
-
 type LoggerMethod = (
   context: {request: Request},
   ...args: Array<any>
@@ -83,21 +81,21 @@ export class Logger {
     },
 
     warn: (context, ...args) => {
-      console.warn(yellow('WARN: '), ...args);
+      console.warn('WARN: ', ...args);
     },
 
     error: (context, error, ...extra) => {
       const url = context ? ` ${context.request.url}` : '';
 
       if (error instanceof Error) {
-        console.error(red(`Error processing route:${url}\n${error.stack}`));
+        console.error(`Error processing route:${url}\n${error.stack}`);
       } else {
-        console.error(red(`Error:${url} ${error}`));
+        console.error(`Error:${url} ${error}`);
       }
     },
 
     fatal: (context, ...args) => {
-      console.error(red('FATAL: '), ...args);
+      console.error('FATAL: ', ...args);
     },
   };
 }

--- a/packages/remix-oxygen/src/server.ts
+++ b/packages/remix-oxygen/src/server.ts
@@ -6,7 +6,8 @@ import {
   type ServerBuild,
 } from '@remix-run/server-runtime';
 import {isDeferredData} from '@remix-run/server-runtime/dist/responses';
-import type {Logger} from '@shopify/hydrogen';
+
+type Logger = {error: (...data: any[]) => any};
 
 export function createRequestHandler<Context = unknown>({
   build,

--- a/templates/skeleton/server.ts
+++ b/templates/skeleton/server.ts
@@ -1,6 +1,10 @@
 // Virtual entry point for the app
 import * as remixBuild from '@remix-run/dev/server-build';
-import {createStorefrontClient, storefrontRedirect} from '@shopify/hydrogen';
+import {
+  createStorefrontClient,
+  storefrontRedirect,
+  Logger,
+} from '@shopify/hydrogen';
 import {
   createRequestHandler,
   getStorefrontHeaders,
@@ -47,14 +51,17 @@ export default {
         storefrontHeaders: getStorefrontHeaders(request),
       });
 
+      const log = new Logger(executionContext.waitUntil, request);
+
       /**
        * Create a Remix request handler and pass
        * Hydrogen's Storefront client to the loader context.
        */
       const handleRequest = createRequestHandler({
+        log,
         build: remixBuild,
         mode: process.env.NODE_ENV,
-        getLoadContext: () => ({session, storefront, env}),
+        getLoadContext: () => ({session, storefront, env, log}),
       });
 
       const response = await handleRequest(request);


### PR DESCRIPTION
## Summary

This PR does two things:

1. It wraps the Remix module build output. This means that every `loader` and `action` method defined in routes now gets automatically wrapped where we call the method before Remix, and catch any errors passing them to a logging abstraction.
2. Add a lite logging abstraction with a default implementation:

```ts
import {Logger} from '@shopify/hydrogen';

// Default log implementation
const log = new Logger(executionContext.waitUntil, request);

// Override specific log options
const log = new Logger(executionContext.waitUntil, request, {
  // Each logger method (trace, debug, warn, error, fatal) is passed a context object,
  // which includes the original request. These methods can also be async functions,
  // which could call a third party API to ingest logs.
  error: ({request}, ...args) => {
    console.log(request.url, ...args);
  }
});
```

## How to test?

1. Add an error within a loader or action within both the demo store and the skeleton app.
2. Notice that the skeleton app passes in a `Logger` instance and the demo store does not. This just verifies that it works with and without the logger passed in. If it isn't passed in, just default to `console.error()`. 