### PR TITLE
Fix sourcemaps in browser devtools

### DIFF
--- a/packages/cli/src/lib/mini-oxygen/workerd.ts
+++ b/packages/cli/src/lib/mini-oxygen/workerd.ts
@@ -115,7 +115,11 @@ export async function startWorkerdServer({
     : undefined;
 
   const inspectorProxy = debug
-    ? createInspectorProxy(publicInspectorPort, inspectorConnection)
+    ? createInspectorProxy(
+        publicInspectorPort,
+        absoluteBundlePath,
+        inspectorConnection,
+      )
     : undefined;
 
   return {


### PR DESCRIPTION
This allows opening DevTools from the browser with sourcemaps from `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=localhost:9229/ws` or `devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=localhost:9229/ws`.

We could show a link in the terminal to open this directly in the browser. Or should we rely on `chrome://inspect` instead? Thoughts?

** Needs to be run with `h2 dev --worker-unstable --debug`

Downside is that this link can only be opened in Chrome or similar browsers (same as chrome://inspect)