### PR TITLE
(fix): skeleton menu links in dev

### DIFF
--- a/.changeset/kind-roses-talk.md
+++ b/.changeset/kind-roses-talk.md
@@ -4,3 +4,112 @@
 ---
 
 Fix skeleton template menu links
+
+1; Update the `HeaderMenu` component to accept a `primaryDomainUrl` and include
+it in the internal url check
+
+```diff
+// app/components/Header.tsx
+
++ import type {HeaderQuery} from 'storefrontapi.generated';
+
+export function HeaderMenu({
+  menu,
++  primaryDomainUrl,
+  viewport,
+}: {
+  menu: HeaderProps['header']['menu'];
++  primaryDomainUrl: HeaderQuery['shop']['primaryDomain']['url'];
+  viewport: Viewport;
+}) {
+
+  // ...code
+
+  // if the url is internal, we strip the domain
+  const url =
+    item.url.includes('myshopify.com') ||
+    item.url.includes(publicStoreDomain) ||
++   item.url.includes(primaryDomainUrl)
+      ? new URL(item.url).pathname
+      : item.url;
+
+   // ...code
+
+}
+```
+
+2; Update the `FooterMenu` component to accept a `primaryDomainUrl` prop and include
+it in the internal url check
+
+```diff
+// app/components/Footer.tsx
+
+- import type {FooterQuery} from 'storefrontapi.generated';
++ import type {FooterQuery, HeaderQuery} from 'storefrontapi.generated';
+
+function FooterMenu({
+  menu,
++  primaryDomainUrl,
+}: {
+  menu: FooterQuery['menu'];
++  primaryDomainUrl: HeaderQuery['shop']['primaryDomain']['url'];
+}) {
+  // code...
+
+  // if the url is internal, we strip the domain
+  const url =
+    item.url.includes('myshopify.com') ||
+    item.url.includes(publicStoreDomain) ||
++   item.url.includes(primaryDomainUrl)
+      ? new URL(item.url).pathname
+      : item.url;
+
+   // ...code
+
+  );
+}
+```
+
+3; Update the `Footer` component to accept a `shop` prop
+
+```diff
+export function Footer({
+  menu,
++ shop,
+}: FooterQuery & {shop: HeaderQuery['shop']}) {
+  return (
+    <footer className="footer">
+-      <FooterMenu menu={menu} />
++      <FooterMenu menu={menu} primaryDomainUrl={shop.primaryDomain.url} />
+    </footer>
+  );
+}
+```
+
+4; Update `Layout.tsx` to pass the `shop`
+
+```diff
+export function Layout({
+  cart,
+  children = null,
+  footer,
+  header,
+  isLoggedIn,
+}: LayoutProps) {
+  return (
+    <>
+      <CartAside cart={cart} />
+      <SearchAside />
+      <MobileMenuAside menu={header.menu} shop={header.shop} />
+      <Header header={header} cart={cart} isLoggedIn={isLoggedIn} />
+      <main>{children}</main>
+      <Suspense>
+        <Await resolve={footer}>
+-          {(footer) => <Footer menu={footer.menu}  />}
++          {(footer) => <Footer menu={footer.menu} shop={header.shop} />}
+        </Await>
+      </Suspense>
+    </>
+  );
+}
+```

--- a/.changeset/kind-roses-talk.md
+++ b/.changeset/kind-roses-talk.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Fix skeleton template menu links

--- a/templates/skeleton/app/components/Footer.tsx
+++ b/templates/skeleton/app/components/Footer.tsx
@@ -1,16 +1,25 @@
 import {NavLink} from '@remix-run/react';
-import type {FooterQuery} from 'storefrontapi.generated';
+import type {FooterQuery, HeaderQuery} from 'storefrontapi.generated';
 import {useRootLoaderData} from '~/root';
 
