### PR TITLE
Custom elements should have class set instead of className in React

### DIFF
--- a/.changeset/silver-buckets-obey.md
+++ b/.changeset/silver-buckets-obey.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen-react': patch
+'@shopify/hydrogen': patch
+---
+
+Fix `<ModelViewer>` to properly set className

--- a/packages/hydrogen-react/src/ModelViewer.tsx
+++ b/packages/hydrogen-react/src/ModelViewer.tsx
@@ -221,10 +221,11 @@ export function ModelViewer(props: ModelViewerProps): JSX.Element | null {
 
   return (
     <model-viewer
-      // @ts-expect-error ref should exist
       ref={callbackRef}
       {...passthroughProps}
-      className={className}
+      // @ts-expect-error src should exist
+      // @eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      class={className}
       id={passthroughProps.id ?? data.id}
       src={data.sources[0].url}
       alt={data.alt ?? null}


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes https://github.com/Shopify/hydrogen/discussions/960


### WHAT is this pull request doing?

When setting the class attribute on a custom element, React expects to use just `class` in the JSX instead of `className`. See https://github.com/facebook/react/issues/4933#issuecomment-256664482

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
