### PR TITLE
Fix stale requests in event logger v1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
   },
   "peerDependencies": {
     "@remix-run/react": "1.19.1",
+    "@shopify/hydrogen": "^2023.7.3",
     "@shopify/hydrogen-react": "^2023.7.3",
     "@shopify/remix-oxygen": "^1.1.3"
   },

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -38,6 +38,13 @@
         "default": "./dist/production/index.js"
       }
     },
+    "./debug": {
+      "types": "./dist/production/debug.d.ts",
+      "default": {
+        "development": "./dist/development/debug.js",
+        "default": "./dist/production/debug.js"
+      }
+    },
     "./storefront-api-types": "./dist/storefront-api-types.d.ts",
     "./storefront.schema.json": "./dist/storefront.schema.json",
     "./package.json": "./package.json"

--- a/packages/hydrogen/src/cache/api.ts
+++ b/packages/hydrogen/src/cache/api.ts
@@ -174,7 +174,7 @@ function calculateAge(response: Response, responseDate: string) {
 /**
  * Manually check the response to see if it's stale.
  */
-function isStale(request: Request, response: Response) {
+export function isStale(request: Request, response: Response) {
   const responseDate = response.headers.get('cache-put-date');
 
   if (!responseDate) {

--- a/packages/hydrogen/src/cache/sub-request.ts
+++ b/packages/hydrogen/src/cache/sub-request.ts
@@ -13,7 +13,7 @@ import {
 /**
  * Cache API is weird. We just need a full URL, so we make one up.
  */
-function getKeyUrl(key: string) {
+export function getKeyUrl(key: string) {
   return `https://shopify.dev/?${key}`;
 }
 

--- a/packages/hydrogen/src/debug.ts
+++ b/packages/hydrogen/src/debug.ts
@@ -1,0 +1,3 @@
+export {hashKey} from './utils/hash.js';
+export {isStale} from './cache/api.js';
+export {getKeyUrl} from './cache/sub-request.js';

--- a/packages/hydrogen/tsup.config.ts
+++ b/packages/hydrogen/tsup.config.ts
@@ -7,7 +7,7 @@ const cjsEntryContent = `module.exports = process.env.NODE_ENV === 'development'
 const cjsEntryFile = path.resolve(process.cwd(), outDir, 'index.cjs');
 
 const commonConfig = defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/debug.ts'],
   format: ['esm', 'cjs'],
   treeshake: true,
   sourcemap: true,


### PR DESCRIPTION
Related: https://github.com/Shopify/mini-oxygen/pull/546

I think this could fix the request event log issue with cache:

<img width="551" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/0dc39739-b890-476d-8769-9eca59969d5a">


@wizardlyhel can you check if this works for you? You need the changes in MiniOxygen as well
