### PR TITLE
Make `<CartProvider>` use country code from `<ShopifyProvider>`

### DIFF
--- a/.changeset/olive-adults-eat.md
+++ b/.changeset/olive-adults-eat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Fix the `<CartProvider>` to by default pull localization from `<ShopifyProvider>`. You can still override the countryCode by passing a prop directly to `<CartProvider>`. Resovles https://github.com/Shopify/hydrogen/issues/622

--- a/packages/hydrogen-react/src/CartProvider.test.tsx
+++ b/packages/hydrogen-react/src/CartProvider.test.tsx
@@ -5,7 +5,7 @@ import {vi, beforeEach, describe, expect, it} from 'vitest';
 import {ComponentProps, PropsWithChildren} from 'react';
 import {renderHook, act} from '@testing-library/react';
 import {getCartMock, getCartLineMock} from './CartProvider.test.helpers.js';
-import {ShopifyProvider} from './ShopifyProvider.js';
+import {ShopifyProvider, type ShopifyProviderProps} from './ShopifyProvider.js';
 import {getShopifyConfig} from './ShopifyProvider.test.js';
 
 const mockUseCartActions = vi.fn();
@@ -23,13 +23,15 @@ vi.mock('./cart-hooks.js', () => ({
 import {CartProvider, useCart} from './CartProvider.js';
 import {cartFromGraphQL} from './useCartAPIStateMachine.js';
 import {CART_ID_STORAGE_KEY} from './cart-constants.js';
+import {CountryCode} from './storefront-api-types.js';
 
 function ShopifyCartProvider(
   props: Omit<ComponentProps<typeof CartProvider>, 'children'> = {},
+  shopifyProviderProps?: Omit<ShopifyProviderProps, 'children'>,
 ) {
   return function Wrapper({children}: PropsWithChildren) {
     return (
-      <ShopifyProvider {...getShopifyConfig()}>
+      <ShopifyProvider {...getShopifyConfig()} {...shopifyProviderProps}>
         <CartProvider {...props}>{children}</CartProvider>
       </ShopifyProvider>
     );
@@ -47,6 +49,82 @@ describe('<CartProvider />', () => {
     mockUseCartActions.mockClear();
     mockUseCartFetch.mockClear();
     vi.spyOn(window.localStorage, 'getItem').mockReturnValue('');
+  });
+
+  describe('localization', () => {
+    it('uses the default countryCode provided to the shopify provider', async () => {
+      const discountCodesUpdateSpy = vi.fn(() => ({
+        data: {cartDiscountCodesUpdate: {cart: cartMock}},
+      }));
+
+      const buyerIdentityUpdateSpy = vi.fn(() => ({
+        data: {cartBuyerIdentityUpdate: {cart: cartMock}},
+      }));
+
+      const result = await useCartWithInitializedCart(
+        {
+          discountCodesUpdate: discountCodesUpdateSpy,
+          buyerIdentityUpdate: buyerIdentityUpdateSpy,
+        },
+        undefined,
+        {
+          ...getShopifyConfig(),
+          countryIsoCode: 'KG' as CountryCode,
+        },
+      );
+
+      void act(() => {
+        result.current.discountCodesUpdate(['DiscountCode']);
+      });
+
+      expect(result.current.status).toEqual('updating');
+
+      // wait till idle
+      await act(async () => {});
+
+      expect(buyerIdentityUpdateSpy).toHaveBeenCalledWith('abc', {
+        countryCode: 'KG',
+        customerAccessToken: undefined,
+      });
+    });
+
+    it('uses countryCode override to the CartProvider component', async () => {
+      const discountCodesUpdateSpy = vi.fn(() => ({
+        data: {cartDiscountCodesUpdate: {cart: cartMock}},
+      }));
+
+      const buyerIdentityUpdateSpy = vi.fn(() => ({
+        data: {cartBuyerIdentityUpdate: {cart: cartMock}},
+      }));
+
+      const result = await useCartWithInitializedCart(
+        {
+          discountCodesUpdate: discountCodesUpdateSpy,
+          buyerIdentityUpdate: buyerIdentityUpdateSpy,
+        },
+        {
+          countryCode: 'UK' as CountryCode,
+        },
+        {
+          ...getShopifyConfig(),
+          countryIsoCode: 'KG' as CountryCode,
+        },
+      );
+
+      void act(() => {
+        result.current.discountCodesUpdate(['DiscountCode']);
+      });
+
+      expect(result.current.status).toEqual('updating');
+
+      // wait till idle
+      await act(async () => {});
+
+      expect(buyerIdentityUpdateSpy).toHaveBeenCalledWith('abc', {
+        countryCode: 'UK',
+        customerAccessToken: undefined,
+      });
+    });
   });
 
   describe('`data` prop', () => {
@@ -1458,6 +1536,7 @@ describe('<CartProvider />', () => {
 async function useCartWithInitializedCart(
   cartActionsMocks = {},
   cartProviderProps: Omit<ComponentProps<typeof CartProvider>, 'children'> = {},
+  shopifyProviderProps?: Omit<ShopifyProviderProps, 'children'>,
 ) {
   const cartCreateSpy = vi.fn(() => ({
     data: {cartCreate: {cart: cartMock}},
@@ -1470,7 +1549,7 @@ async function useCartWithInitializedCart(
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const {result} = renderHook(() => useCart(), {
-    wrapper: ShopifyCartProvider(cartProviderProps),
+    wrapper: ShopifyCartProvider(cartProviderProps, shopifyProviderProps),
   });
 
   // creates a cart and wait till idle

--- a/packages/hydrogen-react/src/CartProvider.tsx
+++ b/packages/hydrogen-react/src/CartProvider.tsx
@@ -30,6 +30,7 @@ import {useCartAPIStateMachine} from './useCartAPIStateMachine.js';
 import {CART_ID_STORAGE_KEY} from './cart-constants.js';
 import {PartialDeep} from 'type-fest';
 import {defaultCartFragment} from './cart-queries.js';
+import {useShop} from './ShopifyProvider.js';
 
 export const CartContext = createContext<CartWithActions | null>(null);
 
@@ -128,8 +129,21 @@ export function CartProvider({
   data: cart,
   cartFragment = defaultCartFragment,
   customerAccessToken,
-  countryCode = 'US',
+  countryCode,
 }: CartProviderProps): JSX.Element {
+  const shop = useShop();
+
+  if (!shop)
+    throw new Error(
+      '<CartProvider> needs to be a descendant of <ShopifyProvider>',
+    );
+
+  countryCode = (
+    (countryCode as string) ??
+    shop.countryIsoCode ??
+    'US'
+  ).toUpperCase() as CountryCode;
+
   if (countryCode) countryCode = countryCode.toUpperCase() as CountryCode;
   const [prevCountryCode, setPrevCountryCode] = useState(countryCode);
   const [prevCustomerAccessToken, setPrevCustomerAccessToken] =


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fix the `<CartProvider>` to by default pull localization from `<ShopifyProvider>`. You can still override the countryCode by passing a prop directly to `<CartProvider>`. Resolves https://github.com/Shopify/hydrogen/issues/622

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
