### PR TITLE
Throw build errors when lockfile is not valid on CI

### DIFF
--- a/.changeset/fresh-cobras-call.md
+++ b/.changeset/fresh-cobras-call.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-hydrogen': minor
+---
+
+The build command now throws errors on CI when it can't find a valid lockfile. This should prevent unforseen issues related to dependency versioning in production.
+
+This behavior can be disabled with the flag `--no-lockfile-check`, which might be useful in monorepos or other setups where the lockfile is not available in the project directory.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,10 @@ jobs:
       #       turbo-${{ github.job }}-${{ github.ref_name }}-
 
       - name: 📦 Build packages
-        run: npm run build
+        run: npm run build:pkg
+
+      - name: 🗒 Build templates
+        run: npm run build:templates -- --no-lockfile-check
 
       - name: ✅ Typecheck
         run: npm run typecheck
@@ -115,7 +118,10 @@ jobs:
         run: npm ci
 
       - name: 📦 Build packages
-        run: npm run build
+        run: npm run build:pkg
+
+      - name: 🗒 Build templates
+        run: npm run build:templates -- --no-lockfile-check
 
       - name: 🔬 Test
         run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,8 @@ jobs:
       #     restore-keys: |
       #       turbo-${{ github.job }}-${{ github.ref_name }}-
 
-      - name: 📦 Build packages
-        run: npm run build:pkg
-
-      - name: 🗒 Build templates
-        run: npm run build:templates -- --no-lockfile-check
+      - name: 📦 Build packages, templates, and examples
+        run: SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npm run build:all
 
       - name: ✅ Typecheck
         run: npm run typecheck
@@ -117,11 +114,8 @@ jobs:
       - name: 📥 Install dependencies
         run: npm ci
 
-      - name: 📦 Build packages
-        run: npm run build:pkg
-
-      - name: 🗒 Build templates
-        run: npm run build:templates -- --no-lockfile-check
+      - name: 📦 Build packages, templates, and examples
+        run: SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npm run build:all
 
       - name: 🔬 Test
         run: npm run test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
           oxygen_deployment_token: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_28966968 }}
           oxygen_worker_dir: dist/worker
           oxygen_client_dir: dist/client
-          build_command: 'HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL npm run build'
+          build_command: 'HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL npm run build -- --no-lockfile-check'
           # Hardcode message and timestamp if manual dispatch
           commit_message: ${{ github.event.head_commit.message || 'Manual deployment' }}
           commit_timestamp: ${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
           oxygen_deployment_token: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_28966968 }}
           oxygen_worker_dir: dist/worker
           oxygen_client_dir: dist/client
