### PR TITLE
Pass `request` to `createStorefrontClient`

### DIFF
--- a/examples/customer-api/server.ts
+++ b/examples/customer-api/server.ts
@@ -3,7 +3,6 @@ import * as remixBuild from '@remix-run/dev/server-build';
 import {createStorefrontClient, storefrontRedirect} from '@shopify/hydrogen';
 import {
   createRequestHandler,
-  getStorefrontHeaders,
   createCookieSessionStorage,
   type SessionStorage,
   type Session,
@@ -27,7 +26,8 @@ export default {
         throw new Error('SESSION_SECRET environment variable is not set');
       }
 
-      const waitUntil = (p: Promise<any>) => executionContext.waitUntil(p);
+      const waitUntil = executionContext.waitUntil.bind(executionContext);
+
       const [cache, session] = await Promise.all([
         caches.open('hydrogen'),
         HydrogenSession.init(request, [env.SESSION_SECRET]),
@@ -38,13 +38,13 @@ export default {
        */
       const {storefront} = createStorefrontClient({
         cache,
+        request,
         waitUntil,
         i18n: {language: 'EN', country: 'US'},
         publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: env.PUBLIC_STORE_DOMAIN,
         storefrontId: env.PUBLIC_STOREFRONT_ID,
-        storefrontHeaders: getStorefrontHeaders(request),
       });
 
       /**

--- a/examples/express/app/routes/_index.tsx
+++ b/examples/express/app/routes/_index.tsx
@@ -7,7 +7,7 @@ export default function Index() {
         Edit this route in <em>app/routes/index.tsx</em>.
       </p>
       <p>
-        <Link to="/collections/freestyle">Freestyle Collection</Link>
+        <Link to="/products/snowboard">Snowboard product</Link>
       </p>
     </>
   );

--- a/examples/express/app/routes/products.$handle.tsx
+++ b/examples/express/app/routes/products.$handle.tsx
@@ -1,0 +1,48 @@
+import {json, type LoaderArgs} from '@shopify/remix-oxygen';
+import {useLoaderData} from '@remix-run/react';
+
+export async function loader({params, context}: LoaderArgs) {
+  const {handle} = params;
+  const {storefront} = context;
+
+  if (!handle) {
+    throw new Error('Expected product handle to be defined');
+  }
+
+  const {product} = await storefront.query(
+    `#graphql
+    query Product( $handle: String!) {
+      product(handle: $handle) {
+        id
+        title
+        descriptionHtml
+      }
+    }`,
+    {variables: {handle}},
+  );
+
+  if (!product?.id) {
+    throw new Response(null, {status: 404});
+  }
+
+  return json({product});
+}
+
+export default function Product() {
+  const {
+    product: {title, descriptionHtml},
+  } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="product">
+      <h1>{title}</h1>
+      <br />
+      <p>
+        <strong>Description</strong>
+      </p>
+      <br />
+      <div dangerouslySetInnerHTML={{__html: descriptionHtml}} />
+      <br />
+    </div>
+  );
+}

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -75,10 +75,11 @@ function purgeRequireCache() {
   }
 }
 
-async function getContext(req) {
-  const session = await HydrogenSession.init(req, [env.SESSION_SECRET]);
+async function getContext(request) {
+  const session = await HydrogenSession.init(request, [env.SESSION_SECRET]);
 
   const {storefront} = createStorefrontClient({
+    request,
     // A [`cache` instance](https://developer.mozilla.org/en-US/docs/Web/API/Cache) is necessary for sub-request caching to work.
     // We provide only an in-memory implementation
     cache: new InMemoryCache(),
@@ -89,11 +90,6 @@ async function getContext(req) {
     privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
     storeDomain: env.PUBLIC_STORE_DOMAIN,
     storefrontId: env.PUBLIC_STOREFRONT_ID,
-    storefrontHeaders: {
-      requestGroupId: req.get('request-id'),
-      buyerIp: req.get('oxygen-buyer-ip'),
-      cookie: req.get('cookie'),
-    },
   });
 
   return {session, storefront, env};

--- a/packages/cli/src/lib/setups/i18n/replacers.test.ts
+++ b/packages/cli/src/lib/setups/i18n/replacers.test.ts
@@ -150,7 +150,6 @@ describe('i18n replacers', () => {
         } from \\"@shopify/hydrogen\\";
         import {
           createRequestHandler,
-          getStorefrontHeaders,
           createCookieSessionStorage,
           type SessionStorage,
           type Session,
@@ -184,13 +183,13 @@ describe('i18n replacers', () => {
                */
               const { storefront } = createStorefrontClient({
                 cache,
+                request,
                 waitUntil,
                 i18n: getLocaleFromRequest(request),
                 publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
                 privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
                 storeDomain: env.PUBLIC_STORE_DOMAIN,
                 storefrontId: env.PUBLIC_STOREFRONT_ID,
-                storefrontHeaders: getStorefrontHeaders(request),
               });
 
               /*

--- a/packages/hydrogen/docs/staticPages/authenticate.server.js
+++ b/packages/hydrogen/docs/staticPages/authenticate.server.js
@@ -10,6 +10,7 @@
  */
 const {storefront} = createStorefrontClient({
   cache,
+  request,
   waitUntil,
   i18n: {language: 'EN', country: 'US'},
   // `env` provides access to runtime data, including environment variables
@@ -17,5 +18,4 @@ const {storefront} = createStorefrontClient({
   privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
   storeDomain: env.PUBLIC_STORE_DOMAIN,
   storefrontId: env.PUBLIC_STOREFRONT_ID,
-  storefrontHeaders: getStorefrontHeaders(request),
 });

--- a/packages/hydrogen/src/cart/createCartHandler.example.js
+++ b/packages/hydrogen/src/cart/createCartHandler.example.js
@@ -5,10 +5,7 @@ import {
   cartSetIdDefault,
 } from '@shopify/hydrogen';
 import * as remixBuild from '@remix-run/dev/server-build';
-import {
-  createRequestHandler,
-  getStorefrontHeaders,
-} from '@shopify/remix-oxygen';
+import {createRequestHandler} from '@shopify/remix-oxygen';
 
 export default {
   async fetch(request, env, executionContext) {

--- a/packages/hydrogen/src/cart/createCartHandler.example.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.example.ts
@@ -5,10 +5,7 @@ import {
   cartSetIdDefault,
 } from '@shopify/hydrogen';
 import * as remixBuild from '@remix-run/dev/server-build';
-import {
-  createRequestHandler,
-  getStorefrontHeaders,
-} from '@shopify/remix-oxygen';
+import {createRequestHandler} from '@shopify/remix-oxygen';
 
 export default {
   async fetch(

--- a/packages/hydrogen/src/constants.ts
+++ b/packages/hydrogen/src/constants.ts
@@ -1,2 +1,7 @@
 export const STOREFRONT_REQUEST_GROUP_ID_HEADER =
   'Custom-Storefront-Request-Group-ID';
+export const STOREFRONT_ACCESS_TOKEN_HEADER =
+  'X-Shopify-Storefront-Access-Token';
+export const SDK_VARIANT_HEADER = 'X-SDK-Variant';
+export const SDK_VARIANT_SOURCE_HEADER = 'X-SDK-Variant-Source';
+export const SDK_VERSION_HEADER = 'X-SDK-Version';

--- a/packages/hydrogen/src/routing/storefrontRedirect.example.js
+++ b/packages/hydrogen/src/routing/storefrontRedirect.example.js
@@ -1,19 +1,16 @@
 import {storefrontRedirect, createStorefrontClient} from '@shopify/hydrogen';
 import * as remixBuild from '@remix-run/dev/server-build';
-import {
-  createRequestHandler,
-  getStorefrontHeaders,
-} from '@shopify/remix-oxygen';
+import {createRequestHandler} from '@shopify/remix-oxygen';
 
 export default {
   async fetch(request, env, executionContext) {
     const {storefront} = createStorefrontClient({
+      request,
       cache: await caches.open('hydrogen'),
-      waitUntil: (p) => executionContext.waitUntil(p),
+      waitUntil: executionContext.waitUntil.bind(executionContext),
       privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
       publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
       storeDomain: env.PUBLIC_STORE_DOMAIN,
-      storefrontHeaders: getStorefrontHeaders(request),
     });
 
     const handleRequest = createRequestHandler({

--- a/packages/hydrogen/src/routing/storefrontRedirect.example.ts
+++ b/packages/hydrogen/src/routing/storefrontRedirect.example.ts
@@ -1,19 +1,16 @@
 import {storefrontRedirect, createStorefrontClient} from '@shopify/hydrogen';
 import * as remixBuild from '@remix-run/dev/server-build';
-import {
-  createRequestHandler,
-  getStorefrontHeaders,
-} from '@shopify/remix-oxygen';
+import {createRequestHandler} from '@shopify/remix-oxygen';
 
 export default {
   async fetch(request: Request, env: Env, executionContext: ExecutionContext) {
     const {storefront} = createStorefrontClient({
+      request,
       cache: await caches.open('hydrogen'),
-      waitUntil: (p: Promise<unknown>) => executionContext.waitUntil(p),
+      waitUntil: executionContext.waitUntil.bind(executionContext),
       privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
       publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
       storeDomain: env.PUBLIC_STORE_DOMAIN,
-      storefrontHeaders: getStorefrontHeaders(request),
     });
 
     const handleRequest = createRequestHandler({

--- a/packages/hydrogen/src/storefront.test.ts
+++ b/packages/hydrogen/src/storefront.test.ts
@@ -1,0 +1,181 @@
+import {vi, describe, it, expect} from 'vitest';
+import {
+  StorefrontApiError,
+  createStorefrontClient,
+  isStorefrontApiError,
+} from './storefront';
+import {fetchWithServerCache} from './cache/fetch';
+import {STOREFRONT_ACCESS_TOKEN_HEADER} from './constants';
+import {
+  SHOPIFY_STOREFRONT_S_HEADER,
+  SHOPIFY_STOREFRONT_Y_HEADER,
+} from '@shopify/hydrogen-react';
+
+vi.mock('./cache/fetch.ts', async () => {
+  const original = await vi.importActual<typeof import('./cache/fetch.ts')>(
+    './cache/fetch.ts',
+  );
+
+  return {
+    ...original,
+    fetchWithServerCache: vi.fn(() =>
+      Promise.resolve(['', new Response('ok')]),
+    ),
+  } satisfies typeof original;
+});
+
+describe('createStorefrontClient', () => {
+  const storeDomain = 'domain';
+  const storefrontId = 'id';
+  const publicStorefrontToken = 'public-token';
+  const privateStorefrontToken = 'private-token';
+  const request = new Request('https://example.com', {
+    headers: {
+      purpose: 'test',
+      cookie: '_shopify_y=123; other=456; _shopify_s=789',
+    },
+  });
+
+  describe('validation errors', () => {
+    it('in browser-like environments', async () => {
+      expect(() =>
+        createStorefrontClient({
+          request,
+          storeDomain,
+          storefrontId,
+        }),
+      ).toThrow('Token');
+    });
+
+    it('fails when calling query or mutate with the wrong string', async () => {
+      const {storefront} = createStorefrontClient({
+        request,
+        storeDomain,
+        storefrontId,
+        publicStorefrontToken,
+      });
+
+      expect(() => storefront.query('mutation {}')).toThrow('execute');
+      expect(() => storefront.mutate('query {}')).toThrow('execute');
+    });
+  });
+
+  describe('headers', () => {
+    it('uses private token if provided', async () => {
+      const {storefront} = createStorefrontClient({
+        request,
+        storeDomain,
+        storefrontId,
+        publicStorefrontToken,
+        privateStorefrontToken,
+      });
+
+      await expect(storefront.query('query {}')).resolves.not.toThrow();
+      expect(vi.mocked(fetchWithServerCache).mock.lastCall?.[1]).toMatchObject({
+        headers: {
+          'Shopify-Storefront-Private-Token': privateStorefrontToken,
+        },
+      });
+    });
+
+    it('fallsback to public token when private one is not provided', async () => {
+      const {storefront} = createStorefrontClient({
+        request,
+        storeDomain,
+        storefrontId,
+        publicStorefrontToken,
+      });
+
+      await expect(storefront.query('query {}')).resolves.not.toThrow();
+      expect(vi.mocked(fetchWithServerCache).mock.lastCall?.[1]).toMatchObject({
+        headers: {
+          [STOREFRONT_ACCESS_TOKEN_HEADER]: publicStorefrontToken,
+        },
+      });
+    });
+
+    it('relays Shopify cookies', async () => {
+      const {storefront} = createStorefrontClient({
+        request,
+        storeDomain,
+        storefrontId,
+        publicStorefrontToken,
+      });
+
+      await expect(storefront.query('query {}')).resolves.not.toThrow();
+      expect(vi.mocked(fetchWithServerCache).mock.lastCall?.[1]).toMatchObject({
+        headers: {
+          [SHOPIFY_STOREFRONT_Y_HEADER]: '123',
+          [SHOPIFY_STOREFRONT_S_HEADER]: '789',
+        },
+      });
+    });
+  });
+
+  it('adds i18n variables automatically if needed', async () => {
+    const {storefront} = createStorefrontClient({
+      request,
+      storeDomain,
+      storefrontId,
+      publicStorefrontToken,
+      i18n: {language: 'EN', country: 'US'},
+    });
+
+    await expect(
+      storefront.query('query Name($something: String) {}'),
+    ).resolves.not.toThrow();
+
+    expect(vi.mocked(fetchWithServerCache).mock.lastCall?.[1]).toMatchObject({
+      body: expect.stringMatching('"variables":{}'),
+    });
+
+    await expect(
+      storefront.query(
+        'query Name($country: CountryCode, $language: LanguageCode) {}',
+      ),
+    ).resolves.not.toThrow();
+    expect(vi.mocked(fetchWithServerCache).mock.lastCall?.[1]).toMatchObject({
+      body: expect.stringMatching(
+        '"variables":{"country":"US","language":"EN"}',
+      ),
+    });
+  });
+
+  describe('response errors', () => {
+    it('throws when the response is not ok', async () => {
+      const {storefront} = createStorefrontClient({
+        request,
+        storeDomain,
+        storefrontId,
+        publicStorefrontToken,
+      });
+
+      vi.mocked(fetchWithServerCache).mockResolvedValueOnce([
+        'my-error',
+        new Response('not ok', {status: 500}),
+      ]);
+
+      await expect(storefront.query('query {}')).rejects.toThrowError(
+        'my-error',
+      );
+    });
+
+    it('throws when the response contains SFAPI errors', async () => {
+      const {storefront} = createStorefrontClient({
+        request,
+        storeDomain,
+        storefrontId,
+        publicStorefrontToken,
+      });
+
+      vi.mocked(fetchWithServerCache).mockResolvedValueOnce([
+        {errors: [{message: 'first'}, {message: 'second'}]},
+        new Response('ok', {status: 200}),
+      ]);
+
+      await expect(storefront.query('query {}')).rejects.toThrowError(
+        StorefrontApiError,
+      );
+    });
+  });
+});

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -20,7 +20,6 @@ import {
   generateCacheControlHeader,
   type CachingStrategy,
 } from './cache/strategies';
-import {generateUUID} from './utils/uuid';
 import {parseJSON} from './utils/parse-json';
 import {
   CountryCode,
@@ -31,8 +30,9 @@ import {LIB_VERSION} from './version';
 import {
   getHeader,
   getDebugHeaders,
-  type CrossRuntimeRequest,
   getClientIp,
+  getRequestId,
+  type CrossRuntimeRequest,
 } from './utils/request';
 
 type StorefrontApiResponse<T> = StorefrontApiResponseOk<T>;
@@ -269,9 +269,9 @@ export function createStorefrontClient<TI18n extends I18nBase>({
 
   if (request) {
     storefrontHeaders = {
-      requestGroupId: getHeader(request, 'request-id'),
-      cookie: getHeader(request, 'cookie'),
+      requestGroupId: getRequestId(request),
       buyerIp: getClientIp(request),
+      cookie: getHeader(request, 'cookie'),
     };
   }
 
@@ -284,9 +284,8 @@ export function createStorefrontClient<TI18n extends I18nBase>({
     buyerIp: storefrontHeaders?.buyerIp || buyerIp,
   });
 
-  defaultHeaders[STOREFRONT_REQUEST_GROUP_ID_HEADER] =
-    storefrontHeaders?.requestGroupId || requestGroupId || generateUUID();
-
+  const requestId = storefrontHeaders?.requestGroupId || requestGroupId || null;
+  if (requestId) defaultHeaders[STOREFRONT_REQUEST_GROUP_ID_HEADER] = requestId;
   if (storefrontId) defaultHeaders[SHOPIFY_STOREFRONT_ID_HEADER] = storefrontId;
   if (LIB_VERSION) defaultHeaders['user-agent'] = `Hydrogen ${LIB_VERSION}`;
 

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -11,7 +11,13 @@ import {
 } from '@shopify/hydrogen-react';
 import type {ExecutionArgs} from 'graphql';
 import {fetchWithServerCache, checkGraphQLErrors} from './cache/fetch';
-import {STOREFRONT_REQUEST_GROUP_ID_HEADER} from './constants';
+import {
+  SDK_VARIANT_HEADER,
+  SDK_VARIANT_SOURCE_HEADER,
+  SDK_VERSION_HEADER,
+  STOREFRONT_ACCESS_TOKEN_HEADER,
+  STOREFRONT_REQUEST_GROUP_ID_HEADER,
+} from './constants';
 import {
   CacheNone,
   CacheLong,
@@ -350,12 +356,13 @@ export function createStorefrontClient<TI18n extends I18nBase>({
         method: requestInit.method,
         headers: {
           'content-type': defaultHeaders['content-type'],
-          'X-SDK-Variant': defaultHeaders['X-SDK-Variant'],
-          'X-SDK-Variant-Source': defaultHeaders['X-SDK-Variant-Source'],
-          'X-SDK-Version': defaultHeaders['X-SDK-Version'],
-          'X-Shopify-Storefront-Access-Token':
-            defaultHeaders['X-Shopify-Storefront-Access-Token'],
           'user-agent': defaultHeaders['user-agent'],
+          [SDK_VARIANT_HEADER]: defaultHeaders[SDK_VARIANT_HEADER],
+          [SDK_VARIANT_SOURCE_HEADER]:
+            defaultHeaders[SDK_VARIANT_SOURCE_HEADER],
+          [SDK_VERSION_HEADER]: defaultHeaders[SDK_VERSION_HEADER],
+          [STOREFRONT_ACCESS_TOKEN_HEADER]:
+            defaultHeaders[STOREFRONT_ACCESS_TOKEN_HEADER],
         },
         body: requestInit.body,
       },

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -32,6 +32,7 @@ import {
   getHeader,
   getDebugHeaders,
   type CrossRuntimeRequest,
+  getClientIp,
 } from './utils/request';
 
 type StorefrontApiResponse<T> = StorefrontApiResponseOk<T>;
@@ -269,8 +270,8 @@ export function createStorefrontClient<TI18n extends I18nBase>({
   if (request) {
     storefrontHeaders = {
       requestGroupId: getHeader(request, 'request-id'),
-      buyerIp: getHeader(request, 'oxygen-buyer-ip'),
       cookie: getHeader(request, 'cookie'),
+      buyerIp: getClientIp(request),
     };
   }
 

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -217,7 +217,7 @@ type StorefrontMutationOptions = StorefrontMutateSecondParam & {
   cache?: never;
 };
 
-const StorefrontApiError = class extends Error {} as ErrorConstructor;
+export const StorefrontApiError = class extends Error {} as ErrorConstructor;
 export const isStorefrontApiError = (error: any) =>
   error instanceof StorefrontApiError;
 

--- a/packages/hydrogen/src/storefrontClient.example.js
+++ b/packages/hydrogen/src/storefrontClient.example.js
@@ -1,29 +1,22 @@
 import {createStorefrontClient} from '@shopify/hydrogen';
-import {
-  createRequestHandler,
-  getStorefrontHeaders,
-} from '@shopify/remix-oxygen';
+import {createRequestHandler} from '@shopify/remix-oxygen';
+
 export default {
   async fetch(request, env, executionContext) {
     /* Create a Storefront client with your credentials and options */
     const {storefront} = createStorefrontClient({
+      /* The request object */
+      request,
       /* Cache API instance */
       cache: await caches.open('hydrogen'),
       /* Runtime utility in serverless environments */
-      waitUntil: (p) => executionContext.waitUntil(p),
+      waitUntil: executionContext.waitUntil.bind(executionContext),
       /* Private Storefront API token for your store */
       privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
       /* Public Storefront API token for your store */
       publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
       /* Your store domain: "{shop}.myshopify.com" */
       storeDomain: env.PUBLIC_STORE_DOMAIN,
-      /**
-       * Storefront API headers containing:
-       * - buyerIp: The IP address of the customer.
-       * - requestGroupId: A unique ID to group all the logs for this request.
-       * - cookie: The 'cookie' header from the request.
-       */
-      storefrontHeaders: getStorefrontHeaders(request),
     });
 
     const handleRequest = createRequestHandler({

--- a/packages/hydrogen/src/storefrontClient.example.ts
+++ b/packages/hydrogen/src/storefrontClient.example.ts
@@ -1,9 +1,6 @@
 import {createStorefrontClient} from '@shopify/hydrogen';
 import * as remixBuild from '@remix-run/dev/server-build';
-import {
-  createRequestHandler,
-  getStorefrontHeaders,
-} from '@shopify/remix-oxygen';
+import {createRequestHandler} from '@shopify/remix-oxygen';
 
 export default {
   async fetch(
@@ -13,23 +10,18 @@ export default {
   ) {
     /* Create a Storefront client with your credentials and options */
     const {storefront} = createStorefrontClient({
+      /* The request object */
+      request,
       /* Cache API instance */
       cache: await caches.open('hydrogen'),
       /* Runtime utility in serverless environments */
-      waitUntil: (p: Promise<unknown>) => executionContext.waitUntil(p),
+      waitUntil: executionContext.waitUntil.bind(executionContext),
       /* Private Storefront API token for your store */
       privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
       /* Public Storefront API token for your store */
       publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
       /* Your store domain: "{shop}.myshopify.com" */
       storeDomain: env.PUBLIC_STORE_DOMAIN,
-      /**
-       * Storefront API headers containing:
-       * - buyerIp: The IP address of the customer.
-       * - requestGroupId: A unique ID to group all the logs for this request.
-       * - cookie: The 'cookie' header from the request.
-       */
-      storefrontHeaders: getStorefrontHeaders(request),
     });
 
     const handleRequest = createRequestHandler({

--- a/packages/hydrogen/src/utils/request.test.ts
+++ b/packages/hydrogen/src/utils/request.test.ts
@@ -1,0 +1,78 @@
+import {describe, it, expect} from 'vitest';
+import {getClientIp, getHeader, getRequestId} from './request';
+import {IncomingMessage} from 'node:http';
+import type {Socket} from 'node:net';
+
+describe('request utils', () => {
+  describe('find cross runtime request headers', () => {
+    it('in browser-like environments', () => {
+      const request = new Request('https://example.com', {
+        headers: {purpose: 'test'},
+      });
+
+      expect(getHeader(request, 'purpose')).toEqual('test');
+    });
+
+    it('in Node', () => {
+      const request = new IncomingMessage({} as Socket);
+      request.headers['purpose'] = 'test';
+
+      expect(getHeader(request, 'purpose')).toEqual('test');
+    });
+  });
+
+  describe('find the client IP from the request', () => {
+    it('in Oxygen', () => {
+      const request = new Request('https://example.com', {
+        headers: {'oxygen-buyer-ip': 'my-ip'},
+      });
+
+      expect(getClientIp(request)).toEqual('my-ip');
+    });
+
+    it('in CFW', () => {
+      const request = new Request('https://example.com', {
+        headers: {'cf-connecting-ip': 'my-ip'},
+      });
+
+      expect(getClientIp(request)).toEqual('my-ip');
+    });
+
+    it('in Node', () => {
+      const request = new IncomingMessage({remoteAddress: 'my-ip'} as Socket);
+      expect(getClientIp(request)).toEqual('my-ip');
+    });
+
+    it('in a proxied server', () => {
+      const request = new IncomingMessage({remoteAddress: 'shrugs'} as Socket);
+      request.headers['x-forwarded-for'] = 'my-ip, somewhere-else';
+      expect(getClientIp(request)).toEqual('my-ip');
+    });
+  });
+
+  describe('get the request ID', () => {
+    it('in Oxygen', () => {
+      const request = new Request('https://example.com', {
+        headers: {'request-id': 'my-id'},
+      });
+
+      const requestId = getRequestId(request);
+      expect(requestId).toEqual('my-id');
+
+      // Does not create a new one
+      expect(requestId).toEqual(getRequestId(request));
+      expect((request as any).headers['request-id']).toBeFalsy();
+    });
+
+    it('in non-Oxygen environments', () => {
+      const request = new Request('https://example.com');
+
+      const requestId = getRequestId(request);
+      expect(requestId).toEqual(expect.any(String));
+
+      // Does not create a new one
+      expect(requestId).toEqual(getRequestId(request));
+      expect((request as any).headers['request-id']).toBeTruthy();
+    });
+  });
+});

--- a/packages/hydrogen/src/utils/request.ts
+++ b/packages/hydrogen/src/utils/request.ts
@@ -1,11 +1,22 @@
 export type CrossRuntimeRequest = {
   url: string;
   method: string;
+  socket?: {remoteAddress?: string}; // For Node request
   headers: {
     get?: (key: string) => string | null | undefined;
     [key: string]: any;
   };
 };
+
+export function getClientIp(request: CrossRuntimeRequest) {
+  return (
+    request.headers?.get?.('oxygen-buyer-ip') ??
+    request.headers?.get?.('cf-connecting-ip') ??
+    request.headers?.['x-forwarded-for']?.split(',')[0] ??
+    request.socket?.remoteAddress ??
+    null
+  );
+}
 
 export function getHeader(request: CrossRuntimeRequest, key: string) {
   const value = request.headers?.get?.(key) ?? request.headers?.[key];

--- a/packages/hydrogen/src/utils/request.ts
+++ b/packages/hydrogen/src/utils/request.ts
@@ -1,8 +1,8 @@
 import {generateUUID} from './uuid';
 
 export type CrossRuntimeRequest = {
-  url: string;
-  method: string;
+  url?: string;
+  method?: string;
   socket?: {remoteAddress?: string}; // For Node request
   headers: {
     get?: (key: string) => string | null | undefined;

--- a/packages/hydrogen/src/utils/request.ts
+++ b/packages/hydrogen/src/utils/request.ts
@@ -1,0 +1,22 @@
+export type CrossRuntimeRequest = {
+  url: string;
+  method: string;
+  headers: {
+    get?: (key: string) => string | null | undefined;
+    [key: string]: any;
+  };
+};
+
+export function getHeader(request: CrossRuntimeRequest, key: string) {
+  const value = request.headers?.get?.(key) ?? request.headers?.[key];
+  return typeof value === 'string' ? value : null;
+}
+
+export function getDebugHeaders(request?: CrossRuntimeRequest) {
+  return request
+    ? {
+        requestId: getHeader(request, 'request-id'),
+        purpose: getHeader(request, 'purpose'),
+      }
+    : {};
+}

--- a/packages/hydrogen/src/utils/request.ts
+++ b/packages/hydrogen/src/utils/request.ts
@@ -1,3 +1,5 @@
+import {generateUUID} from './uuid';
+
 export type CrossRuntimeRequest = {
   url: string;
   method: string;
@@ -18,6 +20,17 @@ export function getClientIp(request: CrossRuntimeRequest) {
   );
 }
 
+export function getRequestId(request: CrossRuntimeRequest) {
+  let requestId = getHeader(request, 'request-id');
+
+  if (!requestId) {
+    // Store it in the headers object for later access
+    request.headers['request-id'] = requestId = generateUUID();
+  }
+
+  return requestId;
+}
+
 export function getHeader(request: CrossRuntimeRequest, key: string) {
   const value = request.headers?.get?.(key) ?? request.headers?.[key];
   return typeof value === 'string' ? value : null;
@@ -26,7 +39,7 @@ export function getHeader(request: CrossRuntimeRequest, key: string) {
 export function getDebugHeaders(request?: CrossRuntimeRequest) {
   return request
     ? {
-        requestId: getHeader(request, 'request-id'),
+        requestId: getRequestId(request),
         purpose: getHeader(request, 'purpose'),
       }
     : {};

--- a/packages/hydrogen/src/with-cache.ts
+++ b/packages/hydrogen/src/with-cache.ts
@@ -1,12 +1,6 @@
 import {type CacheKey, runWithCache} from './cache/fetch';
 import type {CachingStrategy} from './cache/strategies';
-
-type CrossRuntimeRequest = {
-  headers: {
-    get?: (key: string) => string | null | undefined;
-    [key: string]: any;
-  };
-};
+import {type CrossRuntimeRequest, getDebugHeaders} from './utils/request';
 
 type CreateWithCacheOptions = {
   /** An instance that implements the [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) */
@@ -16,11 +10,6 @@ type CreateWithCacheOptions = {
   /** The `request` object is used to access certain headers for debugging */
   request?: CrossRuntimeRequest;
 };
-
-function getHeader(key: string, request?: CrossRuntimeRequest) {
-  const value = request?.headers?.get?.(key) ?? request?.headers?.[key];
-  return typeof value === 'string' ? value : undefined;
-}
 
 /**
  * Creates a utility function that executes an asynchronous operation
@@ -43,10 +32,7 @@ export function createWithCache<T = unknown>({
       strategy,
       cacheInstance: cache,
       waitUntil,
-      debugInfo: {
-        requestId: getHeader('request-id', request),
-        purpose: getHeader('purpose', request),
-      },
+      debugInfo: getDebugHeaders(request),
     });
   };
 }

--- a/packages/remix-oxygen/src/server.ts
+++ b/packages/remix-oxygen/src/server.ts
@@ -69,15 +69,16 @@ type StorefrontHeaders = {
   requestGroupId: string | null;
   buyerIp: string | null;
   cookie: string | null;
-  purpose: string | null;
 };
 
+/**
+ * @deprecated Since 2023-10
+ */
 export function getStorefrontHeaders(request: Request): StorefrontHeaders {
   const headers = request.headers;
   return {
     requestGroupId: headers.get('request-id'),
     buyerIp: headers.get('oxygen-buyer-ip'),
     cookie: headers.get('cookie'),
-    purpose: headers.get('purpose'),
   };
 }

--- a/templates/demo-store/server.ts
+++ b/templates/demo-store/server.ts
@@ -1,9 +1,6 @@
 // Virtual entry point for the app
 import * as remixBuild from '@remix-run/dev/server-build';
-import {
-  createRequestHandler,
-  getStorefrontHeaders,
-} from '@shopify/remix-oxygen';
+import {createRequestHandler} from '@shopify/remix-oxygen';
 import {
   cartGetIdDefault,
   cartSetIdDefault,
@@ -43,13 +40,13 @@ export default {
        */
       const {storefront} = createStorefrontClient({
         cache,
+        request,
         waitUntil,
         i18n: getLocaleFromRequest(request),
         publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: env.PUBLIC_STORE_DOMAIN,
         storefrontId: env.PUBLIC_STOREFRONT_ID,
-        storefrontHeaders: getStorefrontHeaders(request),
       });
 
       const cart = createCartHandler({

--- a/templates/hello-world/server.ts
+++ b/templates/hello-world/server.ts
@@ -3,7 +3,6 @@ import * as remixBuild from '@remix-run/dev/server-build';
 import {createStorefrontClient, storefrontRedirect} from '@shopify/hydrogen';
 import {
   createRequestHandler,
-  getStorefrontHeaders,
   createCookieSessionStorage,
   type SessionStorage,
   type Session,
@@ -26,7 +25,7 @@ export default {
         throw new Error('SESSION_SECRET environment variable is not set');
       }
 
-      const waitUntil = (p: Promise<any>) => executionContext.waitUntil(p);
+      const waitUntil = executionContext.waitUntil.bind(executionContext);
       const [cache, session] = await Promise.all([
         caches.open('hydrogen'),
         HydrogenSession.init(request, [env.SESSION_SECRET]),
@@ -37,13 +36,13 @@ export default {
        */
       const {storefront} = createStorefrontClient({
         cache,
+        request,
         waitUntil,
         i18n: {language: 'EN', country: 'US'},
         publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: env.PUBLIC_STORE_DOMAIN,
         storefrontId: env.PUBLIC_STOREFRONT_ID,
-        storefrontHeaders: getStorefrontHeaders(request),
       });
 
       /**

--- a/templates/skeleton/server.ts
+++ b/templates/skeleton/server.ts
@@ -9,7 +9,6 @@ import {
 } from '@shopify/hydrogen';
 import {
   createRequestHandler,
-  getStorefrontHeaders,
   createCookieSessionStorage,
   type SessionStorage,
   type Session,
@@ -43,13 +42,13 @@ export default {
        */
       const {storefront} = createStorefrontClient({
         cache,
+        request,
         waitUntil,
         i18n: {language: 'EN', country: 'US'},
         publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
         privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
         storeDomain: env.PUBLIC_STORE_DOMAIN,
         storefrontId: env.PUBLIC_STOREFRONT_ID,
-        storefrontHeaders: getStorefrontHeaders(request),
       });
 
       /*


### PR DESCRIPTION
Let's discuss if this is a good API or not ([original public discussion](https://github.com/Shopify/hydrogen/pull/1438#issuecomment-1774223145)). The problem is the "cross runtime request" issue.

I've added tests here for a the storefront client as well (the tests we had before were in an e2e that we removed long ago...), so we should merge at least that (will revert other things if we don't want it).