### PR TITLE
Update to latest oxygen-worker-types

### DIFF
--- a/.changeset/bright-cameras-do.md
+++ b/.changeset/bright-cameras-do.md
@@ -1,0 +1,5 @@
+---
+'@shopify/remix-oxygen': patch
+---
+
+Change peer dependency of `@shopify/oxygen-workers-types` to allow for `^4.0.0` versions.

--- a/.changeset/eleven-rivers-check.md
+++ b/.changeset/eleven-rivers-check.md
@@ -1,0 +1,16 @@
+---
+'skeleton': patch
+---
+
+In TypeScript projects, when updating to the latest `@shopify/remix-oxygen` adapter release, please update also to the latest version of `@shopify/oxygen-workers-types`:
+
+```diff
+"devDependencies": {
+  "@remix-run/dev": "2.1.0",
+  "@remix-run/eslint-config": "2.1.0",
+- "@shopify/oxygen-workers-types": "^3.17.3",
++ "@shopify/oxygen-workers-types": "^4.0.0",
+  "@shopify/prettier-config": "^1.1.2",
+  ...
+},
+```

--- a/examples/customer-api/package.json
+++ b/examples/customer-api/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@remix-run/dev": "2.1.0",
-    "@shopify/oxygen-workers-types": "^3.17.2",
+    "@shopify/oxygen-workers-types": "^4.0.0",
     "@shopify/prettier-config": "^1.1.2",
     "@types/eslint": "^8.4.10",
     "@types/react": "^18.2.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
       },
       "devDependencies": {
         "@remix-run/dev": "2.1.0",
-        "@shopify/oxygen-workers-types": "^3.17.2",
+        "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.2.22",
@@ -8089,9 +8089,11 @@
       }
     },
     "node_modules/@shopify/oxygen-workers-types": {
-      "version": "3.17.3",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@shopify/oxygen-workers-types/-/oxygen-workers-types-4.0.0.tgz",
+      "integrity": "sha512-9MiXUSu0kXA9mNPMDK6+S8eRuGZ6o0HB4/P1ebZzFlsxFYxfvTu29KDJv/RYKoJufniv/WNSvwHKFyDgEmkJnw==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "hasInstallScript": true
     },
     "node_modules/@shopify/plugin-did-you-mean": {
       "version": "3.50.0",
@@ -30625,11 +30627,11 @@
       "license": "MIT",
       "devDependencies": {
         "@remix-run/server-runtime": "^2.1.0",
-        "@shopify/oxygen-workers-types": "^3.17.3"
+        "@shopify/oxygen-workers-types": "^4.0.0"
       },
       "peerDependencies": {
         "@remix-run/server-runtime": "^2.1.0",
-        "@shopify/oxygen-workers-types": "^3.17.3"
+        "@shopify/oxygen-workers-types": "^3.17.3 || ^4.0.0"
       }
     },
     "templates/demo-store": {
@@ -30659,7 +30661,7 @@
         "@remix-run/dev": "2.1.0",
         "@remix-run/eslint-config": "2.1.0",
         "@shopify/eslint-plugin": "^42.0.1",
-        "@shopify/oxygen-workers-types": "^3.17.3",
+        "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/typography": "^0.5.9",
@@ -30700,7 +30702,7 @@
       },
       "devDependencies": {
         "@remix-run/dev": "2.1.0",
-        "@shopify/oxygen-workers-types": "^3.17.3",
+        "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@types/eslint": "^8.4.10",
         "@types/react": "^18.2.22",
@@ -30732,7 +30734,7 @@
       "devDependencies": {
         "@remix-run/dev": "2.1.0",
         "@remix-run/eslint-config": "2.1.0",
-        "@shopify/oxygen-workers-types": "^3.17.3",
+        "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@total-typescript/ts-reset": "^0.4.2",
         "@types/eslint": "^8.4.10",
@@ -36448,7 +36450,9 @@
       }
     },
     "@shopify/oxygen-workers-types": {
-      "version": "3.17.3",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@shopify/oxygen-workers-types/-/oxygen-workers-types-4.0.0.tgz",
+      "integrity": "sha512-9MiXUSu0kXA9mNPMDK6+S8eRuGZ6o0HB4/P1ebZzFlsxFYxfvTu29KDJv/RYKoJufniv/WNSvwHKFyDgEmkJnw==",
       "dev": true
     },
     "@shopify/plugin-did-you-mean": {
@@ -36469,7 +36473,7 @@
       "version": "file:packages/remix-oxygen",
       "requires": {
         "@remix-run/server-runtime": "^2.1.0",
-        "@shopify/oxygen-workers-types": "^3.17.3"
+        "@shopify/oxygen-workers-types": "^4.0.0"
       }
     },
     "@sinclair/typebox": {
@@ -39176,7 +39180,7 @@
         "@shopify/cli": "3.50.0",
         "@shopify/cli-hydrogen": "^6.0.0",
         "@shopify/hydrogen": "^2023.10.0",
-        "@shopify/oxygen-workers-types": "^3.17.2",
+        "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.0",
         "@types/eslint": "^8.4.10",
@@ -39420,7 +39424,7 @@
         "@shopify/cli-hydrogen": "^6.0.2",
         "@shopify/eslint-plugin": "^42.0.1",
         "@shopify/hydrogen": "~2023.10.2",
-        "@shopify/oxygen-workers-types": "^3.17.3",
+        "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.1",
         "@tailwindcss/forms": "^0.5.3",
@@ -41586,7 +41590,7 @@
         "@shopify/cli": "3.50.0",
         "@shopify/cli-hydrogen": "^6.0.2",
         "@shopify/hydrogen": "~2023.10.2",
-        "@shopify/oxygen-workers-types": "^3.17.3",
+        "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.1",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -48557,7 +48561,7 @@
         "@shopify/cli": "3.50.0",
         "@shopify/cli-hydrogen": "^6.0.0",
         "@shopify/hydrogen": "~2023.10.2",
-        "@shopify/oxygen-workers-types": "^3.17.3",
+        "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.1",
         "@total-typescript/ts-reset": "^0.4.2",

--- a/packages/remix-oxygen/package.json
+++ b/packages/remix-oxygen/package.json
@@ -41,10 +41,10 @@
   ],
   "devDependencies": {
     "@remix-run/server-runtime": "^2.1.0",
-    "@shopify/oxygen-workers-types": "^3.17.3"
+    "@shopify/oxygen-workers-types": "^4.0.0"
   },
   "peerDependencies": {
     "@remix-run/server-runtime": "^2.1.0",
-    "@shopify/oxygen-workers-types": "^3.17.3"
+    "@shopify/oxygen-workers-types": "^3.17.3 || ^4.0.0"
   }
 }

