### PR TITLE
Use `shop.primaryDomain` to mark internal links in demo store

### DIFF
--- a/templates/demo-store/app/lib/utils.ts
+++ b/templates/demo-store/app/lib/utils.ts
@@ -145,7 +145,7 @@ function resolveToFromType(
 /*
   Parse each menu link and adding, isExternal, to and target
 */
-function parseItem(customPrefixes = {}) {
+function parseItem(primaryDomain: string, customPrefixes = {}) {
   return function (
     item:
       | MenuFragment['items'][number]
@@ -161,13 +161,9 @@ function parseItem(customPrefixes = {}) {
     }
 
     // extract path from url because we don't need the origin on internal to attributes
-    const {pathname} = new URL(item.url);
+    const {host, pathname} = new URL(item.url);
 
-    /*
-      Currently the MenuAPI only returns online store urls e.g — xyz.myshopify.com/..
-      Note: update logic when API is updated to include the active qualified domain
-    */
-    const isInternalLink = /\.myshopify\.com/g.test(item.url);
+    const isInternalLink = host === new URL(primaryDomain).host;
 
     const parsedItem = isInternalLink
       ? // internal links
@@ -188,7 +184,7 @@ function parseItem(customPrefixes = {}) {
     if ('items' in item) {
       return {
         ...parsedItem,
-        items: item.items.map(parseItem(customPrefixes)).filter(Boolean),
+        items: item.items.map(parseItem(primaryDomain, customPrefixes)).filter(Boolean),
       } as EnhancedMenu['items'][number];
     } else {
       return parsedItem as EnhancedMenu['items'][number]['items'][number];
@@ -203,6 +199,7 @@ function parseItem(customPrefixes = {}) {
 */
 export function parseMenu(
   menu: MenuFragment,
+  primaryDomain: string,
   customPrefixes = {},
 ): EnhancedMenu | null {
   if (!menu?.items) {
@@ -211,7 +208,7 @@ export function parseMenu(
     return null;
   }
 
-  const parser = parseItem(customPrefixes);
+  const parser = parseItem(primaryDomain, customPrefixes);
 
   const parsedMenu = {
     ...menu,

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -222,11 +222,11 @@ async function getLayoutData({storefront}: AppLoadContext) {
   const customPrefixes = {BLOG: '', CATALOG: 'products'};
 
   const headerMenu = data?.headerMenu
-    ? parseMenu(data.headerMenu, customPrefixes)
+    ? parseMenu(data.headerMenu, data.shop.primaryDomain.url, customPrefixes)
     : undefined;
 
   const footerMenu = data?.footerMenu
-    ? parseMenu(data.footerMenu, customPrefixes)
+    ? parseMenu(data.footerMenu, data.shop.primaryDomain.url, customPrefixes)
     : undefined;
 
   return {shop: data.shop, headerMenu, footerMenu};


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fixes #1035 

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

Checking if the nav item url host matches the `shop.primaryDomain`'s host, and marks the nav item as internal if so. Previously it was a simple regex.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

Spin up the demo store and see that the nav links are indeed internal.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
