### PR TITLE
Adds optional channel prop to ShopPayButton

### DIFF
--- a/.changeset/small-zoos-grab.md
+++ b/.changeset/small-zoos-grab.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': minor
+---
+
+This change adds an optional prop to the `ShopPayButton` that adds order attribution support for either the Headless or Hydrogen sales channel.

--- a/.changeset/small-zoos-grab.md
+++ b/.changeset/small-zoos-grab.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/hydrogen-react': minor
+'@shopify/hydrogen-react': patch
 ---
 
 This change adds an optional prop to the `ShopPayButton` that adds order attribution support for either the Headless or Hydrogen sales channel.

--- a/.changeset/witty-lamps-fly.md
+++ b/.changeset/witty-lamps-fly.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Adds default channel value of "hydrogen" to the ShopPayButton component exported out of the @shopify/hydrogen package.

--- a/packages/hydrogen-react/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen-react/docs/generated/generated_docs_data.json
@@ -2019,7 +2019,7 @@
                 "filePath": "/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-current",
-                "value": "boolean | \"time\" | \"step\" | \"page\" | \"date\" | \"true\" | \"false\" | \"location\"",
+                "value": "boolean | \"time\" | \"step\" | \"date\" | \"true\" | \"false\" | \"page\" | \"location\"",
                 "description": "Indicates the element that represents the current item within a container or set of related elements.",
                 "isOptional": true
               },
@@ -5705,7 +5705,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "pop",
                 "value": "() => unknown",
