### PR TITLE
Add a PoC implementation of the new GraphQL defer directive on the SFAPI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "docs/preview",
         "examples/custom-cart-method",
         "examples/express",
+        "examples/infinite-scroll",
         "examples/legacy-customer-account-flow",
         "examples/metaobjects",
         "examples/multipass",
@@ -16,7 +17,6 @@
         "examples/partytown",
         "examples/subscriptions",
         "examples/third-party-queries-caching",
-        "examples/infinite-scroll",
         "packages/cli",
         "packages/create-hydrogen",
         "packages/hydrogen",
@@ -89,7 +89,7 @@
         "@remix-run/node": "^2.6.0",
         "@remix-run/react": "^2.6.0",
         "@remix-run/server-runtime": "^2.6.0",
-        "@shopify/hydrogen": "2024.1.1",
+        "@shopify/hydrogen": "2024.1.2",
         "compression": "^1.7.4",
         "cross-env": "^7.0.3",
         "express": "^4.18.2",
@@ -102,7 +102,7 @@
         "@remix-run/dev": "^2.6.0",
         "@remix-run/eslint-config": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
         "@types/compression": "^1.7.2",
         "@types/express": "^4.17.17",
         "@types/morgan": "^1.9.4",
@@ -119,6 +119,7 @@
       }
     },
     "examples/infinite-scroll": {
+      "name": "example-infinite-scroll",
       "dependencies": {
         "react-intersection-observer": "^8.32.0"
       }
@@ -146,8 +147,8 @@
       "dependencies": {
         "@remix-run/react": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
         "crypto-js": "^4.2.0",
         "graphql": "^16.6.0",
@@ -192,8 +193,8 @@
         "@builder.io/partytown": "^0.8.1",
         "@remix-run/react": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
@@ -225,8 +226,8 @@
       "dependencies": {
         "@remix-run/react": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
@@ -8572,6 +8573,11 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/@shopify/graphql-client": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@shopify/graphql-client/-/graphql-client-0.10.2.tgz",
+      "integrity": "sha512-KYZ2m/VFDOCv457tgeUT+NsRC6qhKtLR/8EPcEbO3GSwfnzejYAfibMfnVNoRDJAJ+jIREVZ47/PbVJ+Hf9CCA=="
+    },
     "node_modules/@shopify/hydrogen": {
       "resolved": "packages/hydrogen",
       "link": true
@@ -8657,6 +8663,14 @@
     "node_modules/@shopify/remix-oxygen": {
       "resolved": "packages/remix-oxygen",
       "link": true
+    },
+    "node_modules/@shopify/storefront-api-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@shopify/storefront-api-client/-/storefront-api-client-0.3.2.tgz",
+      "integrity": "sha512-bB1FWtIfM/jg/zqgZ6ykve3vGrfxfSzrw+ZNLTUoZrHVlfL1l146UCpUlKbGC0O/YOJvonHzvGWQDAUXO2rXDw==",
+      "dependencies": {
+        "@shopify/graphql-client": "^0.10.2"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -31922,7 +31936,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -32176,10 +32190,10 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2024.1.1",
+      "version": "2024.1.2",
       "license": "MIT",
       "dependencies": {
-        "@shopify/hydrogen-react": "2024.1.0",
+        "@shopify/hydrogen-react": "2024.1.1",
         "content-security-policy-builder": "^2.1.1",
         "type-fest": "^4.5.0"
       },
@@ -32233,7 +32247,7 @@
     },
     "packages/hydrogen-react": {
       "name": "@shopify/hydrogen-react",
-      "version": "2024.1.0",
+      "version": "2024.1.1",
       "license": "MIT",
       "dependencies": {
         "@google/model-viewer": "^1.12.1",
@@ -32617,9 +32631,10 @@
         "@remix-run/react": "^2.6.0",
         "@remix-run/server-runtime": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
+        "@shopify/storefront-api-client": "^0.3.2",
         "clsx": "^1.2.1",
         "cross-env": "^7.0.3",
         "graphql": "^16.6.0",
@@ -32667,8 +32682,8 @@
         "@remix-run/react": "^2.6.0",
         "@remix-run/server-runtime": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
         "@total-typescript/ts-reset": "^0.4.2",
         "graphql": "^16.6.0",
@@ -32694,13 +32709,13 @@
       }
     },
     "templates/skeleton": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@remix-run/react": "^2.6.0",
         "@remix-run/server-runtime": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
@@ -38367,6 +38382,11 @@
         }
       }
     },
