### PR TITLE
Fix skeleton predictive search

### DIFF
--- a/templates/skeleton/app/components/Layout.tsx
+++ b/templates/skeleton/app/components/Layout.tsx
@@ -76,7 +76,15 @@ function SearchAside() {
                 type="search"
               />
               &nbsp;
-              <button type="submit">Search</button>
+              <button
+                onClick={() => {
+                  window.location.href = inputRef?.current?.value
+                    ? `/search?q=${inputRef.current.value}`
+                    : `/search`;
+                }}
+              >
+                Search
+              </button>
             </div>
           )}
         </PredictiveSearchForm>

--- a/templates/skeleton/app/components/Search.tsx
+++ b/templates/skeleton/app/components/Search.tsx
@@ -3,7 +3,6 @@ import {
   Form,
   useParams,
   useFetcher,
-  useFetchers,
   type FormProps,
 } from '@remix-run/react';
 import {Image, Money, Pagination} from '@shopify/hydrogen';
@@ -251,7 +250,9 @@ export function PredictiveSearchForm({
   ...props
 }: SearchFromProps) {
   const params = useParams();
-  const fetcher = useFetcher<NormalizedPredictiveSearchResults>();
+  const fetcher = useFetcher<NormalizedPredictiveSearchResults>({
+    key: 'search',
+  });
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   function fetchResults(event: React.ChangeEvent<HTMLInputElement>) {
@@ -318,7 +319,6 @@ export function PredictiveSearchResults() {
           />
         ))}
       </div>
