### PR TITLE
Switch changeset to main branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "2023-07",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["hello-world", "skeleton"],
   "privatePackages": {"version": true, "tag": true}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -3,7 +3,7 @@ name: Changesets
 on:
   push:
     branches:
-      - '[0-9]+-[0-9]+'
+      - main
 
 concurrency:
   group: changeset-${{ github.head_ref }}
@@ -17,12 +17,14 @@ jobs:
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       latest: ${{ env.latest }}
+      latestBranch: ${{ env.latestBranch }}
     steps:
       - name: Flags
         id: flags
         run: |
-          # IMPORTANT: Update this variable whenever we move to a new major version:
-          echo "latest=${{ github.ref_name == '2023-07' }}" >> $GITHUB_ENV
+          # IMPORTANT: Update this latestBranch whenever we move to a new major version:
+          echo "latestBranch=2023-07" >> $GITHUB_ENV
+          echo "latest=${{ github.ref_name == 'main' }}" >> $GITHUB_ENV
 
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -54,24 +56,11 @@ jobs:
           version: npm run version
           publish: npm run changeset publish
           # we use the commit message in next release workflow file. This avoid a next release when an actual release is happening
-          commit: '[ci] release ${{ github.ref_name }}'
-          title: '[ci] release ${{ github.ref_name }}'
+          commit: '[ci] release ${{ env.latestBranch }}'
+          title: '[ci] release ${{ env.latestBranch }}'
         env:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # - name: Create Release Pull Request or Publish (for legacy patch release)
-      #   if: env.latest != 'true'
-      #   id: changesets_legacy
-      #   uses: changesets/action@v1
-      #   with:
-      #     version: npm run version
-      #     publish: npm run changeset publish --tag legacy
-      #     commit: '[ci] release ${{ github.ref_name }}'
-      #     title: '[ci] release ${{ github.ref_name }}'
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   compile:
     needs: changelog
@@ -106,6 +95,37 @@ jobs:
           git show-ref
           git commit -m "Update templates for dist"
           git push origin HEAD:dist --force
+
+  update_lock_and_sync_latest:
+    needs: changelog
+    # Only update package-lock.json if a release was published, and we're on the "latest" release branch
+    if: needs.changelog.outputs.published == 'true' && needs.changelog.outputs.latest == 'true'
+    runs-on: ubuntu-latest
+    name: Update package-lock.json
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Update package-lock.json
+        run: npm install --package-lock-only --ignore-engines
+
+      - name: Push commit to main branch
+        run: |
+          git add .
+          git status
+          git config user.email "hydrogen@shopify.com"
+          git config user.name "Hydrogen Bot"
+          git show-ref
+          git commit -m "Update package-lock.json"
+          git push origin HEAD:main
+
+      - name: Sync latest to version branch
+        run: |
+          git config user.email "hydrogen@shopify.com"
+          git config user.name "Hydrogen Bot"
+          git show-ref
+          git commit -m "[ci] release ${{ needs.changelog.outputs.latestBranch }}"
+          git push origin HEAD:${{ needs.changelog.outputs.latestBranch }}
 
   # discord_announcement:
   #   needs: changelog

--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -3,8 +3,7 @@ name: ⏭️ Next Release
 on:
   push:
     branches:
-      # update to latest cal release to keep this action working
-      - 2023-07
+      - main
 
 jobs:
   next-release:


### PR DESCRIPTION
- Updates all changeset workflow to main branch
- Update repo `package-lock.json` after publish
- Sync to latest version branch after publish

## Steps

1. [x] Force push `2023-07` onto `main` and change merge branch of this PR to `main`
2. [x] Merge this PR
3. [x] Set github default branch to `main`
4. [x] Set Oxygen default production branch to `main`