### PR TITLE
Hide token warning in mock.shop

### DIFF
--- a/.changeset/plenty-bikes-confess.md
+++ b/.changeset/plenty-bikes-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Skip private access token warning when using mock.shop.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "hydrogen-repo",
+  "name": "hydrogen",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "hydrogen",
       "workspaces": [
         "templates/hello-world",
         "templates/demo-store",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "hydrogen",
   "private": true,
   "sideEffects": false,
   "scripts": {

--- a/packages/hydrogen-react/src/storefront-client.ts
+++ b/packages/hydrogen-react/src/storefront-client.ts
@@ -17,6 +17,8 @@ export type StorefrontClientProps = {
   contentType?: 'json' | 'graphql';
 };
 
+const isMockShop = (domain: string): boolean => domain.includes('mock.shop');
+
 /**
  * The `createStorefrontClient()` function creates helpers that enable you to quickly query the Shopify Storefront API.
  *
@@ -48,7 +50,12 @@ export function createStorefrontClient(
   }
 
   // only warn if not in a browser environment
-  if (__HYDROGEN_DEV__ && !privateStorefrontToken && !globalThis.document) {
+  if (
+    __HYDROGEN_DEV__ &&
+    !privateStorefrontToken &&
+    !globalThis.document &&
+    !isMockShop(storeDomain)
+  ) {
     warnOnce(
       `Using a private storefront token is recommended for server environments.` +
         `\nRefer to the authentication https://shopify.dev/api/storefront#authentication documentation for more details.`,
@@ -63,7 +70,6 @@ export function createStorefrontClient(
     );
   }
 
-  const isMockShop = (domain: string): boolean => domain.includes('mock.shop');
   const getShopifyDomain: StorefrontClientReturn['getShopifyDomain'] = (
     overrideProps,
   ) => {


### PR DESCRIPTION
Hides the following warning when using `mock.shop` since there's no private token available:


<img width="812" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/e744f006-aaed-4ea0-8bb6-a33f4ac66a06">

-- Also fixes a weird thing in `package-lock.json` where the name changed to `hydrogen-repo` instead of `hydrogen`. I suspect it takes the name of the directory when it's not specified in `package.json`.