### PR TITLE
Fix changeset

### DIFF
--- a/.changeset/fluffy-houses-itch.md
+++ b/.changeset/fluffy-houses-itch.md
@@ -1,6 +1,6 @@
 ---
-'@shopify/hydrogen-react': minor
-'@shopify/hydrogen': minor
+'@shopify/hydrogen-react': patch
+'@shopify/hydrogen': patch
 ---
 
 ✨ add schema generation for customer account api in hydrogen-react and export these types in both hydrogen-react & hydrogen. Note the current CA API version is `2024-01` which is a release candidate and subject to change.


### PR DESCRIPTION
We should not use `minor` in changesets for hydrogen or hydrogen-react because this breaks our versioning:

https://github.com/Shopify/hydrogen/pull/1573

<img width="323" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/d5cfeaf9-19d6-4411-bdb9-d09266599200">
