### PR TITLE
Remove Prettier pre-commit githook linting for Markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,9 +73,6 @@
     "*.html": [
       "prettier --write"
     ],
-    "*.md": [
-      "prettier --write"
-    ],
     "*.css": [
       "prettier --write"
     ]


### PR DESCRIPTION
### WHY are these changes introduced?
This PR removes the pre-commit Git hook that runs the Prettier lint rules on Markdown files. I don't think Prettier's markdown rules are that helpful, and in the case of tables, they actively make files harder to read. And unlike other linting rules, the risk posed by invalid Markdown is pretty much nil.

### WHAT is this pull request doing?

This would prevent Prettier from mangling perfectly valid table markdown, which is currently what it does without asking:

Before | After
--- | ---
<img width="1011" alt="bad" src="https://github.com/Shopify/hydrogen/assets/547470/91d19c27-db2d-4d59-9113-f15df53bd255"> | <img width="250" alt="good" src="https://github.com/Shopify/hydrogen/assets/547470/32ce8c27-e4ce-4fd7-b75c-ce75c72f2244">


#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] ~I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes~
- [ ] ~I've added [tests](CONTRIBUTING.md#testing) to cover my changes~
- [ ] ~I've added or updated the documentation~
