### PR TITLE
Minor CLI fixes

### DIFF
--- a/.changeset/spicy-starfishes-work.md
+++ b/.changeset/spicy-starfishes-work.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Fix `--routes` and `--markets` flag when creating new projects.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -345,7 +345,7 @@
           "type": "boolean",
           "description": "Generate routes for all pages.",
           "hidden": true,
-          "allowNo": false
+          "allowNo": true
         },
         "git": {
           "name": "git",

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -56,6 +56,7 @@ export default class Init extends Command {
       description: 'Generate routes for all pages.',
       env: 'SHOPIFY_HYDROGEN_FLAG_ROUTES',
       hidden: true,
+      allowNo: true,
     }),
     git: Flags.boolean({
       description: 'Init Git and create initial commits.',

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -67,12 +67,16 @@ export default class Init extends Command {
   };
 
   async run(): Promise<void> {
-    const {flags} = await this.parse(Init);
+    // Rename markets => i18n
+    const {
+      flags: {markets, ..._flags},
+    } = await this.parse(Init);
+    const flags = {..._flags, i18n: markets};
 
-    if (flags.markets && !I18N_CHOICES.includes(flags.markets as I18nChoice)) {
+    if (flags.i18n && !I18N_CHOICES.includes(flags.i18n as I18nChoice)) {
       throw new AbortError(
         `Invalid URL structure strategy: ${
-          flags.markets
+          flags.i18n
         }. Must be one of ${I18N_CHOICES.join(', ')}`,
       );
     }

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -380,12 +380,12 @@ export async function handleCssStrategy(
   controller: AbortController,
   flagStyling?: StylingChoice,
 ) {
-  const selection = flagStyling
-    ? flagStyling
-    : await renderCssPrompt({
-        abortSignal: controller.signal,
-        extraChoices: {none: 'Skip and set up later'},
-      });
+  const selection =
+    flagStyling ??
+    (await renderCssPrompt({
+      abortSignal: controller.signal,
+      extraChoices: {none: 'Skip and set up later'},
+    }));
 
   const cssStrategy = selection === 'none' ? undefined : selection;
 

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -119,11 +119,14 @@ export async function handleRouteGeneration(
   flagRoutes?: boolean,
 ) {
   // TODO: Need a multi-select UI component
-  const routesToScaffold = flagRoutes
-    ? 'all'
-    : await renderRoutePrompt({
-        abortSignal: controller.signal,
-      });
+  const routesToScaffold =
+    flagRoutes === true
+      ? 'all'
+      : flagRoutes === false
+      ? []
+      : await renderRoutePrompt({
+          abortSignal: controller.signal,
+        });
 
   const needsRouteGeneration =
     routesToScaffold === 'all' || routesToScaffold.length > 0;

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -282,7 +282,7 @@ export async function setupLocalStarterTemplate(
 
     const {setupRoutes} = await handleRouteGeneration(
       controller,
-      options.routes || true, // TODO: Remove default value when multi-select UI component is available
+      options.routes ?? true, // TODO: Remove default value when multi-select UI component is available
     );
 
     setupSummary.i18n = i18nStrategy;


### PR DESCRIPTION
The `--markets` flag was completely ignored due to a change in internal naming.
The `--no-routes` variation was casted to `true` by mistake.