### PR TITLE
SEO component: Remove params from canonical URL

### DIFF
--- a/.changeset/tender-books-watch.md
+++ b/.changeset/tender-books-watch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+SEO component: remove URL params from canonical tags

--- a/packages/hydrogen/src/seo/generate-seo-tags.test.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.test.ts
@@ -235,6 +235,30 @@ describe('generateSeoTags', () => {
         'Error in SEO input: `url` should be a valid URL',
       );
     });
+
+    it('should remove URL parameters from the url', () => {
+      // Given
+      const input = {
+        url: 'https://hydrogen.shop/products/snowboard?Size=154cm&Binding+mount=Nested&Material=Carbon-fiber',
+      };
+
+      // When
+      const output = generateSeoTags(input);
+
+      // Then
+      expect(output).toEqual(
+        expect.arrayContaining([
+          {
+            key: 'link-canonical',
+            props: {
+              href: 'https://hydrogen.shop/products/snowboard',
+              rel: 'canonical',
+            },
+            tag: 'link',
+          },
+        ]),
+      );
+    });
   });
 
   describe('media', () => {

--- a/packages/hydrogen/src/seo/generate-seo-tags.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.ts
@@ -410,14 +410,16 @@ export function generateSeoTags<
           break;
         }
 
+        const urlWithoutParams = content.split('?')[0];
+
         tagResults.push(
           generateTag('link', {
             rel: 'canonical',
-            href: content,
+            href: urlWithoutParams,
           }),
           generateTag('meta', {
             property: 'og:url',
-            content,
+            content: urlWithoutParams,
           }),
         );
 


### PR DESCRIPTION
### WHY are these changes introduced?

URL parameters shouldn't appear in canonical tag (in most cases).

### WHAT is this pull request doing?

Removes URL parameters from canonical tag.

Before:

<img width="923" alt="image" src="https://github.com/Shopify/hydrogen/assets/59898611/fa250f42-740a-4099-9f44-f7c2ab51fc3b">

After:

<img width="853" alt="image" src="https://github.com/Shopify/hydrogen/assets/59898611/e77915d0-eb6c-40f1-888a-729e6e4af188">

### HOW to test your changes?

Run the demo-store template locally.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation