### PR TITLE
Fix create-hydrogen dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
     "test": "turbo run test --parallel",
     "test:watch": "turbo run test:watch",
     "version": "changeset version && npm run version:post",
-    "version:post": "npm run version:hydrogen && npm run version:cli && npm run version:create-hydrogen",
+    "version:post": "npm run version:hydrogen && npm run version:cli",
     "version:hydrogen": "node -p \"'export const LIB_VERSION = \\'' + require('./packages/hydrogen/package.json').version + '\\';'\" > packages/hydrogen/src/version.ts",
     "version:cli": "cd packages/cli && npm run generate:manifest",
-    "version:create-hydrogen": "cd packages/create-hydrogen && npm run build",
     "changeset": "changeset",
     "clean-all": "rimraf node_modules/.bin && rimraf node_modules/.cache && rimraf packages/*/dist && rimraf templates/*/.cache"
   },

--- a/packages/create-hydrogen/tsup.config.ts
+++ b/packages/create-hydrogen/tsup.config.ts
@@ -1,6 +1,4 @@
 import {defineConfig} from 'tsup';
-import {createRequire} from 'module';
-import fs from 'fs/promises';
 
 export default defineConfig({
   entry: ['src/**/*.ts'],
@@ -12,18 +10,4 @@ export default defineConfig({
   treeshake: true,
   sourcemap: false,
   dts: false,
-  async onSuccess() {
-    const require = createRequire(import.meta.url);
-    const {version} = require('@shopify/cli-hydrogen/package.json');
-
-    const content = await fs.readFile('./package.json', 'utf-8');
-    await fs.writeFile(
-      './package.json',
-      content.replace(
-        /"(@shopify\/cli-hydrogen)":\s+".*"/gm,
-        `"$1": "^${version}"`,
-      ),
-      'utf-8',
-    );
-  },
 });


### PR DESCRIPTION
This code was overwriting the dependency version added by Changesets, and possibly breaking the `next` release.

Expected result:

```diff
-"@shopify/cli-hydrogen": "^0.0.0-next-<hash>"
+"@shopify/cli-hydrogen": "0.0.0-next-<hash>"
```