### PR TITLE
Update and pin ast-grep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -257,25 +257,25 @@
       }
     },
     "node_modules/@ast-grep/napi": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi/-/napi-0.5.3.tgz",
-      "integrity": "sha512-VfZse78HTNYMHgiXrMDq1OPIwECW3CAYNC1jPql26EXFvUlj7gp7eBdJGFp8Zxm3vN0BjXQrGyb+e35LnU6DIA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi/-/napi-0.11.0.tgz",
+      "integrity": "sha512-b+R8h20+ClsYZBJqcyguLy4THfGmg2a54HgfZ0a1vdCkfe9ftjblALiZf2DsOc0+Si8BDWd09TMNn2psUuibJA==",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@ast-grep/napi-darwin-arm64": "0.5.3",
-        "@ast-grep/napi-darwin-x64": "0.5.3",
-        "@ast-grep/napi-linux-x64-gnu": "0.5.3",
-        "@ast-grep/napi-win32-arm64-msvc": "0.5.3",
-        "@ast-grep/napi-win32-ia32-msvc": "0.5.3",
-        "@ast-grep/napi-win32-x64-msvc": "0.5.3"
+        "@ast-grep/napi-darwin-arm64": "0.11.0",
+        "@ast-grep/napi-darwin-x64": "0.11.0",
+        "@ast-grep/napi-linux-x64-gnu": "0.11.0",
+        "@ast-grep/napi-win32-arm64-msvc": "0.11.0",
+        "@ast-grep/napi-win32-ia32-msvc": "0.11.0",
+        "@ast-grep/napi-win32-x64-msvc": "0.11.0"
       }
     },
     "node_modules/@ast-grep/napi-darwin-arm64": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.5.3.tgz",
-      "integrity": "sha512-gJqqK39zcMw4ztTOIq8kRyzkZvJEjjiP+2J797CJ4pWME+vthVFAQZeUA+E/KYtDMOuwIRoN2S/3faCyasQCvA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.11.0.tgz",
+      "integrity": "sha512-IxY3b102tNNm+cYLngZvUKzM1fNKCpDDWz69Yt+QnKCZNx10Hvd7mqrYE2aXTtkaNalmg/p1n6kMA8KmshGgCA==",
       "cpu": [
         "arm64"
       ],
@@ -288,9 +288,9 @@
       }
     },
     "node_modules/@ast-grep/napi-darwin-x64": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-x64/-/napi-darwin-x64-0.5.3.tgz",
-      "integrity": "sha512-Ua0bXk0U6XHqHq9N3S72wa04nNAA22M+iSnp2357a+S2QoD0mw7IHnXwba9IwzbBwyiWCwiRVZxTK4RzQ7xFjw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-x64/-/napi-darwin-x64-0.11.0.tgz",
+      "integrity": "sha512-6afu1fNUwTkyE7tknVx8+d+BPKVL3623QLI9uJbJ0SZQShzSb1+dRegT4NpzPaPtFdPkflh6KfvOQ4chTw8hUg==",
       "cpu": [
         "x64"
       ],
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@ast-grep/napi-linux-x64-gnu": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.5.3.tgz",
-      "integrity": "sha512-So2Bmvrgi9tF7PAWRXRVbFMtTM0jdpJFRShbT0MDNvj+2jSsmQIXkf3aUJ60VuN2JFN/4c/VmddMicltOe8H8A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.11.0.tgz",
+      "integrity": "sha512-Rm0biBfIxg14tL9yAMxW6RngAEA2vYLIq1guff6Uc9Vb7yQ3HE8dnW8WAysyieIqXdVkraTTV2ZwfoUqeKfc1Q==",
       "cpu": [
         "x64"
       ],
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@ast-grep/napi-win32-arm64-msvc": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.5.3.tgz",
-      "integrity": "sha512-bO7OZrX4AmKtVAhFz9Ju42ld7/oOAZGV2zXUqlMdNfaoPcpbAO8xcdkIWoK/c/Ul+r7wE6y3/73a8fk3TecNqA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.11.0.tgz",
+      "integrity": "sha512-TfX6KXxtXGQS/sWzJ1wWwWbpm3OJWpqiWGttpifSGs6DJmzfwuK0b63yX5JlhNXeUVqXkZyfYqIh5RPIPOtXSA==",
       "cpu": [
         "arm64"
       ],
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@ast-grep/napi-win32-ia32-msvc": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-ia32-msvc/-/napi-win32-ia32-msvc-0.5.3.tgz",
-      "integrity": "sha512-Cbj4Soi8MHzeq1XhnWjGEHkwUey1LP3fL6J9ppDtjh0cV/zBbnby6yq8I25+dvt85BVwc18vrMQ7X1SdtsK+Kw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-ia32-msvc/-/napi-win32-ia32-msvc-0.11.0.tgz",
+      "integrity": "sha512-oQGbxYYfQn6LPbMKQ1T2cjQ+DelYDO06w/gFPmdWrE6M/YUIv+KfKdEscBkr3ehJyvXZW5h3vmxuApiMuCyfAQ==",
       "cpu": [
         "ia32"
       ],
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@ast-grep/napi-win32-x64-msvc": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-x64-msvc/-/napi-win32-x64-msvc-0.5.3.tgz",
-      "integrity": "sha512-1Gum/fOT9t32GbmqEoiSTsJh0yAvmXb5cO3wOJVdANkK37qX2i+F5jMXxt767m+O7Chdf3MXJLRg4KcVmcxThw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-x64-msvc/-/napi-win32-x64-msvc-0.11.0.tgz",
+      "integrity": "sha512-qrXI4+S8W7IF6e1nlDYX2KfdzxGHyAOj5kGvWk+TqBuAnA0rWQ513hJzdviiGpbB5VPnJkEhOVsDets8acKd6w==",
       "cpu": [
         "x64"
       ],
