### PR TITLE
Workaround for buyerIdentity bug

### DIFF
--- a/templates/demo-store/app/components/AddToCartButton.tsx
+++ b/templates/demo-store/app/components/AddToCartButton.tsx
@@ -11,6 +11,7 @@ import {useEffect} from 'react';
 
 import {Button} from '~/components';
 import {usePageAnalytics} from '~/hooks/usePageAnalytics';
+import {useRootLoaderData} from '~/root';
 
 export function AddToCartButton({
   children,
@@ -31,9 +32,11 @@ export function AddToCartButton({
   analytics?: unknown;
   [key: string]: any;
 }) {
+  const pathPrefix = useRootLoaderData()?.selectedLocale.pathPrefix ?? '';
+
   return (
     <CartForm
-      route="/cart"
+      route={pathPrefix + '/cart'}
       inputs={{
         lines,
       }}

--- a/templates/demo-store/app/components/Cart.tsx
+++ b/templates/demo-store/app/components/Cart.tsx
@@ -25,6 +25,7 @@ import {
   FeaturedProducts,
 } from '~/components';
 import {getInputStyleClasses} from '~/lib/utils';
+import {useRootLoaderData} from '~/root';
 
 type Layouts = 'page' | 'drawer';
 
@@ -139,9 +140,11 @@ function UpdateDiscountForm({
   discountCodes?: string[];
   children: React.ReactNode;
 }) {
+  const pathPrefix = useRootLoaderData()?.selectedLocale.pathPrefix ?? '';
+
   return (
     <CartForm
-      route="/cart"
+      route={pathPrefix + '/cart'}
       action={CartForm.ACTIONS.DiscountCodesUpdate}
       inputs={{
         discountCodes: discountCodes || [],
@@ -308,9 +311,11 @@ function CartLineItem({line}: {line: CartLine}) {
 }
 
 function ItemRemoveButton({lineId}: {lineId: CartLine['id']}) {
+  const pathPrefix = useRootLoaderData()?.selectedLocale.pathPrefix ?? '';
+
   return (
     <CartForm
-      route="/cart"
+      route={pathPrefix + '/cart'}
       action={CartForm.ACTIONS.LinesRemove}
       inputs={{
         lineIds: [lineId],
@@ -392,9 +397,11 @@ function UpdateCartButton({
   children: React.ReactNode;
   lines: CartLineUpdateInput[];
 }) {
+  const pathPrefix = useRootLoaderData()?.selectedLocale.pathPrefix ?? '';
+
   return (
     <CartForm
-      route="/cart"
+      route={pathPrefix + '/cart'}
       action={CartForm.ACTIONS.LinesUpdate}
       inputs={{
         lines,


### PR DESCRIPTION
Potential temporary workaround for the known bug where `buyerIdentity` is reset after a cart mutation.