-export function Footer({menu}: FooterQuery) {
+export function Footer({
+  menu,
+  shop,
+}: FooterQuery & {shop: HeaderQuery['shop']}) {
   return (
     <footer className="footer">
-      <FooterMenu menu={menu} />
+      <FooterMenu menu={menu} primaryDomainUrl={shop.primaryDomain.url} />
     </footer>
   );
 }
 
-function FooterMenu({menu}: Pick<FooterQuery, 'menu'>) {
+function FooterMenu({
+  menu,
+  primaryDomainUrl,
+}: {
+  menu: FooterQuery['menu'];
+  primaryDomainUrl: HeaderQuery['shop']['primaryDomain']['url'];
+}) {
   const {publicStoreDomain} = useRootLoaderData();
 
   return (
@@ -20,7 +29,8 @@ function FooterMenu({menu}: Pick<FooterQuery, 'menu'>) {
         // if the url is internal, we strip the domain
         const url =
           item.url.includes('myshopify.com') ||
-          item.url.includes(publicStoreDomain)
+          item.url.includes(publicStoreDomain) ||
+          item.url.includes(primaryDomainUrl)
             ? new URL(item.url).pathname
             : item.url;
         const isExternal = !url.startsWith('/');

--- a/templates/skeleton/app/components/Header.tsx
+++ b/templates/skeleton/app/components/Header.tsx
@@ -1,5 +1,6 @@
 import {Await, NavLink} from '@remix-run/react';
 import {Suspense} from 'react';
+import type {HeaderQuery} from 'storefrontapi.generated';
 import type {LayoutProps} from './Layout';
 import {useRootLoaderData} from '~/root';
 
@@ -14,7 +15,11 @@ export function Header({header, isLoggedIn, cart}: HeaderProps) {
       <NavLink prefetch="intent" to="/" style={activeLinkStyle} end>
         <strong>{shop.name}</strong>
       </NavLink>
-      <HeaderMenu menu={menu} viewport="desktop" />
+      <HeaderMenu
+        menu={menu}
+        viewport="desktop"
+        primaryDomainUrl={header.shop.primaryDomain.url}
+      />
       <HeaderCtas isLoggedIn={isLoggedIn} cart={cart} />
     </header>
   );
@@ -22,9 +27,11 @@ export function Header({header, isLoggedIn, cart}: HeaderProps) {
 
 export function HeaderMenu({
   menu,
+  primaryDomainUrl,
   viewport,
 }: {
   menu: HeaderProps['header']['menu'];
+  primaryDomainUrl: HeaderQuery['shop']['primaryDomain']['url'];
   viewport: Viewport;
 }) {
   const {publicStoreDomain} = useRootLoaderData();
@@ -56,7 +63,8 @@ export function HeaderMenu({
         // if the url is internal, we strip the domain
         const url =
           item.url.includes('myshopify.com') ||
-          item.url.includes(publicStoreDomain)
+          item.url.includes(publicStoreDomain) ||
+          item.url.includes(primaryDomainUrl)
             ? new URL(item.url).pathname
             : item.url;
         return (

--- a/templates/skeleton/app/components/Layout.tsx
+++ b/templates/skeleton/app/components/Layout.tsx
@@ -33,12 +33,12 @@ export function Layout({
     <>
       <CartAside cart={cart} />
       <SearchAside />
-      <MobileMenuAside menu={header.menu} />
+      <MobileMenuAside menu={header.menu} shop={header.shop} />
       <Header header={header} cart={cart} isLoggedIn={isLoggedIn} />
       <main>{children}</main>
       <Suspense>
         <Await resolve={footer}>
-          {(footer) => <Footer menu={footer.menu} />}
+          {(footer) => <Footer menu={footer.menu} shop={header.shop} />}
         </Await>
       </Suspense>
     </>
@@ -86,10 +86,20 @@ function SearchAside() {
   );
 }
 
-function MobileMenuAside({menu}: {menu: HeaderQuery['menu']}) {
+function MobileMenuAside({
+  menu,
+  shop,
+}: {
+  menu: HeaderQuery['menu'];
+  shop: HeaderQuery['shop'];
+}) {
   return (
     <Aside id="mobile-menu-aside" heading="MENU">
-      <HeaderMenu menu={menu} viewport="mobile" />
+      <HeaderMenu
+        menu={menu}
+        viewport="mobile"
+        primaryDomainUrl={shop.primaryDomain.url}
+      />
     </Aside>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Skeleton header and footer links where pointing to the production domain in dev on 2023.10

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
