### PR TITLE
Show `createStorefrontClient` warnings only once

### DIFF
--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -158,15 +158,15 @@ async function runDev({
       extraLines: [colors.dim(`\nView GraphiQL API browser: ${graphiqlUrl}`)],
     });
 
+    if (useCodegen) {
+      spawnCodegenProcess({...remixConfig, configFilePath: codegenConfigPath});
+    }
+
     const showUpgrade = await checkingHydrogenVersion;
     if (showUpgrade) showUpgrade();
   }
 
   const remixConfig = await reloadConfig();
-
-  if (useCodegen) {
-    spawnCodegenProcess({...remixConfig, configFilePath: codegenConfigPath});
-  }
 
   const fileWatchCache = createFileWatchCache();
   let skipRebuildLogs = false;

--- a/packages/cli/src/lib/log.ts
+++ b/packages/cli/src/lib/log.ts
@@ -39,7 +39,7 @@ const printedMessages = new Set<string | Object>();
  * Certain messages like errors might be printed multiple times.
  * This ensures they are only printed once per second.
  */
-function debounceMessage(args: unknown[]) {
+function debounceMessage(args: unknown[], debounceFor?: true | number) {
   const key = args
     .map((item) => {
       const message = (item as Error)?.message ?? (item as string);
@@ -51,16 +51,21 @@ function debounceMessage(args: unknown[]) {
   if (printedMessages.has(key)) return true;
 
   printedMessages.add(key);
-  setTimeout(() => printedMessages.delete(key), 1000);
+  if (debounceFor !== true) {
+    setTimeout(() => printedMessages.delete(key), debounceFor ?? 1000);
+  }
 
   return false;
 }
 
-function injectLogReplacer(method: ConsoleMethod) {
+function injectLogReplacer(
+  method: ConsoleMethod,
+  debouncer?: (args: unknown[]) => true | number | undefined,
+) {
   if (!methodsReplaced.has(method)) {
     methodsReplaced.add(method);
     console[method] = (...args: unknown[]) => {
-      if (debounceMessage(args)) return;
+      if (debounceMessage(args, debouncer?.(args))) return;
 
       const replacer = messageReplacers.find(([matcher]) => matcher(args))?.[1];
       if (!replacer) return originalConsole[method](...args);
@@ -177,8 +182,13 @@ export function enhanceH2Logs(options: {
   graphiqlUrl: string;
   appDirectory: string;
 }) {
-  injectLogReplacer('warn');
   injectLogReplacer('error');
+  injectLogReplacer('warn', ([first]) =>
+    // Show createStorefrontClient warnings only once.
+    (first as any)?.includes?.('[h2:warn:createStorefrontClient]')
+      ? true
+      : undefined,
+  );
 
   addMessageReplacers('h2-warn', [
     ([first]) => {

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -238,7 +238,6 @@ export function createStorefrontClient<TI18n extends I18nBase>(
     ...clientOptions
   } = options;
   const H2_PREFIX_WARN = '[h2:warn:createStorefrontClient] ';
-  const H2_PREFIX_ERROR = '[h2:error:createStorefrontClient] ';
 
   if (process.env.NODE_ENV === 'development' && !cache) {
     warnOnce(
@@ -388,7 +387,7 @@ export function createStorefrontClient<TI18n extends I18nBase>(
         query = minifyQuery(query);
         if (isMutationRE.test(query)) {
           throw new Error(
-            H2_PREFIX_ERROR + '`storefront.query` cannot execute mutations',
+            '[h2:error:storefront.query] Cannot execute mutations',
           );
         }
 
@@ -411,7 +410,7 @@ export function createStorefrontClient<TI18n extends I18nBase>(
         mutation = minifyQuery(mutation);
         if (isQueryRE.test(mutation)) {
           throw new Error(
-            H2_PREFIX_ERROR + '`storefront.mutate` cannot execute queries',
+            '[h2:error:storefront.mutate] Cannot execute queries',
           );
         }
 


### PR DESCRIPTION
The following warning banner was shown every time the app rebuilds because HR cannot keep state and know if the message has been already shown or not. However, the CLI can do this so we can show it only once.

<img width="551" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/9b4ce2c4-95c2-47d1-b001-02f185482eab">
