### PR TITLE
Fix undefined property error for SearchResult component in skeleton template

### DIFF
--- a/templates/skeleton/app/components/Search.tsx
+++ b/templates/skeleton/app/components/Search.tsx
@@ -116,14 +116,14 @@ export function SearchResults({
         keys.map((type) => {
           const resourceResults = results[type];
 
-          if (results[type].nodes[0].__typename === 'Page') {
+          if (resourceResults.nodes[0]?.__typename === 'Page') {
             const pageResults = resourceResults as SearchQuery['pages'];
             return resourceResults.nodes.length ? (
               <SearchResultPageGrid key="pages" pages={pageResults} />
             ) : null;
           }
 
-          if (results[type].nodes[0].__typename === 'Product') {
+          if (resourceResults.nodes[0]?.__typename === 'Product') {
             const productResults = resourceResults as SearchQuery['products'];
             return resourceResults.nodes.length ? (
               <SearchResultsProductsGrid
@@ -133,7 +133,7 @@ export function SearchResults({
             ) : null;
           }
 
-          if (results[type].nodes[0].__typename === 'Article') {
+          if (resourceResults.nodes[0]?.__typename === 'Article') {
             const articleResults = resourceResults as SearchQuery['articles'];
             return resourceResults.nodes.length ? (
               <SearchResultArticleGrid


### PR DESCRIPTION
If you search for something in the skeleton template that doesn't return any results for one of either products, articles or pages you will get a 500 error:

```
TypeError: Cannot read properties of undefined (reading '__typename')
    at /Users/chrishannaby/hydrogen-next/app/components/Search.tsx:120:38
    at Array.map (<anonymous>)
    at Component (/Users/chrishannaby/hydrogen-next/app/components/Search.tsx:117:14)
    at renderWithHooks (/Users/chrishannaby/hydrogen-next/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5658:16)
    at renderIndeterminateComponent (/Users/chrishannaby/hydrogen-next/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5731:15)
    at renderElement (/Users/chrishannaby/hydrogen-next/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5946:7)
    at renderNodeDestructiveImpl (/Users/chrishannaby/hydrogen-next/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6104:11)
    at renderNodeDestructive (/Users/chrishannaby/hydrogen-next/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6076:14)
    at renderNode (/Users/chrishannaby/hydrogen-next/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6259:12)
    at renderChildrenArray (/Users/chrishannaby/hydrogen-next/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6211:7)
   GET  500  render  /search?q=s 
```
<img width="628" alt="Screenshot 2023-07-21 at 11 26 44 AM" src="https://github.com/Shopify/hydrogen/assets/9747201/939bcda8-63b7-4ad6-9371-73165ceb2185">

This change fixes this issue

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
