### PR TITLE
Minor fixes to merging diff examples

### DIFF
--- a/packages/cli/src/commands/hydrogen/init.test.ts
+++ b/packages/cli/src/commands/hydrogen/init.test.ts
@@ -222,8 +222,10 @@ describe('init', () => {
         // --- Test file diff
         const ignore = ['**/node_modules/**', '**/dist/**'];
         const resultFiles = await glob('**/*', {ignore, cwd: tmpDir});
-        const templateFiles = await glob('**/*', {ignore, cwd: templatePath});
         const exampleFiles = await glob('**/*', {ignore, cwd: examplePath});
+        const templateFiles = (
+          await glob('**/*', {ignore, cwd: templatePath})
+        ).filter((item) => !item.endsWith('CHANGELOG.md'));
 
         expect(resultFiles).toEqual(
           expect.arrayContaining([

--- a/packages/cli/src/lib/file.ts
+++ b/packages/cli/src/lib/file.ts
@@ -82,7 +82,10 @@ type ManagedKey = (typeof MANAGED_PACKAGE_JSON_KEYS)[number];
 export async function mergePackageJson(
   sourceDir: string,
   targetDir: string,
-  options?: {ignoredKeys?: string[]},
+  options?: {
+    ignoredKeys?: string[];
+    onResult?: (pkgJson: PackageJson) => PackageJson;
+  },
 ) {
   const targetPkgJson: PackageJson = await readAndParsePackageJson(
     joinPath(targetDir, 'package.json'),
@@ -142,5 +145,8 @@ export async function mergePackageJson(
     }
   }
 
-  await writePackageJSON(targetDir, targetPkgJson);
+  await writePackageJSON(
+    targetDir,
+    options?.onResult?.(targetPkgJson) ?? targetPkgJson,
+  );
 }

--- a/packages/cli/src/lib/template-diff.ts
+++ b/packages/cli/src/lib/template-diff.ts
@@ -106,7 +106,16 @@ export async function applyTemplateDiff(
   });
 
   await mergePackageJson(diffDirectory, targetDirectory, {
-    ignoredKeys: ['scripts'],
+    onResult: (pkgJson) => {
+      for (const key of ['build', 'dev']) {
+        const scriptLine = pkgJson.scripts?.[key];
+        if (pkgJson.scripts?.[key] && typeof scriptLine === 'string') {
+          pkgJson.scripts[key] = scriptLine.replace(/\s+--diff/, '');
+        }
+      }
+
+      return pkgJson;
+    },
   });
 }
 

--- a/packages/cli/src/lib/template-diff.ts
+++ b/packages/cli/src/lib/template-diff.ts
@@ -95,11 +95,13 @@ export async function applyTemplateDiff(
     !re.test(relativePath(templateDir, filepath));
 
   await copyDirectory(templateDir, targetDirectory, {
-    filter: createFilter(/[\/\\](dist|node_modules|\.cache)(\/|\\|$)/i),
+    filter: createFilter(
+      /(^|\/|\\)(dist|node_modules|\.cache|CHANGELOG\.md)(\/|\\|$)/i,
+    ),
   });
   await copyDirectory(diffDirectory, targetDirectory, {
     filter: createFilter(
-      /[\/\\](dist|node_modules|\.cache|package\.json|tsconfig\.json)(\/|\\|$)/i,
+      /(^|\/|\\)(dist|node_modules|\.cache|package\.json|tsconfig\.json)(\/|\\|$)/i,
     ),
   });
 


### PR DESCRIPTION
- Stop copying skeleton's `CHANGELOG.md`
- Use the example's `package.json#scripts` instead of skeleton's.