-          build_command: 'HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL npm run build -- --no-lockfile-check'
+          build_command: 'HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL npm run build'
           # Hardcode message and timestamp if manual dispatch
           commit_message: ${{ github.event.head_commit.message || 'Manual deployment' }}
           commit_timestamp: ${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29088,7 +29088,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -29688,7 +29688,7 @@
       "dependencies": {
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.3.0",
+        "@shopify/cli-hydrogen": "^5.3.1",
         "@shopify/hydrogen": "^2023.7.8",
         "@shopify/remix-oxygen": "^1.1.4",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -29719,7 +29719,7 @@
       "dependencies": {
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.3.0",
+        "@shopify/cli-hydrogen": "^5.3.1",
         "@shopify/hydrogen": "^2023.7.8",
         "@shopify/remix-oxygen": "^1.1.4",
         "graphql": "^16.6.0",
@@ -39653,7 +39653,7 @@
         "@remix-run/dev": "1.19.1",
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.3.0",
+        "@shopify/cli-hydrogen": "^5.3.1",
         "@shopify/hydrogen": "^2023.7.8",
         "@shopify/oxygen-workers-types": "^3.17.3",
         "@shopify/prettier-config": "^1.1.2",
@@ -46483,7 +46483,7 @@
         "@remix-run/dev": "1.19.1",
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.3.0",
+        "@shopify/cli-hydrogen": "^5.3.1",
         "@shopify/hydrogen": "^2023.7.8",
         "@shopify/oxygen-workers-types": "^3.17.3",
         "@shopify/prettier-config": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "build": "turbo build --parallel",
-    "build:pkg": "npm run build -- --filter=./packages/*",
+    "build": "npm run build:pkg",
+    "build:pkg": "turbo build --parallel --filter=./packages/*",
+    "build:templates": "turbo build --parallel --filter=./templates/* --filter=./examples/*",
     "ci:checks": "turbo run lint test format:check typecheck",
     "dev": "npm run dev:pkg",
     "dev:pkg": "cross-env LOCAL_DEV=true turbo dev --parallel --filter=./packages/*",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "npm run build:pkg",
     "build:pkg": "turbo build --parallel --filter=./packages/*",
-    "build:templates": "turbo build --parallel --filter=./templates/* --filter=./examples/*",
+    "build:all": "turbo build --parallel",
     "ci:checks": "turbo run lint test format:check typecheck",
     "dev": "npm run dev:pkg",
     "dev:pkg": "cross-env LOCAL_DEV=true turbo dev --parallel --filter=./packages/*",

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -28,6 +28,12 @@
           "description": "Show a bundle size summary after building.",
           "allowNo": true
         },
+        "lockfile-check": {
+          "name": "lockfile-check",
+          "type": "boolean",
+          "description": "Checks that there is exactly 1 valid lockfile in the project.",
+          "allowNo": true
+        },
         "disable-route-warning": {
           "name": "disable-route-warning",
           "type": "boolean",

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -51,6 +51,7 @@ export default class Build extends Command {
     'lockfile-check': Flags.boolean({
       description:
         'Checks that there is exactly 1 valid lockfile in the project.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK',
       default: true,
       allowNo: true,
     }),

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -29,6 +29,7 @@ import {
   hasMetafile,
 } from '../../lib/bundle/analyzer.js';
 import {AbortError} from '@shopify/cli-kit/node/error';
+import {isCI} from '../../lib/is-ci.js';
 
 const LOG_WORKER_BUILT = '📦 Worker built';
 const MAX_WORKER_BUNDLE_SIZE = 10;
@@ -116,7 +117,7 @@ export async function runBuild({
     getProjectPaths(directory);
 
   if (lockfileCheck) {
-    await checkLockfileStatus(root);
+    await checkLockfileStatus(root, isCI());
   }
 
   await muteRemixLogs();

--- a/packages/cli/src/lib/check-lockfile.test.ts
+++ b/packages/cli/src/lib/check-lockfile.test.ts
@@ -49,6 +49,16 @@ describe('checkLockfileStatus()', () => {
           );
         });
       });
+
+      it('throws when shouldExit is true', async () => {
+        await inTemporaryDirectory(async (tmpDir) => {
+          await writeFile(joinPath(tmpDir, 'package-lock.json'), '');
+
+          await expect(checkLockfileStatus(tmpDir, true)).rejects.toThrow(
+            /Lockfile ignored by Git/is,
+          );
+        });
+      });
     });
   });
 
@@ -65,6 +75,17 @@ describe('checkLockfileStatus()', () => {
         );
       });
     });
+
+    it('throws when shouldExit is true', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        await writeFile(joinPath(tmpDir, 'package-lock.json'), '');
+        await writeFile(joinPath(tmpDir, 'pnpm-lock.yaml'), '');
+
+        await expect(checkLockfileStatus(tmpDir, true)).rejects.toThrow(
+          /Multiple lockfiles found/is,
+        );
+      });
+    });
   });
 
   describe('when a lockfile is missing', () => {
@@ -73,6 +94,14 @@ describe('checkLockfileStatus()', () => {
         await checkLockfileStatus(tmpDir);
 
         expect(outputMock.warn()).toMatch(/ warning .+ No lockfile found .+/is);
+      });
+    });
+
+    it('throws when shouldExit is true', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        await expect(checkLockfileStatus(tmpDir, true)).rejects.toThrow(
+          /No lockfile found/is,
+        );
       });
     });
   });

