### PR TITLE
Remove CLI Check for Bundle Size, Rely on Server

### DIFF
--- a/.changeset/green-mice-hide.md
+++ b/.changeset/green-mice-hide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Rely on server-side check for bundle size >10mb

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -40,7 +40,6 @@ import {AbortError} from '@shopify/cli-kit/node/error';
 import {isCI} from '../../lib/is-ci.js';
 
 const LOG_WORKER_BUILT = '📦 Worker built';
-const MAX_WORKER_BUNDLE_SIZE = 10;
 
 export default class Build extends Command {
   static description = 'Builds a Hydrogen storefront for production.';
@@ -242,7 +241,7 @@ async function writeBundleAnalysis(
     )}\n`,
   );
 
-  if (bundleStats && sizeMB < MAX_WORKER_BUNDLE_SIZE) {
+  if (bundleStats) {
     outputInfo(
       outputContent`${
         (await getBundleAnalysisSummary(buildPathWorkerFile)) || '\n'
@@ -253,15 +252,7 @@ async function writeBundleAnalysis(
     );
   }
 
-  if (sizeMB >= MAX_WORKER_BUNDLE_SIZE) {
-    throw new AbortError(
-      '🚨 Worker bundle exceeds 10 MB! Oxygen has a maximum worker bundle size of 10 MB.',
-      outputContent`See the bundle analysis for a breakdown of what is contributing to the bundle size:\n${outputToken.link(
-        bundleAnalysisPath,
-        bundleAnalysisPath,
-      )}`,
-    );
-  } else if (sizeMB >= 5) {
+  if (sizeMB >= 5) {
     outputWarn(
       `🚨 Worker bundle exceeds 5 MB! This can delay your worker response.${
         remixConfig.serverMinify
@@ -284,11 +275,7 @@ async function writeSimpleBuildStatus(
     )}  ${colors.yellow(sizeMB.toFixed(2) + ' MB')}\n`,
   );
 
-  if (sizeMB >= MAX_WORKER_BUNDLE_SIZE) {
-    throw new AbortError(
-      '🚨 Worker bundle exceeds 10 MB! Oxygen has a maximum worker bundle size of 10 MB.',
-    );
-  } else if (sizeMB >= 5) {
+  if (sizeMB >= 5) {
     outputWarn(
       `🚨 Worker bundle exceeds 5 MB! This can delay your worker response.${
         remixConfig.serverMinify


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

When pushing a deployment that is too large, there is no way to track this in the admin or know what happened outside of the CLI feedback. We are looking to improve error messaging to better understand what has going wrong when a bundle size is greater than 10mb.

### WHAT is this pull request doing?


I am removing the 10mb check on the CLI so that bundles that are too large create a deployment in the admin. The error messaging will now also available inside the admin on the deployment since there is a new record created.

We've added a server-side check prior to ensure there is still an error message being shown when running the CLI command.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

Run `npx shopify hydrogen deploy` to create a deployment that is larger than 10mb and see error message back and that it shows up in the admin.

Also see it work normally when the bundle size is <10mb.

A warning should continue to show when >5mb and <10mb.

Happy to demo on a call.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
