### PR TITLE
Increase body size limit in MiniOxygen

### DIFF
--- a/.changeset/thirty-news-study.md
+++ b/.changeset/thirty-news-study.md
@@ -1,0 +1,6 @@
+---
+'@shopify/mini-oxygen': patch
+'@shopify/cli-hydrogen': patch
+---
+
+Increase the request body size limit to 100mb when running locally.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29290,7 +29290,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "5.4.1",
+      "version": "5.4.2",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -29340,7 +29340,7 @@
         "@remix-run/dev": "1.19.1",
         "@remix-run/react": "1.19.1",
         "@shopify/hydrogen-react": "^2023.7.4",
-        "@shopify/remix-oxygen": "^1.1.5"
+        "@shopify/remix-oxygen": "^1.1.6"
       },
       "peerDependenciesMeta": {
         "@remix-run/dev": {
@@ -29568,7 +29568,7 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2023.7.9",
+      "version": "2023.7.10",
       "license": "MIT",
       "dependencies": {
         "@shopify/hydrogen-react": "2023.7.4",
@@ -30249,7 +30249,7 @@
     },
     "packages/remix-oxygen": {
       "name": "@shopify/remix-oxygen",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@remix-run/server-runtime": "1.19.1"
@@ -30262,14 +30262,14 @@
       }
     },
     "templates/demo-store": {
-      "version": "2.1.3",
+      "version": "2.1.4",
       "dependencies": {
         "@headlessui/react": "^1.7.2",
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.4.0",
-        "@shopify/hydrogen": "^2023.7.9",
-        "@shopify/remix-oxygen": "^1.1.3",
+        "@shopify/cli-hydrogen": "^5.4.2",
+        "@shopify/hydrogen": "^2023.7.10",
+        "@shopify/remix-oxygen": "^1.1.6",
         "clsx": "^1.2.1",
         "cross-env": "^7.0.3",
         "graphql": "^16.6.0",
@@ -30315,9 +30315,9 @@
       "dependencies": {
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.4.1",
-        "@shopify/hydrogen": "^2023.7.9",
-        "@shopify/remix-oxygen": "^1.1.5",
+        "@shopify/cli-hydrogen": "^5.4.2",
+        "@shopify/hydrogen": "^2023.7.10",
+        "@shopify/remix-oxygen": "^1.1.6",
         "@total-typescript/ts-reset": "^0.4.2",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
@@ -30346,9 +30346,9 @@
       "dependencies": {
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.4.1",
-        "@shopify/hydrogen": "^2023.7.9",
-        "@shopify/remix-oxygen": "^1.1.5",
+        "@shopify/cli-hydrogen": "^5.4.2",
+        "@shopify/hydrogen": "^2023.7.10",
+        "@shopify/remix-oxygen": "^1.1.6",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^3.6.6",
@@ -38737,12 +38737,12 @@
         "@remix-run/eslint-config": "1.19.1",
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.4.0",
+        "@shopify/cli-hydrogen": "^5.4.2",
         "@shopify/eslint-plugin": "^42.0.1",
-        "@shopify/hydrogen": "^2023.7.9",
+        "@shopify/hydrogen": "^2023.7.10",
         "@shopify/oxygen-workers-types": "^3.17.3",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.1.3",
+        "@shopify/remix-oxygen": "^1.1.6",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/typography": "^0.5.9",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -40789,11 +40789,11 @@
         "@remix-run/dev": "1.19.1",
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.4.1",
-        "@shopify/hydrogen": "^2023.7.9",
+        "@shopify/cli-hydrogen": "^5.4.2",
+        "@shopify/hydrogen": "^2023.7.10",
         "@shopify/oxygen-workers-types": "^3.17.3",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.1.5",
+        "@shopify/remix-oxygen": "^1.1.6",
         "@total-typescript/ts-reset": "^0.4.2",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.2.22",
@@ -47618,11 +47618,11 @@
         "@remix-run/dev": "1.19.1",
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
-        "@shopify/cli-hydrogen": "^5.4.1",
-        "@shopify/hydrogen": "^2023.7.9",
+        "@shopify/cli-hydrogen": "^5.4.2",
+        "@shopify/hydrogen": "^2023.7.10",
         "@shopify/oxygen-workers-types": "^3.17.3",
         "@shopify/prettier-config": "^1.1.2",
-        "@shopify/remix-oxygen": "^1.1.5",
+        "@shopify/remix-oxygen": "^1.1.6",
         "@total-typescript/ts-reset": "^0.4.2",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.2.22",

--- a/packages/mini-oxygen/src/mini-oxygen/server.ts
+++ b/packages/mini-oxygen/src/mini-oxygen/server.ts
@@ -323,7 +323,7 @@ export function createServer(
     app.use(SSEUrl, createAutoReloadMiddleware(mf));
   }
 
-  app.use(bodyParser.raw({type: '*/*'}));
+  app.use(bodyParser.raw({type: '*/*', limit: '100mb'}));
   app.use(createRequestMiddleware(mf, {autoReload, proxyServer, ...rest}));
 
   const server = http.createServer(app);


### PR DESCRIPTION
We were limiting request body size to 100kb without noticing because that's the default value in `body-parser`. Increasing it here to 100mb, which is the limit for the free plan in CFW.