### PR TITLE
Add `--env-file` for cli `deploy` command

### DIFF
--- a/.changeset/chatty-donuts-rule.md
+++ b/.changeset/chatty-donuts-rule.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add `--environment-file` flag to the `deploy` command
+
+Optionally provide the path to a local .env file to override the environment variables set on Admin.

--- a/.changeset/chatty-donuts-rule.md
+++ b/.changeset/chatty-donuts-rule.md
@@ -2,6 +2,6 @@
 '@shopify/cli-hydrogen': patch
 ---
 
-Add `--environment-file` flag to the `deploy` command
+Add `--env-file` flag to the `deploy` command
 
 Optionally provide the path to a local .env file to override the environment variables set on Admin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1692,9 +1692,9 @@
       "license": "MIT"
     },
     "node_modules/@bugsnag/browser": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.22.3.tgz",
-      "integrity": "sha512-TWQSdsCqzxEVmaKzbtmqoBLWF58yjXi/ScC+6L5VNgSj+62jkIQuw5Evjs+7kLQX8WCnaG6XLiDmUJmPx6ZUrA==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.22.4.tgz",
+      "integrity": "sha512-h2o9RZhAEIgJAUsECd7a00IkLnvQvLT7dUyUYx/s8VLvcq89gKa8E59rlM7f15wtkJ5MPfozhErXDpsdOvF4Rg==",
       "dependencies": {
         "@bugsnag/core": "^7.19.0"
       }
@@ -8566,6 +8566,42 @@
       "resolved": "packages/mini-oxygen",
       "link": true
     },
+    "node_modules/@shopify/oxygen-cli": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.1.0.tgz",
+      "integrity": "sha512-AowugeJRZQPcsYVUtkGiqoLS7H9xIUCyPsRRG4iNuUD6sXBtCETSBNXrpekYI9fpAUsOLyirKSiFRxAaCkY/0g==",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@bugsnag/core": "^7.19.0",
+        "@bugsnag/js": "^7.22.4",
+        "@bugsnag/node": "^7.19.0",
+        "async": "^3.2.5",
+        "dotenv": "^16.4.1"
+      },
+      "bin": {
+        "oxygen-cli": "dist/oxygen-cli.js"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      },
+      "peerDependencies": {
+        "@oclif/core": "^2.11.7",
+        "@shopify/cli-kit": "^3.51.0"
+      }
+    },
+    "node_modules/@shopify/oxygen-cli/node_modules/@bugsnag/js": {
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.22.4.tgz",
+      "integrity": "sha512-GjU3YmCNxVl1QZ64e8D4hKSfhHiymHu4hyYlyKxIdqmnhpHvoFnADcdAHEnWPG82O9j9w+JoDXvL460aiOEgHg==",
+      "dependencies": {
+        "@bugsnag/browser": "^7.22.4",
+        "@bugsnag/node": "^7.22.3"
+      }
+    },
     "node_modules/@shopify/oxygen-workers-types": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@shopify/oxygen-workers-types/-/oxygen-workers-types-4.0.0.tgz",
@@ -13661,14 +13697,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.2.tgz",
+      "integrity": "sha512-rZSSFxke7d9nYQ5NeMIwp5PP+f8wXgKNljpOb7KtH6SKW1cEqcXAz9VSJYVLKe7Jhup/gUYOkaeSVyK8GJ+nBg==",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dset": {
@@ -31825,41 +31861,6 @@
         }
       }
     },
-    "packages/cli/node_modules/@bugsnag/js": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.22.3.tgz",
-      "integrity": "sha512-SAZEElVlmQgZBPLbTdMAyFD2Pp1mP4t3bv+GmDVGSgBi4W6doKQVk0J/K9f5+JGw8fEh9AJHRlyub3XnlGI6Zw==",
-      "dependencies": {
-        "@bugsnag/browser": "^7.22.3",
-        "@bugsnag/node": "^7.22.3"
-      }
-    },
-    "packages/cli/node_modules/@shopify/oxygen-cli": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.0.0.tgz",
-      "integrity": "sha512-mkUffl5zUGrvrds935ncWQdzLIThrF1CNGpvLUA17dMwQxqVIfb3pM9/4iWBNgvvORaLWG1ceXsUTg5xVEra1Q==",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "dependencies": {
-        "@bugsnag/core": "^7.19.0",
-        "@bugsnag/js": "^7.22.3",
-        "@bugsnag/node": "^7.19.0",
-        "async": "^3.2.5"
-      },
-      "bin": {
-        "oxygen-cli": "dist/oxygen-cli.js"
-      },
-      "engines": {
-        "node": ">=16.14.0"
-      },
-      "peerDependencies": {
-        "@oclif/core": "^2.11.7",
-        "@shopify/cli-kit": "^3.51.0"
-      }
-    },
     "packages/cli/node_modules/ansi-escapes": {
       "version": "6.2.0",
       "license": "MIT",
@@ -33559,9 +33560,9 @@
       "dev": true
     },
     "@bugsnag/browser": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.22.3.tgz",
