### PR TITLE
Update create-app to use 5.1.1 cli-hydrogen

### DIFF
--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@shopify/cli-hydrogen": "^5.1.0"
+    "@shopify/cli-hydrogen": "^5.1.1"
   },
   "bin": "dist/create-app.js",
   "files": [


### PR DESCRIPTION
Should help fix this issue where create-app is still scaffolding package.json pointing to `@remix-run/react@1.17.1` despite the skeleton being in `1.19.1`

<img width="1193" alt="Screenshot 2023-08-07 at 1 23 01 PM" src="https://github.com/Shopify/hydrogen/assets/12080141/8e7d198a-e69e-489f-8c9d-85c78ce4eaf4">

<img width="827" alt="Screenshot 2023-08-07 at 1 51 19 PM" src="https://github.com/Shopify/hydrogen/assets/12080141/b9b9894e-1218-4f4d-ba14-0cf7d59718e6">

