### PR TITLE
Update MiniOxygen to support nonce in autoreload script

### DIFF
--- a/.changeset/old-frogs-drum.md
+++ b/.changeset/old-frogs-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Use nonce from CSP header in MiniOxygen's auto-reload script.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7651,9 +7651,9 @@
       "link": true
     },
     "node_modules/@shopify/mini-oxygen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@shopify/mini-oxygen/-/mini-oxygen-2.1.0.tgz",
-      "integrity": "sha512-pGFegd2p2bVQbuSPFucGhkwPTkZ2NUQ+1nGWOGAK/2QWRpcwRiU8nyMphLasxIaHdp6fsamSUGtF+4Akbgz7Bw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@shopify/mini-oxygen/-/mini-oxygen-2.1.1.tgz",
+      "integrity": "sha512-6Y0LKJfiqFmYT2oMhEUWnD2e8F0Aa8Vb23JIYthG+5z4YCyXn5N+Umi+f9WwjNIpWG5SDs9oxRQzgfJIDkquVQ==",
       "dependencies": {
         "@miniflare/cache": "^2.14.0",
         "@miniflare/core": "^2.14.0",
@@ -26570,7 +26570,7 @@
         "@remix-run/dev": "1.19.1",
         "@shopify/cli-kit": "3.48.0",
         "@shopify/hydrogen-codegen": "^0.0.2",
-        "@shopify/mini-oxygen": "^2.1.0",
+        "@shopify/mini-oxygen": "^2.1.1",
         "ansi-escapes": "^6.2.0",
         "diff": "^5.1.0",
         "fast-glob": "^3.2.12",
@@ -31465,7 +31465,7 @@
         "@remix-run/dev": "1.19.1",
         "@shopify/cli-kit": "3.48.0",
         "@shopify/hydrogen-codegen": "^0.0.2",
-        "@shopify/mini-oxygen": "^2.1.0",
+        "@shopify/mini-oxygen": "^2.1.1",
         "@types/diff": "^5.0.2",
         "@types/fs-extra": "^11.0.1",
         "@types/gunzip-maybe": "^1.4.0",
@@ -32139,9 +32139,9 @@
       }
     },
     "@shopify/mini-oxygen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@shopify/mini-oxygen/-/mini-oxygen-2.1.0.tgz",
-      "integrity": "sha512-pGFegd2p2bVQbuSPFucGhkwPTkZ2NUQ+1nGWOGAK/2QWRpcwRiU8nyMphLasxIaHdp6fsamSUGtF+4Akbgz7Bw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@shopify/mini-oxygen/-/mini-oxygen-2.1.1.tgz",
+      "integrity": "sha512-6Y0LKJfiqFmYT2oMhEUWnD2e8F0Aa8Vb23JIYthG+5z4YCyXn5N+Umi+f9WwjNIpWG5SDs9oxRQzgfJIDkquVQ==",
       "requires": {
         "@miniflare/cache": "^2.14.0",
         "@miniflare/core": "^2.14.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "@remix-run/dev": "1.19.1",
     "@shopify/cli-kit": "3.48.0",
     "@shopify/hydrogen-codegen": "^0.0.2",
-    "@shopify/mini-oxygen": "^2.1.0",
+    "@shopify/mini-oxygen": "^2.1.1",
     "ansi-escapes": "^6.2.0",
     "diff": "^5.1.0",
     "fast-glob": "^3.2.12",


### PR DESCRIPTION
We are adding CSP headers by default in #1235 but MiniOxygen didn't pass the nonce to its auto-reload script. Fixed in https://github.com/Shopify/mini-oxygen/pull/522