### PR TITLE
Catch development store errors during init

### DIFF
--- a/.changeset/tall-lamps-confess.md
+++ b/.changeset/tall-lamps-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Catch more errors during init while connecting to Shopify

--- a/packages/cli/src/lib/graphql/admin/client.test.ts
+++ b/packages/cli/src/lib/graphql/admin/client.test.ts
@@ -71,4 +71,28 @@ describe('adminRequest', () => {
       );
     });
   });
+
+  describe("when the user doesn't have access to hydrogenStorefrontCreate", () => {
+    it('throws an AbortError', async () => {
+      const fakeGraphqlError = {
+        errors: [
+          {
+            message: 'Access denied for hydrogenStorefrontCreate field',
+          },
+        ],
+      };
+
+      vi.mocked(graphqlRequest).mockRejectedValue(fakeGraphqlError);
+
+      const response = adminRequest<TestSchema>('', {
+        token: '',
+        storeFqdn: '',
+      });
+
+      await expect(response).rejects.toThrowError(AbortError);
+      await expect(response).rejects.toMatch(
+        /Couldn\'t connect storefront to Shopify/,
+      );
+    });
+  });
 });

--- a/packages/cli/src/lib/graphql/admin/client.ts
+++ b/packages/cli/src/lib/graphql/admin/client.ts
@@ -51,6 +51,27 @@ export async function adminRequest<T>(
       );
     }
 
+    if (
+      errors?.some?.((error) =>
+        error.message.includes(
+          'Access denied for hydrogenStorefrontCreate field',
+        ),
+      )
+    ) {
+      throw new AbortError("Couldn't connect storefront to Shopify", [
+        'Common reasons for this error include:',
+        {
+          list: {
+            items: [
+              "The Hydrogen sales channel isn't installed on the store.",
+              "You don't have the required account permission to manage apps or channels.",
+              "You're trying to connect to an ineligible store type (Trial, Development store)",
+            ],
+          },
+        },
+      ]);
+    }
+
     throw error;
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When developers go through the `init` flow and try to create a storefront on a Development Store we throw an unhelpful error.

### WHAT is this pull request doing?

This updates the code to explicitly catch that error and return possible reasons for why it failed. The API throws this error for a number of reasons so we're listing them all out instead of just mentioning Development Stores.

<img width="637" alt="image" src="https://github.com/Shopify/hydrogen/assets/836758/05e62e22-06f1-47f1-955d-5a7f1a5c0acf">

### HOW to test your changes?

Run the `init` command and try to connect to a shop that's on a Development Store plan.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation