### PR TITLE
Add defensive null checks to the default cart implementation in all applicable /examples

### DIFF
--- a/examples/custom-cart-method/app/components/Cart.tsx
+++ b/examples/custom-cart-method/app/components/Cart.tsx
@@ -24,7 +24,7 @@ export function CartMain({layout, cart}: CartMainProps) {
   const linesCount = Boolean(cart?.lines?.nodes?.length || 0);
   const withDiscount =
     cart &&
-    Boolean(cart.discountCodes.filter((code) => code.applicable).length);
+    Boolean(cart?.discountCodes?.filter((code) => code.applicable)?.length);
   const className = `cart-main ${withDiscount ? 'with-discount' : ''}`;
 
   return (

--- a/examples/multipass/app/components/Cart.tsx
+++ b/examples/multipass/app/components/Cart.tsx
@@ -15,7 +15,7 @@ export function CartMain({layout, cart}: CartMainProps) {
   const linesCount = Boolean(cart?.lines?.nodes?.length || 0);
   const withDiscount =
     cart &&
-    Boolean(cart.discountCodes.filter((code) => code.applicable).length);
+    Boolean(cart?.discountCodes?.filter((code) => code.applicable)?.length);
   const className = `cart-main ${withDiscount ? 'with-discount' : ''}`;
 
   return (

--- a/examples/optimistic-cart-ui/app/components/Cart.tsx
+++ b/examples/optimistic-cart-ui/app/components/Cart.tsx
@@ -18,7 +18,7 @@ export function CartMain({layout, cart}: CartMainProps) {
   const linesCount = Boolean(cart?.lines?.nodes?.length || 0);
   const withDiscount =
     cart &&
-    Boolean(cart.discountCodes.filter((code) => code.applicable).length);
+    Boolean(cart?.discountCodes?.filter((code) => code.applicable)?.length);
   const className = `cart-main ${withDiscount ? 'with-discount' : ''}`;
 
   return (

--- a/examples/subscriptions/app/components/Cart.tsx
+++ b/examples/subscriptions/app/components/Cart.tsx
@@ -15,7 +15,7 @@ export function CartMain({layout, cart}: CartMainProps) {
   const linesCount = Boolean(cart?.lines?.nodes?.length || 0);
   const withDiscount =
     cart &&
-    Boolean(cart.discountCodes.filter((code) => code.applicable).length);
+    Boolean(cart?.discountCodes?.filter((code) => code.applicable)?.length);
   const className = `cart-main ${withDiscount ? 'with-discount' : ''}`;
 
   return (


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up to https://github.com/Shopify/hydrogen/pull/1746 

Some carts may not have discount codes, so make the default implementation more defensive.

### WHAT is this pull request doing?

Fixes the same bug, just in the applicable `/examples` folder, for the examples where this bug exists
