### PR TITLE
Add package-lock.json to generated templates for Hydrogen Channel

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -81,6 +81,8 @@ jobs:
       - name: Compile skeleton
         run: |
           node scripts/compile-template-for-dist.mjs skeleton
+          (cd templates/skeleton-js && npm i --package-lock-only --workspaces false)
+          (cd templates/skeleton-ts && npm i --package-lock-only --workspaces false)
 
       - name: Compile hello-world
         run: |


### PR DESCRIPTION
This generates `package-lock.json` in the templates that we add to the `dist` branch. Only the skeleton variations since those are the only ones used in the channel.