### PR TITLE
Show link to docs when debugging

### DIFF
--- a/.changeset/shy-cheetahs-carry.md
+++ b/.changeset/shy-cheetahs-carry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Show link to docs in the terminal when debugging.

--- a/packages/cli/src/lib/mini-oxygen/workerd.ts
+++ b/packages/cli/src/lib/mini-oxygen/workerd.ts
@@ -11,6 +11,8 @@ import {
 import {dirname, resolvePath} from '@shopify/cli-kit/node/path';
 import {readFile} from '@shopify/cli-kit/node/fs';
 import {renderSuccess} from '@shopify/cli-kit/node/ui';
+import {outputContent, outputToken} from '@shopify/cli-kit/node/output';
+import colors from '@shopify/cli-kit/node/colors';
 import {createInspectorConnector} from './workerd-inspector.js';
 import {findPort} from '../find-port.js';
 import type {MiniOxygenInstance, MiniOxygenOptions} from './types.js';
@@ -145,9 +147,19 @@ export async function startWorkerdServer({
     showBanner(options) {
       console.log(''); // New line
 
-      const debuggerMessage = `\n\nDebug mode enabled. Attach a ${
-        process.env.TERM_PROGRAM === 'vscode' ? 'VSCode ' : ''
-      }debugger to port ${publicInspectorPort}\nor open DevTools in http://localhost:${publicInspectorPort}`;
+      const isVSCode = process.env.TERM_PROGRAM === 'vscode';
+      const debuggingDocsLink =
+        'https://shopify.dev/docs/custom-storefronts/hydrogen/debugging/server-code' +
+        (isVSCode ? '#vscode' : '#step-2-attach-a-debugger');
+
+      const debuggerMessage =
+        outputContent`\n\nDebugging enabled on port ${String(
+          publicInspectorPort,
+        )}.\nAttach a ${outputToken.link(
+          colors.yellow(isVSCode ? 'VSCode debugger' : 'debugger'),
+          debuggingDocsLink,
+        )} or open DevTools in http://localhost:${String(publicInspectorPort)}.`
+          .value;
 
       renderSuccess({
         headline: `${


### PR DESCRIPTION
When using `--debug`:

<img width="646" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/df501446-8a25-4033-9b77-77438f22fab4">

The link is currently broken until we merge and release the docs PR.