### PR TITLE
Suppress Script hydration warning

### DIFF
--- a/.changeset/silent-baboons-love.md
+++ b/.changeset/silent-baboons-love.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Supress the hydration warning in the new `<Script>` component when `nonce` values differ between the server and client, which is expected.

--- a/packages/hydrogen/src/csp/Script.tsx
+++ b/packages/hydrogen/src/csp/Script.tsx
@@ -6,6 +6,8 @@ type ScriptProps = JSX.IntrinsicElements['script'];
 export const Script = forwardRef<HTMLScriptElement, ScriptProps>(
   (props, ref) => {
     const nonce = useNonce();
-    return <script {...props} nonce={nonce} ref={ref} />;
+    return (
+      <script suppressHydrationWarning {...props} nonce={nonce} ref={ref} />
+    );
   },
 );


### PR DESCRIPTION
`nonce` values are always `undefined` in the client and it triggers a hydration mismatch. Afaik this is unavoidable so we can [suppress the hydration warning](https://react.dev/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors).