### PR TITLE
Update CLI `init` command to create or link storefront

### DIFF
--- a/.changeset/witty-clouds-sing.md
+++ b/.changeset/witty-clouds-sing.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+`init` command can link an existing storefront on Admin when creating a storefront from the CLI.
+
+After logging into your Shop, the CLI will let you choose if you wish to create a new storefront on Admin or link an existing one. `npm create @shopify/hydrogen` command will also benefit from this change.

--- a/packages/cli/src/commands/hydrogen/link.test.ts
+++ b/packages/cli/src/commands/hydrogen/link.test.ts
@@ -54,6 +54,9 @@ describe('link', () => {
     storefront: undefined,
   };
 
+  const expectedStorefrontName = 'New Storefront';
+  const expectedJobId = 'gid://shopify/Job/1';
+
   beforeEach(async () => {
     vi.mocked(login).mockResolvedValue({
       session: ADMIN_SESSION,
@@ -69,6 +72,15 @@ describe('link', () => {
     ]);
 
     vi.mocked(renderSelectPrompt).mockResolvedValue(FULL_SHOPIFY_CONFIG.shop);
+
+    vi.mocked(createStorefront).mockResolvedValue({
+      storefront: {
+        id: 'gid://shopify/HydrogenStorefront/1',
+        title: expectedStorefrontName,
+        productionUrl: 'https://example.com',
+      },
+      jobId: expectedJobId,
+    });
   });
 
   afterEach(() => {
@@ -128,20 +140,8 @@ describe('link', () => {
   });
 
   describe('when you want to link a new Hydrogen storefront', () => {
-    const expectedStorefrontName = 'New Storefront';
-    const expectedJobId = 'gid://shopify/Job/1';
-
     beforeEach(async () => {
       vi.mocked(renderSelectPrompt).mockResolvedValue(null);
-
-      vi.mocked(createStorefront).mockResolvedValue({
-        storefront: {
-          id: 'gid://shopify/HydrogenStorefront/1',
-          title: expectedStorefrontName,
-          productionUrl: 'https://example.com',
-        },
-        jobId: expectedJobId,
-      });
     });
 
     it('chooses to create a new storefront given the directory path', async () => {

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -78,6 +78,7 @@ export async function setupLocalStarterTemplate(
 
   const createStorefrontPromise =
     storefrontInfo &&
+    !storefrontInfo.id &&
     createStorefront(storefrontInfo.session, storefrontInfo.title)
       .then(async ({storefront, jobId}) => {
         if (jobId) await waitForJob(storefrontInfo.session, jobId);
@@ -141,17 +142,25 @@ export async function setupLocalStarterTemplate(
       '# Run `h2 link` to also inject environment variables from your storefront,\n' +
       '# or `h2 env pull` to populate this file.';
 
-    if (storefrontInfo && createStorefrontPromise) {
+    let storefrontToLink: {id: string; title: string} | undefined;
+
+    if (storefrontInfo) {
       promises.push(
         // Save linked storefront in project
         setUserAccount(project.directory, storefrontInfo),
-        createStorefrontPromise.then((storefront) =>
-          // Save linked storefront in project
-          setStorefront(project.directory, storefront),
-        ),
         // Write empty dotenv file to fallback to remote Oxygen variables
         writeFile(joinPath(project.directory, '.env'), envLeadingComment),
       );
+
+      if (storefrontInfo.id) {
+        storefrontToLink = {id: storefrontInfo.id, title: storefrontInfo.title};
+      } else if (createStorefrontPromise) {
+        promises.push(
+          createStorefrontPromise.then((createdStorefront) => {
+            storefrontToLink = createdStorefront;
+          }),
+        );
+      }
     } else if (templateAction === 'mock') {
       promises.push(
         // Set required env vars
@@ -170,7 +179,14 @@ export async function setupLocalStarterTemplate(
       );
     }
 
-    return Promise.all(promises).catch(abort);
+    return Promise.all(promises)
+      .then(() => {
+        if (storefrontToLink) {
+          // Save linked storefront in project
+          return setStorefront(project.directory, storefrontToLink);
+        }
+      })
+      .catch(abort);
   });
 
   const {language, transpileProject} = await handleLanguage(


### PR DESCRIPTION
### WHY are these changes introduced?

- Quality of life improvement for CLI users
  - When they create a storefront on Admin, they can just `npm create @shopify/hydrogen` or `shopify hydrogen init` command to connect to their existing storefront instead of creating another one

### WHAT is this pull request doing?

During the creation of the storefront using the `init` command, we want to give the option to link an existing storefront on Admin.
- The old flow always assumed that you'd be creating a brand new storefront on Admin.
- The current flow follows an identical path to the `link` command
  - It will ask to either create a new storefront or link an existing storefront on Admin


#### Old process
![image](https://github.com/Shopify/hydrogen/assets/2907059/e10ef20a-f411-4485-94a3-e948e3380f42)

#### New process
![image](https://github.com/Shopify/hydrogen/assets/2907059/68570cce-66cd-422b-a0d9-3bedf22d404f)

### HOW to test your changes?

1. checkout the branch
2. `npm ci` on the parent folder
3. `cd packages/cli && npm run build`
4. run `../../node_modules/.bin/shopify hydrogen init`
5. Create a new storefront
6. run `../../node_modules/.bin/shopify hydrogen link --path=<path-to-your-storefront>`
    - ensure you get a message saying what storefront on Admin it is connected to
7. run `../../node_modules/.bin/shopify hydrogen init`
8. Link an existing storefront
9. run `../../node_modules/.bin/shopify hydrogen link --path=<path-to-your-storefront>`
    - ensure you get a message saying what storefront on Admin it is connected to
    - for regression, link it to another storefront or create another storefront on Admin

#### Post-merge steps

n/a

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
  - I've updated existing tests. `commons.ts` and `local.ts` doesn't have a test file. 
- [ ] I've added or updated the documentation
