### PR TITLE
Add missing eslint dependency to skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31349,6 +31349,7 @@
       },
       "devDependencies": {
         "@remix-run/dev": "1.19.1",
+        "@remix-run/eslint-config": "1.19.1",
         "@shopify/oxygen-workers-types": "^3.17.3",
         "@shopify/prettier-config": "^1.1.2",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -48998,6 +48999,7 @@
       "version": "file:templates/skeleton",
       "requires": {
         "@remix-run/dev": "1.19.1",
+        "@remix-run/eslint-config": "1.19.1",
         "@remix-run/react": "1.19.1",
         "@shopify/cli": "3.49.2",
         "@shopify/cli-hydrogen": "^5.4.3",

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@remix-run/dev": "1.19.1",
+    "@remix-run/eslint-config": "1.19.1",
     "@shopify/oxygen-workers-types": "^3.17.3",
     "@shopify/prettier-config": "^1.1.2",
     "@total-typescript/ts-reset": "^0.4.2",


### PR DESCRIPTION
I found and fixed this in #1289 but extracting it here to release it in 2023-07 as well.

Closes #1426