### PR TITLE
Debug network improvements

### DIFF
--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -29,6 +29,7 @@ import {getAllEnvironmentVariables} from '../../lib/environment-variables.js';
 import {getConfig} from '../../lib/shopify-config.js';
 import {setupLiveReload} from '../../lib/live-reload.js';
 import {checkRemixVersions} from '../../lib/remix-version-check.js';
+import {getGraphiQLUrl} from '../../lib/graphiql-url.js';
 
 const LOG_REBUILDING = '🧱 Rebuilding...';
 const LOG_REBUILT = '🚀 Rebuilt';
@@ -173,9 +174,8 @@ async function runDev({
       workerRuntime,
     );
 
-    const graphiqlUrl = `${miniOxygen.listeningAt}/graphiql`;
     const debugNetworkUrl = `${miniOxygen.listeningAt}/debug-network`;
-    enhanceH2Logs({graphiqlUrl, ...remixConfig});
+    enhanceH2Logs({host: miniOxygen.listeningAt, ...remixConfig});
 
     miniOxygen.showBanner({
       appName: storefront ? colors.cyan(storefront?.title) : undefined,
@@ -184,7 +184,11 @@ async function runDev({
           ? `Initial build: ${initialBuildDurationMs}ms\n`
           : '',
       extraLines: [
-        colors.dim(`\nView GraphiQL API browser: ${graphiqlUrl}`),
+        colors.dim(
+          `\nView GraphiQL API browser: ${getGraphiQLUrl({
+            host: miniOxygen.listeningAt,
+          })}`,
+        ),
         workerRuntime
           ? ''
           : colors.dim(

--- a/packages/cli/src/lib/graphiql-url.ts
+++ b/packages/cli/src/lib/graphiql-url.ts
@@ -1,0 +1,20 @@
+export function getGraphiQLUrl({
+  host = '',
+  graphql,
+}: {
+  host?: string;
+  graphql?: {query: string; variables: string | Record<string, any>};
+}) {
+  let url = `${host.endsWith('/') ? host.slice(0, -1) : host}/graphiql`;
+
+  if (graphql) {
+    let {query, variables} = graphql;
+    if (typeof variables !== 'string') variables = JSON.stringify(variables);
+
+    url += `?query=${encodeURIComponent(query)}${
+      variables ? `&variables=${encodeURIComponent(variables)}` : ''
+    }`;
+  }
+
+  return url;
+}

--- a/packages/cli/src/lib/log.test.ts
+++ b/packages/cli/src/lib/log.test.ts
@@ -5,7 +5,7 @@ import {resetAllLogs, enhanceH2Logs} from './log.js';
 
 describe('log replacer', () => {
   describe('enhanceH2Logs', () => {
-    const graphiqlUrl = 'http://localhost:3000/graphiql';
+    const host = 'http://localhost:3000';
     const rootDirectory = fileURLToPath(import.meta.url);
     const outputMock = mockAndCaptureOutput();
 
@@ -21,7 +21,7 @@ describe('log replacer', () => {
 
     describe('enhances h2:info pattern', () => {
       it('renders in an info banner', () => {
-        enhanceH2Logs({graphiqlUrl, rootDirectory});
+        enhanceH2Logs({host, rootDirectory});
 
         console.warn('[h2:info:storefront.query] Tip');
 
@@ -35,7 +35,7 @@ describe('log replacer', () => {
 
     describe('enhances h2:warn pattern', () => {
       it('renders in a warning banner', () => {
-        enhanceH2Logs({graphiqlUrl, rootDirectory});
+        enhanceH2Logs({host, rootDirectory});
 
         console.warn('[h2:warn:storefront.query] Wrong query 1');
 
@@ -47,7 +47,7 @@ describe('log replacer', () => {
       });
 
       it('shows links from the last line as a list', () => {
-        enhanceH2Logs({graphiqlUrl, rootDirectory});
+        enhanceH2Logs({host, rootDirectory});
 
         console.warn(
           '[h2:warn:storefront.query] Wrong query.\nhttps://docs.com/something',
@@ -62,7 +62,7 @@ describe('log replacer', () => {
 
     describe('enhances h2:error pattern', () => {
       it('renders in an error banner', () => {
-        enhanceH2Logs({graphiqlUrl, rootDirectory});
+        enhanceH2Logs({host, rootDirectory});
 
         console.error(new Error('[h2:error:storefront.query] Wrong query 2'));
 
@@ -75,7 +75,7 @@ describe('log replacer', () => {
       });
 
       it('shows a GraphiQL link when the error is related to a GraphQL query', () => {
-        enhanceH2Logs({graphiqlUrl, rootDirectory});
+        enhanceH2Logs({host, rootDirectory});
 
         console.error(
           new Error('[h2:error:storefront.query] Wrong query 3', {
@@ -95,7 +95,7 @@ describe('log replacer', () => {
       });
 
       it('trims stack traces when the error is related to a GraphQL query', () => {
-        enhanceH2Logs({graphiqlUrl, rootDirectory});
+        enhanceH2Logs({host, rootDirectory});
 
         console.error(
           new Error('[h2:error:storefront.query] Wrong query 4', {

--- a/packages/cli/src/lib/log.ts
+++ b/packages/cli/src/lib/log.ts
@@ -8,6 +8,7 @@ import {
 import {BugError} from '@shopify/cli-kit/node/error';
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output';
 import colors from '@shopify/cli-kit/node/colors';
+import {getGraphiQLUrl} from './graphiql-url.js';
 
 type ConsoleMethod = 'log' | 'warn' | 'error' | 'debug' | 'info';
 const originalConsole = {...console};
@@ -221,10 +222,7 @@ export function muteAuthLogs({
  * Where the message can be multiline and the last line
  * can contain links to docs or other resources.
  */
-export function enhanceH2Logs(options: {
-  graphiqlUrl: string;
-  rootDirectory: string;
-}) {
+export function enhanceH2Logs(options: {rootDirectory: string; host: string}) {
   injectLogReplacer('error');
   injectLogReplacer('warn', ([first]) =>
     // Show createStorefrontClient warnings only once.
@@ -274,13 +272,13 @@ export function enhanceH2Logs(options: {
         }
 
         if (typeof cause !== 'string' && !!cause?.graphql?.query) {
-          const {query, variables} = cause.graphql;
-          const link = `${options.graphiqlUrl}?query=${encodeURIComponent(
-            query,
-          )}${variables ? `&variables=${encodeURIComponent(variables)}` : ''}`;
+          const link = getGraphiQLUrl({
+            host: options.host,
+            graphql: cause.graphql,
+          });
 
           const [, queryType, queryName] =
-            query.match(/(query|mutation)\s+(\w+)/) || [];
+            cause.graphql.query.match(/(query|mutation)\s+(\w+)/) || [];
 
           tryMessage =
             (tryMessage ? `${tryMessage}\n\n` : '') +

--- a/packages/cli/src/lib/mini-oxygen/node.ts
+++ b/packages/cli/src/lib/mini-oxygen/node.ts
@@ -1,6 +1,5 @@
 import {randomUUID} from 'node:crypto';
 import {AsyncLocalStorage} from 'node:async_hooks';
-import {resolvePath} from '@shopify/cli-kit/node/path';
 import {readFile} from '@shopify/cli-kit/node/fs';
 import {renderSuccess} from '@shopify/cli-kit/node/ui';
 import {
@@ -18,7 +17,6 @@ import {
 } from '../request-events.js';
 
 export async function startNodeServer({
-  root,
   port = DEFAULT_PORT,
   watch = false,
   buildPathWorkerFile,

--- a/packages/cli/src/lib/request-events.ts
+++ b/packages/cli/src/lib/request-events.ts
@@ -73,7 +73,7 @@ export async function logRequestEvent(request: Request): Promise<Response> {
 
     // This might need to be passed through sourcemaps in Workerd
     const [, fnName, filePath] =
-      stackLine?.match(/\s+at ([^\s]+) \(.*?\/(app\/[^\)\n]*)\)/) || [];
+      stackLine?.match(/\s+at ([^\s]+) \(.*?\/(app\/[^\n]*)\)/) || [];
 
     if (fnName && filePath) {
       originFile = `${fnName}:${filePath}`;

--- a/packages/cli/src/lib/request-events.ts
+++ b/packages/cli/src/lib/request-events.ts
@@ -61,6 +61,7 @@ export async function logRequestEvent(request: Request): Promise<Response> {
   const {eventType, purpose, stackLine, graphql, ...data} =
     await getRequestInfo(request);
 
+  let originFile = '';
   let graphiqlLink = '';
   let description = request.url;
 
@@ -75,7 +76,7 @@ export async function logRequestEvent(request: Request): Promise<Response> {
       stackLine?.match(/\s+at ([^\s]+) \(.*?\/(app\/[^\)\n]*)\)/) || [];
 
     if (fnName && filePath) {
-      description += ` (${fnName}:${filePath})`;
+      originFile = `${fnName}:${filePath}`;
     }
 
     if (graphql) {
@@ -89,6 +90,7 @@ export async function logRequestEvent(request: Request): Promise<Response> {
       ...data,
       url: `${purpose} ${description}`.trim(),
       graphiqlLink,
+      originFile,
     }),
   };
 

--- a/packages/cli/src/virtual-routes/routes/debug-network.tsx
+++ b/packages/cli/src/virtual-routes/routes/debug-network.tsx
@@ -11,6 +11,8 @@ type ServerEvent = {
   startTime: number;
   endTime: number;
   cacheStatus: string;
+  stackLine?: string;
+  graphql?: string;
 };
 
 type ServerEvents = {

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -16,6 +16,7 @@ export type CacheKey = string | readonly unknown[];
 
 export type FetchDebugInfo = {
   stackLine?: string;
+  graphql?: string;
 };
 
 export type WithCacheOptions<T = unknown> = {

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -14,12 +14,16 @@ import {
  */
 export type CacheKey = string | readonly unknown[];
 
+export type FetchDebugInfo = {
+  stackLine?: string;
+};
+
 export type WithCacheOptions<T = unknown> = {
   strategy?: CachingStrategy | null;
   cacheInstance?: Cache;
   shouldCacheResult?: (value: T) => boolean;
   waitUntil?: ExecutionContext['waitUntil'];
-  stackLine?: string;
+  debugInfo?: FetchDebugInfo;
 };
 
 export type FetchCacheOptions = {
@@ -29,7 +33,7 @@ export type FetchCacheOptions = {
   shouldCacheResponse?: (body: any, response: Response) => boolean;
   waitUntil?: ExecutionContext['waitUntil'];
   returnType?: 'json' | 'text' | 'arrayBuffer' | 'blob';
-  stackLine?: string;
+  debugInfo?: FetchDebugInfo;
 };
 
 function toSerializableResponse(body: any, response: Response) {
@@ -66,7 +70,7 @@ export async function runWithCache<T = unknown>(
     cacheInstance,
     shouldCacheResult = () => true,
     waitUntil,
-    stackLine,
+    debugInfo,
   }: WithCacheOptions<T>,
 ): Promise<T> {
   const startTime = Date.now();
@@ -87,7 +91,7 @@ export async function runWithCache<T = unknown>(
             startTime: overrideStartTime || startTime,
             cacheStatus,
             waitUntil,
-            stackLine,
+            ...debugInfo,
           });
         }
       : undefined;
@@ -178,7 +182,7 @@ export async function fetchWithServerCache(
     shouldCacheResponse = () => true,
     waitUntil,
     returnType = 'json',
-    stackLine,
+    debugInfo,
   }: FetchCacheOptions = {},
 ): Promise<readonly [any, Response]> {
   if (!cacheOptions && (!requestInit.method || requestInit.method === 'GET')) {
@@ -212,7 +216,7 @@ export async function fetchWithServerCache(
       cacheInstance,
       waitUntil,
       strategy: cacheOptions ?? null,
-      stackLine,
+      debugInfo,
       shouldCacheResult: (result) =>
         shouldCacheResponse(...fromSerializableResponse(result)),
     },

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -337,7 +337,7 @@ export function createStorefrontClient<TI18n extends I18nBase>(
       cache: cacheOptions || CacheShort(),
       shouldCacheResponse: checkGraphQLErrors,
       waitUntil,
-      stackLine,
+      debugInfo: {stackLine},
     });
 
     const errorOptions: StorefrontErrorOptions<T> = {

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -323,13 +323,11 @@ export function createStorefrontClient<TI18n extends I18nBase>(
     }
 
     const url = getStorefrontApiUrl({storefrontApiVersion});
+    const graphqlData = JSON.stringify({query, variables: queryVariables});
     const requestInit: RequestInit = {
       method: 'POST',
       headers: {...defaultHeaders, ...userHeaders},
-      body: JSON.stringify({
-        query,
-        variables: queryVariables,
-      }),
+      body: graphqlData,
     };
 
     const [body, response] = await fetchWithServerCache(url, requestInit, {
@@ -337,7 +335,7 @@ export function createStorefrontClient<TI18n extends I18nBase>(
       cache: cacheOptions || CacheShort(),
       shouldCacheResponse: checkGraphQLErrors,
       waitUntil,
-      debugInfo: {stackLine},
+      debugInfo: {stackLine, graphql: graphqlData},
     });
 
     const errorOptions: StorefrontErrorOptions<T> = {

--- a/packages/hydrogen/src/with-cache.ts
+++ b/packages/hydrogen/src/with-cache.ts
@@ -1,4 +1,4 @@
-import {type CacheKey, runWithCache} from './cache/fetch';
+import {type CacheKey, runWithCache, getCallerStackLine} from './cache/fetch';
 import type {CachingStrategy} from './cache/strategies';
 
 type CreateWithCacheOptions = {
@@ -28,6 +28,7 @@ export function createWithCache<T = unknown>(
       strategy,
       cacheInstance: cache,
       waitUntil,
+      stackLine: getCallerStackLine?.(),
     });
   };
 }

--- a/packages/hydrogen/src/with-cache.ts
+++ b/packages/hydrogen/src/with-cache.ts
@@ -28,7 +28,9 @@ export function createWithCache<T = unknown>(
       strategy,
       cacheInstance: cache,
       waitUntil,
-      stackLine: getCallerStackLine?.(),
+      debugInfo: {
+        stackLine: getCallerStackLine?.(),
+      },
     });
   };
 }

--- a/packages/remix-oxygen/src/event-logger.ts
+++ b/packages/remix-oxygen/src/event-logger.ts
@@ -7,6 +7,7 @@ export type H2OEvent = {
   endTime?: number;
   cacheStatus?: 'MISS' | 'HIT' | 'STALE' | 'PUT';
   waitUntil?: ExecutionContext['waitUntil'];
+  stackLine?: string;
 };
 
 export function createEventLogger(appLoadContext: Record<string, unknown>) {
@@ -29,6 +30,7 @@ export function createEventLogger(appLoadContext: Record<string, unknown>) {
     startTime,
     endTime,
     cacheStatus,
+    stackLine,
     waitUntil = context?.waitUntil,
   }: H2OEvent) => {
     const promise = eventLoggerService
@@ -41,6 +43,7 @@ export function createEventLogger(appLoadContext: Record<string, unknown>) {
             'hydrogen-start-time': String(startTime),
             'hydrogen-end-time': String(endTime || Date.now()),
             'hydrogen-cache-status': cacheStatus || '',
+            'hydrogen-stack-line': encodeURIComponent(stackLine || ''),
           },
         }),
       )

--- a/packages/remix-oxygen/src/event-logger.ts
+++ b/packages/remix-oxygen/src/event-logger.ts
@@ -24,27 +24,18 @@ export function createEventLogger(appLoadContext: Record<string, unknown>) {
 
   return ({
     url,
-    eventType,
-    requestId,
-    purpose,
-    startTime,
-    endTime,
-    cacheStatus,
-    stackLine,
+    endTime = Date.now(),
     waitUntil = context?.waitUntil,
+    ...rest
   }: H2OEvent) => {
     const promise = eventLoggerService
       .fetch(
         new Request(url, {
-          headers: {
-            purpose: purpose || '',
-            'request-id': requestId || '',
-            'hydrogen-event-type': eventType,
-            'hydrogen-start-time': String(startTime),
-            'hydrogen-end-time': String(endTime || Date.now()),
-            'hydrogen-cache-status': cacheStatus || '',
-            'hydrogen-stack-line': encodeURIComponent(stackLine || ''),
-          },
+          method: 'POST',
+          body: JSON.stringify({
+            endTime,
+            ...rest,
+          }),
         }),
       )
       .catch((error: Error) => {


### PR DESCRIPTION
- Change the request method for the service binding to POST
- Provide the path of the file that calls `storefront.query` or ` withCache` to the frontend
- Provide a link to GraphiQL to the frontend

This is not showing anything yet in the frontend. I'm trying to add support for Workerd but couldn't make it work yet. We can do it in another PR and merge this for now.