### PR TITLE
[2023.4] Allow generic inference in standalone usage of WithCache type

### DIFF
--- a/.changeset/twelve-bottles-exist.md
+++ b/.changeset/twelve-bottles-exist.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Allow generic inference in standalone usage of WithCache type

--- a/packages/hydrogen/src/with-cache.ts
+++ b/packages/hydrogen/src/with-cache.ts
@@ -37,10 +37,10 @@ export function createWithCache<T = unknown>(
  *
  * Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the built-in caching strategies: `CacheNone`, `CacheShort`, `CacheLong`.
  */
-type CreateWithCacheReturn<T> = (
+type CreateWithCacheReturn<T> = <U = T>(
   cacheKey: CacheKey,
   strategy: CachingStrategy,
-  actionFn: () => T | Promise<T>,
-) => Promise<T>;
+  actionFn: () => U | Promise<U>,
+) => Promise<U>;
 
 export type WithCache = ReturnType<typeof createWithCache>;


### PR DESCRIPTION
### WHY are these changes introduced?

When the `WithCache` type is used in a standalone fashion, the inferred return type of `actionFn` is lost and the result becomes `unknown`.

In a codebase I contribute to, we use `createWithCache_unstable` to create a generic `withCache` function that is passed to several other downstream functions. `withCache` in those functions is typed with `WithCache` from @shopify/hydrogen.

When `withCache()` is called downstream, the inferred return type of the `actionFn()` is lost and the result of `withCache()` becomes `unknown`.

I noticed this issue when upgrading from 2023.4.0 to latest 2023.4 and found the breaking change in 808b8c47281a61fe1179477d799995a47e989fd7 when `CreateWithCacheReturn` was broken out into its own type in `packages/hydrogen/src/with-cache.ts:40`.  In 2023.4.0, the `createWithCache_unstable` function return type was defined inline with the function rather than being broken out and allowed the inference to work.

### WHAT is this pull request doing?

The change in this PR allows the inference of the `actionFn()` return type to propagate through to the result of `withCache()`.

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)