### PR TITLE
Default turn source maps on

### DIFF
--- a/.changeset/witty-kiwis-cross.md
+++ b/.changeset/witty-kiwis-cross.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Make sourcemaps to default be turned on. They were off to prevent sourcemaps leaking server code to the client. Oxygen now makes sure to not serve the sourcemaps, so it's okay to generate them. Also, when sourcemaps are present, we hope to enable sourcemapped stack traces in error logs on Oxygen.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -20,7 +20,7 @@
           "name": "sourcemap",
           "type": "boolean",
           "description": "Generate sourcemaps for the build.",
-          "allowNo": false
+          "allowNo": true
         },
         "bundle-stats": {
           "name": "bundle-stats",

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -45,7 +45,8 @@ export default class Build extends Command {
     sourcemap: Flags.boolean({
       description: 'Generate sourcemaps for the build.',
       env: 'SHOPIFY_HYDROGEN_FLAG_SOURCEMAP',
-      default: false,
+      allowNo: true,
+      default: true,
     }),
     ['bundle-stats']: Flags.boolean({
       description: 'Show a bundle size summary after building.',
@@ -185,20 +186,6 @@ export async function runBuild({
             : ' Minify your bundle by adding `serverMinify: true` to remix.config.js.'
         }\n`,
       );
-    }
-
-    if (sourcemap) {
-      if (process.env.HYDROGEN_ASSET_BASE_URL) {
-        // Oxygen build
-        const filepaths = await glob(joinPath(buildPathClient, '**/*.js.map'));
-        for (const filepath of filepaths) {
-          await removeFile(filepath);
-        }
-      } else {
-        outputWarn(
-          '🚨 Sourcemaps are enabled in production! Use this only for testing.\n',
-        );
-      }
     }
   }
 


### PR DESCRIPTION


<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Source maps were turned off by default to prevent server code from leaking to the client via source maps. Oxygen has been updated to not serve the sourcemaps to the browser, but we'd still like the sourcemaps available to Oxygen. Having them means that Oxygen can provide a better developer and debugging experience when errors are logged.

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

Default turn sourcemaps on. They can be disabled with `--no-sourcemap` via the CLI: `npx shopify hydrogen build --no-sourcemap`
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
