### PR TITLE
Handle hydrogen app installation error on CLI

### DIFF
--- a/.changeset/eight-scissors-cheer.md
+++ b/.changeset/eight-scissors-cheer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Show proper error message when Hydrogen App isn't installed on Shop

--- a/packages/cli/src/lib/graphql/admin/client.test.ts
+++ b/packages/cli/src/lib/graphql/admin/client.test.ts
@@ -1,0 +1,72 @@
+import {AbortError} from '@shopify/cli-kit/node/error';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+
+import {adminRequest} from './client.js';
+
+import {
+  graphqlRequest,
+  type GraphQLVariables,
+} from '@shopify/cli-kit/node/api/graphql';
+
+vi.mock('@shopify/cli-kit/node/api/graphql');
+
+interface TestSchema {
+  test: string;
+}
+
+describe('adminRequest', () => {
+  it('sends a query to the Admin API and returns the successful response', async () => {
+    const fakeResponse = {
+      test: 'test',
+    };
+
+    vi.mocked(graphqlRequest).mockResolvedValue(fakeResponse);
+
+    const response = await adminRequest<TestSchema>('', {
+      token: '',
+      storeFqdn: '',
+    });
+
+    expect(response).toContain(fakeResponse);
+  });
+
+  describe('error response', () => {
+    it('sends a query to the Admin API and returns an unknown error response', async () => {
+      const fakeGraphqlError = {
+        errors: [
+          {
+            message: 'test error',
+          },
+        ],
+      };
+
+      vi.mocked(graphqlRequest).mockRejectedValue(fakeGraphqlError);
+
+      const response = adminRequest<TestSchema>('', {
+        token: '',
+        storeFqdn: '',
+      });
+
+      await expect(response).rejects.toContain(fakeGraphqlError);
+    });
+
+    it("sends a query to the Admin API and returns an error where app isn't installed", async () => {
+      const fakeGraphqlError = {
+        errors: [
+          {
+            message: 'app is not installed',
+          },
+        ],
+      };
+
+      vi.mocked(graphqlRequest).mockRejectedValue(fakeGraphqlError);
+
+      const response = adminRequest<TestSchema>('', {
+        token: '',
+        storeFqdn: '',
+      });
+
+      await expect(response).rejects.toThrowError(AbortError);
+    });
+  });
+});

--- a/packages/cli/src/lib/missing-storefronts.ts
+++ b/packages/cli/src/lib/missing-storefronts.ts
@@ -9,7 +9,6 @@ export function logMissingStorefronts(adminSession: AdminSession) {
     body: 'There are no Hydrogen storefronts on your Shop.',
     nextSteps: [
       `Ensure you have specified the correct shop (you specified: ${adminSession.storeFqdn})`,
-      `Ensure you have the Hydrogen sales channel installed https://apps.shopify.com/hydrogen`,
       `Create a new Hydrogen storefront: ${newHydrogenStorefrontUrl(
         adminSession,
       )}`,


### PR DESCRIPTION
### WHY are these changes introduced?

- Modify the Admin client to show a proper error message when the Hydrogen Channel App isn't installed

### WHAT is this pull request doing?

When Hydrogen Channel app isn't installed on Admin, we can't do the following commands:
- `h2 link`
- `h2 list`
- `h2 init` (when "Link you Shopify account" is selected)

Instead of throwing an error when this happens, we show a proper error message with an action item.

#### Before
<img width="574" alt="image" src="https://github.com/Shopify/hydrogen/assets/2907059/7016581d-7e2a-4a5d-816e-ce47c234c9ad">

#### After
<img width="580" alt="image" src="https://github.com/Shopify/hydrogen/assets/2907059/b5045da0-4287-45b6-ab4c-b6116d62ec39">

### HOW to test your changes?

- checkout the branch
- `npm i`
- `cd packages/cli`
- `npm i && npm run build`
- `h2 init` or `h2 list` or `h2 link`

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
