### PR TITLE
Add `getCliCommand` utility

### DIFF
--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -1,4 +1,6 @@
 import Command from '@shopify/cli-kit/node/base-command';
+import {readdir} from 'node:fs/promises';
+import {fileURLToPath} from 'node:url';
 import {
   installNodeModules,
   packageManagerUsedForCreating,
@@ -33,8 +35,7 @@ import {
 import {transpileProject} from '../../lib/transpile-ts.js';
 import {getLatestTemplates} from '../../lib/template-downloader.js';
 import {checkHydrogenVersion} from '../../lib/check-version.js';
-import {readdir} from 'fs/promises';
-import {fileURLToPath} from 'url';
+import {supressNodeExperimentalWarnings} from '../../lib/process.js';
 
 const STARTER_TEMPLATES = ['hello-world', 'demo-store'];
 const FLAG_MAP = {f: 'force'} as Record<string, string>;
@@ -254,16 +255,4 @@ async function projectExists(projectDir: string) {
     (await isDirectory(projectDir)) &&
     (await readdir(projectDir)).length > 0
   );
-}
-
-function supressNodeExperimentalWarnings() {
-  const warningListener = process.listeners('warning')[0]!;
-  if (warningListener) {
-    process.removeAllListeners('warning');
-    process.prependListener('warning', (warning) => {
-      if (warning.name != 'ExperimentalWarning') {
-        warningListener(warning);
-      }
-    });
-  }
 }

--- a/packages/cli/src/commands/hydrogen/shortcut.ts
+++ b/packages/cli/src/commands/hydrogen/shortcut.ts
@@ -1,19 +1,15 @@
 import Command from '@shopify/cli-kit/node/base-command';
 import {renderFatalError, renderSuccess} from '@shopify/cli-kit/node/ui';
 import {
-  hasAlias,
-  homeFileExists,
   isGitBash,
   isWindows,
+  ALIAS_NAME,
   shellRunScript,
-  shellWriteFile,
-  supportsShell,
+  shellWriteAlias,
   type Shell,
   type UnixShell,
   type WindowsShell,
 } from '../../lib/shell.js';
-
-const ALIAS_NAME = 'h2';
 
 export default class Shortcut extends Command {
   static description = `Creates a global \`${ALIAS_NAME}\` shortcut for the Hydrogen CLI`;
@@ -59,27 +55,15 @@ end
 async function createShortcutsForUnix() {
   const shells: UnixShell[] = [];
 
-  if (
-    supportsShell('zsh') &&
-    (hasAlias(ALIAS_NAME, '~/.zshrc') ||
-      shellWriteFile('~/.zshrc', BASH_ZSH_COMMAND, true))
-  ) {
+  if (await shellWriteAlias('zsh', ALIAS_NAME, BASH_ZSH_COMMAND)) {
     shells.push('zsh');
   }
 
-  if (
-    supportsShell('bash') &&
-    (hasAlias(ALIAS_NAME, '~/.bashrc') ||
-      shellWriteFile('~/.bashrc', BASH_ZSH_COMMAND, true))
-  ) {
+  if (await shellWriteAlias('bash', ALIAS_NAME, BASH_ZSH_COMMAND)) {
     shells.push('bash');
   }
 
-  if (
-    supportsShell('fish') &&
-    (await homeFileExists('~/.config/fish/functions')) &&
-    shellWriteFile(`~/.config/fish/functions/${ALIAS_NAME}.fish`, FISH_FUNCTION)
-  ) {
+  if (await shellWriteAlias('fish', ALIAS_NAME, FISH_FUNCTION)) {
     shells.push('fish');
   }
 
@@ -105,13 +89,13 @@ async function createShortcutsForWindows() {
   const shells: WindowsShell[] = [];
 
   // Legacy PowerShell
-  if (shellRunScript(PS_APPEND_PROFILE_COMMAND, 'powershell.exe')) {
+  if (await shellRunScript(PS_APPEND_PROFILE_COMMAND, 'powershell.exe')) {
     shells.push('PowerShell');
   }
 
   // PowerShell 7+ has a different executable name and installation path:
   // https://learn.microsoft.com/en-us/powershell/scripting/whats-new/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.3#separate-installation-path-and-executable-name
-  if (shellRunScript(PS_APPEND_PROFILE_COMMAND, 'pwsh.exe')) {
+  if (await shellRunScript(PS_APPEND_PROFILE_COMMAND, 'pwsh.exe')) {
     shells.push('PowerShell 7+');
   }
 

--- a/packages/cli/src/lib/process.ts
+++ b/packages/cli/src/lib/process.ts
@@ -1,0 +1,16 @@
+import {exec} from 'node:child_process';
+import {promisify} from 'node:util';
+
+export const execAsync = promisify(exec);
+
+export function supressNodeExperimentalWarnings() {
+  const warningListener = process.listeners('warning')[0]!;
+  if (warningListener) {
+    process.removeAllListeners('warning');
+    process.prependListener('warning', (warning) => {
+      if (warning.name != 'ExperimentalWarning') {
+        warningListener(warning);
+      }
+    });
+  }
+}

--- a/packages/cli/src/lib/shell.test.ts
+++ b/packages/cli/src/lib/shell.test.ts
@@ -1,0 +1,80 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {fileExists} from '@shopify/cli-kit/node/fs';
+import {shellWriteAlias} from './shell.js';
+import {execAsync} from './process.js';
+
+describe('shell', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mock('node:child_process');
+    vi.mock('@shopify/cli-kit/node/fs');
+    vi.mock('./process.js', async () => {
+      const original = await vi.importActual<typeof import('./process.js')>(
+        './process.js',
+      );
+
+      return {
+        ...original,
+        execAsync: vi.fn(),
+      };
+    });
+
+    vi.mocked(fileExists).mockResolvedValue(false);
+  });
+
+  describe('shellWriteAlias', () => {
+    (['bash', 'zsh', 'fish'] as const).forEach((shell) => {
+      const alias = 'h2';
+      const command = 'command';
+
+      it(`writes ${shell} alias to file`, async () => {
+        await expect(
+          shellWriteAlias(shell, alias, command),
+        ).resolves.toBeTruthy();
+
+        expect(execAsync).toHaveBeenLastCalledWith(
+          expect.stringMatching(
+            new RegExp(
+              `printf "${command}" ${
+                shell === 'fish' ? '>' : '>>'
+              } .*\.${shell}`,
+            ),
+          ),
+        );
+      });
+
+      it(`skips writing ${shell} alias when not supported`, async () => {
+        vi.mocked(execAsync).mockImplementation((shellCommand) =>
+          shellCommand.startsWith('which')
+            ? Promise.reject(null)
+            : (Promise.resolve({stdout: 'stuff', stderr: ''}) as any),
+        );
+
+        await expect(
+          shellWriteAlias(shell, alias, command),
+        ).resolves.toBeFalsy();
+
+        expect(execAsync).not.toHaveBeenLastCalledWith(
+          expect.stringMatching(/^printf/),
+        );
+      });
+
+      it(`skips writing ${shell} alias when already aliased`, async () => {
+        vi.mocked(fileExists).mockResolvedValue(true);
+        vi.mocked(execAsync).mockImplementation((shellCommand) =>
+          shellCommand.startsWith('which') || shellCommand.startsWith('grep')
+            ? (Promise.resolve({stdout: 'stuff', stderr: ''}) as any)
+            : Promise.reject(null),
+        );
+
+        await expect(
+          shellWriteAlias(shell, alias, command),
+        ).resolves.toBeTruthy();
+
+        expect(execAsync).not.toHaveBeenLastCalledWith(
+          expect.stringMatching(/^printf/),
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adding a `getCliCommand ` utility here to show `h2 dev` in logs when the alias exists instead of the full `npx shopify hydrogen dev`.

The first commit refactors some code and adds more unit tests.
The second commit adds the utility.