### PR TITLE
Fix PNA preflight headers

### DIFF
--- a/.changeset/violet-seas-knock.md
+++ b/.changeset/violet-seas-knock.md
@@ -1,0 +1,7 @@
+---
+'@shopify/remix-oxygen': patch
+'@shopify/hydrogen': patch
+'@shopify/cli-hydrogen': patch
+---
+
+Fix local asset path to Oxygen to return valid preflight headers

--- a/packages/cli/src/lib/mini-oxygen/assets.ts
+++ b/packages/cli/src/lib/mini-oxygen/assets.ts
@@ -27,7 +27,19 @@ export function buildAssetsUrl(assetsPort: number) {
 export function createAssetsServer(buildPathClient: string) {
   return createServer(async (req: IncomingMessage, res: ServerResponse) => {
     // Similar headers to Shopify CDN
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    if (req.method === 'OPTIONS') {
+      // Setting PNA preflight headers
+      // https://developer.chrome.com/blog/private-network-access-preflight
+      res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+      res.setHeader('Access-Control-Allow-Private-Network', 'true');
+      res.setHeader('Access-Control-Max-Age', '86400');
+      res.writeHead(204);
+      res.end();
+      return;
+    } else {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+    }
     res.setHeader('X-Content-Type-Options', 'nosniff');
 
     const pathname = req.url?.split('?')[0] || '';

--- a/templates/demo-store/customer-accountapi.generated.d.ts
+++ b/templates/demo-store/customer-accountapi.generated.d.ts
@@ -15,7 +15,7 @@ export type CustomerAddressUpdateMutation = {
   customerAddressUpdate?: CustomerAccountAPI.Maybe<{
     userErrors: Array<
       Pick<
-        CustomerAccountAPI.UserErrorsAddressUserErrors,
+        CustomerAccountAPI.UserErrorsCustomerAddressUserErrors,
         'code' | 'field' | 'message'
       >
     >;


### PR DESCRIPTION
### WHY are these changes introduced?

When trying to follow the instruction to set up the ngrok proxy for Customer Account API to work locally, CORS errors will prevent the page from loading properly on proxied URL.

<img width="820" alt="Screenshot 2024-01-29 at 11 34 45 AM" src="https://github.com/Shopify/hydrogen/assets/2319002/741a8187-b923-4e82-a5c3-a13ca262f942">

### WHAT is this pull request doing?

Provide the required headers to the asset preflights according to spec https://developer.chrome.com/blog/private-network-access-preflight

This asset server will only exist in local development environment. Therefore, setting `Access-Control-Allow-Private-Network` to `true` is not a security issue.

### HOW to test your changes?

Still unsure what browser or browser version these asset preflight are enforced. But if you follow the instruction in a generated project https://github.com/Shopify/hydrogen/tree/main/templates/skeleton#setup-for-using-customer-account-api-account-section and attempts to access the proxied url at `https://<your-ngrok-domain>.app`, the assets should load properly with this fix.

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