-                "description": "Removes the last element from an array and returns it. If the array is empty, undefined is returned and the array is not modified."
+                "description": "Removes the last element from an array and returns it.\r\nIf the array is empty, undefined is returned and the array is not modified."
               },
               {
                 "filePath": "/flatten-connection.ts",
@@ -5719,7 +5719,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "concat",
                 "value": "{ (...items: ConcatArray<unknown>[]): unknown[]; (...items: unknown[]): unknown[]; }",
-                "description": "Combines two or more arrays. This method returns a new array without modifying any existing arrays."
+                "description": "Combines two or more arrays.\r\nThis method returns a new array without modifying any existing arrays."
               },
               {
                 "filePath": "/flatten-connection.ts",
@@ -5733,28 +5733,28 @@
                 "syntaxKind": "MethodSignature",
                 "name": "reverse",
                 "value": "() => unknown[]",
-                "description": "Reverses the elements in an array in place. This method mutates the array and returns a reference to the same array."
+                "description": "Reverses the elements in an array in place.\r\nThis method mutates the array and returns a reference to the same array."
               },
               {
                 "filePath": "/flatten-connection.ts",
                 "syntaxKind": "MethodSignature",
                 "name": "shift",
                 "value": "() => unknown",
-                "description": "Removes the first element from an array and returns it. If the array is empty, undefined is returned and the array is not modified."
+                "description": "Removes the first element from an array and returns it.\r\nIf the array is empty, undefined is returned and the array is not modified."
               },
               {
                 "filePath": "/flatten-connection.ts",
                 "syntaxKind": "MethodSignature",
                 "name": "slice",
                 "value": "(start?: number, end?: number) => unknown[]",
-                "description": "Returns a copy of a section of an array. For both start and end, a negative index can be used to indicate an offset from the end of the array. For example, -2 refers to the second to last element of the array."
+                "description": "Returns a copy of a section of an array.\r\nFor both start and end, a negative index can be used to indicate an offset from the end of the array.\r\nFor example, -2 refers to the second to last element of the array."
               },
               {
                 "filePath": "/flatten-connection.ts",
                 "syntaxKind": "MethodSignature",
                 "name": "sort",
                 "value": "(compareFn?: (a: unknown, b: unknown) => number) => FlattenConnectionReturnForDoc",
-                "description": "Sorts an array in place. This method mutates the array and returns a reference to the same array."
+                "description": "Sorts an array in place.\r\nThis method mutates the array and returns a reference to the same array."
               },
               {
                 "filePath": "/flatten-connection.ts",
@@ -5837,15 +5837,15 @@
                 "filePath": "/flatten-connection.ts",
                 "syntaxKind": "MethodSignature",
                 "name": "find",
-                "value": "{ <S extends unknown>(predicate: (value: unknown, index: number, obj: unknown[]) => value is S, thisArg?: any): S; (predicate: (value: unknown, index: number, obj: unknown[]) => unknown, thisArg?: any): unknown; }",
-                "description": "Returns the value of the first element in the array where predicate is true, and undefined otherwise."
+                "value": "{ <S extends unknown>(predicate: (this: void, value: unknown, index: number, obj: unknown[]) => value is S, thisArg?: any): S; (predicate: (value: unknown, index: number, obj: unknown[]) => unknown, thisArg?: any): unknown; }",
+                "description": "Returns the value of the first element in the array where predicate is true, and undefined\r\notherwise."
               },
               {
                 "filePath": "/flatten-connection.ts",
                 "syntaxKind": "MethodSignature",
                 "name": "findIndex",
                 "value": "(predicate: (value: unknown, index: number, obj: unknown[]) => unknown, thisArg?: any) => number",
-                "description": "Returns the index of the first element in the array where predicate is true, and -1 otherwise."
+                "description": "Returns the index of the first element in the array where predicate is true, and -1\r\notherwise."
               },
               {
                 "filePath": "/flatten-connection.ts",
@@ -5859,7 +5859,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "copyWithin",
                 "value": "(target: number, start: number, end?: number) => FlattenConnectionReturnForDoc",
-                "description": "Returns the this object after copying a section of the array identified by start and end to the same array starting at position target"
+                "description": "Returns the this object after copying a section of the array identified by start and end\r\nto the same array starting at position target"
               },
               {
                 "filePath": "/flatten-connection.ts",
@@ -5894,28 +5894,28 @@
                 "syntaxKind": "MethodSignature",
                 "name": "flatMap",
                 "value": "<U, This = undefined>(callback: (this: This, value: unknown, index: number, array: unknown[]) => U | readonly U[], thisArg?: This) => U[]",
-                "description": "Calls a defined callback function on each element of an array. Then, flattens the result into a new array. This is identical to a map followed by flat with depth 1."
+                "description": "Calls a defined callback function on each element of an array. Then, flattens the result into\r\na new array.\r\nThis is identical to a map followed by flat with depth 1."
               },
               {
                 "filePath": "/flatten-connection.ts",
                 "syntaxKind": "MethodSignature",
                 "name": "flat",
                 "value": "<A, D extends number = 1>(this: A, depth?: D) => FlatArray<A, D>[]",
-                "description": "Returns a new array with all sub-array elements concatenated into it recursively up to the specified depth."
+                "description": "Returns a new array with all sub-array elements concatenated into it recursively up to the\r\nspecified depth."
               },
               {
                 "filePath": "/flatten-connection.ts",
                 "syntaxKind": "MethodSignature",
-                "name": "__@iterator@448",
+                "name": "__@iterator@441",
                 "value": "() => IterableIterator<unknown>",
                 "description": "Iterator"
               },
               {
                 "filePath": "/flatten-connection.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "__@unscopables@450",
-                "value": "{ [x: number]: boolean; length?: boolean; toString?: boolean; toLocaleString?: boolean; pop?: boolean; push?: boolean; concat?: boolean; join?: boolean; reverse?: boolean; shift?: boolean; slice?: boolean; sort?: boolean; splice?: boolean; unshift?: boolean; indexOf?: boolean; lastIndexOf?: boolean; every?: boolean; some?: boolean; forEach?: boolean; map?: boolean; filter?: boolean; reduce?: boolean; reduceRight?: boolean; find?: boolean; findIndex?: boolean; fill?: boolean; copyWithin?: boolean; entries?: boolean; keys?: boolean; values?: boolean; includes?: boolean; flatMap?: boolean; flat?: boolean; [Symbol.iterator]?: boolean; readonly [Symbol.unscopables]?: boolean; at?: boolean; }",
-                "description": "Is an object whose properties have the value 'true' when they will be absent when used in a 'with' statement."
+                "syntaxKind": "MethodSignature",
+                "name": "__@unscopables@443",
+                "value": "() => { copyWithin: boolean; entries: boolean; fill: boolean; find: boolean; findIndex: boolean; keys: boolean; values: boolean; }",
+                "description": "Returns an object whose properties have the value 'true'\r\nwhen they will be absent when used in a 'with' statement."
               },
               {
                 "filePath": "/flatten-connection.ts",

--- a/packages/hydrogen-react/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen-react/docs/generated/generated_docs_data.json
@@ -4367,12 +4367,12 @@
         "tabs": [
           {
             "title": "JavaScript",
-            "code": "import {ShopPayButton} from '@shopify/hydrogen-react';\n\nexport function AddVariantQuantity1({variantId, storeDomain}) {\n  return &lt;ShopPayButton variantIds={[variantId]} storeDomain={storeDomain} /&gt;;\n}\n\nexport function AddVariantQuantityMultiple({variantId, quantity, storeDomain}) {\n  return (\n    &lt;ShopPayButton\n      variantIdsAndQuantities={[{id: variantId, quantity}]}\n      storeDomain={storeDomain}\n    /&gt;\n  );\n}\n",
+            "code": "import {ShopPayButton} from '@shopify/hydrogen-react';\n\nexport function AddVariantQuantity1({variantId, storeDomain}) {\n  return &lt;ShopPayButton variantIds={[variantId]} storeDomain={storeDomain} /&gt;;\n}\n\nexport function AddVariantQuantityMultiple({variantId, quantity, storeDomain}) {\n  return (\n    &lt;ShopPayButton\n      variantIdsAndQuantities={[{id: variantId, quantity}]}\n      storeDomain={storeDomain}\n    /&gt;\n  );\n}\n\nexport function ChannelAttribution({channel, variantId, storeDomain}) {\n  return (\n    &lt;ShopPayButton\n      channel={channel}\n      variantIds={[variantId]}\n      storeDomain={storeDomain}\n    /&gt;\n  );\n}\n",
             "language": "jsx"
           },
           {
             "title": "TypeScript",
-            "code": "import {ShopPayButton} from '@shopify/hydrogen-react';\n\nexport function AddVariantQuantity1({\n  variantId,\n  storeDomain,\n}: {\n  variantId: string;\n  storeDomain: string;\n}) {\n  return &lt;ShopPayButton variantIds={[variantId]} storeDomain={storeDomain} /&gt;;\n}\n\nexport function AddVariantQuantityMultiple({\n  variantId,\n  quantity,\n  storeDomain,\n}: {\n  variantId: string;\n  quantity: number;\n  storeDomain: string;\n}) {\n  return (\n    &lt;ShopPayButton\n      variantIdsAndQuantities={[{id: variantId, quantity}]}\n      storeDomain={storeDomain}\n    /&gt;\n  );\n}\n",
+            "code": "import {ShopPayButton} from '@shopify/hydrogen-react';\n\nexport function AddVariantQuantity1({\n  variantId,\n  storeDomain,\n}: {\n  variantId: string;\n  storeDomain: string;\n}) {\n  return &lt;ShopPayButton variantIds={[variantId]} storeDomain={storeDomain} /&gt;;\n}\n\nexport function AddVariantQuantityMultiple({\n  variantId,\n  quantity,\n  storeDomain,\n}: {\n  variantId: string;\n  quantity: number;\n  storeDomain: string;\n}) {\n  return (\n    &lt;ShopPayButton\n      variantIdsAndQuantities={[{id: variantId, quantity}]}\n      storeDomain={storeDomain}\n    /&gt;\n  );\n}\n\nexport function ChannelAttribution({\n  channel,\n  variantId,\n  storeDomain,\n}: {\n  channel: 'headless' | 'hydrogen';\n  variantId: string;\n  storeDomain: string;\n}) {\n  return (\n    &lt;ShopPayButton\n      channel={channel}\n      variantIds={[variantId]}\n      storeDomain={storeDomain}\n    /&gt;\n  );\n}\n",
             "language": "tsx"
           }
         ],
@@ -4412,7 +4412,7 @@
             "filePath": "/ShopPayButton.tsx",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ShopPayButtonProps",
-            "value": "ShopPayButtonStyleProps & ShopPayDomainProps & (ShopPayVariantIds | ShopPayVariantAndQuantities)",
+            "value": "ShopPayButtonStyleProps & ShopPayDomainProps & ShopPayChannelAttribution & (ShopPayVariantIds | ShopPayVariantAndQuantities)",
             "description": ""
           },
           "ShopPayButtonStyleProps": {
@@ -4453,6 +4453,23 @@
                 "name": "storeDomain",
                 "value": "string",
                 "description": "The domain of your Shopify storefront URL (eg: `your-store.myshopify.com`).",
+                "isOptional": true
+              }
+            ]
+          },
+          "ShopPayChannelAttribution": {
+            "filePath": "/ShopPayButton.tsx",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopPayChannelAttribution",
+            "value": "{\n  /** A string that adds channel attribution to the order. Can be either `headless` or `hydrogen` */\n  channel?: 'headless' | 'hydrogen';\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/ShopPayButton.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "channel",
+                "value": "\"headless\" | \"hydrogen\"",
+                "description": "A string that adds channel attribution to the order. Can be either `headless` or `hydrogen`",
                 "isOptional": true
               }
             ]

