### PR TITLE
Add variant option color on product page in demo store

### DIFF
--- a/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
@@ -323,8 +323,10 @@ export function ProductForm({
                           prefetch="intent"
                           replace
                           className={clsx(
-                            'leading-none p-1 bg-secondary border-[1.5px] cursor-pointer transition-all duration-200',
-                            isActive ? 'border-primary/50' : 'border-primary/10',
+                            'p-1 bg-secondary border-[1.5px] cursor-pointer transition-all duration-200',
+                            isActive
+                              ? 'border-primary/50'
+                              : 'border-primary/10',
                           )}
                         >
                           <div

--- a/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
@@ -251,6 +251,9 @@ export function ProductForm({
               >
                 <Heading as="legend" size="lead" className="min-w-[4rem]">
                   {option.name}
+                  {option.name === 'Color' && (
+                    <span className="font-medium px-1">: {option.value}</span>
+                  )}
                 </Heading>
                 <div className="flex flex-wrap items-baseline gap-4">
                   {option.values.length > 7 ? (
@@ -311,22 +314,44 @@ export function ProductForm({
                       </Listbox>
                     </div>
                   ) : (
-                    option.values.map(({value, isAvailable, isActive, to}) => (
-                      <Link
-                        key={option.name + value}
-                        to={to}
-                        preventScrollReset
-                        prefetch="intent"
-                        replace
-                        className={clsx(
-                          'leading-none py-1 border-b-[1.5px] cursor-pointer transition-all duration-200',
-                          isActive ? 'border-primary/50' : 'border-primary/0',
-                          isAvailable ? 'opacity-100' : 'opacity-50',
-                        )}
-                      >
-                        {value}
-                      </Link>
-                    ))
+                    option.values.map(({value, isAvailable, isActive, to}) => {
+                      return option.name === 'Color' ? (
+                        <Link
+                          key={option.name + value}
+                          to={to}
+                          preventScrollReset
+                          prefetch="intent"
+                          replace
+                          className={clsx(
+                            'leading-none p-1 bg-secondary border-[1.5px] cursor-pointer transition-all duration-200',
+                            isActive ? 'border-primary/50' : 'border-primary/10',
+                          )}
+                        >
+                          <div
+                            className={clsx(
+                              'product-options-item border border-primary/20 w-[38px] h-[38px]',
+                              isAvailable ? 'opacity-100' : 'strike-diagonal',
+                            )}
+                            style={{backgroundColor: value}}
+                          />
+                        </Link>
+                      ) : (
+                        <Link
+                          key={option.name + value}
+                          to={to}
+                          preventScrollReset
+                          prefetch="intent"
+                          replace
+                          className={clsx(
+                            'leading-none py-1 border-b-[1.5px] cursor-pointer transition-all duration-200',
+                            isActive ? 'border-primary/50' : 'border-primary/0',
+                            isAvailable ? 'opacity-100' : 'opacity-50',
+                          )}
+                        >
+                          {value}
+                        </Link>
+                      );
+                    })
                   )}
                 </div>
               </div>

--- a/templates/demo-store/app/styles/app.css
+++ b/templates/demo-store/app/styles/app.css
@@ -169,6 +169,20 @@ shop-pay-button {
     }
   }
 
+  .strike-diagonal {
+    position: relative;
+    &:before {
+      position: absolute;
+      content: '';
+      left: 0;
+      top: 50%;
+      right: 0;
+      border-top: 1px solid rgb(var(--color-contrast) / 0.6);
+      border-bottom: 1px solid rgb(var(--color-primary) / 0.3);
+      transform: skewY(-45deg);
+    }
+  }
+
   .card-image {
     @apply relative flex items-center justify-center overflow-clip rounded;
     &::before {


### PR DESCRIPTION
### WHY are these changes introduced?

This adds the usual functionality common to e-commerce

### WHAT is this pull request doing?

This implementation allows the user to see the colour of the product variants and select the product of the desired colour

![изображение](https://github.com/Shopify/hydrogen/assets/45523536/e61df834-9937-448a-8234-7a07bb73809b)

- Clicking on a coloured square will take you to the page of the selected product variant.
- The selected colour variant is highlighted with a frame
- Unavailable colour variant is crossed out with a diagonal line.


### HOW to test your changes?
- Go to a page of product that has several colour variants
- Here you will see squares with the colours of the product variants. 
- Click on a colour you want to go to the page of the selected product variant.
- Chek selected and unavailabled pvoduct variants
- Check with browser dark theme

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation