### PR TITLE
Update next steps on deploy

### DIFF
--- a/packages/cli/src/commands/hydrogen/deploy.test.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.test.ts
@@ -554,10 +554,97 @@ describe('deploy', () => {
     } catch (err) {
       if (err instanceof AbortError) {
         expect(err.message).toBe('oh shit');
-        expect(err.tryMessage).toBe('Retrying the deployement may succeed.');
+        expect(err.tryMessage).toBe('Retrying the deployment may succeed.');
       } else {
         expect(true).toBe(false);
       }
     }
+  });
+
+  describe('next steps', () => {
+    it('renders a link to the deployment', async () => {
+      vi.mocked(createDeploy).mockResolvedValue({
+        url: 'https://a-lovely-deployment.com',
+      });
+
+      await oxygenDeploy(deployParams);
+
+      expect(vi.mocked(renderSuccess)).toHaveBeenCalledWith({
+        body: ['Successfully deployed to Oxygen'],
+        nextSteps: [
+          [
+            'Open',
+            {link: {url: 'https://a-lovely-deployment.com'}},
+            'in your browser to view your deployment.',
+          ],
+        ],
+      });
+    });
+
+    it('renders a link to the deployment and shows auth bypass token when one is created', async () => {
+      vi.mocked(createDeploy).mockResolvedValue({
+        url: 'https://a-lovely-deployment.com',
+        authBypassToken: 'some-token',
+      });
+
+      await oxygenDeploy(deployParams);
+
+      expect(vi.mocked(renderSuccess)).toHaveBeenCalledWith({
+        body: ['Successfully deployed to Oxygen'],
+        nextSteps: [
+          [
+            'Open',
+            {link: {url: 'https://a-lovely-deployment.com'}},
+            'in your browser to view your deployment.',
+          ],
+          [
+            'Use the',
+            {subdued: 'some-token'},
+            'token to perform end-to-end tests against the deployment.',
+          ],
+        ],
+      });
+    });
+
+    describe('when in a CI environment', () => {
+      it('renders information about h2_deploy_log.json', async () => {
+        vi.mocked(ciPlatform).mockReturnValue({
+          isCI: true,
+          name: 'github',
+          metadata: {},
+        });
+
+        await oxygenDeploy({...deployParams, token: 'fake-token'});
+
+        expect(vi.mocked(renderSuccess)).toHaveBeenCalledWith({
+          body: ['Successfully deployed to Oxygen'],
+          nextSteps: [
+            [
+              'View the deployment information in',
+              {subdued: 'h2_deploy_log.json'},
+            ],
+          ],
+        });
+      });
+
+      it('renders no next steps if jsonOutput is set to false', async () => {
+        vi.mocked(ciPlatform).mockReturnValue({
+          isCI: true,
+          name: 'github',
+          metadata: {},
+        });
+
+        await oxygenDeploy({
+          ...deployParams,
+          token: 'fake-token',
+          jsonOutput: false,
+        });
+
+        expect(vi.mocked(renderSuccess)).toHaveBeenCalledWith({
+          body: ['Successfully deployed to Oxygen'],
+          nextSteps: [],
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

When we have a successful deploy to Oxygen in CI, we don't want to output the deployment URL + the auth bypass token into the console

### WHAT is this pull request doing?

Update the "Next steps" and only output the URL + auth bypass token if you're not in CI

### HOW to test your changes?

checkout the repo
- `npm run ci`
- `cd packages/cli`
- `npm run build`
- `h2 deploy --path=/path/to/hydrogen-repo` (you have to run `h2 init` if you don't have an existing repo)

Set the `isCI` flag in the code to `true` to see what it would look like if you're in CI

#### No CI + no auth bypass token
![image](https://github.com/Shopify/hydrogen/assets/2907059/4f837e6d-f2f3-462c-8200-9d3ea18a759f)

#### NO CI + auth bypass token
![image](https://github.com/Shopify/hydrogen/assets/2907059/54b3f561-1e74-4ca2-8a81-07dd34a8a411)

#### CI + output JSON file
![image](https://github.com/Shopify/hydrogen/assets/2907059/d51005f8-b295-4ae1-bab1-18a3cd8c1896)

#### CI + don't output JSON file
![image](https://github.com/Shopify/hydrogen/assets/2907059/9bfce358-7353-4fbb-bf33-88d5ba59b112)


#### Post-merge steps

#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
