### PR TITLE
Improve CA client logs

### DIFF
--- a/.changeset/fifty-queens-obey.md
+++ b/.changeset/fifty-queens-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Improve warning logs for Customer Account client.

--- a/packages/cli/src/lib/log.ts
+++ b/packages/cli/src/lib/log.ts
@@ -259,10 +259,12 @@ export function enhanceH2Logs(options: {rootDirectory: string; host: string}) {
       const lines = message.split('\n');
       const lastLine = lines.at(-1) ?? '';
       const hasLinks = /https?:\/\//.test(lastLine);
-      if (hasLinks) lines.pop();
+      const hasCommands = /`h2 [^`]+`/.test(lastLine);
+
+      if (hasLinks || hasCommands) lines.pop();
 
       if (type === 'error' || errorObject) {
-        let tryMessage = hasLinks ? lastLine : undefined;
+        let tryMessage = hasLinks || hasCommands ? lastLine : undefined;
         let stack = errorObject?.stack;
         let cause = errorObject?.cause as
           | {[key: string]: any; graphql?: {query: string; variables: string}}
@@ -341,6 +343,13 @@ export function enhanceH2Logs(options: {rootDirectory: string; host: string}) {
       render({
         body: headline + colors.bold(lines.join('\n')),
         reference,
+        nextSteps: hasCommands
+          ? [
+              lastLine.replace(/`h2 [^`]+`/g, (cmd) =>
+                colors.bold(colors.yellow(cmd)),
+              ),
+            ]
+          : undefined,
       });
 
       return;

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -140,14 +140,14 @@ export function createCustomerClient({
   authUrl = '/account/authorize',
 }: CustomerClientOptions): CustomerClient {
   if (customerApiVersion !== DEFAULT_CUSTOMER_API_VERSION) {
-    console.log(
+    console.warn(
       `[h2:warn:createCustomerClient] You are using Customer Account API version ${customerApiVersion} when this version of Hydrogen was built for ${DEFAULT_CUSTOMER_API_VERSION}.`,
     );
   }
 
   if (!customerAccountId || !customerAccountUrl) {
-    console.log(
-      "[h2:warn:createCustomerClient] customerAccountId and customerAccountUrl need to be provided to use Customer Account API. mock.shop doesn't automatically supply these variables. Use `h2 env pull` to link your store credentials.",
+    console.warn(
+      "[h2:warn:createCustomerClient] `customerAccountId` and `customerAccountUrl` need to be provided to use Customer Account API. mock.shop doesn't automatically supply these variables. Use `h2 env pull` to link your store credentials.",
     );
   }
 

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -116,9 +116,9 @@ export type CustomerClient = {
 type CustomerClientOptions = {
   /** The client requires a session to persist the auth and refresh token. By default Hydrogen ships with cookie session storage, but you can use [another session storage](https://remix.run/docs/en/main/utils/sessions) implementation.  */
   session: HydrogenSession;
-  /** Unique UUID prefixed with `shp_` associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountId. Use h2 env pull to link your store credentials. */
+  /** Unique UUID prefixed with `shp_` associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountId. Use `h2 env pull` to link your store credentials. */
   customerAccountId: string;
-  /** The account URL associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountUrl. Use h2 env pull to link your store credentials. */
+  /** The account URL associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountUrl. Use `h2 env pull` to link your store credentials. */
   customerAccountUrl: string;
   /** Override the version of the API */
   customerApiVersion?: string;
@@ -147,7 +147,7 @@ export function createCustomerClient({
 
   if (!customerAccountId || !customerAccountUrl) {
     console.warn(
-      "[h2:warn:createCustomerClient] `customerAccountId` and `customerAccountUrl` need to be provided to use Customer Account API. mock.shop doesn't automatically supply these variables. Use `h2 env pull` to link your store credentials.",
+      "[h2:warn:createCustomerClient] `customerAccountId` and `customerAccountUrl` need to be provided to use Customer Account API. Mock.shop doesn't automatically supply these variables.\nUse `h2 env pull` to link your store credentials.",
     );
   }
 


### PR DESCRIPTION
The warning for creating the CA client was shown once per request. This PR changes this log to be shown only once, and slightly improves its format.

### Before

<img width="662" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/6bef2f76-3cf8-4f80-9940-d4dba7e1596f">

---

### After

<img width="797" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/c16b8bca-a8ba-44a5-9006-b333f87c1e26">

