### PR TITLE
Fix broken link in cli-hydrogen readme

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @shopify/cli-hydrogen
 
-The Hydrogen extension for the [Shopify CLI](https://shopify.dev/apps/tools/cli). Hydrogen is a set of tools, utilities, and best-in-class examples for building a commerce application with [Remix](https://wwww.remix.run).
+The Hydrogen extension for the [Shopify CLI](https://shopify.dev/apps/tools/cli). Hydrogen is a set of tools, utilities, and best-in-class examples for building a commerce application with [Remix](https://remix.run).
 
 [Check out the docs](https://shopify.dev/custom-storefronts/hydrogen)
 


### PR DESCRIPTION
Fixes broken link in `@shopify/cli-hydrogen` readme.