### PR TITLE
Remove error boundary from robots.txt skeleton

### DIFF
--- a/.changeset/bright-steaks-talk.md
+++ b/.changeset/bright-steaks-talk.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Remove error boundary from robots.txt in hydrogen template

--- a/templates/skeleton/app/routes/[robots.txt].tsx
+++ b/templates/skeleton/app/routes/[robots.txt].tsx
@@ -20,33 +20,6 @@ export async function loader({request, context}: LoaderFunctionArgs) {
   });
 }
 
-export function ErrorBoundary() {
-  const error = useRouteError();
-
-  if (isRouteErrorResponse(error)) {
-    return (
-      <div>
-        <h1>Oops</h1>
-        <p>Status: {error.status}</p>
-        <p>{error.data.message}</p>
-      </div>
-    );
-  }
-
-  let errorMessage = 'Unknown error';
-  if (error instanceof Error) {
-    errorMessage = error.message;
-  }
-
-  return (
-    <div>
-      <h1>Uh oh ...</h1>
-      <p>Something went wrong.</p>
-      <pre>{errorMessage}</pre>
-    </div>
-  );
-}
-
 function robotsTxtData({url, shopId}: {shopId?: string; url?: string}) {
   const sitemapUrl = url ? `${url}/sitemap.xml` : undefined;
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

There was a bug fix introduced (see https://github.com/remix-run/remix/issues/7538#issuecomment-1737600138) where routes exporting an `ErrorBoundary` are presumed not to be a resource route. 

When you generate a new hydrogen project and navigate to `/robots.txt`, you will get an "empty" page instead of the robots xml, and remix will warn:
```
Matched leaf route at location "/robots.txt" does not have an element or Component. This means it will render an <Outlet /> with a null value by default resulting in an "empty" page.
```

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?
Removing the `ErrorBoundary` from the generated hydrogen template

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
