### PR TITLE
Fix Codegen on Windows

### DIFF
--- a/.changeset/warm-onions-smile.md
+++ b/.changeset/warm-onions-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix GraphQL Codegen throwing error related to Git on Windows.

--- a/packages/cli/scripts/generate-manifest.mjs
+++ b/packages/cli/scripts/generate-manifest.mjs
@@ -4,13 +4,14 @@
  * https://github.com/oclif/oclif/blob/main/src/commands/manifest.ts#L76
  */
 
-import path from 'path';
-import {Plugin} from '@oclif/core';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {writeFile, access} from 'node:fs/promises';
+import {Plugin} from '@oclif/core';
 
 console.log('\n', 'Generating Oclif manifest...');
 
-const cwd = new URL('..', import.meta.url).pathname;
+const cwd = fileURLToPath(new URL('..', import.meta.url));
 
 if (
   !(await access(path.join(cwd, 'dist', 'commands', 'hydrogen'))

--- a/packages/cli/src/lib/ast.ts
+++ b/packages/cli/src/lib/ast.ts
@@ -1,0 +1,12 @@
+export type {SgNode} from '@ast-grep/napi';
+
+export async function importLangAstGrep(lang: 'ts' | 'tsx' | 'js' | 'jsx') {
+  // Delay CJS dependency import and binary import
+  const astGrep = await import('@ast-grep/napi');
+
+  if (!(lang in astGrep)) {
+    throw new Error(`Wrong language for AST: ${lang}`);
+  }
+
+  return astGrep[lang];
+}

--- a/packages/cli/src/lib/codegen.ts
+++ b/packages/cli/src/lib/codegen.ts
@@ -11,7 +11,7 @@ import {
 } from '@shopify/hydrogen-codegen';
 import {formatCode, getCodeFormatOptions} from './format-code.js';
 import {renderFatalError, renderWarning} from '@shopify/cli-kit/node/ui';
-import {joinPath} from '@shopify/cli-kit/node/path';
+import {joinPath, relativePath} from '@shopify/cli-kit/node/path';
 import {AbortError} from '@shopify/cli-kit/node/error';
 import {spawn} from 'node:child_process';
 import {fileURLToPath} from 'node:url';
@@ -161,6 +161,7 @@ function generateDefaultConfig(
   forceSfapiVersion?: string,
 ): LoadCodegenConfigResult {
   const tsDefaultGlob = '*!(*.d).{ts,tsx}'; // No d.ts files
+  const appDirRelative = relativePath(rootDirectory, appDirectory);
 
   return {
     filepath: 'virtual:codegen',
@@ -172,8 +173,8 @@ function generateDefaultConfig(
           preset,
           schema,
           documents: [
-            joinPath(rootDirectory, tsDefaultGlob), // E.g. ./server.ts
-            joinPath(appDirectory, '**', tsDefaultGlob), // E.g. app/routes/_index.tsx
+            tsDefaultGlob, // E.g. ./server.ts
+            joinPath(appDirRelative, '**', tsDefaultGlob), // E.g. app/routes/_index.tsx
           ],
 
           ...(!!forceSfapiVersion && {

--- a/packages/cli/src/lib/setups/css/replacers.ts
+++ b/packages/cli/src/lib/setups/css/replacers.ts
@@ -1,9 +1,7 @@
 import {AbortError} from '@shopify/cli-kit/node/error';
-import {ts, tsx, js, jsx, type SgNode} from '@ast-grep/napi';
 import {type FormatOptions} from '../../format-code.js';
 import {findFileWithExtension, replaceFileContent} from '../../file.js';
-
-const astGrep = {ts, tsx, js, jsx};
+import {importLangAstGrep, type SgNode} from '../../ast.js';
 
 /**
  * Adds new properties to the Remix config file.
@@ -28,7 +26,8 @@ export async function replaceRemixConfig(
   }
 
   await replaceFileContent(filepath, formatConfig, async (content) => {
-    const root = astGrep[astType].parse(content).root();
+    const astGrep = await importLangAstGrep(astType);
+    const root = astGrep.parse(content).root();
 
     const remixConfigNode = root.find({
       rule: {
@@ -135,7 +134,8 @@ export async function replaceRootLinks(
       return; // Already installed
     }
 
-    const root = astGrep[astType].parse(content).root();
+    const astGrep = await importLangAstGrep(astType);
+    const root = astGrep.parse(content).root();
 
     const lastImportNode = root
       .findAll({rule: {kind: 'import_statement'}})


### PR DESCRIPTION
Closes #1196 

The absolute path passed to the Codegen CLI on Windows was like `C:/Users/.../project`, and for some reason, the drive letter was making it fail with `git ls-tree -r --name-only C`.
Removing the letter fixes it but here I'm reverting the code back to using relative paths instead.

The rest of the changes are just to make it possible to build the CLI package on Windows.