### PR TITLE
Server request tool showing cached requests

### DIFF
--- a/packages/cli/src/lib/mini-oxygen.ts
+++ b/packages/cli/src/lib/mini-oxygen.ts
@@ -18,6 +18,7 @@ import {
 } from '@shopify/mini-oxygen';
 import {DEFAULT_PORT} from './flags.js';
 import {
+  LogSubRequestProps,
   logRequestEvent,
   logSubRequestEvent,
   streamRequestEvents,
@@ -98,6 +99,23 @@ export async function startMiniOxygen({
       });
 
       return response;
+    },
+    async globalLog(args: unknown) {
+      const cachedRequest = args as LogSubRequestProps;
+      const cacheStatus = cachedRequest.response.headers.get(
+        'hydrogen-cache-status',
+      );
+
+      if (cacheStatus === 'HIT' || cacheStatus === 'STALE') {
+        logSubRequestEvent({
+          response: cachedRequest.response,
+          startTime: cachedRequest.startTime,
+          requestGroupId: asyncLocalStorage.getStore() as string,
+          requestUrl: cachedRequest.requestUrl,
+          requestHeaders: cachedRequest.requestHeaders,
+          requestBody: cachedRequest.requestUrl,
+        });
+      }
     },
   });
 

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -29,6 +29,10 @@ import {
 import {warnOnce} from './utils/warning';
 import {LIB_VERSION} from './version';
 
+declare global {
+  var logOxygen: (args: unknown) => void;
+}
+
 type StorefrontApiResponse<T> = StorefrontApiResponseOk<T>;
 
 export type I18nBase = {
@@ -293,6 +297,7 @@ export function createStorefrontClient<TI18n extends I18nBase>(
     headers = [],
     storefrontApiVersion,
   }: StorefrontQueryOptions | StorefrontMutationOptions): Promise<T> {
+    const startTime = new Date().getTime();
     const userHeaders =
       headers instanceof Headers
         ? Object.fromEntries(headers.entries())
@@ -338,6 +343,13 @@ export function createStorefrontClient<TI18n extends I18nBase>(
       queryVariables,
       errors: undefined,
     };
+
+    logOxygen({
+      requestUrl: query,
+      requestHeaders: {...defaultHeaders, ...userHeaders},
+      response,
+      startTime,
+    });
 
     if (!response.ok) {
       /**


### PR DESCRIPTION
### WHY are these changes introduced?

Requires this PR: https://github.com/Shopify/mini-oxygen/pull/545

Introducing a global scoped `logOxygen` function so that we can manually pass information about cached requests.

#### Problem:
* The `globalFetch` patch doesn't capture the cached requests (missing HIT and STALE requests)
* It capture the PUT requests (since it is a fetch request) which made it confusing when display in the flame chart (showing oddly delayed fetch requests)

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