-      {/* view all results /search?q=term */}
       {searchTerm.current && (
         <Link onClick={goToSearchResult} to={`/search?q=${searchTerm.current}`}>
           <p>
@@ -425,10 +425,9 @@ type UseSearchReturn = NormalizedPredictiveSearch & {
 };
 
 function usePredictiveSearch(): UseSearchReturn {
-  const fetchers = useFetchers();
+  const searchFetcher = useFetcher<FetchSearchResultsReturn>({key: 'search'});
   const searchTerm = useRef<string>('');
   const searchInputRef = useRef<HTMLInputElement | null>(null);
-  const searchFetcher = fetchers.find((fetcher) => fetcher.data?.searchResults);
 
   if (searchFetcher?.state === 'loading') {
     searchTerm.current = (searchFetcher.formData?.get('q') || '') as string;

--- a/templates/skeleton/app/components/Search.tsx
+++ b/templates/skeleton/app/components/Search.tsx
@@ -7,7 +7,7 @@ import {
 } from '@remix-run/react';
 import {Image, Money, Pagination} from '@shopify/hydrogen';
 import React, {useRef, useEffect} from 'react';
-import {applyTrackingParams} from '~/routes/api.predictive-search';
+import {applyTrackingParams} from '~/lib/search';
 
 import type {
   PredictiveProductFragment,

--- a/templates/skeleton/app/lib/search.ts
+++ b/templates/skeleton/app/lib/search.ts
@@ -1,0 +1,29 @@
+import type {
+  PredictiveQueryFragment,
+  SearchProductFragment,
+  PredictiveProductFragment,
+  PredictiveCollectionFragment,
+  PredictivePageFragment,
+  PredictiveArticleFragment,
+} from 'storefrontapi.generated';
+
+export function applyTrackingParams(
+  resource:
+    | PredictiveQueryFragment
+    | SearchProductFragment
+    | PredictiveProductFragment
+    | PredictiveCollectionFragment
+    | PredictiveArticleFragment
+    | PredictivePageFragment,
+  params?: string,
+) {
+  if (params) {
+    return resource?.trackingParameters
+      ? `?${params}&${resource.trackingParameters}`
+      : `?${params}`;
+  } else {
+    return resource?.trackingParameters
+      ? `?${resource.trackingParameters}`
+      : '';
+  }
+}

--- a/templates/skeleton/app/routes/api.predictive-search.tsx
+++ b/templates/skeleton/app/routes/api.predictive-search.tsx
@@ -4,6 +4,7 @@ import type {
   NormalizedPredictiveSearchResults,
 } from '~/components/Search';
 import {NO_PREDICTIVE_SEARCH_RESULTS} from '~/components/Search';
+import {applyTrackingParams} from '~/lib/search';
 
 import type {
   PredictiveArticleFragment,
@@ -13,12 +14,6 @@ import type {
   PredictiveQueryFragment,
   PredictiveSearchQuery,
 } from 'storefrontapi.generated';
-
-type PredictiveSearchResultItem =
-  | PredictiveArticleFragment
-  | PredictiveCollectionFragment
-  | PredictivePageFragment
-  | PredictiveProductFragment;
 
 type PredictiveSearchTypes =
   | 'ARTICLE'
@@ -104,19 +99,6 @@ async function fetchPredictiveSearchResults({
   );
 
   return {searchResults, searchTerm, searchTypes};
-}
-
-export function applyTrackingParams(
-  resource: PredictiveSearchResultItem | PredictiveQueryFragment,
-  params?: string,
-) {
-  if (params) {
-    return resource.trackingParameters
-      ? `?${params}&${resource.trackingParameters}`
-      : `?${params}`;
-  } else {
-    return resource.trackingParameters ? `?${resource.trackingParameters}` : '';
-  }
 }
 
 /**

--- a/templates/skeleton/app/routes/api.predictive-search.tsx
+++ b/templates/skeleton/app/routes/api.predictive-search.tsx
@@ -106,6 +106,19 @@ async function fetchPredictiveSearchResults({
   return {searchResults, searchTerm, searchTypes};
 }
 
+export function applyTrackingParams(
+  resource: PredictiveSearchResultItem | PredictiveQueryFragment,
+  params?: string,
+) {
+  if (params) {
+    return resource.trackingParameters
+      ? `?${params}&${resource.trackingParameters}`
+      : `?${params}`;
+  } else {
+    return resource.trackingParameters ? `?${resource.trackingParameters}` : '';
+  }
+}
+
 /**
  * Normalize results and apply tracking qurery parameters to each result url
  */
@@ -119,21 +132,6 @@ export function normalizePredictiveSearchResults(
       results: NO_PREDICTIVE_SEARCH_RESULTS,
       totalResults,
     };
-  }
-
-  function applyTrackingParams(
-    resource: PredictiveSearchResultItem | PredictiveQueryFragment,
-    params?: string,
-  ) {
-    if (params) {
-      return resource.trackingParameters
-        ? `?${params}&${resource.trackingParameters}`
-        : `?${params}`;
-    } else {
-      return resource.trackingParameters
-        ? `?${resource.trackingParameters}`
-        : '';
-    }
   }
 
   const localePrefix = locale ? `/${locale}` : '';

--- a/templates/skeleton/app/routes/search.tsx
+++ b/templates/skeleton/app/routes/search.tsx
@@ -41,7 +41,10 @@ export async function loader({request, context}: LoaderFunctionArgs) {
     totalResults,
   };
 
-  return defer({searchTerm, searchResults});
+  return defer({
+    searchTerm,
+    searchResults,
+  });
 }
 
 export default function SearchPage() {
@@ -54,7 +57,10 @@ export default function SearchPage() {
       {!searchTerm || !searchResults.totalResults ? (
         <NoSearchResults />
       ) : (
-        <SearchResults results={searchResults.results} />
+        <SearchResults
+          results={searchResults.results}
+          searchTerm={searchTerm}
+        />
       )}
     </div>
   );

--- a/templates/skeleton/app/styles/app.css
+++ b/templates/skeleton/app/styles/app.css
@@ -292,6 +292,15 @@ aside li {
   margin-bottom: 0.5rem;
 }
 
+.search-results-item a {
+  display: flex;
+  flex: row;
+  align-items: center;
+  gap: 1rem;
+}
+
+
+
 /*
 * --------------------------------------------------
 * routes/__index


### PR DESCRIPTION
Closes https://github.com/Shopify/hydrogen/issues/1760

- Adds trackingParams to /search route results
- Adds image and price to product /search results
- Fixes predictive search UI bug

Fixed UI
![search](https://github.com/Shopify/hydrogen/assets/12080141/e9539ee9-d859-4e30-ac91-650e678dc423)


Tracking on product search results
<img width="746" alt="Screenshot 2024-02-21 at 11 48 56 AM" src="https://github.com/Shopify/hydrogen/assets/12080141/e08844a8-edee-48ea-bbc0-8013e510f5a7">
