### PR TITLE
Generate skeleton templates in dist branch

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -78,6 +78,10 @@ jobs:
       - name: Build the dist code
         run: npm run build
 
+      - name: Compile skeleton
+        run: |
+          node scripts/compile-template-for-dist.mjs skeleton
+
       - name: Compile hello-world
         run: |
           node scripts/compile-template-for-dist.mjs hello-world


### PR DESCRIPTION
Generate `templates/skeleton-js` and `templates/skeleton-ts` in `dist` branch to be used in Admin when creating new projects.