### PR TITLE
Add SellingPlanAllocation to CART_QUERY

### DIFF
--- a/packages/hydrogen/src/cart/queries/cartGetDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.ts
@@ -135,6 +135,16 @@ export const DEFAULT_CART_FRAGMENT = `#graphql
               }
             }
           }
+          sellingPlanAllocation {
+            sellingPlan {
+              id
+              name
+              options {
+                name
+                value
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fixes #1410 <!-- link to issue if one exists -->

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

Added SellingPlanAllocation to CART_QUERY so it can be accessed as described in:
https://shopify.dev/docs/api/storefront/2023-10/objects/CartLine
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