+    "@shopify/graphql-client": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@shopify/graphql-client/-/graphql-client-0.10.2.tgz",
+      "integrity": "sha512-KYZ2m/VFDOCv457tgeUT+NsRC6qhKtLR/8EPcEbO3GSwfnzejYAfibMfnVNoRDJAJ+jIREVZ47/PbVJ+Hf9CCA=="
+    },
     "@shopify/hydrogen": {
       "version": "file:packages/hydrogen",
       "requires": {
@@ -38374,7 +38394,7 @@
         "@remix-run/server-runtime": "^2.6.0",
         "@shopify/generate-docs": "0.11.1",
         "@shopify/hydrogen-codegen": "*",
-        "@shopify/hydrogen-react": "2024.1.0",
+        "@shopify/hydrogen-react": "2024.1.1",
         "@testing-library/react": "^14.0.0",
         "content-security-policy-builder": "^2.1.1",
         "happy-dom": "^8.9.0",
@@ -38709,6 +38729,14 @@
       "requires": {
         "@remix-run/server-runtime": "^2.6.0",
         "@shopify/oxygen-workers-types": "^4.0.0"
+      }
+    },
+    "@shopify/storefront-api-client": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@shopify/storefront-api-client/-/storefront-api-client-0.3.2.tgz",
+      "integrity": "sha512-bB1FWtIfM/jg/zqgZ6ykve3vGrfxfSzrw+ZNLTUoZrHVlfL1l146UCpUlKbGC0O/YOJvonHzvGWQDAUXO2rXDw==",
+      "requires": {
+        "@shopify/graphql-client": "^0.10.2"
       }
     },
     "@sinclair/typebox": {
@@ -41953,12 +41981,13 @@
         "@remix-run/react": "^2.6.0",
         "@remix-run/server-runtime": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
         "@shopify/eslint-plugin": "^42.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
+        "@shopify/storefront-api-client": "^0.3.2",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/typography": "^0.5.9",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -43136,8 +43165,8 @@
         "@remix-run/react": "^2.6.0",
         "@remix-run/server-runtime": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "2024.1.2",
         "@types/compression": "^1.7.2",
         "@types/express": "^4.17.17",
         "@types/morgan": "^1.9.4",
@@ -43188,8 +43217,8 @@
         "@remix-run/eslint-config": "^2.6.0",
         "@remix-run/react": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/oxygen-workers-types": "^3.17.3",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
@@ -43230,8 +43259,8 @@
         "@remix-run/eslint-config": "^2.6.0",
         "@remix-run/react": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
@@ -43258,8 +43287,8 @@
         "@remix-run/eslint-config": "^2.6.0",
         "@remix-run/react": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
@@ -44305,8 +44334,8 @@
         "@remix-run/react": "^2.6.0",
         "@remix-run/server-runtime": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.3",
@@ -51330,8 +51359,8 @@
         "@remix-run/react": "^2.6.0",
         "@remix-run/server-runtime": "^2.6.0",
         "@shopify/cli": "3.52.0",
-        "@shopify/cli-hydrogen": "^7.0.1",
-        "@shopify/hydrogen": "~2024.1.1",
+        "@shopify/cli-hydrogen": "^7.1.0",
+        "@shopify/hydrogen": "~2024.1.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.3",

--- a/templates/demo-store/app/routes/test.tsx
+++ b/templates/demo-store/app/routes/test.tsx
@@ -1,0 +1,157 @@
+import {Await, useLoaderData} from '@remix-run/react';
+import {type LoaderFunctionArgs, defer} from '@remix-run/server-runtime';
+import {createStorefrontApiClient} from '@shopify/storefront-api-client';
+import {type DocumentNode, parse} from 'graphql';
+import {Suspense} from 'react';
+
+export async function loader({context}: LoaderFunctionArgs) {
+  const result = await deferQuery(context.env, query, {
+    productId: 'gid://shopify/Product/6730850828344',
+  });
+
+  return defer(result);
+}
+
+export default function () {
+  const {product, productRecommendations} = useLoaderData<typeof loader>();
+  return (
+    <>
+      <h1>Product: {product.title}</h1>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Await
+          errorElement="There was a problem loading related products"
+          resolve={productRecommendations}
+        >
+          {(products) => (
+            <h2>
+              Related products:{' '}
+              {products.map((product) => product.title).join(', ')}
+            </h2>
+          )}
+        </Await>
+      </Suspense>
+    </>
+  );
+}
+
+const query = `#graphql
+query productA($productId: ID!) {
+  product(id: $productId) {
+    id
+    title
+  }
+  ... relatedProducts @defer
+}
+fragment relatedProducts on QueryRoot {
+  productRecommendations(productId: $productId) {
+    id
+    title
+  }
+}
+`;
+
+async function deferQuery(
+  env: any,
+  query: string,
+  variables: Record<string, string> = {},
+): Promise<any> {
+  const parsed = parse(query);
+
+  const {responsePromises, responseResolvers} =
+    getDeferredQueryPromises(parsed);
+
+  const client = createStorefrontApiClient({
+    storeDomain: env.PUBLIC_STORE_DOMAIN,
+    apiVersion: 'unstable',
+    publicAccessToken: env.PUBLIC_STOREFRONT_API_TOKEN,
+  });
+
+  const stream = await client.requestStream(query, {variables});
+
+  // eslint-disable-next-line no-async-promise-executor
+  return new Promise(async (resolve, reject) => {
+    try {
+      let initialResolution;
+      for await (const chunk of stream) {
+        if (!initialResolution) {
+          initialResolution = {...chunk.data, ...responsePromises};
+          resolve(initialResolution);
+        }
+        for (const key in responseResolvers) {
+          if (chunk.data && key in chunk.data) {
+            responseResolvers[key].resolved = true;
+            responseResolvers[key].resolve(chunk.data[key]);
+          }
+        }
+      }
+
+      for (const key in responseResolvers) {
+        if (!responseResolvers[key].resolved) {
+          responseResolvers[key].reject(
+            new Error('Deferred response not resolved'),
+          );
+        }
+      }
+    } catch (e) {
+      reject(e);
+    }
+  });
+}
+
+function getDeferredQueryPromises(parsed: DocumentNode) {
+  const responsePromises: Record<string, Promise<any>> = {};
+  const responseResolvers: Record<
+    string,
+    {
+      resolve: (resolve: any) => void;
+      reject: (error: any) => void;
+      resolved: boolean;
+    }
+  > = {};
+
+  const operations = parsed.definitions.filter((definition) =>
+    'kind' in definition ? definition?.kind === 'OperationDefinition' : false,
+  );
+  const fragments = parsed.definitions.filter((definition) =>
+    'kind' in definition ? definition?.kind === 'FragmentDefinition' : false,
+  );
+
+  operations.forEach((operation) => {
+    if ('selectionSet' in operation) {
+      operation.selectionSet.selections.forEach((selection) => {
+        if (
+          selection.directives?.find(
+            (directive) => directive.name.value === 'defer',
+          ) &&
+          'name' in selection
+        ) {
+          const matchingFragment = fragments.find((fragment) =>
+            'name' in fragment
+              ? fragment.name?.value === selection.name.value
+              : false,
+          );
+
+          if (matchingFragment && 'selectionSet' in matchingFragment) {
+            matchingFragment.selectionSet.selections.forEach(
+              (fragmentSelection) => {
+                if ('name' in fragmentSelection) {
+                  responsePromises[fragmentSelection.name.value] = new Promise(
+                    (resolve, reject) => {
+                      responseResolvers[fragmentSelection.name.value] = {
+                        resolved: false,
+                        resolve,
+                        reject,
+                      };
+                    },
+                  );
+                }
+              },
+            );
+          }
+        }
+      });
+    }
+  });
+
+  return {responsePromises, responseResolvers};
+}

--- a/templates/demo-store/package.json
+++ b/templates/demo-store/package.json
@@ -37,7 +37,8 @@
     "react-use": "^17.4.0",
     "schema-dts": "^1.1.0",
     "tiny-invariant": "^1.2.0",
-    "typographic-base": "^1.0.4"
+    "typographic-base": "^1.0.4",
+    "@shopify/storefront-api-client": "^0.3.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.40.1",


### PR DESCRIPTION
This is a proof of concept implementation of the new [GraphQL defer directive on the SFAPI](https://shopify.dev/docs/custom-storefronts/building-with-the-storefront-api/defer).

A few notes:

1. It requires the defer directive developer preview: https://shopify.dev/docs/api/release-notes/developer-previews#defer-directive-developer-preview
2. It uses the `@shopify/storefront-api-client` package, because hydrogen's built in api client does not yet support defer/streaming.
3. At runtime, it parses the GraphQL query, finds the `defer` directives, and replaces the associated fragment properties with inline promises that resolve after the data is available.
4. It only supports top level deferred properties. Not nested.