### PR TITLE
Add variant option color on product page in demo store

### DIFF
--- a/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
+++ b/templates/demo-store/app/routes/($locale).products.$productHandle.tsx
@@ -39,6 +39,8 @@ import {MEDIA_FRAGMENT, PRODUCT_CARD_FRAGMENT} from '~/data/fragments';
 
 export const headers = routeHeaders;
 
+const VARIANT_OPTIONS_LIST_NUMBER = 7;
+
 export async function loader({params, request, context}: LoaderFunctionArgs) {
   const {productHandle} = params;
   invariant(productHandle, 'Missing productHandle param, check route filename');
@@ -251,9 +253,13 @@ export function ProductForm({
               >
                 <Heading as="legend" size="lead" className="min-w-[4rem]">
                   {option.name}
+                  {option.name === 'Color' &&
+                    option.values.length <= VARIANT_OPTIONS_LIST_NUMBER && (
+                      <span className="font-medium px-1">: {option.value}</span>
+                    )}
                 </Heading>
                 <div className="flex flex-wrap items-baseline gap-4">
-                  {option.values.length > 7 ? (
+                  {option.values.length > VARIANT_OPTIONS_LIST_NUMBER ? (
                     <div className="relative w-full">
                       <Listbox>
                         {({open}) => (
@@ -267,7 +273,15 @@ export function ProductForm({
                                   : 'rounded',
                               )}
                             >
-                              <span>{option.value}</span>
+                              <div className="flex items-center w-full">
+                                {option.name === 'Color' && (
+                                  <span
+                                    className="mr-2 border border-primary/20 w-6 h-6"
+                                    style={{backgroundColor: option.value}}
+                                  />
+                                )}
+                                <span>{option.value}</span>
+                              </div>
                               <IconCaret direction={open ? 'up' : 'down'} />
                             </Listbox.Button>
                             <Listbox.Options
@@ -295,6 +309,12 @@ export function ProductForm({
                                           closeRef.current.click();
                                         }}
                                       >
+                                        {option.name === 'Color' && (
+                                          <span
+                                            className="mr-2 border border-primary/20 w-6 h-6"
+                                            style={{backgroundColor: value}}
+                                          />
+                                        )}
                                         {value}
                                         {isActive && (
                                           <span className="ml-2">
@@ -311,22 +331,46 @@ export function ProductForm({
                       </Listbox>
                     </div>
                   ) : (
-                    option.values.map(({value, isAvailable, isActive, to}) => (
-                      <Link
-                        key={option.name + value}
-                        to={to}
-                        preventScrollReset
-                        prefetch="intent"
-                        replace
-                        className={clsx(
-                          'leading-none py-1 border-b-[1.5px] cursor-pointer transition-all duration-200',
-                          isActive ? 'border-primary/50' : 'border-primary/0',
-                          isAvailable ? 'opacity-100' : 'opacity-50',
-                        )}
-                      >
-                        {value}
-                      </Link>
-                    ))
+                    option.values.map(({value, isAvailable, isActive, to}) => {
+                      return option.name === 'Color' ? (
+                        <Link
+                          key={option.name + value}
+                          to={to}
+                          preventScrollReset
+                          prefetch="intent"
+                          replace
+                          className={clsx(
+                            'p-1 bg-secondary border-[1.5px] cursor-pointer transition-all duration-200',
+                            isActive
+                              ? 'border-primary/60'
+                              : 'border-primary/10',
+                          )}
+                        >
+                          <div
+                            className={clsx(
+                              'border border-primary/20 w-[38px] h-[38px]',
+                              isAvailable ? 'opacity-100' : 'strike-diagonal',
+                            )}
+                            style={{backgroundColor: value}}
+                          />
+                        </Link>
+                      ) : (
+                        <Link
+                          key={option.name + value}
+                          to={to}
+                          preventScrollReset
+                          prefetch="intent"
+                          replace
+                          className={clsx(
+                            'leading-none py-1 border-b-[1.5px] cursor-pointer transition-all duration-200',
+                            isActive ? 'border-primary/50' : 'border-primary/0',
+                            isAvailable ? 'opacity-100' : 'opacity-50',
+                          )}
+                        >
+                          {value}
+                        </Link>
+                      );
+                    })
                   )}
                 </div>
               </div>

--- a/templates/demo-store/app/styles/app.css
+++ b/templates/demo-store/app/styles/app.css
@@ -169,6 +169,20 @@ shop-pay-button {
     }
   }
 
+  .strike-diagonal {
+    position: relative;
+  &:before {
+     position: absolute;
+     content: '';
+     left: 0;
+     top: 50%;
+     right: 0;
+     border-top: 1px solid rgb(var(--color-contrast) / 0.6);
+     border-bottom: 1px solid rgb(var(--color-primary) / 0.3);
+     transform: skewY(-45deg);
+   }
+  }
+
   .card-image {
     @apply relative flex items-center justify-center overflow-clip rounded;
     &::before {


### PR DESCRIPTION
Improve UI/UX of product colour option selection on product page in demo-store

### WHAT is this pull request doing?

This implementation allows the user to see the colour of the product variants and select the product of the desired colour

![изображение](https://github.com/Shopify/hydrogen/assets/45523536/e61df834-9937-448a-8234-7a07bb73809b)

- Clicking on a coloured square will take you to the page of the selected product variant.
- The selected colour variant is highlighted with a frame
- Unavailable colour variant is crossed out with a diagonal line.


 it was also added colours to the options listbox (it shows up when there are more than 7 colours)

![изображение](https://github.com/Shopify/hydrogen/assets/159531672/19e201b5-58e9-4e41-8a12-d00521fe7a2d)

### HOW to test your changes?
- Go to a page of product that has several colour variants
- Here you will see squares with the colours of the product variants. 
- Click on a coloured square to take you to the page of the selected product variant.
- Chek selected and unavailabled pvoduct variants
- Go to a page of product that has more then 7 colour variants
- Here you will see variant colors in listbox 
- Check with browser dark theme

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation