### PR TITLE
Add defensive null checks to the default cart implementation

### DIFF
--- a/.changeset/moody-colts-refuse.md
+++ b/.changeset/moody-colts-refuse.md
@@ -1,0 +1,5 @@
+---
+'skeleton': patch
+---
+
+Add defensive null checks to the default cart implementation in the starter template

--- a/templates/skeleton/app/components/Cart.tsx
+++ b/templates/skeleton/app/components/Cart.tsx
@@ -15,7 +15,7 @@ export function CartMain({layout, cart}: CartMainProps) {
   const linesCount = Boolean(cart?.lines?.nodes?.length || 0);
   const withDiscount =
     cart &&
-    Boolean(cart.discountCodes.filter((code) => code.applicable).length);
+    Boolean(cart?.discountCodes?.filter((code) => code.applicable)?.length);
   const className = `cart-main ${withDiscount ? 'with-discount' : ''}`;
 
   return (


### PR DESCRIPTION
Some carts may not have discount codes, so make the default implementation more defensive.

#### Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
