### PR TITLE
Mute Node polyfills warning in the correct place

### DIFF
--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -11,12 +11,7 @@ import {
   getRemixConfig,
   type ServerMode,
 } from '../../lib/remix-config.js';
-import {
-  createRemixLogger,
-  enhanceH2Logs,
-  muteDevLogs,
-  muteRemixLogs,
-} from '../../lib/log.js';
+import {createRemixLogger, enhanceH2Logs, muteDevLogs} from '../../lib/log.js';
 import {
   deprecated,
   commonFlags,
@@ -101,7 +96,6 @@ async function runDev({
   if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development';
 
   muteDevLogs();
-  await muteRemixLogs();
 
   if (debug) (await import('node:inspector')).open();
 

--- a/packages/cli/src/lib/remix-config.ts
+++ b/packages/cli/src/lib/remix-config.ts
@@ -7,6 +7,7 @@ import type {RemixConfig} from '@remix-run/dev/dist/config.js';
 import {AbortError} from '@shopify/cli-kit/node/error';
 import {outputWarn} from '@shopify/cli-kit/node/output';
 import {fileExists} from '@shopify/cli-kit/node/fs';
+import {muteRemixLogs} from './log.js';
 
 export type {RemixConfig, ServerMode};
 
@@ -36,6 +37,7 @@ export async function getRemixConfig(
   root: string,
   mode = process.env.NODE_ENV as ServerMode,
 ) {
+  await muteRemixLogs();
   const {readConfig} = await import('@remix-run/dev/dist/config.js');
   const config = await readConfig(root, mode);
 


### PR DESCRIPTION
Remix warns about Node polyfills and its future change in v2. We were muting this warning in the wrong place so it was still shown in some commands.