### PR TITLE
fix: improve page SEO configuration in demo store

### DIFF
--- a/templates/demo-store/app/lib/seo.server.ts
+++ b/templates/demo-store/app/lib/seo.server.ts
@@ -394,7 +394,7 @@ function page({
 }): SeoConfig<WebPage> {
   return {
     description: truncate(page?.seo?.description || ''),
-    title: page?.seo?.title,
+    title: page?.seo?.title ?? page?.title,
     titleTemplate: '%s | Page',
     url,
     jsonLd: {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

Currently, if there is no SEO title set for a page, the default meta title given to the browser might look off. We should fall back to the default `page.title` instad.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
