### PR TITLE
Skip upgrade banner when using `@next` version

### DIFF
--- a/.changeset/late-ghosts-glow.md
+++ b/.changeset/late-ghosts-glow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Do not show the version upgrade banner when using `@next` version.

--- a/packages/cli/src/lib/check-version.ts
+++ b/packages/cli/src/lib/check-version.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import {createRequire} from 'module';
+import path from 'node:path';
+import {createRequire} from 'node:module';
 import {checkForNewVersion} from '@shopify/cli-kit/node/node-package-manager';
 import {renderInfo} from '@shopify/cli-kit/node/ui';
 
@@ -34,7 +34,7 @@ export async function checkHydrogenVersion(
 
   const currentVersion = require(pkgJsonPath).version as string;
 
-  if (!currentVersion) return;
+  if (!currentVersion || currentVersion.includes('next')) return;
 
   const newVersionAvailable = await checkForNewVersion(pkgName, currentVersion);
 


### PR DESCRIPTION
`@next` versions follow a pattern like `0.0.0-next...` so it was always showing the upgrade version.