### PR TITLE
Revert "Avoid waterfall request in home route"

### DIFF
--- a/templates/skeleton/app/routes/_index.tsx
+++ b/templates/skeleton/app/routes/_index.tsx
@@ -18,11 +18,9 @@ export const meta: V2_MetaFunction = () => {
 
 export async function loader({context}: LoaderArgs) {
   const {storefront} = context;
-
-  const recommendedProducts = storefront.query(RECOMMENDED_PRODUCTS_QUERY);
-
   const {collections} = await storefront.query(FEATURED_COLLECTION_QUERY);
   const featuredCollection = collections.nodes[0];
+  const recommendedProducts = storefront.query(RECOMMENDED_PRODUCTS_QUERY);
 
   return defer({featuredCollection, recommendedProducts});
 }


### PR DESCRIPTION
While this commit prevented a waterfall request, it opens the possibility for having unhandled promise rejections when `RECOMMENDED_PRODUCTS_QUERY` rejects before `FEATURED_COLLECTION_QUERY` settles. In this case, `return defer` is not even called and the whole thing throws.

The best fix would be adding `.catch` to every deferred promise immediately (before awaiting anything else) but we need to discuss what's the best pattern to do this.