### PR TITLE
Update to TS 5.2

### DIFF
--- a/.changeset/purple-weeks-ring.md
+++ b/.changeset/purple-weeks-ring.md
@@ -12,7 +12,7 @@ If you have `typescript` as a dev dependency in your app, it is recommended to c
   "devDependencies": {
     ...
 -   "typescript": "^4.9.5",
-+   "typescript": "^5.1.6",
++   "typescript": "^5.2.2",
   },
 ```
 

--- a/examples/customer-api/package.json
+++ b/examples/customer-api/package.json
@@ -34,7 +34,7 @@
     "eslint": "^8.20.0",
     "eslint-plugin-hydrogen": "0.12.2",
     "prettier": "^2.8.4",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=16.13"

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -38,7 +38,7 @@
     "eslint": "^8.38.0",
     "nodemon": "^2.0.22",
     "npm-run-all": "^4.1.5",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "rimraf": "^3.0.2",
         "tsup": "7.2.0",
         "turbo": "1.10.12",
-        "typescript": "^5.1.6",
+        "typescript": "^5.2.2",
         "yorkie": "^2.0.0"
       },
       "engines": {
@@ -67,7 +67,7 @@
         "eslint": "^8.38.0",
         "nodemon": "^2.0.22",
         "npm-run-all": "^4.1.5",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=14"
@@ -24282,9 +24282,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26102,7 +26102,7 @@
         "react-dom": "^18.0.0",
         "rimraf": "^4.1.2",
         "ts-expect": "^1.3.0",
-        "typescript": "^5.1.6",
+        "typescript": "^5.2.2",
         "vite": "^4.4.6",
         "vitest": "^0.33.0"
       },
@@ -26333,7 +26333,7 @@
         "prettier": "^2.8.4",
         "rimraf": "^3.0.2",
         "tailwindcss": "^3.3.0",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=16.13"
@@ -26364,7 +26364,7 @@
         "eslint": "^8.20.0",
         "eslint-plugin-hydrogen": "0.12.2",
         "prettier": "^2.8.4",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=16.13"
@@ -26395,7 +26395,7 @@
         "eslint": "^8.20.0",
         "eslint-plugin-hydrogen": "0.12.2",
         "prettier": "^2.8.4",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=16.13"
@@ -31136,7 +31136,7 @@
         "rimraf": "^4.1.2",
         "ts-expect": "^1.3.0",
         "type-fest": "^3.6.0",
-        "typescript": "^5.1.6",
+        "typescript": "^5.2.2",
         "vite": "^4.4.6",
         "vitest": "^0.33.0",
         "worktop": "^0.7.3"
@@ -34224,7 +34224,7 @@
         "schema-dts": "^1.1.0",
         "tailwindcss": "^3.3.0",
         "tiny-invariant": "^1.2.0",
-        "typescript": "^5.1.6",
+        "typescript": "^5.2.2",
         "typographic-base": "^1.0.4",
         "worktop": "^0.7.3"
       }
@@ -36132,7 +36132,7 @@
         "prettier": "^2.8.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       }
     },
     "history": {
@@ -36273,7 +36273,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       }
     },
     "hyperlinker": {
@@ -40767,7 +40767,7 @@
         "prettier": "^2.8.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       }
     },
     "slash": {
@@ -41935,9 +41935,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
     },
     "typographic-apostrophes": {
       "version": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "rimraf": "^3.0.2",
     "tsup": "7.2.0",
     "turbo": "1.10.12",
-    "typescript": "^5.1.6",
+    "typescript": "^5.2.2",
     "yorkie": "^2.0.0"
   },
   "engines": {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["dist", "__tests__", "node_modules", ".turbo"],
   "compilerOptions": {
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "jsx": "react-jsx",
     "rootDir": "src",

--- a/packages/create-hydrogen/tsconfig.json
+++ b/packages/create-hydrogen/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["dist", "__tests__", "node_modules", ".turbo"],
   "compilerOptions": {
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "rootDir": "src",
     "noUncheckedIndexedAccess": true,

--- a/packages/hydrogen-react/package.json
+++ b/packages/hydrogen-react/package.json
@@ -127,7 +127,7 @@
     "react-dom": "^18.0.0",
     "rimraf": "^4.1.2",
     "ts-expect": "^1.3.0",
-    "typescript": "^5.1.6",
+    "typescript": "^5.2.2",
     "vite": "^4.4.6",
     "vitest": "^0.33.0"
   },

--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -58,7 +58,7 @@
     "prettier": "^2.8.4",
     "rimraf": "^3.0.2",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=16.13"

--- a/templates/hello-world/package.json
+++ b/templates/hello-world/package.json
@@ -34,7 +34,7 @@
     "eslint": "^8.20.0",
     "eslint-plugin-hydrogen": "0.12.2",
     "prettier": "^2.8.4",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=16.13"

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -35,7 +35,7 @@
     "eslint": "^8.20.0",
     "eslint-plugin-hydrogen": "0.12.2",
     "prettier": "^2.8.4",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=16.13"


### PR DESCRIPTION
[TS 5.2 ](https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#breaking-changes-and-correctness-fixes) was just released so perhaps we should update before releasing Hydrogen with 5.1.6 (currently in `main` branch).