### PR TITLE
Add option to create storefront in `h2 link` CLI command

### DIFF
--- a/.changeset/twelve-suits-dance.md
+++ b/.changeset/twelve-suits-dance.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': minor
+---
+
+Link local storefront to a newly created storefront on Admin

--- a/packages/cli/src/commands/hydrogen/link.ts
+++ b/packages/cli/src/commands/hydrogen/link.ts
@@ -1,18 +1,26 @@
 import {Flags} from '@oclif/core';
 import Command from '@shopify/cli-kit/node/base-command';
+import {basename} from '@shopify/cli-kit/node/path';
+
 import {
   renderConfirmationPrompt,
   renderSelectPrompt,
   renderSuccess,
+  renderTasks,
+  renderTextPrompt,
   renderWarning,
 } from '@shopify/cli-kit/node/ui';
 
 import {commonFlags} from '../../lib/flags.js';
 import {getHydrogenShop} from '../../lib/shop.js';
 import {getStorefronts} from '../../lib/graphql/admin/link-storefront.js';
+import {createStorefront} from '../../lib/graphql/admin/create-storefront.js';
+import {waitForJob} from '../../lib/graphql/admin/fetch-job.js';
 import {getConfig, setStorefront} from '../../lib/shopify-config.js';
 import {logMissingStorefronts} from '../../lib/missing-storefronts.js';
+import {titleize} from '../../lib/string.js';
 import {getCliCommand} from '../../lib/shell.js';