-      "integrity": "sha512-TWQSdsCqzxEVmaKzbtmqoBLWF58yjXi/ScC+6L5VNgSj+62jkIQuw5Evjs+7kLQX8WCnaG6XLiDmUJmPx6ZUrA==",
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.22.4.tgz",
+      "integrity": "sha512-h2o9RZhAEIgJAUsECd7a00IkLnvQvLT7dUyUYx/s8VLvcq89gKa8E59rlM7f15wtkJ5MPfozhErXDpsdOvF4Rg==",
       "requires": {
         "@bugsnag/core": "^7.19.0"
       }
@@ -37863,26 +37864,6 @@
         "ws": "^8.13.0"
       },
       "dependencies": {
-        "@bugsnag/js": {
-          "version": "7.22.3",
-          "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.22.3.tgz",
-          "integrity": "sha512-SAZEElVlmQgZBPLbTdMAyFD2Pp1mP4t3bv+GmDVGSgBi4W6doKQVk0J/K9f5+JGw8fEh9AJHRlyub3XnlGI6Zw==",
-          "requires": {
-            "@bugsnag/browser": "^7.22.3",
-            "@bugsnag/node": "^7.22.3"
-          }
-        },
-        "@shopify/oxygen-cli": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.0.0.tgz",
-          "integrity": "sha512-mkUffl5zUGrvrds935ncWQdzLIThrF1CNGpvLUA17dMwQxqVIfb3pM9/4iWBNgvvORaLWG1ceXsUTg5xVEra1Q==",
-          "requires": {
-            "@bugsnag/core": "^7.19.0",
-            "@bugsnag/js": "^7.22.3",
-            "@bugsnag/node": "^7.19.0",
-            "async": "^3.2.5"
-          }
-        },
         "ansi-escapes": {
           "version": "6.2.0",
           "requires": {
@@ -38552,6 +38533,29 @@
             "http-errors": "2.0.0",
             "iconv-lite": "0.4.24",
             "unpipe": "1.0.0"
+          }
+        }
+      }
+    },
+    "@shopify/oxygen-cli": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.1.0.tgz",
+      "integrity": "sha512-AowugeJRZQPcsYVUtkGiqoLS7H9xIUCyPsRRG4iNuUD6sXBtCETSBNXrpekYI9fpAUsOLyirKSiFRxAaCkY/0g==",
+      "requires": {
+        "@bugsnag/core": "^7.19.0",
+        "@bugsnag/js": "^7.22.4",
+        "@bugsnag/node": "^7.19.0",
+        "async": "^3.2.5",
+        "dotenv": "^16.4.1"
+      },
+      "dependencies": {
+        "@bugsnag/js": {
+          "version": "7.22.4",
+          "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.22.4.tgz",
+          "integrity": "sha512-GjU3YmCNxVl1QZ64e8D4hKSfhHiymHu4hyYlyKxIdqmnhpHvoFnADcdAHEnWPG82O9j9w+JoDXvL460aiOEgHg==",
+          "requires": {
+            "@bugsnag/browser": "^7.22.4",
+            "@bugsnag/node": "^7.22.3"
           }
         }
       }
@@ -41955,9 +41959,9 @@
       }
     },
     "dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.2.tgz",
+      "integrity": "sha512-rZSSFxke7d9nYQ5NeMIwp5PP+f8wXgKNljpOb7KtH6SKW1cEqcXAz9VSJYVLKe7Jhup/gUYOkaeSVyK8GJ+nBg=="
     },
     "dset": {
       "version": "3.1.3",

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -149,6 +149,13 @@
           "required": false,
           "multiple": false
         },
+        "env-file": {
+          "name": "env-file",
+          "type": "option",
+          "description": "Path to an environment file to override existing environment variables for the deployment.",
+          "required": false,
+          "multiple": false
+        },
         "preview": {
           "name": "preview",
           "type": "boolean",
@@ -224,13 +231,6 @@
           "name": "metadata-version",
           "type": "option",
           "hidden": true,
-          "required": false,
-          "multiple": false
-        },
-        "environment-file": {
-          "name": "environment-file",
-          "type": "option",
-          "description": "Path to an environment file to override existing environment variables for the deployment.",
           "required": false,
           "multiple": false
         }

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -226,6 +226,13 @@
           "hidden": true,
           "required": false,
           "multiple": false
+        },
+        "environment-file": {
+          "name": "environment-file",
+          "type": "option",
+          "description": "Path to an environment file to override existing environment variables for the deployment.",
+          "required": false,
+          "multiple": false
         }
       },
       "args": {}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
     "@shopify/cli-kit": "3.52.0",
     "@shopify/hydrogen-codegen": "^0.2.1",
     "@shopify/mini-oxygen": "^2.2.5",
