### PR TITLE
Add initial build to MiniOxygen banner

### DIFF
--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import {outputInfo} from '@shopify/cli-kit/node/output';
 import {fileExists} from '@shopify/cli-kit/node/fs';
 import {renderFatalError} from '@shopify/cli-kit/node/ui';
+import colors from '@shopify/cli-kit/node/colors';
 import {copyPublicFiles} from './build.js';
 import {
   getProjectPaths,
@@ -153,6 +154,11 @@ async function runDev({
         initialBuildDurationMs > 0
           ? `Initial build: ${initialBuildDurationMs}ms\n`
           : '',
+      extraLines: [
+        colors.dim(
+          `\nView GraphiQL API browser: ${miniOxygen.listeningAt}/graphiql`,
+        ),
+      ],
     });
 
     const showUpgrade = await checkingHydrogenVersion;

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -40,5 +40,5 @@ export async function runPreview({
     buildPathWorkerFile,
   });
 
-  miniOxygen.showBanner();
+  miniOxygen.showBanner({mode: 'preview'});
 }

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -33,10 +33,12 @@ export async function runPreview({
 
   const {root, buildPathWorkerFile, buildPathClient} = getProjectPaths(appPath);
 
-  await startMiniOxygen({
+  const miniOxygen = await startMiniOxygen({
     root,
     port,
     buildPathClient,
     buildPathWorkerFile,
   });
+
+  miniOxygen.showBanner();
 }

--- a/packages/cli/src/lib/mini-oxygen.ts
+++ b/packages/cli/src/lib/mini-oxygen.ts
@@ -62,15 +62,22 @@ export async function startMiniOxygen({
   });
 
   const listeningAt = `http://localhost:${actualPort}`;
-  const graphiqlUrl = `${listeningAt}/graphiql`;
 
-  renderSuccess({
-    headline: 'MiniOxygen development server running.',
-    body: [
-      `View Hydrogen app: ${listeningAt}`,
-      colors.dim(`\nView GraphiQL API browser: ${graphiqlUrl}`),
-    ],
-  });
+  return {
+    listeningAt,
+    port: actualPort,
+    showBanner(options?: {headlinePrefix?: string}) {
+      renderSuccess({
+        headline: `${
+          options?.headlinePrefix ?? ''
+        }MiniOxygen development server running.`,
+        body: [
+          `View Hydrogen app: ${listeningAt}`,
+          colors.dim(`\nView GraphiQL API browser: ${listeningAt}/graphiql`),
+        ],
+      });
+    },
+  };
 }
 
 export function logResponse(request: Request, response: Response) {

--- a/packages/cli/src/lib/mini-oxygen.ts
+++ b/packages/cli/src/lib/mini-oxygen.ts
@@ -66,14 +66,18 @@ export async function startMiniOxygen({
   return {
     listeningAt,
     port: actualPort,
-    showBanner(options?: {headlinePrefix?: string}) {
+    showBanner(options?: {
+      mode?: string;
+      headlinePrefix?: string;
+      extraLines?: string[];
+    }) {
       renderSuccess({
-        headline: `${
-          options?.headlinePrefix ?? ''
-        }MiniOxygen development server running.`,
+        headline: `${options?.headlinePrefix ?? ''}MiniOxygen ${
+          options?.mode ?? 'development'
+        } server running.`,
         body: [
           `View Hydrogen app: ${listeningAt}`,
-          colors.dim(`\nView GraphiQL API browser: ${listeningAt}/graphiql`),
+          ...(options?.extraLines ?? []),
         ],
       });
     },


### PR DESCRIPTION
Move the "initial build" line inside the new success banner.
This also removes the GraphiQL link when running MiniOxygen in preview mode because it doesn't work there.

<img width="653" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/4c8e99f2-41d3-4aa3-88a6-f68b3cc65e35">
