### PR TITLE
Updating remix-run packages to fix error from using createReactStub

### DIFF
--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -13,8 +13,8 @@
   },
   "prettier": "@shopify/prettier-config",
   "dependencies": {
-    "@remix-run/react": "2.1.0",
-    "@remix-run/server-runtime": "2.1.0",
+    "@remix-run/react": "2.3.1",
+    "@remix-run/server-runtime": "2.3.1",
     "@shopify/cli": "3.51.0",
     "@shopify/cli-hydrogen": "^6.1.0",
     "@shopify/hydrogen": "~2023.10.3",
@@ -26,8 +26,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "2.1.0",
-    "@remix-run/eslint-config": "2.1.0",
+    "@remix-run/dev": "2.3.1",
+    "@remix-run/eslint-config": "2.3.1",
     "@shopify/oxygen-workers-types": "^4.0.0",
     "@shopify/prettier-config": "^1.1.2",
     "@total-typescript/ts-reset": "^0.4.2",


### PR DESCRIPTION
### WHY are these changes introduced?

When using the skeleton template as it stands and implementing `createReactStub` (https://remix.run/docs/en/main/utils/create-remix-stub) within unit tests the follow error was being thrown:

```
Error: useHref() may be used only in the context of a <Router> component
```

### WHAT is this pull request doing?

This PR fixes that error by updating the `@remix-run/react` package from version `2.1.0` to 2.3.1`