### PR TITLE
Hide non-actionable warning in Codegen

### DIFF
--- a/.changeset/mighty-lizards-whisper.md
+++ b/.changeset/mighty-lizards-whisper.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Hide a non-actionable warning in Codegen about a deprecated module `punycode`.

--- a/packages/cli/src/lib/codegen.ts
+++ b/packages/cli/src/lib/codegen.ts
@@ -74,6 +74,8 @@ export function spawnCodegenProcess({
 
     const {message, details} = normalizeCodegenError(dataString, rootDirectory);
 
+    if (/`punycode`/.test(message)) return;
+
     console.log('');
     renderWarning({headline: message, body: details});
   });


### PR DESCRIPTION
We are starting to get a warning about a deprecated Node module in a subdependency. This hides the warning since it's not actionable:

<img width="679" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/88942e1e-077b-4b62-86a4-d0bb15b39767">

I've tracked this to be in `whatwg-url`, which has already fixed this in v13 or so. However, other Codegen and GraphQL dependencies are using v2 or v5...