### PR TITLE
Fix model-viewer and format code from contribute PR

### DIFF
--- a/.changeset/chatty-tomatoes-breathe.md
+++ b/.changeset/chatty-tomatoes-breathe.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+* Format code for improved readability contributed by @sanjaiyan-dev
+* Fix `<model-viewer>`'s `onPause` event listener

--- a/packages/hydrogen-react/src/ModelViewer.tsx
+++ b/packages/hydrogen-react/src/ModelViewer.tsx
@@ -77,109 +77,45 @@ export function ModelViewer(props: ModelViewerProps): JSX.Element | null {
     },
   );
 
+  const hydrogenEventListener = {
+    error: passthroughProps.onError,
+    load: passthroughProps.onLoad,
+    preload: passthroughProps.onPreload,
+    "model-visibility": passthroughProps.onModelVisibility,
+    progress: passthroughProps.onProgress,
+    "ar-status": passthroughProps.onArStatus,
+    "ar-tracking": passthroughProps.onArTracking,
+    "quick-look-button-tapped": passthroughProps.onQuickLookButtonTapped,
+    "camera-change": passthroughProps.onCameraChange,
+    "environment-change": passthroughProps.onEnvironmentChange,
+    play: passthroughProps.onPlay,
+    pause: passthroughProps.onPause,
+    "scene-graph-ready": passthroughProps.onSceneGraphReady,
+  };
+
   useEffect(() => {
     if (!modelViewer) {
       return;
     }
-    if (passthroughProps.onError)
-      modelViewer.addEventListener('error', passthroughProps.onError);
-    if (passthroughProps.onLoad)
-      modelViewer.addEventListener('load', passthroughProps.onLoad);
-    if (passthroughProps.onPreload)
-      modelViewer.addEventListener('preload', passthroughProps.onPreload);
-    if (passthroughProps.onModelVisibility)
-      modelViewer.addEventListener(
-        'model-visibility',
-        passthroughProps.onModelVisibility,
-      );
-    if (passthroughProps.onProgress)
-      modelViewer.addEventListener('progress', passthroughProps.onProgress);
-    if (passthroughProps.onArStatus)
-      modelViewer.addEventListener('ar-status', passthroughProps.onArStatus);
-    if (passthroughProps.onArTracking)
-      modelViewer.addEventListener(
-        'ar-tracking',
-        passthroughProps.onArTracking,
-      );
-    if (passthroughProps.onQuickLookButtonTapped)
-      modelViewer.addEventListener(
-        'quick-look-button-tapped',
-        passthroughProps.onQuickLookButtonTapped,
-      );
-    if (passthroughProps.onCameraChange)
-      modelViewer.addEventListener(
-        'camera-change',
-        passthroughProps.onCameraChange,
-      );
-    if (passthroughProps.onEnvironmentChange)
-      modelViewer.addEventListener(
-        'environment-change',
-        passthroughProps.onEnvironmentChange,
-      );
-    if (passthroughProps.onPlay)
-      modelViewer.addEventListener('play', passthroughProps.onPlay);
-    if (passthroughProps.onPause)
-      modelViewer.addEventListener('ar-status', passthroughProps.onPause);
-    if (passthroughProps.onSceneGraphReady)
-      modelViewer.addEventListener(
-        'scene-graph-ready',
-        passthroughProps.onSceneGraphReady,
-      );
+    Object.entries(hydrogenEventListener).forEach(
+      ([eventName, callbackFunc]) => {
+        if (callbackFunc) {
+          modelViewer.addEventListener(eventName, callbackFunc);
+        }
+      }
+    );
 
     return () => {
       if (modelViewer == null) {
         return;
       }
-      if (passthroughProps.onError)
-        modelViewer.removeEventListener('error', passthroughProps.onError);
-      if (passthroughProps.onLoad)
-        modelViewer.removeEventListener('load', passthroughProps.onLoad);
-      if (passthroughProps.onPreload)
-        modelViewer.removeEventListener('preload', passthroughProps.onPreload);
-      if (passthroughProps.onModelVisibility)
-        modelViewer.removeEventListener(
-          'model-visibility',
-          passthroughProps.onModelVisibility,
-        );
-      if (passthroughProps.onProgress)
-        modelViewer.removeEventListener(
-          'progress',
-          passthroughProps.onProgress,
-        );
-      if (passthroughProps.onArStatus)
-        modelViewer.removeEventListener(
-          'ar-status',
-          passthroughProps.onArStatus,
-        );
-      if (passthroughProps.onArTracking)
-        modelViewer.removeEventListener(
-          'ar-tracking',
-          passthroughProps.onArTracking,
-        );
-      if (passthroughProps.onQuickLookButtonTapped)
-        modelViewer.removeEventListener(
-          'quick-look-button-tapped',
-          passthroughProps.onQuickLookButtonTapped,
-        );
-      if (passthroughProps.onCameraChange)
-        modelViewer.removeEventListener(
-          'camera-change',
-          passthroughProps.onCameraChange,
-        );
-      if (passthroughProps.onEnvironmentChange)
-        modelViewer.removeEventListener(
-          'environment-change',
-          passthroughProps.onEnvironmentChange,
-        );
-      if (passthroughProps.onPlay)
-        modelViewer.removeEventListener('play', passthroughProps.onPlay);
-      if (passthroughProps.onPause)
-        modelViewer.removeEventListener('ar-status', passthroughProps.onPause);
-      if (passthroughProps.onSceneGraphReady)
-        modelViewer.removeEventListener(
-          'scene-graph-ready',
-          passthroughProps.onSceneGraphReady,
-        );
+      Object.entries(hydrogenEventListener).forEach(
+        ([eventName, callbackFunc]) => {
+          if (callbackFunc) {
+            modelViewer.removeEventListener(eventName, callbackFunc);
+          }
+        }
+      );
     };
   }, [
     modelViewer,

--- a/packages/hydrogen-react/src/ModelViewer.tsx
+++ b/packages/hydrogen-react/src/ModelViewer.tsx
@@ -81,16 +81,16 @@ export function ModelViewer(props: ModelViewerProps): JSX.Element | null {
     error: passthroughProps.onError,
     load: passthroughProps.onLoad,
     preload: passthroughProps.onPreload,
-    "model-visibility": passthroughProps.onModelVisibility,
+    'model-visibility': passthroughProps.onModelVisibility,
     progress: passthroughProps.onProgress,
-    "ar-status": passthroughProps.onArStatus,
-    "ar-tracking": passthroughProps.onArTracking,
-    "quick-look-button-tapped": passthroughProps.onQuickLookButtonTapped,
-    "camera-change": passthroughProps.onCameraChange,
-    "environment-change": passthroughProps.onEnvironmentChange,
+    'ar-status': passthroughProps.onArStatus,
+    'ar-tracking': passthroughProps.onArTracking,
+    'quick-look-button-tapped': passthroughProps.onQuickLookButtonTapped,
+    'camera-change': passthroughProps.onCameraChange,
+    'environment-change': passthroughProps.onEnvironmentChange,
     play: passthroughProps.onPlay,
     pause: passthroughProps.onPause,
-    "scene-graph-ready": passthroughProps.onSceneGraphReady,
+    'scene-graph-ready': passthroughProps.onSceneGraphReady,
   };
 
   useEffect(() => {
@@ -102,7 +102,7 @@ export function ModelViewer(props: ModelViewerProps): JSX.Element | null {
         if (callbackFunc) {
           modelViewer.addEventListener(eventName, callbackFunc);
         }
-      }
+      },
     );
 
     return () => {
@@ -114,7 +114,7 @@ export function ModelViewer(props: ModelViewerProps): JSX.Element | null {
           if (callbackFunc) {
             modelViewer.removeEventListener(eventName, callbackFunc);
           }
-        }
+        },
       );
     };
   }, [


### PR DESCRIPTION
Follow up from https://github.com/Shopify/hydrogen/pull/1000

### WHY are these changes introduced?

Fix wrong event listener for `onPause`

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