--- a/packages/cli/src/lib/check-lockfile.test.ts
+++ b/packages/cli/src/lib/check-lockfile.test.ts
@@ -49,16 +49,6 @@ describe('checkLockfileStatus()', () => {
           );
         });
       });
-
-      it('throws when shouldExit is true', async () => {
-        await inTemporaryDirectory(async (tmpDir) => {
-          await writeFile(joinPath(tmpDir, 'package-lock.json'), '');
-
-          await expect(checkLockfileStatus(tmpDir, true)).rejects.toThrow(
-            /Lockfile ignored by Git/is,
-          );
-        });
-      });
     });
   });
 

--- a/packages/cli/src/lib/check-lockfile.ts
+++ b/packages/cli/src/lib/check-lockfile.ts
@@ -1,12 +1,13 @@
 import {fileExists} from '@shopify/cli-kit/node/fs';
 import {resolvePath} from '@shopify/cli-kit/node/path';
 import {checkIfIgnoredInGitRepository} from '@shopify/cli-kit/node/git';
-import {renderFatalError, renderWarning} from '@shopify/cli-kit/node/ui';
+import {renderWarning} from '@shopify/cli-kit/node/ui';
 import {AbortError} from '@shopify/cli-kit/node/error';
 import {
   lockfiles,
   type Lockfile,
 } from '@shopify/cli-kit/node/node-package-manager';
