### PR TITLE
Fixed typo on Blogs

### DIFF
--- a/templates/skeleton/app/routes/blogs._index.tsx
+++ b/templates/skeleton/app/routes/blogs._index.tsx
@@ -3,7 +3,7 @@ import {Link, useLoaderData, type V2_MetaFunction} from '@remix-run/react';
 import {Pagination, getPaginationVariables} from '@shopify/hydrogen';
 
 export const meta: V2_MetaFunction = () => {
-  return [{title: `Hydrogen | Logs`}];
+  return [{title: `Hydrogen | Blogs`}];
 };
 
 export const loader = async ({request, context: {storefront}}: LoaderArgs) => {


### PR DESCRIPTION
 Fixed typo for Title tag. Was showing 'Logs' instead of 'Blogs'


### WHY are these changes introduced?

Gav doesn't like typos.

