### PR TITLE
renamed type CustomerClient

### DIFF
--- a/.changeset/rude-waves-fetch.md
+++ b/.changeset/rude-waves-fetch.md
@@ -1,0 +1,7 @@
+---
+'skeleton': patch
+'@shopify/hydrogen': patch
+'@shopify/cli-hydrogen': patch
+---
+
+♻️ `CustomerClient` type is deprecated and replaced by `CustomerAccount`

--- a/examples/third-party-queries-caching/remix.env.d.ts
+++ b/examples/third-party-queries-caching/remix.env.d.ts
@@ -5,7 +5,11 @@
 // Enhance TypeScript's built-in typings.
 import '@total-typescript/ts-reset';
 
-import type {Storefront, CustomerClient, HydrogenCart} from '@shopify/hydrogen';
+import type {
+  Storefront,
+  CustomerAccount,
+  HydrogenCart,
+} from '@shopify/hydrogen';
 import type {AppSession} from '~/lib/session';
 import {createRickAndMortyClient} from './app/lib/createRickAndMortyClient.server';
 
@@ -37,7 +41,7 @@ declare module '@shopify/remix-oxygen' {
     env: Env;
     cart: HydrogenCart;
     storefront: Storefront;
-    customerAccount: CustomerClient;
+    customerAccount: CustomerAccount;
     rickAndMorty: ReturnType<typeof createRickAndMortyClient>;
     session: AppSession;
     waitUntil: ExecutionContext['waitUntil'];

--- a/packages/cli/src/lib/setups/i18n/replacers.test.ts
+++ b/packages/cli/src/lib/setups/i18n/replacers.test.ts
@@ -61,7 +61,7 @@ describe('i18n replacers', () => {
 
         import type {
           Storefront,
-          CustomerClient,
+          CustomerAccount,
           HydrogenCart,
         } from "@shopify/hydrogen";
         import type {
@@ -103,7 +103,7 @@ describe('i18n replacers', () => {
             env: Env;
             cart: HydrogenCart;
             storefront: Storefront<I18nLocale>;
-            customerAccount: CustomerClient;
+            customerAccount: CustomerAccount;
             session: AppSession;
             waitUntil: ExecutionContext["waitUntil"];
           }

--- a/packages/hydrogen/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen/docs/generated/generated_docs_data.json
@@ -948,7 +948,7 @@
                 "filePath": "/cart/CartForm.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "inputs",
-                "value": "{ key: Scalars; } & OtherFormData",
+                "value": "{ key: string; } & OtherFormData",
                 "description": "",
                 "isOptional": true
               }
@@ -1413,28 +1413,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -1824,7 +1824,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -1957,7 +1957,7 @@
               {
                 "name": "key",
                 "description": "",
-                "value": "Scalars",
+                "value": "string",
                 "filePath": "/cart/queries/cartMetafieldDeleteDefault.ts"
               },
               {
@@ -2684,28 +2684,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -2967,7 +2967,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -3200,28 +3200,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -3483,7 +3483,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -3716,28 +3716,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -3999,7 +3999,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -4232,28 +4232,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -4508,7 +4508,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -4741,28 +4741,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -5208,28 +5208,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -5491,7 +5491,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -5724,28 +5724,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -6000,7 +6000,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -6233,28 +6233,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -6516,7 +6516,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -6749,28 +6749,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -6995,7 +6995,7 @@
               {
                 "name": "key",
                 "description": "",
-                "value": "Scalars",
+                "value": "string",
                 "filePath": "/cart/queries/cartMetafieldDeleteDefault.ts"
               },
               {
@@ -7025,7 +7025,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -7258,28 +7258,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -7541,7 +7541,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -7774,28 +7774,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -8050,7 +8050,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -8283,28 +8283,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {
@@ -8566,7 +8566,7 @@
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cartId",
-                "value": "Scalars",
+                "value": "string",
                 "description": "The cart id.",
                 "isOptional": true,
                 "defaultValue": "cart.getCartId();"
@@ -8903,7 +8903,7 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": "Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint. See [`getPublicTokenHeaders` in Hydrogen React](/docs/api/hydrogen-react/2024-01/utilities/createstorefrontclient#:~:text=%27graphql%27.-,getPublicTokenHeaders,-(props%3F%3A) for more details.",
                 "isOptional": true
               },
@@ -8911,7 +8911,7 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": "Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint for API calls made from a server. See [`getPrivateTokenHeaders` in  Hydrogen React](/docs/api/hydrogen-react/2024-01/utilities/createstorefrontclient#:~:text=storefrontApiVersion-,getPrivateTokenHeaders,-(props%3F%3A) for more details.",
                 "isOptional": true
               },
@@ -8919,7 +8919,7 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": "Creates the fully-qualified URL to your myshopify.com domain. See [`getShopifyDomain` in  Hydrogen React](/docs/api/hydrogen-react/2024-01/utilities/createstorefrontclient#:~:text=StorefrontClientReturn-,getShopifyDomain,-(props%3F%3A) for more details.",
                 "isOptional": true
               },
@@ -8927,7 +8927,7 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": "Creates the fully-qualified URL to your store's GraphQL endpoint. See [`getStorefrontApiUrl` in  Hydrogen React](/docs/api/hydrogen-react/2024-01/utilities/createstorefrontclient#:~:text=storeDomain-,getStorefrontApiUrl,-(props%3F%3A) for more details.",
                 "isOptional": true
               },
@@ -9415,7 +9415,7 @@
           },
           {
             "title": "TypeScript",
-            "code": "import type {CustomerClient} from '@shopify/hydrogen';\nimport {\n  createCustomerAccountClient,\n  type HydrogenSession,\n} from '@shopify/hydrogen';\nimport * as remixBuild from '@remix-run/dev/server-build';\nimport {\n  createRequestHandler,\n  createCookieSessionStorage,\n  type SessionStorage,\n  type Session,\n} from '@shopify/remix-oxygen';\n\nexport default {\n  async fetch(\n    request: Request,\n    env: Record&lt;string, string&gt;,\n    executionContext: ExecutionContext,\n  ) {\n    const session = await AppSession.init(request, [env.SESSION_SECRET]);\n\n    /* Create a Customer API client with your credentials and options */\n    const customerAccount = createCustomerAccountClient({\n      /* Runtime utility in serverless environments */\n      waitUntil: (p) =&gt; executionContext.waitUntil(p),\n      /* Public Customer Account API client ID for your store */\n      customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_ID,\n      /* Public account URL for your store */\n      customerAccountUrl: env.PUBLIC_CUSTOMER_ACCOUNT_URL,\n      request,\n      session,\n    });\n\n    const handleRequest = createRequestHandler({\n      build: remixBuild,\n      mode: process.env.NODE_ENV,\n      /* Inject the customer account client in the Remix context */\n      getLoadContext: () =&gt; ({customerAccount}),\n    });\n\n    return handleRequest(request);\n  },\n};\n\nclass AppSession implements HydrogenSession {\n  constructor(\n    private sessionStorage: SessionStorage,\n    private session: Session,\n  ) {}\n\n  static async init(request: Request, secrets: string[]) {\n    const storage = createCookieSessionStorage({\n      cookie: {\n        name: 'session',\n        httpOnly: true,\n        path: '/',\n        sameSite: 'lax',\n        secrets,\n      },\n    });\n\n    const session = await storage.getSession(request.headers.get('Cookie'));\n\n    return new this(storage, session);\n  }\n\n  get(key: string) {\n    return this.session.get(key);\n  }\n\n  destroy() {\n    return this.sessionStorage.destroySession(this.session);\n  }\n\n  flash(key: string, value: any) {\n    this.session.flash(key, value);\n  }\n\n  unset(key: string) {\n    this.session.unset(key);\n  }\n\n  set(key: string, value: any) {\n    this.session.set(key, value);\n  }\n\n  commit() {\n    return this.sessionStorage.commitSession(this.session);\n  }\n}\n",
+            "code": "import {\n  createCustomerAccountClient,\n  type HydrogenSession,\n} from '@shopify/hydrogen';\nimport * as remixBuild from '@remix-run/dev/server-build';\nimport {\n  createRequestHandler,\n  createCookieSessionStorage,\n  type SessionStorage,\n  type Session,\n} from '@shopify/remix-oxygen';\n\nexport default {\n  async fetch(\n    request: Request,\n    env: Record&lt;string, string&gt;,\n    executionContext: ExecutionContext,\n  ) {\n    const session = await AppSession.init(request, [env.SESSION_SECRET]);\n\n    /* Create a Customer API client with your credentials and options */\n    const customerAccount = createCustomerAccountClient({\n      /* Runtime utility in serverless environments */\n      waitUntil: (p) =&gt; executionContext.waitUntil(p),\n      /* Public Customer Account API client ID for your store */\n      customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_ID,\n      /* Public account URL for your store */\n      customerAccountUrl: env.PUBLIC_CUSTOMER_ACCOUNT_URL,\n      request,\n      session,\n    });\n\n    const handleRequest = createRequestHandler({\n      build: remixBuild,\n      mode: process.env.NODE_ENV,\n      /* Inject the customer account client in the Remix context */\n      getLoadContext: () =&gt; ({customerAccount}),\n    });\n\n    return handleRequest(request);\n  },\n};\n\nclass AppSession implements HydrogenSession {\n  constructor(\n    private sessionStorage: SessionStorage,\n    private session: Session,\n  ) {}\n\n  static async init(request: Request, secrets: string[]) {\n    const storage = createCookieSessionStorage({\n      cookie: {\n        name: 'session',\n        httpOnly: true,\n        path: '/',\n        sameSite: 'lax',\n        secrets,\n      },\n    });\n\n    const session = await storage.getSession(request.headers.get('Cookie'));\n\n    return new this(storage, session);\n  }\n\n  get(key: string) {\n    return this.session.get(key);\n  }\n\n  destroy() {\n    return this.sessionStorage.destroySession(this.session);\n  }\n\n  flash(key: string, value: any) {\n    this.session.flash(key, value);\n  }\n\n  unset(key: string) {\n    this.session.unset(key);\n  }\n\n  set(key: string, value: any) {\n    this.session.set(key, value);\n  }\n\n  commit() {\n    return this.sessionStorage.commitSession(this.session);\n  }\n}\n",
             "language": "tsx"
           }
         ],
@@ -9426,12 +9426,12 @@
       {
         "title": "createCustomerAccountClient(options)",
         "description": "",
-        "type": "CustomerClientOptions",
+        "type": "CustomerAccountOptions",
         "typeDefinitions": {
-          "CustomerClientOptions": {
+          "CustomerAccountOptions": {
             "filePath": "/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
-            "name": "CustomerClientOptions",
+            "name": "CustomerAccountOptions",
             "value": "{\n  /** The client requires a session to persist the auth and refresh token. By default Hydrogen ships with cookie session storage, but you can use [another session storage](https://remix.run/docs/en/main/utils/sessions) implementation.  */\n  session: HydrogenSession;\n  /** Unique UUID prefixed with `shp_` associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountId. Use `h2 env pull` to link your store credentials. */\n  customerAccountId: string;\n  /** The account URL associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountUrl. Use `h2 env pull` to link your store credentials. */\n  customerAccountUrl: string;\n  /** Override the version of the API */\n  customerApiVersion?: string;\n  /** The object for the current Request. It should be provided by your platform. */\n  request: CrossRuntimeRequest;\n  /** The waitUntil function is used to keep the current request/response lifecycle alive even after a response has been sent. It should be provided by your platform. */\n  waitUntil?: ExecutionContext['waitUntil'];\n  /** This is the route in your app that authorizes the customer after logging in. Make sure to call `customer.authorize()` within the loader on this route. It defaults to `/account/authorize`. */\n  authUrl?: string;\n  /** Use this method to overwrite the default logged-out redirect behavior. The default handler [throws a redirect](https://remix.run/docs/en/main/utils/redirect#:~:text=!session) to `/account/login` with current path as `return_to` query param. */\n  customAuthStatusHandler?: () => DataFunctionValue;\n}",
             "description": "",
             "members": [
@@ -9541,13 +9541,13 @@
       {
         "title": "Returns",
         "description": "",
-        "type": "CustomerClientForDocs",
+        "type": "CustomerAccountForDocs",
         "typeDefinitions": {
-          "CustomerClientForDocs": {
+          "CustomerAccountForDocs": {
             "filePath": "/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
-            "name": "CustomerClientForDocs",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use) */\n  login?: () => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize?: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn?: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus?: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken?: () => Promise<string | undefined>;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.*/\n  logout?: () => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query?: <TData = any>(\n    query: string,\n    options: CustomerClientQueryOptionsForDocs,\n  ) => Promise<TData>;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate?: <TData = any>(\n    mutation: string,\n    options: CustomerClientQueryOptionsForDocs,\n  ) => Promise<TData>;\n}",
+            "name": "CustomerAccountForDocs",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use) */\n  login?: () => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize?: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn?: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus?: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken?: () => Promise<string | undefined>;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.*/\n  logout?: () => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query?: <TData = any>(\n    query: string,\n    options: CustomerAccountQueryOptionsForDocs,\n  ) => Promise<TData>;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate?: <TData = any>(\n    mutation: string,\n    options: CustomerAccountQueryOptionsForDocs,\n  ) => Promise<TData>;\n}",
             "description": "Below are types meant for documentation only. Ensure it stay in sync with the type above.",
             "members": [
               {
@@ -9602,7 +9602,7 @@
                 "filePath": "/customer/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "query",
-                "value": "<TData = any>(query: string, options: CustomerClientQueryOptionsForDocs) => Promise<TData>",
+                "value": "<TData = any>(query: string, options: CustomerAccountQueryOptionsForDocs) => Promise<TData>",
                 "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query.",
                 "isOptional": true
               },
@@ -9610,7 +9610,7 @@
                 "filePath": "/customer/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "mutate",
-                "value": "<TData = any>(mutation: string, options: CustomerClientQueryOptionsForDocs) => Promise<TData>",
+                "value": "<TData = any>(mutation: string, options: CustomerAccountQueryOptionsForDocs) => Promise<TData>",
                 "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation.",
                 "isOptional": true
               }
@@ -9623,10 +9623,10 @@
             "value": "Response | NonNullable<unknown> | null",
             "description": ""
           },
-          "CustomerClientQueryOptionsForDocs": {
+          "CustomerAccountQueryOptionsForDocs": {
             "filePath": "/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
-            "name": "CustomerClientQueryOptionsForDocs",
+            "name": "CustomerAccountQueryOptionsForDocs",
             "value": "{\n  /** The variables for the GraphQL statement. */\n  variables?: Record<string, unknown>;\n}",
             "description": "",
             "members": [
@@ -9684,7 +9684,7 @@
                   },
                   {
                     "title": "TypeScript",
-                    "code": "import type {CustomerClient} from '@shopify/hydrogen';\nimport {type HydrogenSession} from '@shopify/hydrogen';\nimport {\n  createCookieSessionStorage,\n  type SessionStorage,\n  type Session,\n} from '@shopify/remix-oxygen';\nimport {\n  useLoaderData,\n  useRouteError,\n  isRouteErrorResponse,\n  useLocation,\n} from '@remix-run/react';\nimport {type LoaderFunctionArgs, json} from '@shopify/remix-oxygen';\n\ndeclare module '@shopify/remix-oxygen' {\n  /**\n   * Declare local additions to the Remix loader context.\n   */\n  export interface AppLoadContext {\n    customerAccount: CustomerClient;\n    session: AppSession;\n  }\n}\n\nclass AppSession implements HydrogenSession {\n  constructor(\n    private sessionStorage: SessionStorage,\n    private session: Session,\n  ) {}\n\n  static async init(request: Request, secrets: string[]) {\n    const storage = createCookieSessionStorage({\n      cookie: {\n        name: 'session',\n        httpOnly: true,\n        path: '/',\n        sameSite: 'lax',\n        secrets,\n      },\n    });\n\n    const session = await storage.getSession(request.headers.get('Cookie'));\n\n    return new this(storage, session);\n  }\n\n  get(key: string) {\n    return this.session.get(key);\n  }\n\n  destroy() {\n    return this.sessionStorage.destroySession(this.session);\n  }\n\n  flash(key: string, value: any) {\n    this.session.flash(key, value);\n  }\n\n  unset(key: string) {\n    this.session.unset(key);\n  }\n\n  set(key: string, value: any) {\n    this.session.set(key, value);\n  }\n\n  commit() {\n    return this.sessionStorage.commitSession(this.session);\n  }\n}\n\nexport async function loader({context}: LoaderFunctionArgs) {\n  if (!(await context.customerAccount.isLoggedIn())) {\n    throw new Response('Customer is not login', {\n      status: 401,\n    });\n  }\n\n  const {data} = await context.customerAccount.query&lt;{\n    customer: {firstName: string; lastName: string};\n  }&gt;(`#graphql\n    query getCustomer {\n      customer {\n        firstName\n        lastName\n      }\n    }\n    `);\n\n  return json(\n    {customer: data.customer},\n    {\n      headers: {\n        'Set-Cookie': await context.session.commit(),\n      },\n    },\n  );\n}\n\nexport function ErrorBoundary() {\n  const error = useRouteError();\n  const location = useLocation();\n\n  if (isRouteErrorResponse(error)) {\n    if (error.status == 401) {\n      return (\n        &lt;a\n          href={`/account/login?${new URLSearchParams({\n            return_to: location.pathname,\n          }).toString()}`}\n        &gt;\n          Login\n        &lt;/a&gt;\n      );\n    }\n  }\n}\n\nexport default function () {\n  const {customer} = useLoaderData&lt;typeof loader&gt;();\n\n  return (\n    &lt;div style={{marginTop: 24}}&gt;\n      {customer ? (\n        &lt;&gt;\n          &lt;div style={{marginBottom: 24}}&gt;\n            &lt;b&gt;\n              Welcome {customer.firstName} {customer.lastName}\n            &lt;/b&gt;\n          &lt;/div&gt;\n        &lt;/&gt;\n      ) : null}\n    &lt;/div&gt;\n  );\n}\n",
+                    "code": "import type {CustomerAccount} from '@shopify/hydrogen';\nimport {type HydrogenSession} from '@shopify/hydrogen';\nimport {\n  createCookieSessionStorage,\n  type SessionStorage,\n  type Session,\n} from '@shopify/remix-oxygen';\nimport {\n  useLoaderData,\n  useRouteError,\n  isRouteErrorResponse,\n  useLocation,\n} from '@remix-run/react';\nimport {type LoaderFunctionArgs, json} from '@shopify/remix-oxygen';\n\ndeclare module '@shopify/remix-oxygen' {\n  /**\n   * Declare local additions to the Remix loader context.\n   */\n  export interface AppLoadContext {\n    customerAccount: CustomerAccount;\n    session: AppSession;\n  }\n}\n\nclass AppSession implements HydrogenSession {\n  constructor(\n    private sessionStorage: SessionStorage,\n    private session: Session,\n  ) {}\n\n  static async init(request: Request, secrets: string[]) {\n    const storage = createCookieSessionStorage({\n      cookie: {\n        name: 'session',\n        httpOnly: true,\n        path: '/',\n        sameSite: 'lax',\n        secrets,\n      },\n    });\n\n    const session = await storage.getSession(request.headers.get('Cookie'));\n\n    return new this(storage, session);\n  }\n\n  get(key: string) {\n    return this.session.get(key);\n  }\n\n  destroy() {\n    return this.sessionStorage.destroySession(this.session);\n  }\n\n  flash(key: string, value: any) {\n    this.session.flash(key, value);\n  }\n\n  unset(key: string) {\n    this.session.unset(key);\n  }\n\n  set(key: string, value: any) {\n    this.session.set(key, value);\n  }\n\n  commit() {\n    return this.sessionStorage.commitSession(this.session);\n  }\n}\n\nexport async function loader({context}: LoaderFunctionArgs) {\n  if (!(await context.customerAccount.isLoggedIn())) {\n    throw new Response('Customer is not login', {\n      status: 401,\n    });\n  }\n\n  const {data} = await context.customerAccount.query&lt;{\n    customer: {firstName: string; lastName: string};\n  }&gt;(`#graphql\n    query getCustomer {\n      customer {\n        firstName\n        lastName\n      }\n    }\n    `);\n\n  return json(\n    {customer: data.customer},\n    {\n      headers: {\n        'Set-Cookie': await context.session.commit(),\n      },\n    },\n  );\n}\n\nexport function ErrorBoundary() {\n  const error = useRouteError();\n  const location = useLocation();\n\n  if (isRouteErrorResponse(error)) {\n    if (error.status == 401) {\n      return (\n        &lt;a\n          href={`/account/login?${new URLSearchParams({\n            return_to: location.pathname,\n          }).toString()}`}\n        &gt;\n          Login\n        &lt;/a&gt;\n      );\n    }\n  }\n}\n\nexport default function () {\n  const {customer} = useLoaderData&lt;typeof loader&gt;();\n\n  return (\n    &lt;div style={{marginTop: 24}}&gt;\n      {customer ? (\n        &lt;&gt;\n          &lt;div style={{marginBottom: 24}}&gt;\n            &lt;b&gt;\n              Welcome {customer.firstName} {customer.lastName}\n            &lt;/b&gt;\n          &lt;/div&gt;\n        &lt;/&gt;\n      ) : null}\n    &lt;/div&gt;\n  );\n}\n",
                     "language": "tsx"
                   }
                 ]
@@ -9960,7 +9960,7 @@
                 "filePath": "/pagination/Pagination.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "state",
-                "value": "{ nodes: NodesType[]; pageInfo: { endCursor: any; startCursor: any; hasPreviousPage: boolean; }; }",
+                "value": "{ nodes: NodesType[]; pageInfo: { endCursor: string; startCursor: string; hasPreviousPage: boolean; }; }",
                 "description": "The `state` property is important to use when building your own `<Link>` component if you want paginated data to continuously append to the page. This means that every time the user clicks \"Next page\", the next page of data will be apppended inline with the previous page. If you want the whole page to re-render with only the next page results, do not pass the `state` prop to the Remix `<Link>` component."
               }
             ],
@@ -10094,14 +10094,14 @@
                 "filePath": "/product/VariantSelector.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "options",
-                "value": "any[]",
+                "value": "PartialObjectDeep<ProductOption, {}>[]",
                 "description": "Product options from the [Storefront API](/docs/api/storefront/2024-01/objects/ProductOption). Make sure both `name` and `values` are apart of your query."
               },
               {
                 "filePath": "/product/VariantSelector.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "variants",
-                "value": "any",
+                "value": "PartialObjectDeep<ProductVariantConnection, {}> | PartialObjectDeep<ProductVariant, {}>[]",
                 "description": "Product variants from the [Storefront API](/docs/api/storefront/2024-01/objects/ProductVariant). You only need to pass this prop if you want to show product availability. If a product option combination is not found within `variants`, it is assumed to be available. Make sure to include `availableForSale` and `selectedOptions.name` and `selectedOptions.value`.",
                 "isOptional": true
               },
@@ -10475,28 +10475,28 @@
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
                 "description": ""
               },
               {
                 "filePath": "/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
-                "value": "any",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
                 "description": ""
               },
               {

--- a/packages/hydrogen/src/customer/customer.doc.ts
+++ b/packages/hydrogen/src/customer/customer.doc.ts
@@ -35,12 +35,12 @@ The \`createCustomerAccountClient\` function creates a GraphQL client for queryi
   definitions: [
     {
       title: 'createCustomerAccountClient(options)',
-      type: 'CustomerClientOptions',
+      type: 'CustomerAccountOptions',
       description: '',
     },
     {
       title: 'Returns',
-      type: 'CustomerClientForDocs',
+      type: 'CustomerAccountForDocs',
       description: '',
     },
   ],

--- a/packages/hydrogen/src/customer/customer.example.tsx
+++ b/packages/hydrogen/src/customer/customer.example.tsx
@@ -1,4 +1,3 @@
-import type {CustomerClient} from '@shopify/hydrogen';
 import {
   createCustomerAccountClient,
   type HydrogenSession,

--- a/packages/hydrogen/src/customer/customer.opt-out-handler.example.tsx
+++ b/packages/hydrogen/src/customer/customer.opt-out-handler.example.tsx
@@ -1,4 +1,4 @@
-import type {CustomerClient} from '@shopify/hydrogen';
+import type {CustomerAccount} from '@shopify/hydrogen';
 import {type HydrogenSession} from '@shopify/hydrogen';
 import {
   createCookieSessionStorage,
@@ -18,7 +18,7 @@ declare module '@shopify/remix-oxygen' {
    * Declare local additions to the Remix loader context.
    */
   export interface AppLoadContext {
-    customerAccount: CustomerClient;
+    customerAccount: CustomerAccount;
     session: AppSession;
   }
 }

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -38,7 +38,7 @@ import {
   type StackInfo,
 } from '../utils/callsites';
 import {getRedirectUrl} from '../utils/get-redirect-url';
-import type {CustomerClientOptions, CustomerClient} from './types';
+import type {CustomerAccountOptions, CustomerAccount} from './types';
 
 const DEFAULT_LOGIN_URL = '/account/login';
 const DEFAULT_AUTH_URL = '/account/authorize';
@@ -65,7 +65,7 @@ export function createCustomerAccountClient({
   waitUntil,
   authUrl = DEFAULT_AUTH_URL,
   customAuthStatusHandler,
-}: CustomerClientOptions): CustomerClient {
+}: CustomerAccountOptions): CustomerAccount {
   if (customerApiVersion !== DEFAULT_CUSTOMER_API_VERSION) {
     console.warn(
       `[h2:warn:createCustomerAccountClient] You are using Customer Account API version ${customerApiVersion} when this version of Hydrogen was built for ${DEFAULT_CUSTOMER_API_VERSION}.`,

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -42,7 +42,7 @@ export interface CustomerAccountMutations {
   // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};
 }
 
-export type CustomerClient = {
+export type CustomerAccount = {
   /** Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use) */
   login: () => Promise<Response>;
   /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */
@@ -87,7 +87,7 @@ export type CustomerClient = {
   >;
 };
 
-export type CustomerClientOptions = {
+export type CustomerAccountOptions = {
   /** The client requires a session to persist the auth and refresh token. By default Hydrogen ships with cookie session storage, but you can use [another session storage](https://remix.run/docs/en/main/utils/sessions) implementation.  */
   session: HydrogenSession;
   /** Unique UUID prefixed with `shp_` associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountId. Use `h2 env pull` to link your store credentials. */
@@ -108,7 +108,7 @@ export type CustomerClientOptions = {
 
 /** Below are types meant for documentation only. Ensure it stay in sync with the type above. */
 
-export type CustomerClientForDocs = {
+export type CustomerAccountForDocs = {
   /** Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use) */
   login?: () => Promise<Response>;
   /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */
@@ -124,16 +124,16 @@ export type CustomerClientForDocs = {
   /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */
   query?: <TData = any>(
     query: string,
-    options: CustomerClientQueryOptionsForDocs,
+    options: CustomerAccountQueryOptionsForDocs,
   ) => Promise<TData>;
   /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */
   mutate?: <TData = any>(
     mutation: string,
-    options: CustomerClientQueryOptionsForDocs,
+    options: CustomerAccountQueryOptionsForDocs,
   ) => Promise<TData>;
 };
 
-export type CustomerClientQueryOptionsForDocs = {
+export type CustomerAccountQueryOptionsForDocs = {
   /** The variables for the GraphQL statement. */
   variables?: Record<string, unknown>;
 };

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -20,7 +20,9 @@ export type {SeoHandleFunction} from './seo/seo';
 export {Pagination, getPaginationVariables} from './pagination/Pagination';
 export {createCustomerAccountClient} from './customer/customer';
 export type {
-  CustomerClient,
+  CustomerAccount,
+  // CustomerClient is a deprecated type that will be remove after 2024-01
+  CustomerAccount as CustomerClient,
   CustomerAccountQueries,
   CustomerAccountMutations,
 } from './customer/types';

--- a/templates/demo-store/remix.env.d.ts
+++ b/templates/demo-store/remix.env.d.ts
@@ -3,7 +3,7 @@
 /// <reference types="@shopify/oxygen-workers-types" />
 
 import type {WithCache, HydrogenCart} from '@shopify/hydrogen';
-import type {Storefront, CustomerClient} from '~/lib/type';
+import type {Storefront, CustomerAccount} from '~/lib/type';
 import type {AppSession} from '~/lib/session.server';
 
 declare global {
@@ -34,7 +34,7 @@ declare module '@shopify/remix-oxygen' {
     waitUntil: ExecutionContext['waitUntil'];
     session: AppSession;
     storefront: Storefront;
-    customerAccount: CustomerClient;
+    customerAccount: CustomerAccount;
     cart: HydrogenCart;
     env: Env;
   }

--- a/templates/skeleton/remix.env.d.ts
+++ b/templates/skeleton/remix.env.d.ts
@@ -5,7 +5,11 @@
 // Enhance TypeScript's built-in typings.
 import '@total-typescript/ts-reset';
 
-import type {Storefront, CustomerClient, HydrogenCart} from '@shopify/hydrogen';
+import type {
+  Storefront,
+  CustomerAccount,
+  HydrogenCart,
+} from '@shopify/hydrogen';
 import type {AppSession} from '~/lib/session';
 
 declare global {
@@ -36,7 +40,7 @@ declare module '@shopify/remix-oxygen' {
     env: Env;
     cart: HydrogenCart;
     storefront: Storefront;
-    customerAccount: CustomerClient;
+    customerAccount: CustomerAccount;
     session: AppSession;
     waitUntil: ExecutionContext['waitUntil'];
   }


### PR DESCRIPTION
`CustomerClient` type is deprecated and replaced by `CustomerAccountClient`.
`CustomerClient` will exist for one release and be remove in v2024.4