--- a/packages/hydrogen-react/src/ShopPayButton.example.jsx
+++ b/packages/hydrogen-react/src/ShopPayButton.example.jsx
@@ -12,3 +12,13 @@ export function AddVariantQuantityMultiple({variantId, quantity, storeDomain}) {
     />
   );
 }
+
+export function ChannelAttribution({channel, variantId, storeDomain}) {
+  return (
+    <ShopPayButton
+      channel={channel}
+      variantIds={[variantId]}
+      storeDomain={storeDomain}
+    />
+  );
+}

--- a/packages/hydrogen-react/src/ShopPayButton.example.tsx
+++ b/packages/hydrogen-react/src/ShopPayButton.example.tsx
@@ -26,3 +26,21 @@ export function AddVariantQuantityMultiple({
     />
   );
 }
+
+export function ChannelAttribution({
+  channel,
+  variantId,
+  storeDomain,
+}: {
+  channel: 'headless' | 'hydrogen';
+  variantId: string;
+  storeDomain: string;
+}) {
+  return (
+    <ShopPayButton
+      channel={channel}
+      variantIds={[variantId]}
+      storeDomain={storeDomain}
+    />
+  );
+}

--- a/packages/hydrogen-react/src/ShopPayButton.stories.tsx
+++ b/packages/hydrogen-react/src/ShopPayButton.stories.tsx
@@ -26,3 +26,14 @@ Quantities.args = {
   className: '',
   width: '',
 };