--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -41,7 +41,7 @@
     "@remix-run/dev": "2.1.0",
     "@remix-run/eslint-config": "2.1.0",
     "@shopify/eslint-plugin": "^42.0.1",
-    "@shopify/oxygen-workers-types": "^3.17.3",
+    "@shopify/oxygen-workers-types": "^4.0.0",
     "@shopify/prettier-config": "^1.1.2",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.9",

--- a/templates/hello-world/package.json
+++ b/templates/hello-world/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@remix-run/dev": "2.1.0",
-    "@shopify/oxygen-workers-types": "^3.17.3",
+    "@shopify/oxygen-workers-types": "^4.0.0",
     "@shopify/prettier-config": "^1.1.2",
     "@types/eslint": "^8.4.10",
     "@types/react": "^18.2.22",

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@remix-run/dev": "2.1.0",
     "@remix-run/eslint-config": "2.1.0",
-    "@shopify/oxygen-workers-types": "^3.17.3",
+    "@shopify/oxygen-workers-types": "^4.0.0",
     "@shopify/prettier-config": "^1.1.2",
     "@total-typescript/ts-reset": "^0.4.2",
     "@types/eslint": "^8.4.10",


### PR DESCRIPTION
More dependency maintenance here. I noticed we have `@shopify/remix-oxygen` outdated.