### PR TITLE
Hydrogen React - Add support for ComponentizableCartLine (Bundles) 

### DIFF
--- a/.changeset/brave-melons-rush.md
+++ b/.changeset/brave-melons-rush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': minor
+---
+
+Add support for ComponentizableCartLines (bundles)

--- a/packages/hydrogen-react/src/ComponentizableCartLineProvider.tsx
+++ b/packages/hydrogen-react/src/ComponentizableCartLineProvider.tsx
@@ -1,0 +1,61 @@
+import {useContext, createContext, type ReactNode} from 'react';
+import {
+  type CartLine,
+  ComponentizableCartLine,
+} from './storefront-api-types.js';
+import type {PartialDeep} from 'type-fest';
+
+type CartLinePartialDeep = PartialDeep<
+  CartLine | ComponentizableCartLine,
+  {recurseIntoArrays: true}
+>;
+
+type ComponentizableCartLinePartialDeep = PartialDeep<
+  ComponentizableCartLine,
+  {recurseIntoArrays: true}
+>;
+
+export const ComponentizableCartLineContext =
+  createContext<ComponentizableCartLinePartialDeep | null>(null);
+
+/**
+ * The `useComponentizableCartLine` hook provides access to the [ComponentizableCartLine object](https://shopify.dev/api/storefront/unstable/objects/ComponentizableCartLine) from the Storefront API. It must be a descendent of a `CartLineProvider` component.
+ */
+export function useComponentizableCartLine(): ComponentizableCartLinePartialDeep {
+  const context = useContext(ComponentizableCartLineContext);
+
+  if (context == null) {
+    throw new Error(
+      'Expected a componentizable cart line context but none was found',
+    );
+  }
+
+  return context;
+}
+
+type ComponentizableCartLineProviderProps = {
+  /** Any `ReactNode` elements. */
+  children: ReactNode;
+  /** A cart line object. */
+  line: CartLinePartialDeep;
+};
+
+/**
+ * The `ComponentizableCartLineProvider` component creates a context for using a componentizable cart line.
+ */
+export function ComponentizableCartLineProvider({
+  children,
+  line,
+}: ComponentizableCartLineProviderProps): JSX.Element {
+  const componentizableCartLine = line as ComponentizableCartLinePartialDeep;
+
+  if ('lineComponents' in componentizableCartLine) {
+    return (
+      <ComponentizableCartLineContext.Provider value={componentizableCartLine}>
+        {children}
+      </ComponentizableCartLineContext.Provider>
+    );
+  }
+
+  return <></>;
+}

--- a/packages/hydrogen-react/src/cart-queries.ts
+++ b/packages/hydrogen-react/src/cart-queries.ts
@@ -173,6 +173,95 @@ export const defaultCartFragment = /* GraphQL */ `
     lines(first: $numCartLines) {
       edges {
         node {
+          ... on ComponentizableCartLine {
+            lineComponents {
+              id
+              quantity
+              attributes {
+                key
+                value
+              }
+              cost {
+                totalAmount {
+                  amount
+                  currencyCode
+                }
+                compareAtAmountPerQuantity {
+                  amount
+                  currencyCode
+                }
+              }
+              merchandise {
+                ... on ProductVariant {
+                  id
+                  availableForSale
+                  compareAtPrice {
+                    ...MoneyFragment
+                  }
+                  price {
+                    ...MoneyFragment
+                  }
+                  requiresShipping
+                  title
+                  image {
+                    ...ImageFragment
+                  }
+                  product {
+                    handle
+                    title
+                    id
+                  }
+                  selectedOptions {
+                    name
+                    value
+                  }
+                }
+              }
+            }
+            id
+            quantity
+            attributes {
+              key
+              value
+            }
+            cost {
+              totalAmount {
+                amount
+                currencyCode
+              }
+              compareAtAmountPerQuantity {
+                amount
+                currencyCode
+              }
+            }
+            merchandise {
+              ... on ProductVariant {
+                id
+                availableForSale
+                compareAtPrice {
+                  ...MoneyFragment
+                }
+                price {
+                  ...MoneyFragment
+                }
+                requiresShipping
+                title
+                image {
+                  ...ImageFragment
+                }
+                product {
+                  handle
+                  title
+                  id
+                }
+                selectedOptions {
+                  name
+                  value
+                }
+              }
+            }
+          }
+
           id
           quantity
           attributes {

--- a/packages/hydrogen-react/src/index.ts
+++ b/packages/hydrogen-react/src/index.ts
@@ -39,6 +39,10 @@ export {CartLineQuantity} from './CartLineQuantity.js';
 export {CartLineQuantityAdjustButton} from './CartLineQuantityAdjustButton.js';
 export {CartProvider, useCart} from './CartProvider.js';
 export {storefrontApiCustomScalars} from './codegen.helpers.js';
+export {
+  ComponentizableCartLineProvider,
+  useComponentizableCartLine,
+} from './ComponentizableCartLineProvider.js';
 export {getShopifyCookies} from './cookies-utils.js';
 export {ExternalVideo} from './ExternalVideo.js';
 export {flattenConnection} from './flatten-connection.js';


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

This PR adds support for ComponentizableCartLines, used in Bundles (https://shopify.dev/docs/apps/selling-strategies/bundles)

Added
- ComponentizableCartLineProvider
- useComponentizableCartLine

#### Example code: 

```
import {
  ComponentizableCartLineProvider,
  useCartLine,
  useComponentizableCartLine,
} from "@shopify/hydrogen-react";

function ComponentizableCartLineComponent() {
  const componentizableCartLine = useComponentizableCartLine();
}

function CartLineComponent() {
   const cartLine = useCartLine();
   <ComponentizableCartLineProvider line={cartLine}>
      <ComponentizableCartLineComponent />
    </ComponentizableCartLineProvider>
}
```