@@ -26831,7 +26831,7 @@
       "version": "5.1.2",
       "license": "MIT",
       "dependencies": {
-        "@ast-grep/napi": "^0.5.3",
+        "@ast-grep/napi": "0.11.0",
         "@graphql-codegen/cli": "3.3.1",
         "@oclif/core": "2.8.11",
         "@remix-run/dev": "1.19.1",
@@ -27581,52 +27581,52 @@
       }
     },
     "@ast-grep/napi": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi/-/napi-0.5.3.tgz",
-      "integrity": "sha512-VfZse78HTNYMHgiXrMDq1OPIwECW3CAYNC1jPql26EXFvUlj7gp7eBdJGFp8Zxm3vN0BjXQrGyb+e35LnU6DIA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi/-/napi-0.11.0.tgz",
+      "integrity": "sha512-b+R8h20+ClsYZBJqcyguLy4THfGmg2a54HgfZ0a1vdCkfe9ftjblALiZf2DsOc0+Si8BDWd09TMNn2psUuibJA==",
       "requires": {
-        "@ast-grep/napi-darwin-arm64": "0.5.3",
-        "@ast-grep/napi-darwin-x64": "0.5.3",
-        "@ast-grep/napi-linux-x64-gnu": "0.5.3",
-        "@ast-grep/napi-win32-arm64-msvc": "0.5.3",
-        "@ast-grep/napi-win32-ia32-msvc": "0.5.3",
-        "@ast-grep/napi-win32-x64-msvc": "0.5.3"
+        "@ast-grep/napi-darwin-arm64": "0.11.0",
+        "@ast-grep/napi-darwin-x64": "0.11.0",
+        "@ast-grep/napi-linux-x64-gnu": "0.11.0",
+        "@ast-grep/napi-win32-arm64-msvc": "0.11.0",
+        "@ast-grep/napi-win32-ia32-msvc": "0.11.0",
+        "@ast-grep/napi-win32-x64-msvc": "0.11.0"
       }
     },
     "@ast-grep/napi-darwin-arm64": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.5.3.tgz",
-      "integrity": "sha512-gJqqK39zcMw4ztTOIq8kRyzkZvJEjjiP+2J797CJ4pWME+vthVFAQZeUA+E/KYtDMOuwIRoN2S/3faCyasQCvA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.11.0.tgz",
+      "integrity": "sha512-IxY3b102tNNm+cYLngZvUKzM1fNKCpDDWz69Yt+QnKCZNx10Hvd7mqrYE2aXTtkaNalmg/p1n6kMA8KmshGgCA==",
       "optional": true
     },
     "@ast-grep/napi-darwin-x64": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-x64/-/napi-darwin-x64-0.5.3.tgz",
