### PR TITLE
Output metafile.json on compile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10759,6 +10759,11 @@
         }
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
@@ -16693,7 +16698,6 @@
     },
     "node_modules/find-yarn-workspace-root": {
       "version": "2.0.0",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2"
@@ -19946,6 +19950,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "license": "MIT",
@@ -22410,21 +22422,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
     },
-    "node_modules/modern-node-polyfills/node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "peer": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -24862,6 +24859,167 @@
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^1.10.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+    },
+    "node_modules/patch-package/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/path-case": {
@@ -32729,7 +32887,8 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "5.0.0",
+      "version": "5.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/cli": "3.3.1",
@@ -32742,6 +32901,7 @@
         "fast-glob": "^3.2.12",
         "fs-extra": "^10.1.0",
         "gunzip-maybe": "^1.4.2",
+        "patch-package": "^6.4.7",
         "prettier": "^2.8.4",
         "recursive-readdir": "^2.2.3",
         "tar-fs": "^2.1.1",
@@ -32767,7 +32927,7 @@
       "peerDependencies": {
         "@remix-run/react": "^1.17.1",
         "@shopify/hydrogen-react": "^2023.4.4",
-        "@shopify/remix-oxygen": "^1.1.0"
+        "@shopify/remix-oxygen": "^1.1.1"
       }
     },
     "packages/cli/node_modules/@bugsnag/js": {
@@ -35472,7 +35632,7 @@
       "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
-        "@shopify/cli-hydrogen": "^5.0.0"
+        "@shopify/cli-hydrogen": "^5.0.1"
       },
       "bin": {
         "create-hydrogen": "dist/create-app.js"
@@ -35480,7 +35640,7 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2023.4.4",
+      "version": "2023.4.5",
       "license": "MIT",
       "dependencies": {
         "@shopify/hydrogen-react": "2023.4.4",
@@ -35805,7 +35965,7 @@
     },
     "packages/remix-oxygen": {
       "name": "@shopify/remix-oxygen",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@remix-run/server-runtime": "1.17.1"
@@ -35818,14 +35978,14 @@
       }
     },
     "templates/demo-store": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@headlessui/react": "^1.7.2",
         "@remix-run/react": "1.17.1",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^5.0.0",
-        "@shopify/hydrogen": "^2023.4.4",
-        "@shopify/remix-oxygen": "^1.1.0",
+        "@shopify/cli-hydrogen": "^5.0.1",
+        "@shopify/hydrogen": "^2023.4.5",
+        "@shopify/remix-oxygen": "^1.1.1",
         "clsx": "^1.2.1",
         "cross-env": "^7.0.3",
         "graphql": "^16.6.0",
@@ -35871,9 +36031,9 @@
       "dependencies": {
         "@remix-run/react": "1.17.1",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^5.0.0",
-        "@shopify/hydrogen": "^2023.4.4",
-        "@shopify/remix-oxygen": "^1.1.0",
+        "@shopify/cli-hydrogen": "^5.0.1",
+        "@shopify/hydrogen": "^2023.4.5",
+        "@shopify/remix-oxygen": "^1.1.1",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^3.6.6",
@@ -35901,9 +36061,9 @@
       "dependencies": {
         "@remix-run/react": "1.17.1",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^5.0.0",
-        "@shopify/hydrogen": "^2023.4.4",
-        "@shopify/remix-oxygen": "^1.1.0",
+        "@shopify/cli-hydrogen": "^5.0.1",
+        "@shopify/hydrogen": "^2023.4.5",
+        "@shopify/remix-oxygen": "^1.1.1",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^3.6.6",
@@ -40770,6 +40930,7 @@
         "fs-extra": "^10.1.0",
         "gunzip-maybe": "^1.4.2",
         "oclif": "2.1.4",
+        "patch-package": "^6.4.7",
         "prettier": "^2.8.4",
         "recursive-readdir": "^2.2.3",
         "tar-fs": "^2.1.1",
@@ -43279,7 +43440,7 @@
     "@shopify/create-hydrogen": {
       "version": "file:packages/create-hydrogen",
       "requires": {
-        "@shopify/cli-hydrogen": "^5.0.0"
+        "@shopify/cli-hydrogen": "^5.0.1"
       }
     },
     "@shopify/eslint-plugin": {
@@ -44897,6 +45058,11 @@
         "use-isomorphic-layout-effect": "^1.0.0",
         "use-sync-external-store": "^1.0.0"
       }
+    },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
     },
     "@zxing/text-encoding": {
       "version": "0.9.0",
@@ -47092,12 +47258,12 @@
         "@remix-run/eslint-config": "1.17.1",
         "@remix-run/react": "1.17.1",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^5.0.0",
+        "@shopify/cli-hydrogen": "^5.0.1",
         "@shopify/eslint-plugin": "^42.0.1",
-        "@shopify/hydrogen": "^2023.4.4",
+        "@shopify/hydrogen": "^2023.4.5",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.1.0",
+        "@shopify/remix-oxygen": "^1.1.1",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/typography": "^0.5.9",
         "@types/eslint": "^8.4.10",
@@ -48775,7 +48941,6 @@
     },
     "find-yarn-workspace-root": {
       "version": "2.0.0",
-      "dev": true,
       "requires": {
         "micromatch": "^4.0.2"
       }
@@ -49653,11 +49818,11 @@
         "@remix-run/dev": "1.17.1",
         "@remix-run/react": "1.17.1",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^5.0.0",
-        "@shopify/hydrogen": "^2023.4.4",
+        "@shopify/cli-hydrogen": "^5.0.1",
+        "@shopify/hydrogen": "^2023.4.5",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.1.0",
+        "@shopify/remix-oxygen": "^1.1.1",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.0.20",
         "@types/react-dom": "^18.0.6",
@@ -51539,6 +51704,14 @@
       "version": "6.0.3",
       "dev": true
     },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "kleur": {
       "version": "4.1.5"
     },
