### PR TITLE
[cli] Push command has quotes around multiline

### DIFF
--- a/packages/cli/src/commands/hydrogen/env/push__unstable.ts
+++ b/packages/cli/src/commands/hydrogen/env/push__unstable.ts
@@ -25,7 +25,7 @@ import {linkStorefront} from '../link.js';
 import {getStorefrontEnvVariables} from '../../../lib/graphql/admin/pull-variables.js';
 import {pushStorefrontEnvVariables} from '../../../lib/graphql/admin/push-variables.js';
 import {AbortError} from '@shopify/cli-kit/node/error';
-import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env';
+import {readAndParseDotEnv, createDotEnvFileLine} from '@shopify/cli-kit/node/dot-env';
 
 export default class EnvPush extends Command {
   static description =
@@ -173,7 +173,7 @@ export async function runEnvPush({
   const comparableRemoteVars =
     remoteVars
       .sort((a, b) => a.key.localeCompare(b.key))
-      .map(({key, value}) => `${key}=${value}`)
+      .map(({key, value}) => createDotEnvFileLine(key, value))
       .join('\n') + '\n';
 
   const compareableLocalVars =
@@ -183,7 +183,7 @@ export async function runEnvPush({
         const {isSecret, readOnly} =
           environmentVariables.find((variable) => variable.key === key) ?? {};
         if (isSecret || readOnly) return acc;
-        return [...acc, `${key}=${localVariables[key]}`];
+        return [...acc, createDotEnvFileLine(key, localVariables[key])];
       }, [] as string[])
       .join('\n') + '\n';
 


### PR DESCRIPTION
### WHY are these changes introduced?

Requires update to cli-kit: https://github.com/Shopify/cli/pull/3494

The current `push__unstable` command does not show quotes around multiline environment variables when showing the diff

### WHAT is this pull request doing?

- Update the cli-kit version
  - Call the `createDotEnvFileLine` method

### HOW to test your changes?

1. checkout code
2. `npm ci`
3. `cd packages/cli`
4. `npx shopify hydrogen env push__unstable --path=/path/to/repo` (if you don't have a repo, create it using the `npx shopify init` command

![image](https://github.com/Shopify/hydrogen/assets/2907059/44fb3d2d-4a05-4253-ae8e-176a983af98f)

#### Post-merge steps


#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
