### PR TITLE
Fix file copy filter

### DIFF
--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -84,12 +84,16 @@ export async function setupLocalStarterTemplate(
       })
       .catch(abort);
 
+  const templateDir = getStarterDir();
   let backgroundWorkPromise: Promise<any> = copyWithFilter(
-    getStarterDir(),
+    templateDir,
     project.directory,
     // Filter out the `app` directory, which will be generated later
     {
-      filter: (filepath: string) => !/\/(app|node_modules)\//i.test(filepath),
+      filter: (filepath: string) =>
+        !/^(app|dist|node_modules)\//i.test(
+          relativePath(templateDir, filepath),
+        ),
     },
   )
     .then(() =>

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -89,8 +89,7 @@ export async function setupLocalStarterTemplate(
     project.directory,
     // Filter out the `app` directory, which will be generated later
     {
-      filter: (filepath: string) =>
-        !/\/(app|dist|node_modules)\//i.test(filepath),
+      filter: (filepath: string) => !/\/(app|node_modules)\//i.test(filepath),
     },
   )
     .then(() =>

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -2,7 +2,7 @@ import {copy as copyWithFilter} from 'fs-extra/esm';
 import {AbortError} from '@shopify/cli-kit/node/error';
 import {AbortController} from '@shopify/cli-kit/node/abort';
 import {writeFile} from '@shopify/cli-kit/node/fs';
-import {joinPath} from '@shopify/cli-kit/node/path';
+import {joinPath, relativePath} from '@shopify/cli-kit/node/path';
 import {hyphenate} from '@shopify/cli-kit/common/string';
 import colors from '@shopify/cli-kit/node/colors';
 import {


### PR DESCRIPTION
The absolute path used in the filter could contain `dist` or `node_modules` before the template directory. Using a relative path should fix the issue.