### PR TITLE
Add README for /examples directory

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Hydrogen examples
+
+The example apps in this directory show how to implement popular design patterns in Hydrogen.
+
+Each example is a complete Hydrogen app, based on Hydrogen’s [Skeleton template](/templates/skeleton/), that you can inspect and run locally. See each example's README file for details on the problem it solves, how the solution works, and any other requirements you’ll need.
+
+Examples are kept intentionally minimal, containing only the new and updated code required to illustrate a working use case.
+
+## Popular examples
+
+These are some of the most commonly used Hydrogen examples. Browse the folders in this directory for the complete list.
+
+Example | Details |
+--- | ---
+[Multipass](/examples/multipass/) | Connect your existing third-party authentication method to Shopify’s customer accounts, so buyers can use a single login across multiple services.
+
+## Request an example
+
+If you don’t see the example you’re looking for, you can [request one through the Discussions tab](https://github.com/Shopify/hydrogen/discussions/new?category=ideas-feature-requests&title=Hydrogen%20example%20request%3A%20%5BYour%20request%20here%5D%0A%0A).
+
+## Contributing examples
+
+Hydrogen is an open-source project, and we welcome your input! See the Hydrogen [contribution docs](/docs/examples/README.md) for more details on how to add your own examples to this repo.


### PR DESCRIPTION
Followup to #1427 — adds a README to the `/examples` directory:

- Brief explanation of how to use example apps
- List of popular examples (currently just one, but easy to update)
- Links for how to request an example
- Link to contribution doc for adding examples.