### PR TITLE
[cli] add no-lockfile-check and custom-build flags to deploy command

### DIFF
--- a/.changeset/chilly-countries-itch.md
+++ b/.changeset/chilly-countries-itch.md
@@ -1,0 +1,8 @@
+---
+'@shopify/cli-hydrogen': minor
+---
+Adds new command line flag options for the `deploy` command:
+
+- `build-command`: Allows users to specify which command is used to build the project (instead of the default build function). This provides more flexibility for projects that have custom build processes.
+- `no-lockfile-check`: Allows users to skip the lockfile check during the build process. This can be useful in scenarios where you want to bypass the lockfile check for certain reasons, such as in monorepos, where the lockfile resides in the root folder.
+

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -19,19 +19,19 @@
         "sourcemap": {
           "name": "sourcemap",
           "type": "boolean",
-          "description": "Generate sourcemaps for the build.",
+          "description": "Controls whether sourcemaps are generated. Default to true, use `--no-sourcemaps` to disable.",
           "allowNo": true
         },
         "bundle-stats": {
           "name": "bundle-stats",
           "type": "boolean",
-          "description": "Show a bundle size summary after building.",
+          "description": "Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
           "allowNo": true
         },
         "lockfile-check": {
           "name": "lockfile-check",
           "type": "boolean",
-          "description": "Checks that there is exactly 1 valid lockfile in the project.",
+          "description": "Checks that there is exactly 1 valid lockfile in the project. Defaults to true, use `--no-lockfile-check` to disable.",
           "allowNo": true
         },
         "disable-route-warning": {
@@ -171,6 +171,19 @@
           "required": false,
           "allowNo": false
         },
+        "build-command": {
+          "name": "build-command",
+          "type": "option",
+          "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
+          "required": false,
+          "multiple": false
+        },
+        "lockfile-check": {
+          "name": "lockfile-check",
+          "type": "boolean",
+          "description": "Checks that there is exactly 1 valid lockfile in the project. Defaults to true, use `--no-lockfile-check` to disable.",
+          "allowNo": true
+        },
         "path": {
           "name": "path",
           "type": "option",
@@ -184,12 +197,12 @@
           "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
           "multiple": false
         },
