### PR TITLE
Move fs-extra back to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26019,6 +26019,7 @@
         "@shopify/mini-oxygen": "^2.2.1",
         "ansi-escapes": "^6.2.0",
         "diff": "^5.1.0",
+        "fs-extra": "^11.1.0",
         "get-port": "^7.0.0",
         "gunzip-maybe": "^1.4.2",
         "prettier": "^2.8.4",
@@ -26036,7 +26037,6 @@
         "@types/recursive-readdir": "^2.2.1",
         "@types/tar-fs": "^2.0.1",
         "@vitest/coverage-v8": "^0.33.0",
-        "fs-extra": "^11.1.0",
         "type-fest": "^3.6.0",
         "vitest": "^0.33.0"
       },
@@ -26289,7 +26289,6 @@
     },
     "packages/cli/node_modules/fs-extra": {
       "version": "11.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -31083,7 +31082,6 @@
         },
         "fs-extra": {
           "version": "11.1.1",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,6 @@
     "@types/recursive-readdir": "^2.2.1",
     "@types/tar-fs": "^2.0.1",
     "@vitest/coverage-v8": "^0.33.0",
-    "fs-extra": "^11.1.0",
     "type-fest": "^3.6.0",
     "vitest": "^0.33.0"
   },
@@ -36,6 +35,7 @@
     "@shopify/mini-oxygen": "^2.2.1",
     "ansi-escapes": "^6.2.0",
     "diff": "^5.1.0",
+    "fs-extra": "^11.1.0",
     "get-port": "^7.0.0",
     "gunzip-maybe": "^1.4.2",
     "prettier": "^2.8.4",


### PR DESCRIPTION
I moved it to devDeps by mistake in https://github.com/Shopify/hydrogen/pull/1272 , didn't see it was imported as `'fs-extra/esm'` in a command.