### PR TITLE
Remove deprecated `getBuyerIp`

### DIFF
--- a/.changeset/clean-timers-peel.md
+++ b/.changeset/clean-timers-peel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/remix-oxygen': major
+---
+
+Remove deprecated function export `getBuyerIp`.

--- a/packages/remix-oxygen/src/index.ts
+++ b/packages/remix-oxygen/src/index.ts
@@ -5,7 +5,7 @@ export {
   createSessionStorage,
 } from './implementations';
 
-export {createRequestHandler, getBuyerIp, getStorefrontHeaders} from './server';
+export {createRequestHandler, getStorefrontHeaders} from './server';
 
 export {
   createSession,

--- a/packages/remix-oxygen/src/server.ts
+++ b/packages/remix-oxygen/src/server.ts
@@ -61,10 +61,6 @@ export function createRequestHandler<Context = unknown>({
   };
 }
 
-export function getBuyerIp(request: Request) {
-  return request.headers.get('oxygen-buyer-ip') ?? undefined;
-}
-
 type StorefrontHeaders = {
   requestGroupId: string | null;
   buyerIp: string | null;

--- a/rfc/fetching-data.md
+++ b/rfc/fetching-data.md
@@ -8,7 +8,7 @@ First of all, it's necessary to create and inject the Hydrogen `storefront` clie
 
 ```ts
 import {createStorefrontClient} from '@shopify/hydrogen';
-import {createRequestHandler, getBuyerIp} from '@shopify/remix-oxygen';
+import {createRequestHandler} from '@shopify/remix-oxygen';
 
 export default {
   async fetch(request: Request, env: Env, executionContext: ExecutionContext) {
@@ -21,7 +21,6 @@ export default {
         const {storefront} = createStorefrontClient({
           cache,
           waitUntil: (p: Promise) => executionContext.waitUntil(p),
-          buyerIp: getBuyerIp(request),
           publicStorefrontToken: env.SHOPIFY_STOREFRONT_API_PUBLIC_TOKEN,
           storefrontApiVersion: env.SHOPIFY_STOREFRONT_API_VERSION,
           storeDomain: env.SHOPIFY_STORE_DOMAIN,


### PR DESCRIPTION
This function deprecated long ago, let's remove it for the major bump.