### PR TITLE
Change the default Hydrogen Session implementation to be more robust in parsing session cookies

### DIFF
--- a/.changeset/late-badgers-return.md
+++ b/.changeset/late-badgers-return.md
@@ -1,0 +1,5 @@
+---
+'skeleton': patch
+---
+
+Change the default HydrogenSession to be more robust in parsing session cookies

--- a/examples/customer-api/server.ts
+++ b/examples/customer-api/server.ts
@@ -120,7 +120,9 @@ export class AppSession implements HydrogenSession {
       },
     });
 
-    const session = await storage.getSession(request.headers.get('Cookie'));
+    const session = await storage
+      .getSession(request.headers.get('Cookie'))
+      .catch(() => storage.getSession());
 
     return new this(storage, session);
   }

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -116,7 +116,9 @@ class AppSession {
       },
     });
 
-    const session = await storage.getSession(request.get('Cookie'));
+    const session = await storage
+      .getSession(request.get('Cookie'))
+      .catch(() => storage.getSession());
 
     return new this(storage, session);
   }

--- a/examples/multipass/server.ts
+++ b/examples/multipass/server.ts
@@ -119,7 +119,9 @@ export class AppSession implements HydrogenSession {
       },
     });
 
-    const session = await storage.getSession(request.headers.get('Cookie'));
+    const session = await storage
+      .getSession(request.headers.get('Cookie'))
+      .catch(() => storage.getSession());
 
     return new this(storage, session);
   }

--- a/examples/subscriptions/server.ts
+++ b/examples/subscriptions/server.ts
@@ -119,7 +119,9 @@ export class AppSession implements HydrogenSession {
       },
     });
 
-    const session = await storage.getSession(request.headers.get('Cookie'));
+    const session = await storage
+      .getSession(request.headers.get('Cookie'))
+      .catch(() => storage.getSession());
 
     return new this(storage, session);
   }

--- a/examples/third-party-queries-caching/server.ts
+++ b/examples/third-party-queries-caching/server.ts
@@ -138,7 +138,9 @@ export class AppSession implements HydrogenSession {
       },
     });
 
-    const session = await storage.getSession(request.headers.get('Cookie'));
+    const session = await storage
+      .getSession(request.headers.get('Cookie'))
+      .catch(() => storage.getSession());
 
     return new this(storage, session);
   }

--- a/templates/demo-store/app/lib/session.server.ts
+++ b/templates/demo-store/app/lib/session.server.ts
@@ -30,7 +30,9 @@ export class AppSession implements HydrogenSession {
       },
     });
 
-    const session = await storage.getSession(request.headers.get('Cookie'));
+    const session = await storage
+      .getSession(request.headers.get('Cookie'))
+      .catch(() => storage.getSession());
 
     return new this(storage, session);
   }

--- a/templates/hello-world/server.ts
+++ b/templates/hello-world/server.ts
@@ -102,7 +102,9 @@ export class AppSession implements HydrogenSession {
       },
     });
 
-    const session = await storage.getSession(request.headers.get('Cookie'));
+    const session = await storage
+      .getSession(request.headers.get('Cookie'))
+      .catch(() => storage.getSession());
 
     return new this(storage, session);
   }

--- a/templates/skeleton/app/lib/session.ts
+++ b/templates/skeleton/app/lib/session.ts
@@ -30,7 +30,9 @@ export class AppSession implements HydrogenSession {
       },
     });
 
-    const session = await storage.getSession(request.headers.get('Cookie'));
+    const session = await storage
+      .getSession(request.headers.get('Cookie'))
+      .catch(() => storage.getSession());
 
     return new this(storage, session);
   }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

The session could include invalid content, and fail to parse. This change makes it so that if an error occurs when parsing, an empty session is created instead.

### HOW to test your changes?

Start up the skeleton template. Find the `session` cookie in the chrome devtools. Replace the value with a garbage value. Load the app, make sure that it doesn't crash.

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
