### PR TITLE
Bump hydrogen-react version

### DIFF
--- a/.changeset/eleven-coins-rescue.md
+++ b/.changeset/eleven-coins-rescue.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Bump hydrogen-react to 2023.10.3

--- a/packages/hydrogen-react/package.json
+++ b/packages/hydrogen-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/hydrogen-react",
-  "version": "2023.10.1",
+  "version": "2023.10.3",
   "description": "React components, hooks, and utilities for creating custom Shopify storefronts",
   "homepage": "https://github.com/Shopify/hydrogen/tree/main/packages/hydrogen-react",
   "license": "MIT",


### PR DESCRIPTION
hydrogen-react is stuck on 2023.10.1, this bumps it to 2023.10.3 to be in sync