### PR TITLE
Fix variant redirect

### DIFF
--- a/.changeset/grumpy-eyes-work.md
+++ b/.changeset/grumpy-eyes-work.md
@@ -1,0 +1,19 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+---
+
+Fix redirection to the product's default variant when there are unknown query params in the URL.
+
+When preparing the redirection URL to the default variant, do not keep the previous URL params for the redirect:
+
+```diff
+return redirect(
+  getVariantUrl({
+    // ...
+-   searchParams: new URLSearchParams(url.search),
++   searchParams: new URLSearchParams(),
+  }),
+  {status: 302},
+);
+```

--- a/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
@@ -59,7 +59,7 @@ export async function loader({params, request, context}: LoaderFunctionArgs) {
   }
 
   if (!product.selectedVariant) {
-    throw redirectToFirstVariant({product, request});
+    throw redirectToFirstVariant({product});
   }
 
   // In order to show which variants are available in the UI, we need to query
@@ -113,14 +113,8 @@ export async function loader({params, request, context}: LoaderFunctionArgs) {
   });
 }
 
-function redirectToFirstVariant({
-  product,
-  request,
-}: {
-  product: ProductQuery['product'];
-  request: Request;
-}) {
-  const searchParams = new URLSearchParams(new URL(request.url).search);
+function redirectToFirstVariant({product}: {product: ProductQuery['product']}) {
+  const searchParams = new URLSearchParams();
   const firstVariant = product!.variants.nodes[0];
   for (const option of firstVariant.selectedOptions) {
     searchParams.set(option.name, option.value);

--- a/templates/skeleton/app/routes/products.$handle.tsx
+++ b/templates/skeleton/app/routes/products.$handle.tsx
@@ -60,20 +60,20 @@ export async function loader({params, request, context}: LoaderFunctionArgs) {
     throw new Response(null, {status: 404});
   }
 
-  const firstVariant = product.variants.nodes[0];
-  const firstVariantIsDefault = Boolean(
-    firstVariant.selectedOptions.find(
-      (option: SelectedOption) =>
-        option.name === 'Title' && option.value === 'Default Title',
-    ),
-  );
+  if (!product.selectedVariant) {
+    const firstVariant = product.variants.nodes[0];
+    const firstVariantIsDefault = Boolean(
+      firstVariant.selectedOptions.find(
+        (option: SelectedOption) =>
+          option.name === 'Title' && option.value === 'Default Title',
+      ),
+    );
 
-  if (firstVariantIsDefault) {
-    product.selectedVariant = firstVariant;
-  } else {
-    // if no selected variant was returned from the selected options,
-    // we redirect to the first variant's url with it's selected options applied
-    if (!product.selectedVariant) {
+    if (firstVariantIsDefault) {
+      product.selectedVariant = firstVariant;
+    } else {
+      // If no selected variant was returned from the selected options,
+      // we redirect to the first variant's url with its selected options applied
       throw redirectToFirstVariant({product, request});
     }
   }

--- a/templates/skeleton/app/routes/products.$handle.tsx
+++ b/templates/skeleton/app/routes/products.$handle.tsx
@@ -105,11 +105,8 @@ function redirectToFirstVariant({
       pathname: url.pathname,
       handle: product.handle,
       selectedOptions: firstVariant.selectedOptions,
-      searchParams: new URLSearchParams(url.search),
     }),
-    {
-      status: 302,
-    },
+    {status: 302},
   );
 }
 

--- a/templates/skeleton/app/utils.ts
+++ b/templates/skeleton/app/utils.ts
@@ -12,7 +12,6 @@ export function useVariantUrl(
     return getVariantUrl({
       handle,
       pathname,
-      searchParams: new URLSearchParams(),
       selectedOptions,
     });
   }, [handle, selectedOptions, pathname]);
@@ -21,12 +20,12 @@ export function useVariantUrl(
 export function getVariantUrl({
   handle,
   pathname,
-  searchParams,
+  searchParams = new URLSearchParams(),
   selectedOptions,
 }: {
   handle: string;
   pathname: string;
-  searchParams: URLSearchParams;
+  searchParams?: URLSearchParams;
   selectedOptions: SelectedOption[];
 }) {
   const match = /(\/[a-zA-Z]{2}-[a-zA-Z]{2}\/)/g.exec(pathname);


### PR DESCRIPTION
Closes #1565 

See #1571 for more context.

We were keeping unknown query params in the redirection, which means the query will never find `selectedVariant`.

To 🎩 : 
- Go to a PDP page. It automatically redirects to the same page with query strings for the default variant.
- Add `&foo=bar` to the URL and reload the page: it works with this PR changes, fails without it.
