### PR TITLE
Allow 404 to be caught be ErrorBoundary in Route

### DIFF
--- a/templates/skeleton/app/routes/$.tsx
+++ b/templates/skeleton/app/routes/$.tsx
@@ -5,3 +5,7 @@ export async function loader({request}: LoaderArgs) {
     status: 404,
   });
 }
+
+export default function CatchAllPage() {
+  return null;
+}


### PR DESCRIPTION
### WHY are these changes introduced?
Currently, (with the remix V2 `v2_errorBoundary` flag) when a 404 is thrown, it is not caught by the Error boundary. 

<img width="368" alt="Screenshot 2023-08-11 at 2 21 18 PM" src="https://github.com/Shopify/hydrogen/assets/58700044/a3eb48bd-b17b-4c92-977e-3766628ef8dd">

### WHAT is this pull request doing?
This PR adds a default exported function that returns null. This allows the ErrorBoundary in `root.tsx` to catch the `404` errorStatus.

<img width="496" alt="Screenshot 2023-08-11 at 2 20 47 PM" src="https://github.com/Shopify/hydrogen/assets/58700044/d3f1aa5a-908c-473a-8448-076543e01d52">

### HOW to test your changes?
- run skeleton build locally
- visit a non existing URL (e.g. `localhost:3000/dsadsadsa`)
- Ensure the Error boundary is rendered

#### Checklist
- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- x ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
