### PR TITLE
feat(hydrogen-react): include `applicable` in discountCode in default…

### DIFF
--- a/.changeset/tidy-points-compete.md
+++ b/.changeset/tidy-points-compete.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Add discountCode.applicable in default Cart fragment

--- a/packages/hydrogen-react/src/cart-queries.ts
+++ b/packages/hydrogen-react/src/cart-queries.ts
@@ -239,6 +239,7 @@ export const defaultCartFragment = /* GraphQL */ `
     }
     discountCodes {
       code
+      applicable
     }
   }
 


### PR DESCRIPTION
…CartFragment

The `useCart` hook from hydrogen-react uses the defaultCartFragment if not specified otherwise.

Developers, when using discountCodes, often want to know is the code is valid.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
