### PR TITLE
Improve error checking on recover page

### DIFF
--- a/templates/demo-store/app/routes/($locale).account.recover.tsx
+++ b/templates/demo-store/app/routes/($locale).account.recover.tsx
@@ -47,8 +47,7 @@ export const action: ActionFunction = async ({request, context}) => {
     return json({resetRequested: true});
   } catch (error: any) {
     return badRequest({
-      formError:
-        error.message ?? 'Something went wrong. Please try again later.',
+      formError: 'Something went wrong. Please try again later.',
     });
   }
 };


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes error handling for recover page

### WHAT is this pull request doing?

Shows error message from mutation error if fails

### HOW to test your changes?

- Visit [recover page](http://localhost:3000/account/recover) (Reference URL: https://hydrogen.shop/account/recover)
- Try submitting an email address which does not exists on store and submit the form
- Error message should be visible now in place of success message

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)