### PR TITLE
performance optimization on product query

### DIFF
--- a/.changeset/two-eyes-perform.md
+++ b/.changeset/two-eyes-perform.md
@@ -1,0 +1,5 @@
+---
+'demo-store': patch
+---
+
+Performance optimization on product page

--- a/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
@@ -54,6 +54,14 @@ export async function loader({params, request, context}: LoaderArgs) {
     },
   });
 
+  if (!product?.id) {
+    throw new Response('product', {status: 404});
+  }
+
+  if (!product.selectedVariant) {
+    return redirectToFirstVariant({product, request});
+  }
+
   // In order to show which variants are available in the UI, we need to query
   // all of them. But there might be a *lot*, so instead separate the variants
   // into it's own separate query that is deferred. So there's a brief moment
@@ -67,15 +75,10 @@ export async function loader({params, request, context}: LoaderArgs) {
     },
   });
 
-  if (!product?.id) {
-    throw new Response('product', {status: 404});
-  }
-
-  if (!product.selectedVariant) {
-    return redirectToFirstVariant({product, request});
-  }
-
   const recommended = getRecommendedProducts(context.storefront, product.id);
+
+  // TODO: firstVariant is never used because we will always have a selectedVariant due to redirect
+  // Investigate if we can avoid the redirect for product pages with no search params for first variant
   const firstVariant = product.variants.nodes[0];
   const selectedVariant = product.selectedVariant ?? firstVariant;
 

--- a/templates/skeleton/app/routes/products.$handle.tsx
+++ b/templates/skeleton/app/routes/products.$handle.tsx
@@ -54,15 +54,6 @@ export async function loader({params, request, context}: LoaderArgs) {
     variables: {handle, selectedOptions},
   });
 
-  // In order to show which variants are available in the UI, we need to query
-  // all of them. But there might be a *lot*, so instead separate the variants
-  // into it's own separate query that is deferred. So there's a brief moment
-  // where variant options might show as available when they're not, but after
-  // this deffered query resolves, the UI will update.
-  const variants = storefront.query(VARIANTS_QUERY, {
-    variables: {handle},
-  });
-
   if (!product?.id) {
     throw new Response(null, {status: 404});
   }
@@ -84,6 +75,16 @@ export async function loader({params, request, context}: LoaderArgs) {
       return redirectToFirstVariant({product, request});
     }
   }
+
+  // In order to show which variants are available in the UI, we need to query
+  // all of them. But there might be a *lot*, so instead separate the variants
+  // into it's own separate query that is deferred. So there's a brief moment
+  // where variant options might show as available when they're not, but after
+  // this deffered query resolves, the UI will update.
+  const variants = storefront.query(VARIANTS_QUERY, {
+    variables: {handle},
+  });
+
   return defer({product, variants});
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Discover an inefficiency with how product page queries are performing.

Before:

<img width="1046" alt="Screenshot 2023-08-21 at 12 19 40 PM" src="https://github.com/Shopify/hydrogen/assets/2319002/84fa1c44-b21a-40f4-b6d4-4e5eba5471c4">

After:

<img width="1044" alt="Screenshot 2023-08-21 at 12 29 45 PM" src="https://github.com/Shopify/hydrogen/assets/2319002/992e5ad2-92a4-4efd-a0df-dcfb9243df65">

 

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
