### PR TITLE
Fix redirects to match what is returned in the online store

### DIFF
--- a/.changeset/calm-pears-lick.md
+++ b/.changeset/calm-pears-lick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix redirects to respond with a 301

--- a/packages/hydrogen/src/routing/redirect.ts
+++ b/packages/hydrogen/src/routing/redirect.ts
@@ -38,7 +38,7 @@ export async function storefrontRedirect(
     const location = urlRedirects?.edges?.[0]?.node?.target;
 
     if (location) {
-      return new Response(null, {status: 302, headers: {location}});
+      return new Response(null, {status: 301, headers: {location}});
     }
 
     const searchParams = new URLSearchParams(search);


### PR DESCRIPTION
Change Hydrogen redirects to match the online store with 301 responses: https://github.com/Shopify/hydrogen/discussions/936#discussioncomment-5991882

Technically this might be a "breaking change". But if we say it was a bug from the beginning?