+import {isCI} from './is-ci.js';
 
 function missingLockfileWarning(shouldExit: boolean) {
   const headline = 'No lockfile found';
@@ -81,7 +82,7 @@ function lockfileIgnoredWarning(lockfile: string, shouldExit: boolean) {
 
 export async function checkLockfileStatus(
   directory: string,
-  shouldExit = false,
+  shouldExit = isCI(),
 ) {
   if (process.env.LOCAL_DEV) return;
 

--- a/packages/cli/src/lib/check-lockfile.ts
+++ b/packages/cli/src/lib/check-lockfile.ts
@@ -1,32 +1,37 @@
 import {fileExists} from '@shopify/cli-kit/node/fs';
 import {resolvePath} from '@shopify/cli-kit/node/path';
 import {checkIfIgnoredInGitRepository} from '@shopify/cli-kit/node/git';
-import {renderWarning} from '@shopify/cli-kit/node/ui';
+import {renderFatalError, renderWarning} from '@shopify/cli-kit/node/ui';
+import {AbortError} from '@shopify/cli-kit/node/error';
 import {
   lockfiles,
   type Lockfile,
 } from '@shopify/cli-kit/node/node-package-manager';
 
-function missingLockfileWarning() {
-  renderWarning({
-    headline: 'No lockfile found',
-    body:
-      `If you don’t commit a lockfile, then your app might install the wrong ` +
-      `package versions when deploying. To avoid versioning issues, generate a ` +
-      `new lockfile and commit it to your repository.`,
-    nextSteps: [
-      [
-        'Generate a lockfile. Run',
-        {
-          command: 'npm|yarn|pnpm install',
-        },
-      ],
-      'Commit the new file to your repository',
+function missingLockfileWarning(shouldExit: boolean) {
+  const headline = 'No lockfile found';
+  const body =
+    `If you don’t commit a lockfile, then your app might install the wrong ` +
+    `package versions when deploying. To avoid versioning issues, generate a ` +
+    `new lockfile and commit it to your repository.`;
+  const nextSteps = [
+    [
+      'Generate a lockfile. Run',
+      {
+        command: 'npm|yarn|pnpm install',
+      },
     ],
-  });
+    'Commit the new file to your repository',
+  ];
+
+  if (shouldExit) {
+    throw new AbortError(headline, body, nextSteps);
+  } else {
+    renderWarning({headline, body, nextSteps});
+  }
 }
 
-function multipleLockfilesWarning(lockfiles: Lockfile[]) {
+function multipleLockfilesWarning(lockfiles: Lockfile[], shouldExit: boolean) {
   const packageManagers = {
     'yarn.lock': 'yarn',
     'package-lock.json': 'npm',
@@ -37,36 +42,47 @@ function multipleLockfilesWarning(lockfiles: Lockfile[]) {
     return `${lockfile} (created by ${packageManagers[lockfile]})`;
   });
 
-  renderWarning({
-    headline: 'Multiple lockfiles found',
-    body: [
-      `Your project contains more than one lockfile. This can cause version ` +
-        `conflicts when installing and deploying your app. The following ` +
-        `lockfiles were detected:\n`,
-      {list: {items: lockfileList}},
-    ],
-    nextSteps: [
-      'Delete any unneeded lockfiles',
-      'Commit the change to your repository',
-    ],
-  });
+  const headline = 'Multiple lockfiles found';
+  const body = [
+    `Your project contains more than one lockfile. This can cause version ` +
+      `conflicts when installing and deploying your app. The following ` +
+      `lockfiles were detected:\n`,
+    {list: {items: lockfileList}},
+  ];
+  const nextSteps = [
+    'Delete any unneeded lockfiles',
+    'Commit the change to your repository',
+  ];
+
+  if (shouldExit) {
+    throw new AbortError(headline, body, nextSteps);
+  } else {
+    renderWarning({headline, body, nextSteps});
+  }
 }
 
-function lockfileIgnoredWarning(lockfile: string) {
-  renderWarning({
-    headline: 'Lockfile ignored by Git',
-    body:
-      `Your project’s lockfile isn’t being tracked by Git. If you don’t commit ` +
-      `a lockfile, then your app might install the wrong package versions when ` +
-      `deploying.`,
-    nextSteps: [
-      `In your project’s .gitignore file, delete any references to ${lockfile}`,
-      'Commit the change to your repository',
-    ],
-  });
+function lockfileIgnoredWarning(lockfile: string, shouldExit: boolean) {
+  const headline = 'Lockfile ignored by Git';
+  const body =
+    `Your project’s lockfile isn’t being tracked by Git. If you don’t commit ` +
+    `a lockfile, then your app might install the wrong package versions when ` +
+    `deploying.`;
+  const nextSteps = [
+    `In your project’s .gitignore file, delete any references to ${lockfile}`,
+    'Commit the change to your repository',
+  ];
+
+  if (shouldExit) {
+    throw new AbortError(headline, body, nextSteps);
+  } else {
+    renderWarning({headline, body, nextSteps});
+  }
 }
 
-export async function checkLockfileStatus(directory: string) {
+export async function checkLockfileStatus(
+  directory: string,
+  shouldExit = false,
+) {
   if (process.env.LOCAL_DEV) return;
 
   const availableLockfiles: Lockfile[] = [];
@@ -76,24 +92,23 @@ export async function checkLockfileStatus(directory: string) {
     }
   }
 
-  if (!availableLockfiles.length) {
-    return missingLockfileWarning();
+  if (availableLockfiles.length === 0) {
+    return missingLockfileWarning(shouldExit);
   }
 
   if (availableLockfiles.length > 1) {
-    return multipleLockfilesWarning(availableLockfiles);
+    return multipleLockfilesWarning(availableLockfiles, shouldExit);
   }
 
-  try {
-    const lockfile = availableLockfiles[0]!;
-    const ignoredLockfile = await checkIfIgnoredInGitRepository(directory, [
-      lockfile,
-    ]);
-
-    if (ignoredLockfile.length) {
-      lockfileIgnoredWarning(lockfile);
-    }
-  } catch {
+  const lockfile = availableLockfiles[0]!;
+  const ignoredLockfile = await checkIfIgnoredInGitRepository(directory, [
+    lockfile,
+  ]).catch(() => {
     // Not a Git repository, ignore
+    return [];
+  });
+
+  if (ignoredLockfile.length > 0) {
+    lockfileIgnoredWarning(lockfile, shouldExit);
   }
 }

--- a/packages/cli/src/lib/check-lockfile.ts
+++ b/packages/cli/src/lib/check-lockfile.ts
@@ -62,7 +62,7 @@ function multipleLockfilesWarning(lockfiles: Lockfile[], shouldExit: boolean) {
   }
 }
 
-function lockfileIgnoredWarning(lockfile: string, shouldExit: boolean) {
+function lockfileIgnoredWarning(lockfile: string) {
   const headline = 'Lockfile ignored by Git';
   const body =
     `Your project’s lockfile isn’t being tracked by Git. If you don’t commit ` +
@@ -73,11 +73,7 @@ function lockfileIgnoredWarning(lockfile: string, shouldExit: boolean) {
     'Commit the change to your repository',
   ];
 
-  if (shouldExit) {
-    throw new AbortError(headline, body, nextSteps);
-  } else {
-    renderWarning({headline, body, nextSteps});
-  }
+  renderWarning({headline, body, nextSteps});
 }
 
 export async function checkLockfileStatus(
@@ -110,6 +106,6 @@ export async function checkLockfileStatus(
   });
 
   if (ignoredLockfile.length > 0) {
-    lockfileIgnoredWarning(lockfile, shouldExit);
+    lockfileIgnoredWarning(lockfile);
   }
 }

--- a/packages/cli/src/lib/check-lockfile.ts
+++ b/packages/cli/src/lib/check-lockfile.ts
@@ -7,7 +7,6 @@ import {
   lockfiles,
   type Lockfile,
 } from '@shopify/cli-kit/node/node-package-manager';
-import {isCI} from './is-ci.js';
 
 function missingLockfileWarning(shouldExit: boolean) {
   const headline = 'No lockfile found';
@@ -78,7 +77,7 @@ function lockfileIgnoredWarning(lockfile: string) {
 
 export async function checkLockfileStatus(
   directory: string,
-  shouldExit = isCI(),
+  shouldExit = false,
 ) {
   if (process.env.LOCAL_DEV) return;
 

--- a/packages/cli/src/lib/is-ci.ts
+++ b/packages/cli/src/lib/is-ci.ts
@@ -1,0 +1,10 @@
+/**
+ * Detects if the process is running in a CI environment.
+ */
+export function isCI() {
+  const {env} = process;
+
+  return env.CI === 'false'
+    ? false // Overrides
+    : !!(env.CI || env.CI_NAME || env.BUILD_NUMBER || env.TF_BUILD);
+}

--- a/packages/cli/src/lib/is-ci.ts
+++ b/packages/cli/src/lib/is-ci.ts
@@ -3,8 +3,6 @@
  */
 export function isCI() {
   const {env} = process;
-  console.log('Printing process.env:');
-  console.log(JSON.stringify(env, null, 2));
 
   return env.CI === 'false'
     ? false // Overrides

--- a/packages/cli/src/lib/is-ci.ts
+++ b/packages/cli/src/lib/is-ci.ts
@@ -3,6 +3,8 @@
  */
 export function isCI() {
   const {env} = process;
+  console.log('Printing process.env:');
+  console.log(JSON.stringify(env, null, 2));
 
   return env.CI === 'false'
     ? false // Overrides


### PR DESCRIPTION
Related: https://github.com/Shopify/custom-storefronts/issues/277

This could be a problem for monorepos where the lockfile can't be found in the project -- I think Yarn and pnpm can output lockfile in every workspace project but NPM can't afaik.

Is the `--no-lockfile-check` flag enough for this? 🤔 

---

🎩 

```
cd templates/skeleton && CI=true h2 build
```