@@ -52995,15 +53168,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
           "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
-        },
-        "rollup": {
-          "version": "2.79.1",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-          "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-          "peer": true,
-          "requires": {
-            "fsevents": "~2.3.2"
-          }
         }
       }
     },
@@ -54733,6 +54897,123 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="
+    },
+    "patch-package": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "open": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+          "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+          "requires": {
+            "is-docker": "^2.0.0",
+            "is-wsl": "^2.1.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+        }
+      }
     },
     "path-case": {
       "version": "3.0.4",
@@ -56844,11 +57125,11 @@
         "@remix-run/dev": "1.17.1",
         "@remix-run/react": "1.17.1",
         "@shopify/cli": "3.45.0",
-        "@shopify/cli-hydrogen": "^5.0.0",
-        "@shopify/hydrogen": "^2023.4.4",
+        "@shopify/cli-hydrogen": "^5.0.1",
+        "@shopify/hydrogen": "^2023.4.5",
         "@shopify/oxygen-workers-types": "^3.17.2",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.1.0",
+        "@shopify/remix-oxygen": "^1.1.1",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.0.20",
         "@types/react-dom": "^18.0.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,8 @@
     "typecheck": "tsc --noEmit",
     "generate:manifest": "oclif manifest",
     "test": "cross-env SHOPIFY_UNIT_TEST=1 vitest run",
-    "test:watch": "cross-env SHOPIFY_UNIT_TEST=1 vitest"
+    "test:watch": "cross-env SHOPIFY_UNIT_TEST=1 vitest",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@types/diff": "^5.0.2",
@@ -45,7 +46,8 @@
     "prettier": "^2.8.4",
     "recursive-readdir": "^2.2.3",
     "tar-fs": "^2.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "patch-package": "^6.4.7"
   },
   "bin": "dist/create-app.js",
   "exports": {

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -7,7 +7,7 @@ import {
   outputContent,
   outputToken,
 } from '@shopify/cli-kit/node/output';
-import {fileSize, copyFile, rmdir} from '@shopify/cli-kit/node/fs';
+import {fileSize, copyFile, rmdir, writeFile} from '@shopify/cli-kit/node/fs';
 import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager';
 import colors from '@shopify/cli-kit/node/colors';
 import {
@@ -75,7 +75,7 @@ export async function runBuild({
       rmdir(buildPath, {force: true}),
     ]);
 
-  await Promise.all([
+  const [, result] = await Promise.all([
     copyPublicFiles(publicPath, buildPathClient),
     build({
       config: remixConfig,
@@ -90,6 +90,20 @@ export async function runBuild({
       process.exit(1);
     }),
   ]);
+
+  console.log(result);
+
+  await writeFile(
+    path.resolve(process.cwd(), 'dist/client/build/metafile.json'),
+    // @ts-expect-error
+    JSON.stringify(result.metafile.client, null, 2),
+  );
+
+  await writeFile(
+    path.resolve(process.cwd(), 'dist/worker/metafile.json'),
+    // @ts-expect-error
+    JSON.stringify(result.metafile.server, null, 2),
+  );
 
   if (process.env.NODE_ENV !== 'development') {
     console.timeEnd(LOG_WORKER_BUILT);

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -91,8 +91,6 @@ export async function runBuild({
     }),
   ]);
 
-  console.log(result);
-
   await writeFile(
     path.resolve(process.cwd(), 'dist/client/build/metafile.json'),
     // @ts-expect-error

--- a/patches/@remix-run+dev+1.17.1.patch
+++ b/patches/@remix-run+dev+1.17.1.patch
@@ -1,0 +1,54 @@
+diff --git a/node_modules/@remix-run/dev/dist/compiler/build.js b/node_modules/@remix-run/dev/dist/compiler/build.js
+index c1c7c91..0271a96 100644
+--- a/node_modules/@remix-run/dev/dist/compiler/build.js
++++ b/node_modules/@remix-run/dev/dist/compiler/build.js
+@@ -16,7 +16,7 @@ var compiler = require('./compiler.js');
+ 
+ async function build(ctx) {
+   let compiler$1 = await compiler.create(ctx);
+-  await compiler$1.compile();
++  return await compiler$1.compile();
+ }
+ 
+ exports.build = build;
+diff --git a/node_modules/@remix-run/dev/dist/compiler/compiler.js b/node_modules/@remix-run/dev/dist/compiler/compiler.js
+index 8d0b3e4..eed30cd 100644
+--- a/node_modules/@remix-run/dev/dist/compiler/compiler.js
++++ b/node_modules/@remix-run/dev/dist/compiler/compiler.js
+@@ -128,9 +128,9 @@ let create = async ctx => {
+     let server = await tasks.server;
+     if (!server.ok) throw error ?? server.error;
+     // artifacts/server
+-    writes.server = write.write(ctx.config, server.value);
++    writes.server = write.write(ctx.config, server.value.outputFiles);
+     await Promise.all(Object.values(writes));
+-    return manifest$1;
++    return {manifest: manifest$1, metafile: {client: metafile, server: server.value.metafile}};
+   };
+   return {
+     compile,
+diff --git a/node_modules/@remix-run/dev/dist/compiler/server/compiler.js b/node_modules/@remix-run/dev/dist/compiler/server/compiler.js
+index ad30727..5cb31e4 100644
+--- a/node_modules/@remix-run/dev/dist/compiler/server/compiler.js
++++ b/node_modules/@remix-run/dev/dist/compiler/server/compiler.js
+@@ -83,6 +83,7 @@ const createEsbuildConfig = (ctx, refs) => {
+     platform: ctx.config.serverPlatform,
+     format: ctx.config.serverModuleFormat,
+     treeShaking: true,
++    metafile: true,
+     // The type of dead code elimination we want to do depends on the
+     // minify syntax property: https://github.com/evanw/esbuild/issues/672#issuecomment-1029682369
+     // Dev builds are leaving code that should be optimized away in the
+@@ -127,9 +128,10 @@ const create = async (ctx, refs) => {
+   });
+   let compile = async () => {
+     let {
+-      outputFiles
++      outputFiles,
++      metafile
+     } = await compiler.rebuild();
+-    return outputFiles;
++    return {outputFiles, metafile};
+   };
+   return {
+     compile,


### PR DESCRIPTION
This change modifies the Remix build to output a `metafile.json` which can then be used at https://esbuild.github.io/analyze/ to visualize what's in the worker and client bundle. This is important because Cloudflare and Oxygen have a maximum bundle size, and it's easy to inflate the bundle with a random third party dependency.

You can test this by running `npm install && npx patch-package` at the root. Then when you run `npm run build` in any of the templates, an output `metafile.json` should be generated.

**Note: this introduces a patch on top of Remix!** This is because we have no way of configuring the Remix build output to include the esbuild `metafile: true` configuration option. Also the build results have to be returned as well. Should we patch on Remix? Already we are using Remix internals, which is brittle and ties us to specific minor Remix versions. Ideally we would get away from using Remix internals entirely, but maybe patching is better because there can be a patch defined for each Remix version? Though that is a pain to maintain.

Demonstration video: https://screenshot.click/20-40-4y2px-f4ck3.mp4

Bundle analysis for the Demo Store:

![image](https://github.com/Shopify/hydrogen/assets/1566869/97363bd2-e6ed-4c63-830f-7e28b8984e3b)
