### PR TITLE
fix(demo-store): default variant for variant selector

### DIFF
--- a/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
@@ -14,6 +14,7 @@ import {
 } from '@shopify/hydrogen';
 import invariant from 'tiny-invariant';
 import clsx from 'clsx';
+import type {SelectedOptionInput} from '@shopify/hydrogen/storefront-api-types';
 
 import type {ProductVariantFragmentFragment} from 'storefrontapi.generated';
 import {
@@ -186,8 +187,11 @@ export function ProductForm({
   variants: ProductVariantFragmentFragment[];
 }) {
   const {product, analytics, storeDomain} = useLoaderData<typeof loader>();
-  const firstVariant =
-    getFirstAvailableVariant(variants) ?? product.variants.nodes[0];
+  const productVariants = variants ? variants : product.variants.nodes;
+
+  const firstVariant = product.selectedVariant
+    ? product.selectedVariant
+    : getFirstAvailableVariant(productVariants);
 
   const closeRef = useRef<HTMLButtonElement>(null);
 


### PR DESCRIPTION
### WHY are these changes introduced?

When using the new variant selector, it does not work correctly for (multi) variants like: https://hydrogen.shop/products/snowboard

### WHAT is this pull request doing?

- I fixed the demo store to retrieve the correct `variants` variable from the promise.
- In the variant selector, I used the new hook `useVariantUrl` to retrieve the product URL of the variant, then I use`navigate()` to update the current URL.

### HOW to test your changes?

**Reproduction of the bug:**

1. Go to the multi-variant product like: https://hydrogen.shop/products/snowboard on the existing demo website.
2. Here, you will see that it displays the wrong variant, which is out of stock

**Verify the fix:**

1. Checkout this branch and run it on your local machine by using `npm dev`.
2. Go to the same product: http://localhost:3000/products/snowboard.
3. You will notice that the URL updates automatically to the correct variant.
4. The buy button is available, and you can also change the material or anything else, while keeping the other properties in check.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
