### PR TITLE
Fix HydrogenSession type import in templates

### DIFF
--- a/templates/hello-world/remix.env.d.ts
+++ b/templates/hello-world/remix.env.d.ts
@@ -3,7 +3,7 @@
 /// <reference types="@shopify/oxygen-workers-types" />
 
 import type {Storefront} from '@shopify/hydrogen';
-import type {HydrogenSession} from '../server';
+import type {HydrogenSession} from './server';
 
 declare global {
   /**

--- a/templates/hello-world/server.ts
+++ b/templates/hello-world/server.ts
@@ -81,7 +81,7 @@ export default {
  * Feel free to customize it to your needs, add helper methods, or
  * swap out the cookie-based implementation with something else!
  */
-class HydrogenSession {
+export class HydrogenSession {
   constructor(
     private sessionStorage: SessionStorage,
     private session: Session,

--- a/templates/skeleton/remix.env.d.ts
+++ b/templates/skeleton/remix.env.d.ts
@@ -3,7 +3,7 @@
 /// <reference types="@shopify/oxygen-workers-types" />
 
 import type {Storefront} from '@shopify/hydrogen';
-import type {HydrogenSession} from '../server';
+import type {HydrogenSession} from './server';
 
 declare global {
   /**

--- a/templates/skeleton/server.ts
+++ b/templates/skeleton/server.ts
@@ -81,7 +81,7 @@ export default {
  * Feel free to customize it to your needs, add helper methods, or
  * swap out the cookie-based implementation with something else!
  */
-class HydrogenSession {
+export class HydrogenSession {
   constructor(
     private sessionStorage: SessionStorage,
     private session: Session,


### PR DESCRIPTION
I've no idea for how long this has been broken 😅 
It affects the `context.session` types in loaders.