### PR TITLE
Avoid duplicating the locale in variant links

### DIFF
--- a/templates/demo-store/app/components/Link.tsx
+++ b/templates/demo-store/app/components/Link.tsx
@@ -33,8 +33,10 @@ export function Link(props: LinkProps) {
 
   let toWithLocale = to;
 
-  if (typeof to === 'string') {
-    toWithLocale = selectedLocale ? `${selectedLocale.pathPrefix}${to}` : to;
+  if (typeof toWithLocale === 'string' && selectedLocale?.pathPrefix) {
+    if (!toWithLocale.toLowerCase().startsWith(selectedLocale.pathPrefix)) {
+      toWithLocale = `${selectedLocale.pathPrefix}${to}`;
+    }
   }
 
   if (typeof className === 'function') {


### PR DESCRIPTION
Hydrogen's variant logic is generating URLs with locale, and the Link component in demo-store is adding it again.