### PR TITLE
Skip cache logic when mode is no-store

### DIFF
--- a/.changeset/modern-rats-dance.md
+++ b/.changeset/modern-rats-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Skip reading and writing cache in sub-requests when the strategy is CacheNone.

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -1,5 +1,5 @@
 import {hashKey} from '../utils/hash.js';
-import {CacheShort, CachingStrategy} from './strategies';
+import {CacheShort, CachingStrategy, NO_STORE} from './strategies';
 import {getItemFromCache, setItemInCache, isStale} from './sub-request';
 
 /**
@@ -59,7 +59,9 @@ export async function runWithCache<T = unknown>(
     waitUntil,
   }: WithCacheOptions<T>,
 ): Promise<T> {
-  if (!cacheInstance || !strategy) return actionFn();
+  if (!cacheInstance || !strategy || strategy.mode === NO_STORE) {
+    return actionFn();
+  }
 
   const key = hashKey([
     // '__HYDROGEN_CACHE_ID__', // TODO purgeQueryCacheOnBuild


### PR DESCRIPTION
We were still running all the cache logic when mode is `no-store`. This PR changes it to skip the whole cache logic when this mode is specified.

This change means we are not reading from cache anymore in this mode. Technically, the "no-store" only signals "don't write", not necessarily "don't read and return an existing cached response". But I think this might be OK?
Or should we keep reading (checking for existing responses) and only skip writing? That would only be useful when the mode changes across requests depending on some condition... not sure if this would ever be desired.

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
