### PR TITLE
Fix the <Seo /> component to render canonical URLs without trailing slashes

### DIFF
--- a/.changeset/polite-singers-joke.md
+++ b/.changeset/polite-singers-joke.md
@@ -1,0 +1,7 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix the `<Seo />` component to render canonical URLs without trailing slashes. For example, both https://hydrogen.shop/collections/freestyle/ and https://hydrogen.shop/collections/freestyle return a canonical link of https://hydrogen.shop/collections/freestyle.
+
+Thank you @joshuafredrickson for reporting.

--- a/packages/hydrogen/src/seo/generate-seo-tags.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.ts
@@ -411,15 +411,16 @@ export function generateSeoTags<
         }
 
         const urlWithoutParams = content.split('?')[0];
+        const urlWithoutTrailingSlash = urlWithoutParams.replace(/\/$/, '');
 
         tagResults.push(
           generateTag('link', {
             rel: 'canonical',
-            href: urlWithoutParams,
+            href: urlWithoutTrailingSlash,
           }),
           generateTag('meta', {
             property: 'og:url',
-            content: urlWithoutParams,
+            content: urlWithoutTrailingSlash,
           }),
         );
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/hydrogen/issues/1619. Thank you @joshuafredrickson!

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

We change the Seo component so that it _always_ strips the trailing slash. Are there scenarios where this is not desirable?

### HOW to test your changes?

Load the demo store, and view the source code of http://localhost:3000/collections/freestyle/ and verify that the trailing slash is not included in the canonical URL tag.

#### Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