-      "integrity": "sha512-Ua0bXk0U6XHqHq9N3S72wa04nNAA22M+iSnp2357a+S2QoD0mw7IHnXwba9IwzbBwyiWCwiRVZxTK4RzQ7xFjw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-x64/-/napi-darwin-x64-0.11.0.tgz",
+      "integrity": "sha512-6afu1fNUwTkyE7tknVx8+d+BPKVL3623QLI9uJbJ0SZQShzSb1+dRegT4NpzPaPtFdPkflh6KfvOQ4chTw8hUg==",
       "optional": true
     },
     "@ast-grep/napi-linux-x64-gnu": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.5.3.tgz",
-      "integrity": "sha512-So2Bmvrgi9tF7PAWRXRVbFMtTM0jdpJFRShbT0MDNvj+2jSsmQIXkf3aUJ60VuN2JFN/4c/VmddMicltOe8H8A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.11.0.tgz",
+      "integrity": "sha512-Rm0biBfIxg14tL9yAMxW6RngAEA2vYLIq1guff6Uc9Vb7yQ3HE8dnW8WAysyieIqXdVkraTTV2ZwfoUqeKfc1Q==",
       "optional": true
     },
     "@ast-grep/napi-win32-arm64-msvc": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.5.3.tgz",
-      "integrity": "sha512-bO7OZrX4AmKtVAhFz9Ju42ld7/oOAZGV2zXUqlMdNfaoPcpbAO8xcdkIWoK/c/Ul+r7wE6y3/73a8fk3TecNqA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.11.0.tgz",
+      "integrity": "sha512-TfX6KXxtXGQS/sWzJ1wWwWbpm3OJWpqiWGttpifSGs6DJmzfwuK0b63yX5JlhNXeUVqXkZyfYqIh5RPIPOtXSA==",
       "optional": true
     },
     "@ast-grep/napi-win32-ia32-msvc": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-ia32-msvc/-/napi-win32-ia32-msvc-0.5.3.tgz",
-      "integrity": "sha512-Cbj4Soi8MHzeq1XhnWjGEHkwUey1LP3fL6J9ppDtjh0cV/zBbnby6yq8I25+dvt85BVwc18vrMQ7X1SdtsK+Kw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-ia32-msvc/-/napi-win32-ia32-msvc-0.11.0.tgz",
+      "integrity": "sha512-oQGbxYYfQn6LPbMKQ1T2cjQ+DelYDO06w/gFPmdWrE6M/YUIv+KfKdEscBkr3ehJyvXZW5h3vmxuApiMuCyfAQ==",
       "optional": true
     },
     "@ast-grep/napi-win32-x64-msvc": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-x64-msvc/-/napi-win32-x64-msvc-0.5.3.tgz",
-      "integrity": "sha512-1Gum/fOT9t32GbmqEoiSTsJh0yAvmXb5cO3wOJVdANkK37qX2i+F5jMXxt767m+O7Chdf3MXJLRg4KcVmcxThw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-x64-msvc/-/napi-win32-x64-msvc-0.11.0.tgz",
+      "integrity": "sha512-qrXI4+S8W7IF6e1nlDYX2KfdzxGHyAOj5kGvWk+TqBuAnA0rWQ513hJzdviiGpbB5VPnJkEhOVsDets8acKd6w==",
       "optional": true
     },
     "@babel/code-frame": {
@@ -32067,7 +32067,7 @@
     "@shopify/cli-hydrogen": {
       "version": "file:packages/cli",
       "requires": {
-        "@ast-grep/napi": "^0.5.3",
+        "@ast-grep/napi": "0.11.0",
         "@graphql-codegen/cli": "3.3.1",
         "@oclif/core": "2.8.11",
         "@remix-run/dev": "1.19.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "@shopify/remix-oxygen": "^1.1.3"
   },
   "dependencies": {
-    "@ast-grep/napi": "^0.5.3",
+    "@ast-grep/napi": "0.11.0",
     "@graphql-codegen/cli": "3.3.1",
     "@oclif/core": "2.8.11",
     "@remix-run/dev": "1.19.1",


### PR DESCRIPTION
I've noticed that ast-grep adds [breaking changes](https://github.com/ast-grep/ast-grep/releases/tag/0.11.0) in their changelogs for minor versions so it's safer to pin this dependency.