### PR TITLE
Update cartActions status docs description

### DIFF
--- a/packages/hydrogen-react/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen-react/docs/generated/generated_docs_data.json
@@ -6886,7 +6886,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "status",
                 "value": "\"uninitialized\" | \"fetching\" | \"creating\" | \"updating\" | \"idle\"",
-                "description": "The status of the cart. This returns 'uninitialized' when the cart is not yet created, `creating` when the cart is being created, `fetching` when an existing cart is being fetched, `updating` when the cart is updating, and `idle` when the cart isn't being created or updated."
+                "description": "The status of the cart. This returns `uninitialized` when the cart is not yet created, `creating` when the cart is being created, `fetching` when an existing cart is being fetched, `updating` when the cart is updating, and `idle` when the cart isn't being created or updated."
               },
               {
                 "filePath": "/cart-types.ts",

--- a/packages/hydrogen-react/src/cart-types.ts
+++ b/packages/hydrogen-react/src/cart-types.ts
@@ -35,7 +35,7 @@ export interface CartBase {
 }
 
 interface CartActions {
-  /** The status of the cart. This returns 'uninitialized' when the cart is not yet created, `creating` when the cart is being created, `fetching` when an existing cart is being fetched, `updating` when the cart is updating, and `idle` when the cart isn't being created or updated. */
+  /** The status of the cart. This returns `uninitialized` when the cart is not yet created, `creating` when the cart is being created, `fetching` when an existing cart is being fetched, `updating` when the cart is updating, and `idle` when the cart isn't being created or updated. */
   status: CartStatus;
   /** If an error occurred on the previous cart action, then `error` will exist and `cart` will be put back into the last valid status it was in. */
   error?: unknown;


### PR DESCRIPTION
### WHY are these changes introduced?

These changes are introduced to fix a typo in the status field description of the useCart hook documentation in Shopify Hydrogen. The current description contains a typo, which needs to be corrected to ensure accurate information for developers.

### WHAT is this pull request doing?

This pull request updates the documentation for the useCart hook in Shopify Hydrogen.

### HOW to test your changes?



#### Post-merge steps

No specific post-merge steps are required for this documentation change.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