+
+export const ChannelAttribution = Template.bind({});
+ChannelAttribution.args = {
+  channel: 'hydrogen',
+  variantIdsAndQuantities: [
+    {id: 'gid://shopify/ProductVariant/123', quantity: 2},
+  ],
+  storeDomain: 'https://notashop.myshopify.io',
+  className: '',
+  width: '',
+};

--- a/packages/hydrogen-react/src/ShopPayButton.test.tsx
+++ b/packages/hydrogen-react/src/ShopPayButton.test.tsx
@@ -7,6 +7,7 @@ import {
   DoublePropsErrorMessage,
   MissingPropsErrorMessage,
   InvalidPropsErrorMessage,
+  InvalidChannelErrorMessage,
   MissingStoreDomainErrorMessage,
 } from './ShopPayButton.js';
 import {getShopifyConfig} from './ShopifyProvider.test.js';
@@ -164,5 +165,47 @@ describe(`<ShopPayButton />`, () => {
       'store-url',
       'https://notashop.myshopify.com',
     );
+  });
+
+  it(`throws an error if you pass an invalid channel value`, () => {
+    expect(() =>
+      render(
+        <ShopPayButton
+          // @ts-expect-error Purposely passing in invalid channel
+          channel="test"
+          variantIdsAndQuantities={[]}
+        />,
+        {
+          wrapper: ({children}) => (
+            <ShopifyProvider {...getShopifyConfig()}>
+              {children}
+            </ShopifyProvider>
+          ),
+        },
+      ),
+    ).toThrow(InvalidChannelErrorMessage);
+  });
+
+  it(`creates the correct attribute when using 'channel'`, () => {
+    const channel = 'hydrogen';
+    const {container} = render(
+      <ShopPayButton
+        channel={channel}
+        variantIds={['gid://shopify/ProductVariant/123']}
+      />,
+      {
+        wrapper: ({children}) => (
+          <ShopifyProvider {...getShopifyConfig()}>{children}</ShopifyProvider>
+        ),
+      },
+    );
+
+    const button = container.querySelector('shop-pay-button');
+
+    expect(button).toHaveAttribute(
+      'store-url',
+      'https://notashop.myshopify.io',
+    );
+    expect(button).toHaveAttribute('channel', channel);
   });
 });

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -63,6 +63,8 @@ export {
   OptimisticInput,
 } from './optimistic-ui/optimistic-ui';
 
