### PR TITLE
Don't display errors when no storefronts exist

### DIFF
--- a/.changeset/seven-lobsters-allow.md
+++ b/.changeset/seven-lobsters-allow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix `link` command when no storefronts exist in Admin

--- a/packages/cli/src/commands/hydrogen/link.test.ts
+++ b/packages/cli/src/commands/hydrogen/link.test.ts
@@ -190,19 +190,6 @@ describe('link', () => {
     });
   });
 
-  describe('when there are no Hydrogen storefronts', () => {
-    it('renders a message and returns early', async () => {
-      vi.mocked(getStorefronts).mockResolvedValue([]);
-
-      await runLink({});
-
-      expect(outputMock.info()).toMatch(/no Hydrogen storefronts/i);
-
-      expect(renderSelectPrompt).not.toHaveBeenCalled();
-      expect(setStorefront).not.toHaveBeenCalled();
-    });
-  });
-
   describe('when a linked storefront already exists', () => {
     beforeEach(() => {
       vi.mocked(login).mockResolvedValue({

--- a/packages/cli/src/commands/hydrogen/link.ts
+++ b/packages/cli/src/commands/hydrogen/link.ts
@@ -110,11 +110,6 @@ export async function linkStorefront(
 
   const storefronts = await getStorefronts(session);
 
-  if (storefronts.length === 0) {
-    logMissingStorefronts(session);
-    return;
-  }
-
   let selectedStorefront: HydrogenStorefront | undefined;
 
   if (flagStorefront) {


### PR DESCRIPTION
### Summary
- Remove error message when no hydrogen storefronts exist on Admin
  - Since we allow people to create a storefront on Admin from the CLI, we no longer need to throw an error when no storefronts exist on Admin

### Testing
#### Before
<img width="892" alt="image" src="https://github.com/Shopify/hydrogen/assets/2907059/44d32896-78a7-4690-b84a-386a1f359df3">

#### Now
<img width="892" alt="image" src="https://github.com/Shopify/hydrogen/assets/2907059/87e3380a-47f6-44a2-8064-97a8a4d66f21">



#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation