### PR TITLE
Change mock.shop option wording

### DIFF
--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -50,7 +50,7 @@ export async function setupLocalStarterTemplate(
         choices: [
           {
             label:
-              'Use sample data from mock.shop (set up shop connection later)',
+              'Use sample data from mock.shop (You can connect a Shopify account later)',
             value: 'mock',
           },
           {label: 'Link your Shopify account', value: 'link'},

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -137,7 +137,9 @@ export async function setupLocalStarterTemplate(
     ];
 
     const envLeadingComment =
-      '# The variables added in this file are only available locally in MiniOxygen\n';
+      '# The variables added in this file are only available locally in MiniOxygen.\n' +
+      '# Run `h2 link` to also inject environment variables from your storefront,\n' +
+      '# or `h2 env pull` to populate this file.';
 
     if (storefrontInfo && createStorefrontPromise) {
       promises.push(

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -49,7 +49,8 @@ export async function setupLocalStarterTemplate(
         message: 'Connect to Shopify',
         choices: [
           {
-            label: 'Use sample data from Mock.shop (no login required)',
+            label:
+              'Use sample data from mock.shop (set up shop connection later)',
             value: 'mock',
           },
           {label: 'Link your Shopify account', value: 'link'},


### PR DESCRIPTION
We had some users confused about this option because they already had tokens and just wanted to use them instead of mock data. Hopefully this change hints that the shop connection is still possible when choosing mock.shop .

Should we be even more explicit and say something like "set up shop connection later or add tokens manually"?

<img width="530" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/51f5bf5a-2e29-486c-9d6f-8ee1684b2f1f">

---

I've also updated the comments in the generated `.env` file to show how to proceed later with env variables. Thoughts?