### PR TITLE
[Docs] Update Hydrogen API reference landing page with Customer Account API links

### DIFF
--- a/packages/hydrogen/docs/staticPages/hydrogen.doc.ts
+++ b/packages/hydrogen/docs/staticPages/hydrogen.doc.ts
@@ -12,13 +12,13 @@ const data: LandingTemplateSchema = {
       title: 'Setup',
       sectionContent: `
 1. Create a new Hydrogen project with your preferred package manager.
-1. Import components, hooks, or utilities that you want to use in your app. For more detailed instructions, see the Getting Started Guide.
+1. Import components, hooks, or utilities that you want to use in your app. For more, see the [getting started guide](/docs/custom-storefronts/hydrogen/getting-started).
       `,
       sectionCard: [
         {
           subtitle: 'Tutorial',
-          name: 'Getting started with Hydrogen',
-          url: '/docs/custom-storefronts/hydrogen/getting-started/quickstart',
+          name: 'Getting started with Hydrogen and Oxygen',
+          url: '/docs/custom-storefronts/hydrogen/getting-started',
           type: 'tutorial',
         },
       ],


### PR DESCRIPTION
This PR adds some more detail about the Customer Account API to the [Hydrogen API reference landing page](https://shopify.dev/docs/api/hydrogen), which currently only addresses Storefront API. Now that CAAPI is GA with 2024-01, we should update this so both are cross-linked and more easily findable. Edits welcome!

Tagging @nickpinto for visibility. @blittle I opted not to run `docs:build` since that should be done once for the 2024-01 release, let me know if that was the wrong move.