### PR TITLE
Support `withCache` in debug-network for workerd

### DIFF
--- a/.changeset/unlucky-wolves-sing.md
+++ b/.changeset/unlucky-wolves-sing.md
@@ -1,0 +1,19 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Calls to `withCache` can now be shown in the `/debug-network` tool when using the Worker runtime. For this to work, use the new `request` parameter in `createWithCache`:
+
+```diff
+export default {
+  fetch(request, env, executionContext) {
+    // ...
+    const withCache = createWithCache({
+      cache,
+      waitUntil,
++     request,
+    });
+    // ...
+  },
+}
+```

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -15,8 +15,8 @@ import {
 export type CacheKey = string | readonly unknown[];
 
 export type FetchDebugInfo = {
-  requestId?: string;
-  graphql?: string;
+  requestId?: string | null;
+  graphql?: string | null;
   purpose?: string | null;
 };
 

--- a/packages/hydrogen/src/with-cache.example.js
+++ b/packages/hydrogen/src/with-cache.example.js
@@ -9,7 +9,8 @@ export default {
     const cache = await caches.open('my-cms');
     const withCache = createWithCache({
       cache,
-      waitUntil: executionContext.waitUntil,
+      waitUntil: executionContext.waitUntil.bind(executionContext),
+      request,
     });
 
     // Create a custom utility to query a third-party API:

--- a/packages/hydrogen/src/with-cache.example.ts
+++ b/packages/hydrogen/src/with-cache.example.ts
@@ -13,7 +13,8 @@ export default {
     const cache = await caches.open('my-cms');
     const withCache = createWithCache({
       cache,
-      waitUntil: executionContext.waitUntil,
+      waitUntil: executionContext.waitUntil.bind(executionContext),
+      request,
     });
 
     // Create a custom utility to query a third-party API:

--- a/packages/hydrogen/src/with-cache.ts
+++ b/packages/hydrogen/src/with-cache.ts
@@ -1,12 +1,26 @@
 import {type CacheKey, runWithCache} from './cache/fetch';
 import type {CachingStrategy} from './cache/strategies';
 
+type CrossRuntimeRequest = {
+  headers: {
+    get?: (key: string) => string | null | undefined;
+    [key: string]: any;
+  };
+};
+
 type CreateWithCacheOptions = {
   /** An instance that implements the [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) */
   cache: Cache;
   /** The `waitUntil` function is used to keep the current request/response lifecycle alive even after a response has been sent. It should be provided by your platform. */
   waitUntil: ExecutionContext['waitUntil'];
+  /** The `request` object is used to access certain headers for debugging */
+  request?: CrossRuntimeRequest;
 };
+
+function getHeader(key: string, request?: CrossRuntimeRequest) {
+  const value = request?.headers?.get?.(key) ?? request?.headers?.[key];
+  return typeof value === 'string' ? value : undefined;
+}
 
 /**
  * Creates a utility function that executes an asynchronous operation
@@ -15,10 +29,11 @@ type CreateWithCacheOptions = {
  * By default, it uses the `CacheShort` strategy.
  *
  */
-export function createWithCache<T = unknown>(
-  options: CreateWithCacheOptions,
-): CreateWithCacheReturn<T> {
-  const {cache, waitUntil} = options;
+export function createWithCache<T = unknown>({
+  cache,
+  waitUntil,
+  request,
+}: CreateWithCacheOptions): CreateWithCacheReturn<T> {
   return function withCache<T = unknown>(
     cacheKey: CacheKey,
     strategy: CachingStrategy,
@@ -28,7 +43,10 @@ export function createWithCache<T = unknown>(
       strategy,
       cacheInstance: cache,
       waitUntil,
-      debugInfo: {},
+      debugInfo: {
+        requestId: getHeader('request-id', request),
+        purpose: getHeader('purpose', request),
+      },
     });
   };
 }


### PR DESCRIPTION
We can't use `AsyncLocalStorage` in Workerd to pass down `request-id` and other information. This PR adds new parameters to `createWithCache` to manually pass the required information down so that we can show calls to `withCache` in `/debug-network`.

Currently passing `request` but we can change it to `headers` or something else. Waiting on another conversation before deciding the final API.