-    "@shopify/oxygen-cli": "^4.0.0",
+    "@shopify/oxygen-cli": "^4.1.0",
     "ansi-escapes": "^6.2.0",
     "cli-truncate": "^4.0.0",
     "diff": "^5.1.0",

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -54,6 +54,11 @@ export default class Deploy extends Command {
       description: 'Environment branch (tag) for environment to deploy to.',
       required: false,
     }),
+    'env-file': Flags.string({
+      description:
+        'Path to an environment file to override existing environment variables for the deployment.',
+      required: false,
+    }),
     preview: Flags.boolean({
       description:
         'Deploys to the Preview environment. Overrides --env-branch and Git metadata.',
@@ -111,11 +116,6 @@ export default class Deploy extends Command {
       env: 'SHOPIFY_HYDROGEN_FLAG_METADATA_VERSION',
       hidden: true,
     }),
-    'environment-file': Flags.string({
-      description:
-        'Path to an environment file to override existing environment variables for the deployment.',
-      required: false,
-    }),
   };
 
   async run() {
@@ -143,6 +143,7 @@ export default class Deploy extends Command {
       ...camelFlags,
       defaultEnvironment: flags.preview,
       environmentTag: flags['env-branch'],
+      environmentFile: flags['env-file'],
       path: flags.path ? resolvePath(flags.path) : process.cwd(),
     } as OxygenDeploymentOptions;
   }

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -31,6 +31,7 @@ import {
   DeploymentVerificationDetailsResponse,
   parseToken,
 } from '@shopify/oxygen-cli/deploy';
+import {loadEnvironmentVariableFile} from '@shopify/oxygen-cli/utils';
 
 import {commonFlags, flagsToCamelObject} from '../../lib/flags.js';
 import {getOxygenDeploymentData} from '../../lib/get-oxygen-deployment-data.js';
@@ -110,6 +111,11 @@ export default class Deploy extends Command {
       env: 'SHOPIFY_HYDROGEN_FLAG_METADATA_VERSION',
       hidden: true,
     }),
+    'environment-file': Flags.string({
+      description:
+        'Path to an environment file to override existing environment variables for the deployment.',
+      required: false,
+    }),
   };
 
   async run() {
@@ -146,6 +152,7 @@ interface OxygenDeploymentOptions {
   authBypassToken: boolean;
   defaultEnvironment: boolean;
   environmentTag?: string;
+  environmentFile?: string;
   force: boolean;
   noJsonOutput: boolean;
   path: string;
@@ -188,6 +195,7 @@ export async function oxygenDeploy(
     authBypassToken: generateAuthBypassToken,
     defaultEnvironment,
     environmentTag,
+    environmentFile,
     force: forceOnUncommitedChanges,
     noJsonOutput,
     path,
@@ -246,6 +254,19 @@ export async function oxygenDeploy(
       ],
     });
     metadataDescription = `${commitHash} with additional changes`;
+  }
+
+  let overriddenEnvironmentVariables;
+
+  if (environmentFile) {
+    try {
+      overriddenEnvironmentVariables =
+        loadEnvironmentVariableFile(environmentFile);
+    } catch (error) {
+      throw new AbortError(
+        `Could not load environment file at ${environmentFile}`,
+      );
+    }
   }
 
   if (!isCI) {
@@ -343,6 +364,7 @@ export async function oxygenDeploy(
     skipBuild: false,
     workerOnly: false,
     workerDir: 'dist/worker',
+    overriddenEnvironmentVariables,
   };
 
   let resolveUpload: () => void;


### PR DESCRIPTION
### WHY are these changes introduced?

- Allowing users to deploy using locally stored environment variables in environment file

### WHAT is this pull request doing?

- Introduce a new flag `--env-file` that allows users to pass in an environment file when creating a deploy
  - this file will override existing environment files defined in Admin

### HOW to test your changes?

- Checkout hydrogen repo
- In hydrogen repo, run the following commands:
  - `npm ci`
  - `cd packages/cli`
  - `npm ci`
  - `npm run build`
  - `h2 deploy --path=./path-to-repo/ --env-file=./path-to-repo/env-file`
  - If you don't have a repo, create one using `h2 init`

#### General case
![image](https://github.com/Shopify/hydrogen/assets/2907059/75967d79-25ca-436e-8d31-af289392f213)

#### File not found
![image](https://github.com/Shopify/hydrogen/assets/2907059/ddf69a5b-6e9d-4c61-bf20-60cfc85ff42d)


#### Unexpected error
![image](https://github.com/Shopify/hydrogen/assets/2907059/d041501c-eb2e-4550-8d68-4380d785eec5)


#### Post-merge steps

Will be updating docs once this flag is added

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
