### PR TITLE
refactor: use PAGINATION_SIZE constant throughout

### DIFF
--- a/templates/demo-store/app/routes/($locale).collections.$collectionHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).collections.$collectionHandle.tsx
@@ -29,14 +29,14 @@ import {routeHeaders} from '~/data/cache';
 import {seoPayload} from '~/lib/seo.server';
 import type {SortParam} from '~/components/SortFilter';
 import {FILTER_URL_PREFIX} from '~/components/SortFilter';
-import {getImageLoadingPriority} from '~/lib/const';
+import {getImageLoadingPriority, PAGINATION_SIZE} from '~/lib/const';
 import {parseAsCurrency} from '~/lib/utils';
 
 export const headers = routeHeaders;
 
 export async function loader({params, request, context}: LoaderFunctionArgs) {
   const paginationVariables = getPaginationVariables(request, {
-    pageBy: 8,
+    pageBy: PAGINATION_SIZE,
   });
   const {collectionHandle} = params;
   const locale = context.storefront.i18n;

--- a/templates/demo-store/app/routes/($locale).products._index.tsx
+++ b/templates/demo-store/app/routes/($locale).products._index.tsx
@@ -5,11 +5,9 @@ import {Pagination, getPaginationVariables} from '@shopify/hydrogen';
 
 import {PageHeader, Section, ProductCard, Grid} from '~/components';
 import {PRODUCT_CARD_FRAGMENT} from '~/data/fragments';
-import {getImageLoadingPriority} from '~/lib/const';
+import {getImageLoadingPriority, PAGINATION_SIZE} from '~/lib/const';
 import {seoPayload} from '~/lib/seo.server';
 import {routeHeaders} from '~/data/cache';
-
-const PAGE_BY = 8;
 
 export const headers = routeHeaders;
 
@@ -17,7 +15,7 @@ export async function loader({
   request,
   context: {storefront},
 }: LoaderFunctionArgs) {
-  const variables = getPaginationVariables(request, {pageBy: PAGE_BY});
+  const variables = getPaginationVariables(request, {pageBy: PAGINATION_SIZE});
 
   const data = await storefront.query(ALL_PRODUCTS_QUERY, {
     variables: {

--- a/templates/demo-store/app/routes/($locale).search.tsx
+++ b/templates/demo-store/app/routes/($locale).search.tsx
@@ -29,7 +29,7 @@ export async function loader({
 }: LoaderFunctionArgs) {
   const searchParams = new URL(request.url).searchParams;
   const searchTerm = searchParams.get('q')!;
-  const variables = getPaginationVariables(request, {pageBy: 8});
+  const variables = getPaginationVariables(request, {pageBy: PAGINATION_SIZE});
 
   const {products} = await storefront.query(SEARCH_QUERY, {
     variables: {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?
This change aims to improve code maintainability in part of the Demo Store where pagination size is set.

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

This PR refactors the Demo Store to use a single shared constant, `PAGINATION_SIZE`, as the default value for`pageBy`, specifically in places where the default pagination size is 8.

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
