### PR TITLE
add shouldRevalidate export to root loaders

### DIFF
--- a/.changeset/wicked-wolves-camp.md
+++ b/.changeset/wicked-wolves-camp.md
@@ -1,0 +1,7 @@
+---
+'demo-store': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Add shouldRevalidate export to limit root loaders revalidation on mutations only

--- a/templates/demo-store/app/root.tsx
+++ b/templates/demo-store/app/root.tsx
@@ -14,6 +14,7 @@ import {
   useLoaderData,
   useMatches,
   useRouteError,
+  type ShouldRevalidateFunction,
 } from '@remix-run/react';
 import {ShopifySalesChannel, Seo} from '@shopify/hydrogen';
 import invariant from 'tiny-invariant';
@@ -28,6 +29,25 @@ import {NotFound} from './components/NotFound';
 import styles from './styles/app.css';
 import {DEFAULT_LOCALE, parseMenu} from './lib/utils';
 import {useAnalytics} from './hooks/useAnalytics';
+
+// This is important to avoid re-fetching root queries on sub-navigations
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  formMethod,
+  currentUrl,
+  nextUrl,
+}) => {
+  // revalidate when a mutation is performed e.g add to cart, login...
+  if (formMethod && formMethod !== 'GET') {
+    return true;
+  }
+
+  // revalidate when manually revalidating via useRevalidator
+  if (currentUrl.toString() === nextUrl.toString()) {
+    return true;
+  }
+
+  return false;
+};
 
 export const links: LinksFunction = () => {
   return [

--- a/templates/hello-world/app/root.tsx
+++ b/templates/hello-world/app/root.tsx
@@ -6,10 +6,30 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  type ShouldRevalidateFunction,
 } from '@remix-run/react';
 import type {Shop} from '@shopify/hydrogen/storefront-api-types';
 import appStyles from './styles/app.css';
 import favicon from '../public/favicon.svg';
+
+// This is important to avoid re-fetching root queries on sub-navigations
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  formMethod,
+  currentUrl,
+  nextUrl,
+}) => {
+  // revalidate when a mutation is performed e.g add to cart, login...
+  if (formMethod && formMethod !== 'GET') {
+    return true;
+  }
+
+  // revalidate when manually revalidating via useRevalidator
+  if (currentUrl.toString() === nextUrl.toString()) {
+    return true;
+  }
+
+  return false;
+};
 
 export const links: LinksFunction = () => {
   return [

--- a/templates/skeleton/app/root.tsx
+++ b/templates/skeleton/app/root.tsx
@@ -10,6 +10,7 @@ import {
   useLoaderData,
   ScrollRestoration,
   isRouteErrorResponse,
+  type ShouldRevalidateFunction,
 } from '@remix-run/react';
 import type {CustomerAccessToken} from '@shopify/hydrogen/storefront-api-types';
 import type {HydrogenSession} from '../server';
@@ -17,6 +18,25 @@ import favicon from '../public/favicon.svg';
 import resetStyles from './styles/reset.css';
 import appStyles from './styles/app.css';
 import {Layout} from '~/components/Layout';
+
+// This is important to avoid re-fetching root queries on sub-navigations
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  formMethod,
+  currentUrl,
+  nextUrl,
+}) => {
+  // revalidate when a mutation is performed e.g add to cart, login...
+  if (formMethod && formMethod !== 'GET') {
+    return true;
+  }
+
+  // revalidate when manually revalidating via useRevalidator
+  if (currentUrl.toString() === nextUrl.toString()) {
+    return true;
+  }
+
+  return false;
+};
 
 export function links() {
   return [


### PR DESCRIPTION
### WHY are these changes introduced?

Remix revalidates layouts and routes when the url searchParams are added, removed or changed. This means that all our product page navigations, paginated collection pages and changing product variants were causing the root layout loader to revalidate.

### WHAT is this pull request doing?

This PR limits the root loaders to only ever revalidate when a mutation is performed. This includes all cart and account POST/PUT/PATCH requests.

### HOW to test your changes?

Console log inside a root loader and navigate into and out of route which include a change in the url. The root loader should only log on first page load and when a mutation e.g add to cart happens.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
