### PR TITLE
Reload environment variables in development

### DIFF
--- a/packages/cli/src/lib/combined-environment-variables.ts
+++ b/packages/cli/src/lib/combined-environment-variables.ts
@@ -26,7 +26,7 @@ export async function combinedEnvironmentVariables({
 
   const formattedRemoteVariables = remoteEnvironmentVariables?.reduce(
     (a, v) => ({...a, [v.key]: v.value}),
-    {},
+    {} as Record<string, string>,
   );
 
   const dotEnvPath = resolvePath(root, '.env');

--- a/packages/cli/src/lib/mini-oxygen.ts
+++ b/packages/cli/src/lib/mini-oxygen.ts
@@ -13,8 +13,10 @@ type MiniOxygenOptions = {
   watch?: boolean;
   buildPathClient: string;
   buildPathWorkerFile: string;
-  environmentVariables?: {[key: string]: string};
+  env?: {[key: string]: string};
 };
+
+export type MiniOxygen = Awaited<ReturnType<typeof startMiniOxygen>>;
 
 export async function startMiniOxygen({
   root,
@@ -22,15 +24,16 @@ export async function startMiniOxygen({
   watch = false,
   buildPathWorkerFile,
   buildPathClient,
-  environmentVariables = {},
+  env,
 }: MiniOxygenOptions) {
-  const {default: miniOxygen} = await import('@shopify/mini-oxygen');
+  const {default: miniOxygenImport} = await import('@shopify/mini-oxygen');
   const miniOxygenPreview =
-    miniOxygen.default ?? (miniOxygen as unknown as typeof miniOxygen.default);
+    miniOxygenImport.default ??
+    (miniOxygenImport as unknown as typeof miniOxygenImport.default);
 
   const dotenvPath = resolvePath(root, '.env');
 
-  const {port: actualPort} = await miniOxygenPreview({
+  const miniOxygen = await miniOxygenPreview({
     workerFile: buildPathWorkerFile,
     assetsDir: buildPathClient,
     publicPath: '',
@@ -39,14 +42,10 @@ export async function startMiniOxygen({
     autoReload: watch,
     modules: true,
     env: {
-      ...environmentVariables,
+      ...env,
       ...process.env,
     },
-    envPath:
-      !Object.keys(environmentVariables).length &&
-      (await fileExists(dotenvPath))
-        ? dotenvPath
-        : undefined,
+    envPath: !env && (await fileExists(dotenvPath)) ? dotenvPath : undefined,
     log: () => {},
     buildWatchPaths: watch
       ? [resolvePath(root, buildPathWorkerFile)]
@@ -60,7 +59,7 @@ export async function startMiniOxygen({
       ),
   });
 
-  const listeningAt = `http://localhost:${actualPort}`;
+  const listeningAt = `http://localhost:${miniOxygen.port}`;
 
   outputInfo(
     outputContent`🚥 MiniOxygen server started at ${outputToken.link(
@@ -68,6 +67,19 @@ export async function startMiniOxygen({
       listeningAt,
     )}\n`,
   );
+
+  return {
+    port: miniOxygen.port,
+    close: miniOxygen.close,
+    reload(nextOptions?: Partial<Pick<MiniOxygenOptions, 'env'>>) {
+      return miniOxygen.reload({
+        env: {
+          ...(nextOptions?.env ?? env),
+          ...process.env,
+        },
+      });
+    },
+  };
 }
 
 export function logResponse(request: Request, response: Response) {

--- a/templates/hello-world/remix.config.js
+++ b/templates/hello-world/remix.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   appDirectory: 'app',
   ignoredRouteFiles: ['**/.*'],
-  watchPaths: ['./public'],
+  watchPaths: ['./public', './.env'],
   server: './server.ts',
   /**
    * The following settings are required to deploy Hydrogen apps to Oxygen:


### PR DESCRIPTION
Builds on top of https://github.com/Shopify/mini-oxygen/pull/458 to allow reloading environment variables when `.env` file changes.

This also changes the behavior of the `combinedEnvironmentVariables` utility to avoid blocking the initial build.

Not sure what to do with the logs. Right now it logs "Injecting variables to MiniOxygen: ....." every time the `.env` file is updated, which is not incorrect but might be too much output. Perhaps we could diff and only show the stuff that has changed.
Also, right now this is downloading remote vars again on file save... Perhaps we should assume the remote variables don't change and we only read the local `.env` on file save?
