### PR TITLE
✨ Improve parseGid with more parts

### DIFF
--- a/.changeset/brave-crabs-pump.md
+++ b/.changeset/brave-crabs-pump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': major
+---
+
+This change updates the implementation of the parseGid function so that it uses the builtin `URL` class to parse the gid. This enables the parts of the string, such as the search params, to be parsed as well

--- a/.changeset/brave-crabs-pump.md
+++ b/.changeset/brave-crabs-pump.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/hydrogen-react': major
+'@shopify/hydrogen-react': patch
 ---
 
 This change updates the implementation of the parseGid function so that it uses the builtin `URL` class to parse the gid. This enables the parts of the string, such as the search params, to be parsed as well

--- a/packages/hydrogen-react/src/analytics-types.ts
+++ b/packages/hydrogen-react/src/analytics-types.ts
@@ -177,7 +177,7 @@ export type ShopifyCookies = {
   [SHOPIFY_S]: string;
 };
 
-export type ShopifyGid = {
+export type ShopifyGid = Pick<URL, 'search' | 'searchParams' | 'hash'> & {
   id: string;
   resource: string | null;
 };

--- a/packages/hydrogen-react/src/analytics-types.ts
+++ b/packages/hydrogen-react/src/analytics-types.ts
@@ -180,4 +180,5 @@ export type ShopifyCookies = {
 export type ShopifyGid = Pick<URL, 'search' | 'searchParams' | 'hash'> & {
   id: string;
   resource: string | null;
+  resourceId: string | null;
 };

--- a/packages/hydrogen-react/src/analytics-utils.test.ts
+++ b/packages/hydrogen-react/src/analytics-utils.test.ts
@@ -5,41 +5,35 @@ describe('analytic-utils', () => {
   describe('parseGid', () => {
     it('returns the id and resource type from a gid', () => {
       const {searchParams, ...gid} = parseGid('gid://shopify/Order/123');
-      expect(gid).toMatchInlineSnapshot(`
-        {
-          "hash": "",
-          "id": "123",
-          "resource": "Order",
-          "search": "",
-        }
-      `);
+      expect(gid).toStrictEqual({
+        hash: '',
+        id: '123',
+        resource: 'Order',
+        search: '',
+      });
       expect(searchParams.toString()).toBe('');
     });
 
     it('returns empty string if the gid is not a string', () => {
       //@ts-expect-error - testing invalid input
       const {searchParams, ...gid} = parseGid(123);
-      expect(gid).toMatchInlineSnapshot(`
-        {
-          "hash": "",
-          "id": "",
-          "resource": null,
-          "search": "",
-        }
-      `);
+      expect(gid).toStrictEqual({
+        hash: '',
+        id: '',
+        resource: null,
+        search: '',
+      });
       expect(searchParams.toString()).toBe('');
     });
 
     it('returns empty string if the gid is not a valid gid', () => {
       const {searchParams, ...gid} = parseGid('gid://shopify/Order');
-      expect(gid).toMatchInlineSnapshot(`
-        {
-          "hash": "",
-          "id": "Order",
-          "resource": "",
-          "search": "",
-        }
-      `);
+      expect(gid).toStrictEqual({
+        hash: '',
+        id: '',
+        resource: null,
+        search: '',
+      });
       expect(searchParams.toString()).toBe('');
     });
 
@@ -47,14 +41,12 @@ describe('analytic-utils', () => {
       const {searchParams, ...gid} = parseGid(
         'gid://shopify/Order/123?namespace=123',
       );
-      expect(gid).toMatchInlineSnapshot(`
-        {
-          "hash": "",
-          "id": "123",
-          "resource": "Order",
-          "search": "?namespace=123",
-        }
-      `);
+      expect(gid).toStrictEqual({
+        hash: '',
+        id: '123',
+        resource: 'Order',
+        search: '?namespace=123',
+      });
       expect(searchParams.toString()).toBe('namespace=123');
     });
 
@@ -62,27 +54,23 @@ describe('analytic-utils', () => {
       const {searchParams, ...gid} = parseGid(
         'gid://shopify/Order/123?namespace=123#fragment',
       );
-      expect(gid).toMatchInlineSnapshot(`
-        {
-          "hash": "#fragment",
-          "id": "123",
-          "resource": "Order",
-          "search": "?namespace=123",
-        }
-      `);
+      expect(gid).toStrictEqual({
+        hash: '#fragment',
+        id: '123',
+        resource: 'Order',
+        search: '?namespace=123',
+      });
       expect(searchParams.toString()).toBe('namespace=123');
     });
 
     it('returns empty string if the resource is missing', () => {
       const {searchParams, ...gid} = parseGid('gid://shopify//123');
-      expect(gid).toMatchInlineSnapshot(`
-        {
-          "hash": "",
-          "id": "123",
-          "resource": "",
-          "search": "",
-        }
-      `);
+      expect(gid).toStrictEqual({
+        hash: '',
+        id: '',
+        resource: null,
+        search: '',
+      });
       expect(searchParams.toString()).toBe('');
     });
 
@@ -90,15 +78,24 @@ describe('analytic-utils', () => {
       const {searchParams, ...gid} = parseGid(
         'gid://shopify/Cart/c1-3d2419bf79df5e91d37b449cc6cd0ba1?test=123',
       );
-      expect(gid).toMatchInlineSnapshot(`
-        {
-          "hash": "",
-          "id": "c1-3d2419bf79df5e91d37b449cc6cd0ba1",
-          "resource": "Cart",
-          "search": "?test=123",
-        }
-      `);
+      expect(gid).toStrictEqual({
+        hash: '',
+        id: 'c1-3d2419bf79df5e91d37b449cc6cd0ba1',
+        resource: 'Cart',
+        search: '?test=123',
+      });
       expect(searchParams.toString()).toBe('test=123');
+    });
+
+    it('should default to empty string', () => {
+      const {searchParams, ...gid} = parseGid('');
+      expect(gid).toStrictEqual({
+        hash: '',
+        id: '',
+        resource: null,
+        search: '',
+      });
+      expect(searchParams.toString()).toBe('');
     });
   });
 

--- a/packages/hydrogen-react/src/analytics-utils.test.ts
+++ b/packages/hydrogen-react/src/analytics-utils.test.ts
@@ -6,10 +6,11 @@ describe('analytic-utils', () => {
     it('returns the id and resource type from a gid', () => {
       const {searchParams, ...gid} = parseGid('gid://shopify/Order/123');
       expect(gid).toStrictEqual({
-        hash: '',
         id: '123',
         resource: 'Order',
+        resourceId: '123',
         search: '',
+        hash: '',
       });
       expect(searchParams.toString()).toBe('');
     });
@@ -18,10 +19,11 @@ describe('analytic-utils', () => {
       //@ts-expect-error - testing invalid input
       const {searchParams, ...gid} = parseGid(123);
       expect(gid).toStrictEqual({
-        hash: '',
         id: '',
         resource: null,
+        resourceId: null,
         search: '',
+        hash: '',
       });
       expect(searchParams.toString()).toBe('');
     });
@@ -29,10 +31,11 @@ describe('analytic-utils', () => {
     it('returns empty string if the gid is not a valid gid', () => {
       const {searchParams, ...gid} = parseGid('gid://shopify/Order');
       expect(gid).toStrictEqual({
-        hash: '',
         id: '',
         resource: null,
+        resourceId: null,
         search: '',
+        hash: '',
       });
       expect(searchParams.toString()).toBe('');
     });
@@ -42,10 +45,11 @@ describe('analytic-utils', () => {
         'gid://shopify/Order/123?namespace=123',
       );
       expect(gid).toStrictEqual({
-        hash: '',
-        id: '123',
+        id: '123?namespace=123',
         resource: 'Order',
+        resourceId: '123',
         search: '?namespace=123',
+        hash: '',
       });
       expect(searchParams.toString()).toBe('namespace=123');
     });
@@ -55,10 +59,11 @@ describe('analytic-utils', () => {
         'gid://shopify/Order/123?namespace=123#fragment',
       );
       expect(gid).toStrictEqual({
-        hash: '#fragment',
-        id: '123',
+        id: '123?namespace=123#fragment',
         resource: 'Order',
+        resourceId: '123',
         search: '?namespace=123',
+        hash: '#fragment',
       });
       expect(searchParams.toString()).toBe('namespace=123');
     });
@@ -66,10 +71,11 @@ describe('analytic-utils', () => {
     it('returns empty string if the resource is missing', () => {
       const {searchParams, ...gid} = parseGid('gid://shopify//123');
       expect(gid).toStrictEqual({
-        hash: '',
         id: '',
         resource: null,
+        resourceId: null,
         search: '',
+        hash: '',
       });
       expect(searchParams.toString()).toBe('');
     });
@@ -79,10 +85,11 @@ describe('analytic-utils', () => {
         'gid://shopify/Cart/c1-3d2419bf79df5e91d37b449cc6cd0ba1?test=123',
       );
       expect(gid).toStrictEqual({
-        hash: '',
-        id: 'c1-3d2419bf79df5e91d37b449cc6cd0ba1',
+        id: 'c1-3d2419bf79df5e91d37b449cc6cd0ba1?test=123',
         resource: 'Cart',
+        resourceId: 'c1-3d2419bf79df5e91d37b449cc6cd0ba1',
         search: '?test=123',
+        hash: '',
       });
       expect(searchParams.toString()).toBe('test=123');
     });
@@ -90,10 +97,11 @@ describe('analytic-utils', () => {
     it('should default to empty string', () => {
       const {searchParams, ...gid} = parseGid('');
       expect(gid).toStrictEqual({
-        hash: '',
         id: '',
         resource: null,
+        resourceId: null,
         search: '',
+        hash: '',
       });
       expect(searchParams.toString()).toBe('');
     });

--- a/packages/hydrogen-react/src/analytics-utils.test.ts
+++ b/packages/hydrogen-react/src/analytics-utils.test.ts
@@ -4,50 +4,101 @@ import {parseGid, addDataIf, schemaWrapper} from './analytics-utils.js';
 describe('analytic-utils', () => {
   describe('parseGid', () => {
     it('returns the id and resource type from a gid', () => {
-      const {id, resource} = parseGid('gid://shopify/Order/123');
-      expect(id).toBe('123');
-      expect(resource).toBe('Order');
+      const {searchParams, ...gid} = parseGid('gid://shopify/Order/123');
+      expect(gid).toMatchInlineSnapshot(`
+        {
+          "hash": "",
+          "id": "123",
+          "resource": "Order",
+          "search": "",
+        }
+      `);
+      expect(searchParams.toString()).toBe('');
     });
 
     it('returns empty string if the gid is not a string', () => {
       //@ts-expect-error - testing invalid input
-      const {id, resource} = parseGid(123);
-      expect(id).toBe('');
-      expect(resource).toBe(null);
+      const {searchParams, ...gid} = parseGid(123);
+      expect(gid).toMatchInlineSnapshot(`
+        {
+          "hash": "",
+          "id": "",
+          "resource": null,
+          "search": "",
+        }
+      `);
+      expect(searchParams.toString()).toBe('');
     });
 
     it('returns empty string if the gid is not a valid gid', () => {
-      const {id, resource} = parseGid('gid://shopify/Order');
-      expect(id).toBe('');
-      expect(resource).toBe(null);
+      const {searchParams, ...gid} = parseGid('gid://shopify/Order');
+      expect(gid).toMatchInlineSnapshot(`
+        {
+          "hash": "",
+          "id": "Order",
+          "resource": "",
+          "search": "",
+        }
+      `);
+      expect(searchParams.toString()).toBe('');
     });
 
     it('returns the id and resource type from a gid with a query string', () => {
-      const {id, resource} = parseGid('gid://shopify/Order/123?namespace=123');
-      expect(id).toBe('123?namespace=123');
-      expect(resource).toBe('Order');
+      const {searchParams, ...gid} = parseGid(
+        'gid://shopify/Order/123?namespace=123',
+      );
+      expect(gid).toMatchInlineSnapshot(`
+        {
+          "hash": "",
+          "id": "123",
+          "resource": "Order",
+          "search": "?namespace=123",
+        }
+      `);
+      expect(searchParams.toString()).toBe('namespace=123');
     });
 
     it('returns the id and resource type from a gid with a query string and a fragment', () => {
-      const {id, resource} = parseGid(
+      const {searchParams, ...gid} = parseGid(
         'gid://shopify/Order/123?namespace=123#fragment',
       );
-      expect(id).toBe('123?namespace=123#fragment');
-      expect(resource).toBe('Order');
+      expect(gid).toMatchInlineSnapshot(`
+        {
+          "hash": "#fragment",
+          "id": "123",
+          "resource": "Order",
+          "search": "?namespace=123",
+        }
+      `);
+      expect(searchParams.toString()).toBe('namespace=123');
     });
 
     it('returns empty string if the resource is missing', () => {
-      const {id, resource} = parseGid('gid://shopify//123');
-      expect(id).toBe('');
-      expect(resource).toBe(null);
+      const {searchParams, ...gid} = parseGid('gid://shopify//123');
+      expect(gid).toMatchInlineSnapshot(`
+        {
+          "hash": "",
+          "id": "123",
+          "resource": "",
+          "search": "",
+        }
+      `);
+      expect(searchParams.toString()).toBe('');
     });
 
     it('returns the c1 cart token', () => {
-      const {id, resource} = parseGid(
+      const {searchParams, ...gid} = parseGid(
         'gid://shopify/Cart/c1-3d2419bf79df5e91d37b449cc6cd0ba1?test=123',
       );
-      expect(id).toBe('c1-3d2419bf79df5e91d37b449cc6cd0ba1?test=123');
-      expect(resource).toBe('Cart');
+      expect(gid).toMatchInlineSnapshot(`
+        {
+          "hash": "",
+          "id": "c1-3d2419bf79df5e91d37b449cc6cd0ba1",
+          "resource": "Cart",
+          "search": "?test=123",
+        }
+      `);
+      expect(searchParams.toString()).toBe('test=123');
     });
   });
 

--- a/packages/hydrogen-react/src/analytics-utils.ts
+++ b/packages/hydrogen-react/src/analytics-utils.ts
@@ -38,23 +38,31 @@ export function schemaWrapper(
  * ```
  **/
 export function parseGid(gid: string | undefined): ShopifyGid {
-  const defaultReturn = {id: '', resource: null};
+  const defaultReturn: ShopifyGid = {
+    id: '',
+    resource: null,
+    search: '',
+    searchParams: new URLSearchParams(),
+    hash: '',
+  };
 
   if (typeof gid !== 'string') {
     return defaultReturn;
   }
 
-  // TODO: add support for parsing query parameters on complex gids
-  // Reference: https://shopify.dev/api/usage/gids
-  const matches = gid.match(/^gid:\/\/shopify\/(\w+)\/([^/]+)/);
+  const {search, searchParams, pathname, hash} = new URL(gid);
+  const pathnameParts = pathname.split('/');
+  const lastPathnamePart = pathnameParts[pathnameParts.length - 1];
+  const resourcePart = pathnameParts[pathnameParts.length - 2];
 
-  if (!matches || matches.length === 1) {
+  if (!lastPathnamePart) {
     return defaultReturn;
   }
-  const id = matches[2] ?? null;
-  const resource = matches[1] ?? null;
 
-  return {id, resource};
+  const id = lastPathnamePart ?? null;
+  const resource = resourcePart ?? null;
+
+  return {id, resource, search, searchParams, hash};
 }
 
 /**

--- a/packages/hydrogen-react/src/analytics-utils.ts
+++ b/packages/hydrogen-react/src/analytics-utils.ts
@@ -50,19 +50,23 @@ export function parseGid(gid: string | undefined): ShopifyGid {
     return defaultReturn;
   }
 
-  const {search, searchParams, pathname, hash} = new URL(gid);
-  const pathnameParts = pathname.split('/');
-  const lastPathnamePart = pathnameParts[pathnameParts.length - 1];
-  const resourcePart = pathnameParts[pathnameParts.length - 2];
+  try {
+    const {search, searchParams, pathname, hash} = new URL(gid);
+    const pathnameParts = pathname.split('/');
+    const lastPathnamePart = pathnameParts[pathnameParts.length - 1];
+    const resourcePart = pathnameParts[pathnameParts.length - 2];
 
-  if (!lastPathnamePart) {
+    if (!lastPathnamePart || !resourcePart) {
+      return defaultReturn;
+    }
+
+    const id = lastPathnamePart ?? null;
+    const resource = resourcePart ?? null;
+
+    return {id, resource, search, searchParams, hash};
+  } catch {
     return defaultReturn;
   }
-
-  const id = lastPathnamePart ?? null;
-  const resource = resourcePart ?? null;
-
-  return {id, resource, search, searchParams, hash};
 }
 
 /**

--- a/packages/hydrogen-react/src/analytics-utils.ts
+++ b/packages/hydrogen-react/src/analytics-utils.ts
@@ -41,6 +41,7 @@ export function parseGid(gid: string | undefined): ShopifyGid {
   const defaultReturn: ShopifyGid = {
     id: '',
     resource: null,
+    resourceId: null,
     search: '',
     searchParams: new URLSearchParams(),
     hash: '',
@@ -60,10 +61,11 @@ export function parseGid(gid: string | undefined): ShopifyGid {
       return defaultReturn;
     }
 
-    const id = lastPathnamePart ?? null;
+    const id = `${lastPathnamePart}${search}${hash}` || '';
+    const resourceId = lastPathnamePart || null;
     const resource = resourcePart ?? null;
 
-    return {id, resource, search, searchParams, hash};
+    return {id, resource, resourceId, search, searchParams, hash};
   } catch {
     return defaultReturn;
   }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

`parseGid` was not properly stripping off search params and hash queries.

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

This change updates the implementation of the parseGid function
so that it uses the builtin `URL` class to parse the gid. This enables
the parts of the string, such as the search params, to be parsed
as well.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

Unit tests have been updated to reflect the new functionality.

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
