### PR TITLE
Minor fixes to skeleton template

### DIFF
--- a/templates/skeleton/app/components/Search.tsx
+++ b/templates/skeleton/app/components/Search.tsx
@@ -1,13 +1,13 @@
 import {
-  useParams,
-  useFetcher,
   Link,
   Form,
+  useParams,
+  useFetcher,
+  useFetchers,
   type FormProps,
 } from '@remix-run/react';
 import {Image, Money, Pagination} from '@shopify/hydrogen';
 import React, {useRef, useEffect} from 'react';
-import {useFetchers} from '@remix-run/react';
 
 import type {
   PredictiveProductFragment,

--- a/templates/skeleton/app/routes/_index.tsx
+++ b/templates/skeleton/app/routes/_index.tsx
@@ -14,9 +14,11 @@ export const meta: V2_MetaFunction = () => {
 
 export async function loader({context}: LoaderArgs) {
   const {storefront} = context;
+
+  const recommendedProducts = storefront.query(RECOMMENDED_PRODUCTS_QUERY);
+
   const {collections} = await storefront.query(FEATURED_COLLECTION_QUERY);
   const featuredCollection = collections.nodes[0];
-  const recommendedProducts = storefront.query(RECOMMENDED_PRODUCTS_QUERY);
 
   return defer({featuredCollection, recommendedProducts});
 }

--- a/templates/skeleton/app/routes/_index.tsx
+++ b/templates/skeleton/app/routes/_index.tsx
@@ -1,6 +1,10 @@
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {defer, type LoaderArgs} from '@shopify/remix-oxygen';
-import {Await, useLoaderData, Link} from '@remix-run/react';
+import {
+  Await,
+  useLoaderData,
+  Link,
+  type V2_MetaFunction,
+} from '@remix-run/react';
 import {Suspense} from 'react';
 import {Image, Money} from '@shopify/hydrogen';
 import type {

--- a/templates/skeleton/app/routes/account.$.tsx
+++ b/templates/skeleton/app/routes/account.$.tsx
@@ -1,5 +1,4 @@
-import type {LoaderArgs} from '@shopify/remix-oxygen';
-import {redirect} from '@shopify/remix-oxygen';
+import {redirect, type LoaderArgs} from '@shopify/remix-oxygen';
 
 export async function loader({context}: LoaderArgs) {
   if (await context.session.get('customerAccessToken')) {

--- a/templates/skeleton/app/routes/account.addresses.tsx
+++ b/templates/skeleton/app/routes/account.addresses.tsx
@@ -5,13 +5,13 @@ import {
   redirect,
   type ActionArgs,
   type LoaderArgs,
-  type V2_MetaFunction,
 } from '@shopify/remix-oxygen';
 import {
   Form,
   useActionData,
   useNavigation,
   useOutletContext,
+  type V2_MetaFunction,
 } from '@remix-run/react';
 
 export type ActionResponse = {

--- a/templates/skeleton/app/routes/account.orders._index.tsx
+++ b/templates/skeleton/app/routes/account.orders._index.tsx
@@ -1,11 +1,6 @@
-import {Link, useLoaderData} from '@remix-run/react';
+import {Link, useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 import {Money, Pagination, getPaginationVariables} from '@shopify/hydrogen';
-import {
-  json,
-  redirect,
-  type LoaderArgs,
-  type V2_MetaFunction,
-} from '@shopify/remix-oxygen';
+import {json, redirect, type LoaderArgs} from '@shopify/remix-oxygen';
 import type {
   CustomerOrdersFragment,
   OrderItemFragment,

--- a/templates/skeleton/app/routes/account.profile.tsx
+++ b/templates/skeleton/app/routes/account.profile.tsx
@@ -1,12 +1,17 @@
 import type {CustomerFragment} from 'storefrontapi.generated';
 import type {CustomerUpdateInput} from '@shopify/hydrogen/storefront-api-types';
-import type {ActionArgs, LoaderArgs} from '@shopify/remix-oxygen';
-import {json, redirect, type V2_MetaFunction} from '@shopify/remix-oxygen';
+import {
+  json,
+  redirect,
+  type ActionArgs,
+  type LoaderArgs,
+} from '@shopify/remix-oxygen';
 import {
   Form,
   useActionData,
   useNavigation,
   useOutletContext,
+  type V2_MetaFunction,
 } from '@remix-run/react';
 
 export type ActionResponse = {

--- a/templates/skeleton/app/routes/account_.activate.$id.$activationToken.tsx
+++ b/templates/skeleton/app/routes/account_.activate.$id.$activationToken.tsx
@@ -1,5 +1,9 @@
-import type {ActionArgs, LoaderArgs} from '@shopify/remix-oxygen';
-import {json, redirect} from '@shopify/remix-oxygen';
+import {
+  json,
+  redirect,
+  type ActionArgs,
+  type LoaderArgs,
+} from '@shopify/remix-oxygen';
 import {Form, useActionData, type V2_MetaFunction} from '@remix-run/react';
 
 type ActionResponse = {

--- a/templates/skeleton/app/routes/account_.login.tsx
+++ b/templates/skeleton/app/routes/account_.login.tsx
@@ -3,9 +3,13 @@ import {
   redirect,
   type ActionArgs,
   type LoaderArgs,
-  type V2_MetaFunction,
 } from '@shopify/remix-oxygen';
-import {Form, Link, useActionData} from '@remix-run/react';
+import {
+  Form,
+  Link,
+  useActionData,
+  type V2_MetaFunction,
+} from '@remix-run/react';
 
 type ActionResponse = {
   error: string | null;

--- a/templates/skeleton/app/routes/account_.logout.tsx
+++ b/templates/skeleton/app/routes/account_.logout.tsx
@@ -1,9 +1,5 @@
-import {
-  json,
-  redirect,
-  type ActionArgs,
-  type V2_MetaFunction,
-} from '@shopify/remix-oxygen';
+import {json, redirect, type ActionArgs} from '@shopify/remix-oxygen';
+import {type V2_MetaFunction} from '@remix-run/react';
 
 export const meta: V2_MetaFunction = () => {
   return [{title: 'Logout'}];

--- a/templates/skeleton/app/routes/blogs.$blogHandle.$articleHandle.tsx
+++ b/templates/skeleton/app/routes/blogs.$blogHandle.$articleHandle.tsx
@@ -1,6 +1,5 @@
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
-import {useLoaderData} from '@remix-run/react';
+import {useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 import {Image} from '@shopify/hydrogen';
 
 export const meta: V2_MetaFunction = ({data}) => {

--- a/templates/skeleton/app/routes/blogs.$blogHandle._index.tsx
+++ b/templates/skeleton/app/routes/blogs.$blogHandle._index.tsx
@@ -1,6 +1,5 @@
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
-import {Link, useLoaderData} from '@remix-run/react';
+import {Link, useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 import {Image, Pagination, getPaginationVariables} from '@shopify/hydrogen';
 import type {ArticleItemFragment} from 'storefrontapi.generated';
 

--- a/templates/skeleton/app/routes/blogs._index.tsx
+++ b/templates/skeleton/app/routes/blogs._index.tsx
@@ -1,6 +1,5 @@
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
-import {Link, useLoaderData} from '@remix-run/react';
+import {Link, useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 import {Pagination, getPaginationVariables} from '@shopify/hydrogen';
 
 export const meta: V2_MetaFunction = () => {

--- a/templates/skeleton/app/routes/cart.tsx
+++ b/templates/skeleton/app/routes/cart.tsx
@@ -1,8 +1,7 @@
-import {Await, useMatches} from '@remix-run/react';
+import {Await, useMatches, type V2_MetaFunction} from '@remix-run/react';
 import {Suspense} from 'react';
 import type {CartQueryData} from '@shopify/hydrogen';
 import {CartForm} from '@shopify/hydrogen';
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {type ActionArgs, json} from '@shopify/remix-oxygen';
 import type {CartApiQueryFragment} from 'storefrontapi.generated';
 import {CartMain} from '~/components/Cart';

--- a/templates/skeleton/app/routes/collections.$handle.tsx
+++ b/templates/skeleton/app/routes/collections.$handle.tsx
@@ -1,6 +1,5 @@
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {json, redirect, type LoaderArgs} from '@shopify/remix-oxygen';
-import {useLoaderData, Link} from '@remix-run/react';
+import {useLoaderData, Link, type V2_MetaFunction} from '@remix-run/react';
 import {
   Pagination,
   getPaginationVariables,

--- a/templates/skeleton/app/routes/pages.$handle.tsx
+++ b/templates/skeleton/app/routes/pages.$handle.tsx
@@ -1,6 +1,5 @@
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
-import {useLoaderData} from '@remix-run/react';
+import {useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 
 export const meta: V2_MetaFunction = ({data}) => {
   return [{title: `Hydrogen | ${data.page.title}`}];

--- a/templates/skeleton/app/routes/policies.$handle.tsx
+++ b/templates/skeleton/app/routes/policies.$handle.tsx
@@ -1,6 +1,5 @@
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {json, type LoaderArgs} from '@shopify/remix-oxygen';
-import {Link, useLoaderData} from '@remix-run/react';
+import {Link, useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 import {type Shop} from '@shopify/hydrogen-react/storefront-api-types';
 
 type SelectedPolicies = keyof Pick<

--- a/templates/skeleton/app/routes/products.$handle.tsx
+++ b/templates/skeleton/app/routes/products.$handle.tsx
@@ -1,8 +1,12 @@
 import {Suspense} from 'react';
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {defer, redirect, type LoaderArgs} from '@shopify/remix-oxygen';
-import type {FetcherWithComponents} from '@remix-run/react';
-import {Await, Link, useLoaderData} from '@remix-run/react';
+import {
+  Await,
+  Link,
+  useLoaderData,
+  type V2_MetaFunction,
+  type FetcherWithComponents,
+} from '@remix-run/react';
 import type {
   ProductFragment,
   ProductVariantsQuery,

--- a/templates/skeleton/app/routes/search.tsx
+++ b/templates/skeleton/app/routes/search.tsx
@@ -1,6 +1,5 @@
-import type {V2_MetaFunction} from '@shopify/remix-oxygen';
 import {defer, type LoaderArgs} from '@shopify/remix-oxygen';
-import {useLoaderData} from '@remix-run/react';
+import {useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 import {getPaginationVariables} from '@shopify/hydrogen';
 
 import {SearchForm, SearchResults, NoSearchResults} from '~/components/Search';


### PR DESCRIPTION
- Avoid waterfall request in home route
- Dedup imports and change `type V2_MetaFunction` import to `remix-react` (afaik, importing it from adapters will be deprecated in Remix v2).