+import {renderError, renderUserErrors} from '../../lib/user-errors.js';
 
 export default class Link extends Command {
   static description =
@@ -42,6 +50,14 @@ export interface LinkStorefrontArguments {
   silent?: boolean;
 }
 
+interface HydrogenStorefront {
+  id: string;
+  title: string;
+  productionUrl: string;
+}
+
+const CREATE_NEW_STOREFRONT_ID = 'NEW_STOREFRONT';
+
 export async function linkStorefront({
   force,
   path,
@@ -69,7 +85,8 @@ export async function linkStorefront({
     return;
   }
 
-  let selectedStorefront;
+  let selectedStorefront: HydrogenStorefront | undefined;
+  let selectCreateNewStorefront = false;
   const cliCommand = await getCliCommand();
 
   if (flagStorefront) {
@@ -100,18 +117,91 @@ export async function linkStorefront({
       label: `${title} (${productionUrl})`,
     }));
 
+    choices.unshift({
+      value: CREATE_NEW_STOREFRONT_ID,
+      label: 'Create a new storefront',
+    });
+
     const storefrontId = await renderSelectPrompt({
       message: 'Choose a Hydrogen storefront to link',
       choices,
     });
 
-    selectedStorefront = storefronts.find(({id}) => id === storefrontId);
+    if (storefrontId === CREATE_NEW_STOREFRONT_ID) {
+      selectCreateNewStorefront = true;
+    } else {
+      selectedStorefront = storefronts.find(({id}) => id === storefrontId);
+    }
   }
 
-  if (!selectedStorefront) {
-    return;
+  if (selectCreateNewStorefront) {
+    const storefront = await createNewStorefront(path, shop);
+
+    if (!storefront) {
+      return;
+    }
+
+    selectedStorefront = storefront;
   }
 
+  if (selectedStorefront) {
+    await linkExistingStorefront(path, selectedStorefront, silent, cliCommand);
+  }
+}
+
+async function createNewStorefront(
+  path: string | undefined,
+  shop: string,
+): Promise<HydrogenStorefront | undefined> {
+  const projectDirectory = path && basename(path);
+
+  const projectName = await renderTextPrompt({
+    message: 'What do you want to name the Hydrogen storefront on Shopify?',
+    defaultValue: titleize(projectDirectory) || 'Hydrogen Storefront',
+  });
+
+  let storefront: HydrogenStorefront | undefined;
+  let jobId: string | undefined;
+
+  await renderTasks([
+    {
+      title: 'Creating storefront',
+      task: async () => {
+        const result = await createStorefront(shop, projectName);
+
+        storefront = result.storefront;
+        jobId = result.jobId;
+
+        if (result.userErrors.length > 0) {
+          renderUserErrors(result.userErrors);
+        }
+      },
+    },
+    {
+      title: 'Creating API tokens',
+      task: async () => {
+        try {
+          await waitForJob(shop, jobId!);
+        } catch (_err) {
+          storefront = undefined;
+          renderError(
+            'Please try again or contact support if the error persists.',
+          );
+        }
+      },
+      skip: () => !jobId,
+    },
+  ]);
+
+  return storefront;
+}
+
+async function linkExistingStorefront(
+  path: string | undefined,
+  selectedStorefront: HydrogenStorefront,
+  silent: boolean,
+  cliCommand: string,
+) {
   await setStorefront(path ?? process.cwd(), selectedStorefront);
 
   if (!silent) {

--- a/packages/cli/src/lib/graphql/admin/create-storefront.ts
+++ b/packages/cli/src/lib/graphql/admin/create-storefront.ts
@@ -1,0 +1,54 @@
+import {adminRequest} from '../../graphql.js';
+import {getAdminSession} from '../../admin-session.js';
+import {type UserError} from '../../user-errors.js';
+
+export const CreateStorefrontMutation = `#graphql
+  mutation CreateStorefront($title: String!) {
+    hydrogenStorefrontCreate(title: $title) {
+      hydrogenStorefront {
+        id
+        title
+        productionUrl
+      }
+      userErrors {
+        code
+        field
+        message
+      }
+      jobId
+    }
+  }
+`;
+
+interface HydrogenStorefront {
+  id: string;
+  title: string;
+  productionUrl: string;
+}
+
+interface CreateStorefrontSchema {
+  hydrogenStorefrontCreate: {
+    hydrogenStorefront: HydrogenStorefront | undefined;
+    userErrors: UserError[];
+    jobId: string | undefined;
+  };
+}
+
+export async function createStorefront(shop: string, title: string) {
+  const adminSession = await getAdminSession(shop);
+
+  const {hydrogenStorefrontCreate} = await adminRequest<CreateStorefrontSchema>(
+    CreateStorefrontMutation,
+    adminSession,
+    {
+      title: title,
+    },
+  );
+
+  return {
+    adminSession,
+    storefront: hydrogenStorefrontCreate.hydrogenStorefront,
+    userErrors: hydrogenStorefrontCreate.userErrors,
+    jobId: hydrogenStorefrontCreate.jobId,
+  };
+}

--- a/packages/cli/src/lib/graphql/admin/fetch-job.ts
+++ b/packages/cli/src/lib/graphql/admin/fetch-job.ts
@@ -1,0 +1,65 @@
+import {adminRequest} from '../../graphql.js';
+import {getAdminSession} from '../../admin-session.js';
+
+export const FetchJobQuery = `#graphql
+  query FetchJob($id: ID!) {
+    hydrogenStorefrontJob(id: $id) {
+      id
+      done
+      errors {
+        code
+        message
+      }
+    }
+  }
+`;
+
+interface JobError {
+  code: string;
+  message: string | undefined;
+}
+
+export interface JobSchema {
+  hydrogenStorefrontJob: {
+    id: string;
+    done: boolean;
+    errors: JobError[];
+  };
+}
+
+export async function fetchJob(shop: string, jobId: string) {
+  const adminSession = await getAdminSession(shop);
+
+  const {hydrogenStorefrontJob} = await adminRequest<JobSchema>(
+    FetchJobQuery,
+    adminSession,
+    {
+      id: jobId,
+    },
+  );
+
+  return {
+    adminSession,
+    id: hydrogenStorefrontJob.id,
+    done: hydrogenStorefrontJob.done,
+    errors: hydrogenStorefrontJob.errors,
+  };
+}
+
+export function waitForJob(shop: string, jobId: string) {
+  return new Promise<void>((resolve, reject) => {
+    const interval = setInterval(async () => {
+      const job = await fetchJob(shop, jobId);
+
+      if (job.errors.length > 0) {
+        clearInterval(interval);
+        return reject();
+      }
+
+      if (job.done) {
+        clearInterval(interval);
+        return resolve();
+      }
+    }, 500);
+  });
+}

--- a/packages/cli/src/lib/string.test.ts
+++ b/packages/cli/src/lib/string.test.ts
@@ -1,0 +1,17 @@
+import {describe, it, expect} from 'vitest';
+import {titleize} from './string.js';
+
+describe('titleize', () => {
+  const TEST_DIRECTORY_NAMES = {
+    'demo-storefront': 'Demo Storefront',
+    'nifty 😂 project ': 'Nifty Project',
+    'Hello 😂': 'Hello',
+    _____: '',
+  };
+
+  it('replaces non-alpha-numeric characters with spaces and capitalizes the first letter of every word', () => {
+    for (const [input, expected] of Object.entries(TEST_DIRECTORY_NAMES)) {
+      expect(titleize(input)).toBe(expected);
+    }
+  });
+});

--- a/packages/cli/src/lib/string.ts
+++ b/packages/cli/src/lib/string.ts
@@ -1,0 +1,11 @@
+export function titleize(name: string = '') {
+  return name
+    .replace(/[\W_]+/g, ' ')
+    .split(' ')
+    .filter((word) => word.length > 0)
+    .map(
+      (word: string) =>
+        word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+    )
+    .join(' ');
+}

--- a/packages/cli/src/lib/user-errors.ts
+++ b/packages/cli/src/lib/user-errors.ts
@@ -1,0 +1,16 @@
+import {AbortError} from '@shopify/cli-kit/node/error';
+
+export interface UserError {
+  code: string | undefined;
+  field: string[];
+  message: string;
+}
+
+export function renderUserErrors(userErrors: UserError[]) {
+  const errorMessages = userErrors.map(({message}) => message).join(', ');
+  renderError(errorMessages);
+}
+
+export function renderError(message: string) {
+  throw new AbortError(message);
+}


### PR DESCRIPTION
### WHY are these changes introduced?

- Adds the ability to create a storefront on Admin by doing `h2 link`
  - The first choice when linking a storefront is to create a new storefront
- The default name chosen when creating a storefront is the local storefront's directory name
  - We titleize the directory name so it's more humanized. E.g. `demo-storefront` will become `Demo Storefront`. If the directory name can't be titleized, we default to `Hydrogen Storefront`


### WHAT is this pull request doing?

- Adding the ability to create a new storefront on Admin and link a local storefront to it
- Update the existing `h2 link` tests by splitting it up between linking existing storefront vs creating and linking a new storefront

### HOW to test your changes?

- You can run `h2 init` with a production copy of the `h2` command
- Checkout this PR branch and navigate to `packages/cli` and run
  - `npm i`
  - `npm run build`
- From the `packages/cli` directory, run `h2 link --path=/path/to/your/project`
  - You will be provided with the following new prompts

<img width="870" alt="image" src="https://github.com/Shopify/hydrogen/assets/2907059/379437d6-fa22-4079-94ea-35ea52909343">
<img width="870" alt="image" src="https://github.com/Shopify/hydrogen/assets/2907059/d4d844e1-8fea-409d-93b9-3cc38ac4000e">

When job to create API tokens fails (this can't be resolved by the user):
<img width="865" alt="image" src="https://github.com/Shopify/hydrogen/assets/2907059/8a92d71f-df9f-45fe-ad3d-139c8c3fc58f">


#### Post-merge steps


#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
