### PR TITLE
Update the return types of the Customer Account API query

### DIFF
--- a/.changeset/sour-owls-greet.md
+++ b/.changeset/sour-owls-greet.md
@@ -1,0 +1,6 @@
+---
+'customer-api': patch
+'@shopify/hydrogen': patch
+---
+
+Update the return types of the Customer Account API query and mutation methods. Also change the Customer Account API to default to 2024-01.

--- a/examples/customer-api/app/routes/_index.tsx
+++ b/examples/customer-api/app/routes/_index.tsx
@@ -3,9 +3,9 @@ import {type LoaderFunctionArgs, json} from '@shopify/remix-oxygen';
 
 export async function loader({context}: LoaderFunctionArgs) {
   if (await context.customer.isLoggedIn()) {
-    const {customer} = await context.customer.query<{
+    const {data, errors} = await context.customer.query<{
       customer: {firstName: string; lastName: string};
-    }>(`#graphql
+    }>(`#graphql customer
       query getCustomer {
         customer {
           firstName
@@ -16,7 +16,7 @@ export async function loader({context}: LoaderFunctionArgs) {
 
     return json(
       {
-        customer,
+        customer: data.customer,
       },
       {
         headers: {

--- a/examples/customer-api/server.ts
+++ b/examples/customer-api/server.ts
@@ -59,6 +59,7 @@ export default {
         session,
         customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_ID,
         customerAccountUrl: env.PUBLIC_CUSTOMER_ACCOUNT_URL,
+        customerApiVersion: '2024-01',
       });
 
       /**


### PR DESCRIPTION


### WHY are these changes introduced?

We can't always assume there is a `data` property on the Customer Account API response. Also, the other properties, `errors` and `extensions` important and useful to the developer.

### WHAT is this pull request doing?

Return a complete response from the Customer Account API. Also change to 2024-01 as the default API version. Also, to prevent collisions on autocomplete/code gen with SFAPI, update the query comment to be `#graphql customer`

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

Does the example still work?

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