-        "no-json-output": {
-          "name": "no-json-output",
+        "json-output": {
+          "name": "json-output",
           "type": "boolean",
-          "description": "Prevents the command from creating a JSON file containing the deployment URL in CI environments.",
+          "description": "Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.",
           "required": false,
-          "allowNo": false
+          "allowNo": true
         },
         "token": {
           "name": "token",

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -45,23 +45,19 @@ export default class Build extends Command {
   static flags = {
     path: commonFlags.path,
     sourcemap: Flags.boolean({
-      description: 'Generate sourcemaps for the build.',
+      description:
+        'Controls whether sourcemaps are generated. Default to true, use `--no-sourcemaps` to disable.',
       env: 'SHOPIFY_HYDROGEN_FLAG_SOURCEMAP',
       allowNo: true,
       default: true,
     }),
     'bundle-stats': Flags.boolean({
-      description: 'Show a bundle size summary after building.',
-      default: true,
-      allowNo: true,
-    }),
-    'lockfile-check': Flags.boolean({
       description:
-        'Checks that there is exactly 1 valid lockfile in the project.',
-      env: 'SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK',
+        'Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.',
       default: true,
       allowNo: true,
     }),
+    'lockfile-check': commonFlags.lockfileCheck,
     'disable-route-warning': Flags.boolean({
       description: 'Disable warning about missing standard routes.',
       env: 'SHOPIFY_HYDROGEN_FLAG_DISABLE_ROUTE_WARNING',

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -73,13 +73,20 @@ export default class Deploy extends Command {
       required: false,
       default: false,
     }),
+    'build-command': Flags.string({
+      description:
+        'Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.',
+      required: false,
+    }),
+    'lockfile-check': commonFlags.lockfileCheck,
     path: commonFlags.path,
     shop: commonFlags.shop,
-    'no-json-output': Flags.boolean({
+    'json-output': Flags.boolean({
+      allowNo: true,
       description:
-        'Prevents the command from creating a JSON file containing the deployment URL in CI environments.',
+        'Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.',
       required: false,
-      default: false,
+      default: true,
     }),
     token: Flags.string({
       char: 't',
@@ -144,10 +151,12 @@ export default class Deploy extends Command {
 
 interface OxygenDeploymentOptions {
   authBypassToken: boolean;
+  buildCommand?: string;
   defaultEnvironment: boolean;
   environmentTag?: string;
   force: boolean;
-  noJsonOutput: boolean;
+  lockfileCheck: boolean;
+  jsonOutput: boolean;
   path: string;
   shop: string;
   token?: string;
@@ -186,10 +195,12 @@ export async function oxygenDeploy(
 ): Promise<void> {
   const {
     authBypassToken: generateAuthBypassToken,
+    buildCommand,
     defaultEnvironment,
     environmentTag,
     force: forceOnUncommitedChanges,
-    noJsonOutput,
+    lockfileCheck,
+    jsonOutput,
     path,
     shop,
     metadataUrl,
@@ -371,17 +382,6 @@ export async function oxygenDeploy(
   });
 
   const hooks: DeploymentHooks = {
-    buildFunction: async (assetPath: string | undefined): Promise<void> => {
-      outputInfo(
-        outputContent`${colors.whiteBright('Building project...')}`.value,
-      );
-      await runBuild({
-        directory: path,
-        assetPath,
-        sourcemap: true,
-        useCodegen: false,
-      });
-    },
     onDeploymentCompleted: () => resolveDeploymentCompletedVerification(),
     onVerificationComplete: () => resolveRoutableCheck(),
     onDeploymentCompletedVerificationError() {
@@ -408,6 +408,25 @@ export async function oxygenDeploy(
       );
     },
   };
+
+  if (buildCommand) {
+    config.buildCommand = buildCommand;
+  } else {
+    hooks.buildFunction = async (
+      assetPath: string | undefined,
+    ): Promise<void> => {
+      outputInfo(
+        outputContent`${colors.whiteBright('Building project...')}`.value,
+      );
+      await runBuild({
+        directory: path,
+        assetPath,
+        lockfileCheck,
+        sourcemap: true,
+        useCodegen: false,
+      });
+    };
+  }
 
   const uploadStart = async () => {
     outputInfo(
@@ -459,9 +478,8 @@ export async function oxygenDeploy(
         body: ['Successfully deployed to Oxygen'],
         nextSteps,
       });
-      // in CI environments, output to a file so consequent steps can access the URL
-      // the formatting of this file is likely to change in future versions.
-      if (isCI && !noJsonOutput) {
+      // in CI environments, output to a file so consequent steps can access the deployment details
+      if (isCI && jsonOutput) {
         await writeFile(
           'h2_deploy_log.json',
           JSON.stringify(completedDeployment),

--- a/packages/cli/src/lib/flags.ts
+++ b/packages/cli/src/lib/flags.ts
@@ -104,6 +104,13 @@ export const commonFlags = {
     default: false,
     required: false,
   }),
+  lockfileCheck: Flags.boolean({
+    allowNo: true,
+    default: true,
+    description:
+      'Checks that there is exactly 1 valid lockfile in the project. Defaults to true, use `--no-lockfile-check` to disable.',
+    env: 'SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK',
+  }),
 };
 
 export function flagsToCamelObject<T extends Record<string, any>>(obj: T) {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
--

Users may be deploying a project that resides in a subfolder in a monorepo. The root folder contains the lockfile, but to deploy the `path` parameter is used. Consequently, the `runBuild` command is called, which is unaware of the existence of the lock file in the parent folder.

Secondly, some merchants use custom build environments and may not want to use the hydrogen-cli to build their projects.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
Adds the `no-lockfile-check` flag to the deploy command, which passes that parameter accordingly to `runBuild`.
Adds the `custom-build` flag to the deploy command. With this set, the `buildFunction` hook is not defined, and instead a build command is passed to `oxygen-cli`. This command is derived from the package manager used.

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
