### PR TITLE
Support annotation suffixes for codegen

### DIFF
--- a/packages/cli/src/lib/codegen.ts
+++ b/packages/cli/src/lib/codegen.ts
@@ -194,6 +194,24 @@ async function generateDefaultConfig(
   const defaultGlob = '*!(*.d).{ts,tsx,js,jsx}'; // No d.ts files
   const appDirRelative = relativePath(rootDirectory, appDirectory);
 
+  const caapiSchema = getSchema('customer-account');
+  const caapiProject = findGqlProject(caapiSchema, gqlConfig);
+
+  const customerAccountAPIConfig = caapiProject?.documents
+    ? {
+        ['customer-accountapi.generated.d.ts']: {
+          preset,
+          schema: caapiSchema,
+          documents: caapiProject?.documents,
+          presetConfig: {
+            gqlSuffix:
+              caapiProject?.extensions?.languageService?.gqlTagOptions
+                ?.annotationSuffix,
+          },
+        },
+      }
+    : undefined;
+
   return {
     filepath: 'virtual:codegen',
     config: {
@@ -207,6 +225,11 @@ async function generateDefaultConfig(
             defaultGlob, // E.g. ./server.(t|j)s
             joinPath(appDirRelative, '**', defaultGlob), // E.g. app/routes/_index.(t|j)sx
           ],
+          presetConfig: {
+            gqlSuffix:
+              sfapiProject?.extensions?.languageService?.gqlTagOptions
+                ?.annotationSuffix,
+          },
 
           ...(!!forceSfapiVersion && {
             presetConfig: {importTypes: false},
@@ -228,6 +251,7 @@ async function generateDefaultConfig(
             },
           }),
         },
+        ...customerAccountAPIConfig,
       },
     },
   };

--- a/packages/hydrogen-codegen/src/pluck.ts
+++ b/packages/hydrogen-codegen/src/pluck.ts
@@ -11,7 +11,7 @@ export const pluckConfig = {
     // Check for internal gql comment: const QUERY = `#graphql ...`
     const hasInternalGqlComment =
       node.type === 'TemplateLiteral' &&
-      /\s*#graphql\s*\n/i.test(node.quasis[0]?.value?.raw || '');
+      /\s*#graphql(:[\w.\-]+)?\s*\n/i.test(node.quasis[0]?.value?.raw || '');
 
     if (hasInternalGqlComment) return true;
 

--- a/packages/hydrogen-codegen/src/preset.ts
+++ b/packages/hydrogen-codegen/src/preset.ts
@@ -2,7 +2,7 @@ import type {Types} from '@graphql-codegen/plugin-helpers';
 import * as addPlugin from '@graphql-codegen/add';
 import * as typescriptPlugin from '@graphql-codegen/typescript';
 import * as typescriptOperationPlugin from '@graphql-codegen/typescript-operations';
-import {processSources} from './sources.js';
+import {processSources, type BuildTypeName} from './sources.js';
 import {getDefaultOptions} from './defaults.js';
 import {
   plugin as dtsPlugin,
@@ -38,6 +38,19 @@ export type HydrogenPresetConfig = {
     queryType: string;
     mutationType: string;
   }) => string;
+  /**
+   * Suffix to filter query documents: `#graphql:<suffix>`.
+   * Documents that don't match the prefix are excluded. Passing
+   * `undefined` or `''` matches only plain comments: `#graphl`
+   */
+  gqlSuffix?: string;
+  /**
+   * Override the way that type names are created from queries.
+   * The names must match the ones generated in typescript-operations.
+   * Use this option to keep the names in sync if you are customizing them in typescript-operations.
+   * https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations
+   */
+  buildTypeName?: BuildTypeName;
 };
 
 export const preset: Types.OutputPreset<HydrogenPresetConfig> = {
@@ -55,8 +68,10 @@ export const preset: Types.OutputPreset<HydrogenPresetConfig> = {
         '[hydrogen-preset] providing additional typescript-based `plugins` leads to duplicated generated types',
       );
     }
-
-    const sourcesWithOperations = processSources(options.documents);
+    const sourcesWithOperations = processSources(
+      options.documents,
+      options.presetConfig,
+    );
     const sources = sourcesWithOperations.map(({source}) => source);
 
     const defaultOptions = getDefaultOptions(options.baseOutputDir);

--- a/packages/hydrogen-codegen/tests/fixtures/mixed-operations.ts
+++ b/packages/hydrogen-codegen/tests/fixtures/mixed-operations.ts
@@ -1,0 +1,23 @@
+export const A = `#graphql
+  query ShopId {
+    shop {
+      id
+    }
+  }
+`;
+
+export const B = /* GraphQL */ `
+  query ShopName {
+    shop {
+      name
+    }
+  }
+`;
+
+export const C = `#graphql:customer
+  query CustomerName {
+    customer {
+      firstName
+    }
+  }
+`;

--- a/templates/skeleton/.graphqlrc.yml
+++ b/templates/skeleton/.graphqlrc.yml
@@ -2,6 +2,16 @@ projects:
   default:
     schema: 'node_modules/@shopify/hydrogen/storefront.schema.json'
     documents:
-     - '!*.d.ts'
-     - '*.{ts,tsx,js,jsx}'
-     - 'app/**/*.{ts,tsx,js,jsx}'
+      - '!*.d.ts'
+      - '*.{ts,tsx,js,jsx}'
+      - 'app/**/*.{ts,tsx,js,jsx}'
+  customer-account:
+    schema: 'node_modules/@shopify/hydrogen/customer-account.schema.json'
+    documents:
+      - '!*.d.ts'
+      - '*.{ts,tsx,js,jsx}'
+      - 'app/**/*.{ts,tsx,js,jsx}'
+    extensions:
+      languageService:
+        gqlTagOptions:
+          annotationSuffix: customer


### PR DESCRIPTION
This adds support for `#graphql:<suffix>` in hydrogen-codegen. We should still wait until this feature is released in the rest of the GraphQL ecosystem: https://github.com/graphql/graphiql/pull/3411