+export {ShopPayButton} from './shop/ShopPayButton';
+
 export {
   AnalyticsEventName,
   AnalyticsPageType,
@@ -79,7 +81,6 @@ export {
   parseMetafield,
   sendShopifyAnalytics,
   ShopifySalesChannel,
-  ShopPayButton,
   storefrontApiCustomScalars,
   useLoadScript,
   useMoney,

--- a/packages/hydrogen/src/shop/ShopPayButton.tsx
+++ b/packages/hydrogen/src/shop/ShopPayButton.tsx
@@ -1,0 +1,6 @@
+import {ShopPayButton as ShopPayButtonBase} from '@shopify/hydrogen-react';
+import {ComponentProps} from 'react';
+
+export function ShopPayButton(props: ComponentProps<typeof ShopPayButtonBase>) {
+  return <ShopPayButtonBase channel="hydrogen" {...props} />;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

This adds an optional `channel` prop to the `ShopPayButton` which will be used to add attribution to an order.

> **Note**
> The channel being specified (either Headless or Hydrogen) **must** be installed otherwise validation will fail at checkout and the buyer will be redirected to the online store domain.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This change leverages a change made in Shop JS that allows `channel` to be forwarded to the checkout for order attribution. Now, when developers add either `headless` or `hydrogen` to their `ShopPayButton` props, they will be able to ensure orders are attributed to the correct channel.

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

> **Important**
> You will need admin access for a storefront to test these changes.

It is recommended to test this change using a store of your own using a **free product**.

1. Navigate to the free product's product details page.
2. Ensure you've included either `headless` or `hydrogen` as the prop on your `ShopPayButton`
  a. Use the channel that aligns with the channel you've added to your storefront.
3.  Pressing the `ShopPayButton` should direct you to your checkout without any errors.
4. Confirm payment (again, it's recommended you use a free item)
5. Check your `Orders` page in admin and check the order attribution for your test order. It should reflect the correct channel.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
