### PR TITLE
Filter out non-actionable warnings and errors

### DIFF
--- a/.changeset/orange-grapes-raise.md
+++ b/.changeset/orange-grapes-raise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Filter out non-actionable warnings and errors during development.

--- a/packages/cli/src/lib/log.ts
+++ b/packages/cli/src/lib/log.ts
@@ -86,7 +86,7 @@ function injectLogReplacer(
 }
 
 /**
- * Mute logs from Miniflare
+ * Mute logs from Miniflare / Workerd
  */
 export function muteDevLogs({workerReload}: {workerReload?: boolean} = {}) {
   injectLogReplacer('log');
@@ -118,20 +118,34 @@ export function muteDevLogs({workerReload}: {workerReload?: boolean} = {}) {
 
   addMessageReplacers(
     'dev-workerd',
+    // Workerd logs
     [
-      // Workerd logs
       ([first]) =>
         typeof first === 'string' &&
         /^\x1B\[31m(workerd\/|stack:( (0|[a-f\d]{4,})){3,})/.test(first),
       () => {},
     ],
+    [
+      ([first]) =>
+        typeof first === 'string' &&
+        /\$LLVM_SYMBOLIZER|recursive isolate lock/.test(first),
+      () => {},
+    ],
 
-    // Non-actionable warnings/errors:
+    // Non-actionable warnings:
     [
       ([first]) =>
         typeof first === 'string' && /^A promise rejection/i.test(first),
       () => {},
     ],
+    [
+      ([first]) =>
+        typeof first === 'string' &&
+        /resolved to multiple addresses/i.test(first), // For win32
+      () => {},
+    ],
+
+    // Non-actionable errors:
     [
       ([first]) => {
         const message = first?.message ?? first;

--- a/packages/cli/src/lib/log.ts
+++ b/packages/cli/src/lib/log.ts
@@ -121,7 +121,8 @@ export function muteDevLogs({workerReload}: {workerReload?: boolean} = {}) {
     [
       // Workerd logs
       ([first]) =>
-        typeof first === 'string' && /^\x1B\[31m(workerd\/|stack:)/.test(first),
+        typeof first === 'string' &&
+        /^\x1B\[31m(workerd\/|stack:( (0|[a-f\d]{4,})){3,})/.test(first),
       () => {},
     ],
 


### PR DESCRIPTION
This should filter out errors like the following:

<img width="1054" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/7a026459-4ff0-4955-82d8-35a9a7da7f68">

It also changes our regexps to match known logs that Wrangler already filters.