### PR TITLE
Add custom product paths to the `VaraiantSelector` component

### DIFF
--- a/.changeset/silent-apes-thank.md
+++ b/.changeset/silent-apes-thank.md
@@ -1,0 +1,11 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add custom product paths to the `VariantSelector` component:
+
+```tsx
+<VariantSelector handle="snowboard" productPath="shop" options={options}>
+  {/* ... */}
+</VariantSelector>
+```

--- a/packages/hydrogen/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen/docs/generated/generated_docs_data.json
@@ -8576,7 +8576,7 @@
             "filePath": "/product/VariantSelector.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "VariantSelectorProps",
-            "value": "{\n  /** The product handle for all of the variants */\n  handle: string;\n  /** Product options from the [Storefront API](/docs/api/storefront/2023-07/objects/ProductOption). Make sure both `name` and `values` are apart of your query. */\n  options: Array<PartialDeep<ProductOption>> | undefined;\n  /** Product variants from the [Storefront API](/docs/api/storefront/2023-07/objects/ProductVariant). You only need to pass this prop if you want to show product availability. If a product option combination is not found within `variants`, it is assumed to be available. Make sure to include `availableForSale` and `selectedOptions.name` and `selectedOptions.value`. */\n  variants?:\n    | PartialDeep<ProductVariantConnection>\n    | Array<PartialDeep<ProductVariant>>;\n  children: ({option}: {option: VariantOption}) => ReactNode;\n}",
+            "value": "{\n  /** The product handle for all of the variants */\n  handle: string;\n  /** Product options from the [Storefront API](/docs/api/storefront/2023-07/objects/ProductOption). Make sure both `name` and `values` are apart of your query. */\n  options: Array<PartialDeep<ProductOption>> | undefined;\n  /** Product variants from the [Storefront API](/docs/api/storefront/2023-07/objects/ProductVariant). You only need to pass this prop if you want to show product availability. If a product option combination is not found within `variants`, it is assumed to be available. Make sure to include `availableForSale` and `selectedOptions.name` and `selectedOptions.value`. */\n  variants?:\n    | PartialDeep<ProductVariantConnection>\n    | Array<PartialDeep<ProductVariant>>;\n  /** By default all products are under /products. Use this prop to provide a custom path. */\n  productPath?: string;\n  children: ({option}: {option: VariantOption}) => ReactNode;\n}",
             "description": "",
             "members": [
               {
@@ -8599,6 +8599,14 @@
                 "name": "variants",
                 "value": "PartialObjectDeep<ProductVariantConnection, {}> | PartialObjectDeep<ProductVariant, {}>[]",
                 "description": "Product variants from the [Storefront API](/docs/api/storefront/2023-07/objects/ProductVariant). You only need to pass this prop if you want to show product availability. If a product option combination is not found within `variants`, it is assumed to be available. Make sure to include `availableForSale` and `selectedOptions.name` and `selectedOptions.value`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/product/VariantSelector.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "productPath",
+                "value": "string",
+                "description": "By default all products are under /products. Use this prop to provide a custom path.",
                 "isOptional": true
               },
               {

--- a/packages/hydrogen/src/product/VariantSelector.test.ts
+++ b/packages/hydrogen/src/product/VariantSelector.test.ts
@@ -147,6 +147,56 @@ describe('<VariantSelector>', () => {
     `);
   });
 
+  it('uses a custom product path with leading slash', () => {
+    const {asFragment} = render(
+      createElement(VariantSelector, {
+        handle: 'snowboard',
+        productPath: '/shop',
+        options: [
+          {name: 'Color', values: ['Red', 'Blue']},
+          {name: 'Size', values: ['S', 'M']},
+        ],
+        children: ({option}) =>
+          createElement(
+            'div',
+            null,
+            option.values.map(({value, to}) =>
+              createElement('a', {key: option.name + value, href: to}, value),
+            ),
+          ),
+      }),
+    );
+
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <div>
+          <a
+            href="/shop/snowboard?Color=Red"
+          >
+            Red
+          </a>
+          <a
+            href="/shop/snowboard?Color=Blue"
+          >
+            Blue
+          </a>
+        </div>
+        <div>
+          <a
+            href="/shop/snowboard?Size=S"
+          >
+            S
+          </a>
+          <a
+            href="/shop/snowboard?Size=M"
+          >
+            M
+          </a>
+        </div>
+      </DocumentFragment>
+    `);
+  });
+
   it('automatically appends options with only one value to the URL', () => {
     const {asFragment} = render(
       createElement(VariantSelector, {

--- a/packages/hydrogen/src/product/VariantSelector.test.ts
+++ b/packages/hydrogen/src/product/VariantSelector.test.ts
@@ -97,6 +97,56 @@ describe('<VariantSelector>', () => {
     `);
   });
 
+  it('uses a custom product path', () => {
+    const {asFragment} = render(
+      createElement(VariantSelector, {
+        handle: 'snowboard',
+        productPath: 'shop',
+        options: [
+          {name: 'Color', values: ['Red', 'Blue']},
+          {name: 'Size', values: ['S', 'M']},
+        ],
+        children: ({option}) =>
+          createElement(
+            'div',
+            null,
+            option.values.map(({value, to}) =>
+              createElement('a', {key: option.name + value, href: to}, value),
+            ),
+          ),
+      }),
+    );
+
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <div>
+          <a
+            href="/shop/snowboard?Color=Red"
+          >
+            Red
+          </a>
+          <a
+            href="/shop/snowboard?Color=Blue"
+          >
+            Blue
+          </a>
+        </div>
+        <div>
+          <a
+            href="/shop/snowboard?Size=S"
+          >
+            S
+          </a>
+          <a
+            href="/shop/snowboard?Size=M"
+          >
+            M
+          </a>
+        </div>
+      </DocumentFragment>
+    `);
+  });
+
   it('automatically appends options with only one value to the URL', () => {
     const {asFragment} = render(
       createElement(VariantSelector, {

--- a/packages/hydrogen/src/product/VariantSelector.ts
+++ b/packages/hydrogen/src/product/VariantSelector.ts
@@ -32,6 +32,8 @@ type VariantSelectorProps = {
   variants?:
     | PartialDeep<ProductVariantConnection>
     | Array<PartialDeep<ProductVariant>>;
+  /** By default all products are under /products. Use this prop to provide a custom path. */
+  productPath?: string;
   children: ({option}: {option: VariantOption}) => ReactNode;
 };
 
@@ -39,12 +41,16 @@ export function VariantSelector({
   handle,
   options = [],
   variants: _variants = [],
+  productPath = 'products',
   children,
 }: VariantSelectorProps) {
   const variants =
     _variants instanceof Array ? _variants : flattenConnection(_variants);
 
-  const {searchParams, path, alreadyOnProductPage} = useVariantPath(handle);
+  const {searchParams, path, alreadyOnProductPage} = useVariantPath(
+    handle,
+    productPath,
+  );
 
   // If an option only has one value, it doesn't need a UI to select it
   // But instead it always needs to be added to the product options so
@@ -144,7 +150,7 @@ export const getSelectedProductOptions: GetSelectedProductOptions = (
   return selectedOptions;
 };
 
-function useVariantPath(handle: string) {
+function useVariantPath(handle: string, productPath: string) {
   const {pathname, search} = useLocation();
 
   return useMemo(() => {
@@ -152,8 +158,8 @@ function useVariantPath(handle: string) {
     const isLocalePathname = match && match.length > 0;
 
     const path = isLocalePathname
-      ? `${match![0]}products/${handle}`
-      : `/products/${handle}`;
+      ? `${match![0]}${productPath}/${handle}`
+      : `/${productPath}/${handle}`;
 
     const searchParams = new URLSearchParams(search);
 

--- a/packages/hydrogen/src/product/VariantSelector.ts
+++ b/packages/hydrogen/src/product/VariantSelector.ts
@@ -156,6 +156,9 @@ function useVariantPath(handle: string, productPath: string) {
   return useMemo(() => {
     const match = /(\/[a-zA-Z]{2}-[a-zA-Z]{2}\/)/g.exec(pathname);
     const isLocalePathname = match && match.length > 0;
+    productPath = productPath.startsWith('/')
+      ? productPath.substring(1)
+      : productPath;
 
     const path = isLocalePathname
       ? `${match![0]}${productPath}/${handle}`
@@ -171,5 +174,5 @@ function useVariantPath(handle: string, productPath: string) {
       alreadyOnProductPage: path === pathname,
       path,
     };
-  }, [pathname, search, handle]);
+  }, [pathname, search, handle, productPath]);
 }


### PR DESCRIPTION



### WHY are these changes introduced?

Add custom product paths to the `VariantSelector` component:

```tsx
<VariantSelector handle="snowboard" productPath="shop" options={options}>
  {/* ... */}
</VariantSelector>
```

Fixes #1262


<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
