### PR TITLE
Fix account query to not be cached

### DIFF
--- a/.changeset/hip-gorillas-yell.md
+++ b/.changeset/hip-gorillas-yell.md
@@ -1,0 +1,5 @@
+---
+'demo-store': patch
+---
+
+Update the demostore to not cache the customer query. This is important to update in your app if you copied the logic from the demo store.

--- a/templates/demo-store/app/routes/($locale).account.tsx
+++ b/templates/demo-store/app/routes/($locale).account.tsx
@@ -305,6 +305,7 @@ export async function getCustomer(
       country: context.storefront.i18n.country,
       language: context.storefront.i18n.language,
     },
+    cache: storefront.CacheNone(),
   });
 
   /**


### PR DESCRIPTION
Resolves: https://github.com/Shopify/hydrogen/issues/943

How to QA:

Login as one person, then login immediately as someone else. Make sure that the login doesn't persist as the previous person 😬 