### PR TITLE
Add `--quickstart` flag to init command

### DIFF
--- a/.changeset/pretty-gifts-rest.md
+++ b/.changeset/pretty-gifts-rest.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Add `--quickstart` flag option to init/create command

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1206,6 +1206,130 @@
         "cpu.js"
       ]
     },
+    "hydrogen:env:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the environments on your linked Hydrogen storefront.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:list",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "env",
+        "list.js"
+      ]
+    },
+    "hydrogen:env:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Populate your .env with variables from your Hydrogen storefront.",
+      "flags": {
+        "env-branch": {
+          "char": "e",
+          "description": "Specifies the environment to pull variables from using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:pull",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "env",
+        "pull.js"
+      ]
+    },
+    "hydrogen:env:push__unstable": {
+      "aliases": [],
+      "args": {},
+      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
+      "flags": {
+        "env": {
+          "description": "Specifies an environment's name when using remote environment variables.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_NAME",
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-file": {
+          "description": "Specify the environment variable file name. Default value is '.env'.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_FILENAME",
+          "name": "env-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:push__unstable",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "env",
+        "push__unstable.js"
+      ]
+    },
     "hydrogen:generate:route": {
       "aliases": [],
       "args": {
@@ -1346,130 +1470,6 @@
         "hydrogen",
         "generate",
         "routes.js"
-      ]
-    },
-    "hydrogen:env:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List the environments on your linked Hydrogen storefront.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:env:list",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "env",
-        "list.js"
-      ]
-    },
-    "hydrogen:env:pull": {
-      "aliases": [],
-      "args": {},
-      "description": "Populate your .env with variables from your Hydrogen storefront.",
-      "flags": {
-        "env-branch": {
-          "char": "e",
-          "description": "Specifies the environment to pull variables from using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "name": "env-branch",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "force": {
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:env:pull",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "env",
-        "pull.js"
-      ]
-    },
-    "hydrogen:env:push__unstable": {
-      "aliases": [],
-      "args": {},
-      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
-      "flags": {
-        "env": {
-          "description": "Specifies an environment's name when using remote environment variables.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_NAME",
-          "name": "env",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "env-file": {
-          "description": "Specify the environment variable file name. Default value is '.env'.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_FILENAME",
-          "name": "env-file",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [],
-      "id": "hydrogen:env:push__unstable",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "env",
-        "push__unstable.js"
       ]
     },
     "hydrogen:setup:css": {

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1206,130 +1206,6 @@
         "cpu.js"
       ]
     },
-    "hydrogen:env:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List the environments on your linked Hydrogen storefront.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:env:list",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "env",
-        "list.js"
-      ]
-    },
-    "hydrogen:env:pull": {
-      "aliases": [],
-      "args": {},
-      "description": "Populate your .env with variables from your Hydrogen storefront.",
-      "flags": {
-        "env-branch": {
-          "char": "e",
-          "description": "Specifies the environment to pull variables from using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "name": "env-branch",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "force": {
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:env:pull",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "env",
-        "pull.js"
-      ]
-    },
-    "hydrogen:env:push__unstable": {
-      "aliases": [],
-      "args": {},
-      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
-      "flags": {
-        "env": {
-          "description": "Specifies an environment's name when using remote environment variables.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_NAME",
-          "name": "env",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "env-file": {
-          "description": "Specify the environment variable file name. Default value is '.env'.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_FILENAME",
-          "name": "env-file",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [],
-      "id": "hydrogen:env:push__unstable",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "env",
-        "push__unstable.js"
-      ]
-    },
     "hydrogen:generate:route": {
       "aliases": [],
       "args": {
@@ -1470,6 +1346,130 @@
         "hydrogen",
         "generate",
         "routes.js"
+      ]
+    },
+    "hydrogen:env:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the environments on your linked Hydrogen storefront.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:list",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "env",
+        "list.js"
+      ]
+    },
+    "hydrogen:env:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Populate your .env with variables from your Hydrogen storefront.",
+      "flags": {
+        "env-branch": {
+          "char": "e",
+          "description": "Specifies the environment to pull variables from using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:pull",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "env",
+        "pull.js"
+      ]
+    },
+    "hydrogen:env:push__unstable": {
+      "aliases": [],
+      "args": {},
+      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
+      "flags": {
+        "env": {
+          "description": "Specifies an environment's name when using remote environment variables.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_NAME",
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-file": {
+          "description": "Specify the environment variable file name. Default value is '.env'.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_FILENAME",
+          "name": "env-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:push__unstable",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "env",
+        "push__unstable.js"
       ]
     },
     "hydrogen:setup:css": {

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -765,6 +765,13 @@
           "name": "git",
           "allowNo": true,
           "type": "boolean"
+        },
+        "quickstart": {
+          "description": "Scaffolds a new Hydrogen project with a set of sensible defaults.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_QUICKSTART",
+          "name": "quickstart",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/cli/src/commands/hydrogen/init.test.ts
+++ b/packages/cli/src/commands/hydrogen/init.test.ts
@@ -196,7 +196,6 @@ describe('init', () => {
         expect(output).not.toMatch('warning');
         expect(output).not.toMatch('Routes');
         expect(output).toMatch(/Language:\s*TypeScript/);
-        expect(output).toMatch('Help');
         expect(output).toMatch('Next steps');
         expect(output).toMatch(
           // Output contains banner characters. USe [^\w]*? to match them.
@@ -368,7 +367,6 @@ describe('init', () => {
         expect(output).toMatch(basename(tmpDir));
         expect(output).not.toMatch('Routes');
         expect(output).toMatch(/Language:\s*TypeScript/);
-        expect(output).toMatch('Help');
         expect(output).toMatch('Next steps');
         expect(output).toMatch(
           // Output contains banner characters. USe [^\w]*? to match them.
@@ -821,6 +819,52 @@ describe('init', () => {
           } finally {
             await close();
           }
+        });
+      });
+    });
+
+    describe('Quickstart options', () => {
+      it('Scaffolds Quickstart project with expected values', async () => {
+        await inTemporaryDirectory(async (tmpDir) => {
+          await runInit({
+            path: tmpDir,
+            quickstart: true,
+            installDeps: false,
+          });
+
+          const templateFiles = await glob('**/*', {
+            cwd: getSkeletonSourceDir().replace(
+              'skeleton',
+              'hydrogen-quickstart',
+            ),
+            ignore: ['**/node_modules/**', '**/dist/**'],
+          });
+          const resultFiles = await glob('**/*', {cwd: tmpDir});
+          const nonAppFiles = templateFiles.filter(
+            (item) => !item.startsWith('app/'),
+          );
+
+          expect(resultFiles).toEqual(expect.arrayContaining(nonAppFiles));
+
+          expect(resultFiles).toContain('app/root.jsx');
+          expect(resultFiles).toContain('app/entry.client.jsx');
+          expect(resultFiles).toContain('app/entry.server.jsx');
+          expect(resultFiles).toContain('app/components/Layout.jsx');
+          expect(resultFiles).toContain('app/routes/_index.jsx');
+          expect(resultFiles).not.toContain('app/routes/($locale)._index.jsx');
+
+          // await expect(readFile(`${tmpDir}/package.json`)).resolves.toMatch(
+          //   `"name": "hello-world"`,
+          // );
+
+          const output = outputMock.info();
+          expect(output).not.toMatch('warning');
+          expect(output).toMatch('success');
+          expect(output).toMatch(/Shopify:\s+Mock.shop/);
+          expect(output).toMatch(/Language:\s+JavaScript/);
+          expect(output).toMatch(/Styling:\s+Tailwind/);
+          expect(output).toMatch('Routes');
+          expect(output).toMatch('Next steps');
         });
       });
     });

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -65,10 +65,11 @@ export default class Init extends Command {
       allowNo: true,
     }),
     quickstart: Flags.boolean({
-      description: 'Scaffolds a new Hydrogen project with a set of sensible defaults.',
-      env: 'SHOPIFY_HYDROGEN_FLAG_QUICKSTART' ,
+      description:
+        'Scaffolds a new Hydrogen project with a set of sensible defaults.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_QUICKSTART',
       default: false,
-    })
+    }),
   };
 
   async run(): Promise<void> {
@@ -113,7 +114,7 @@ export async function runInit(
    * Logical OR assignment means you can still override individual options by flag:
    * $ h2 init --quickstart --language ts
    */
-  if(options.quickstart) {
+  if (options.quickstart) {
     options.i18n ||= 'none';
     options.installDeps ||= true;
     options.language ||= 'js';

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -64,6 +64,11 @@ export default class Init extends Command {
       default: true,
       allowNo: true,
     }),
+    quickstart: Flags.boolean({
+      description: 'Scaffolds a new Hydrogen project with a set of sensible defaults.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_QUICKSTART' ,
+      default: false,
+    })
   };
 
   async run(): Promise<void> {
@@ -102,6 +107,22 @@ export async function runInit(
   supressNodeExperimentalWarnings();
 
   options.git ??= true;
+
+  /**
+   * Quickstart options. A set of sensible defaults to streamline documentation.
+   * Logical OR assignment means you can still override individual options by flag:
+   * $ h2 init --quickstart --language ts
+   */
+  if(options.quickstart) {
+    options.i18n ||= 'none';
+    options.installDeps ||= true;
+    options.language ||= 'js';
+    options.mockShop ||= true;
+    options.path ||= './hydrogen-quickstart';
+    options.routes ||= true;
+    options.shortcut ||= true;
+    options.styling ||= 'tailwind';
+  }
 
   const showUpgrade = await checkHydrogenVersion(
     // Resolving the CLI package from a local directory might fail because

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -75,6 +75,7 @@ export type InitOptions = {
   shortcut?: boolean;
   installDeps?: boolean;
   git?: boolean;
+  quickstart?: boolean;
 };
 
 export const LANGUAGES = {

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -626,6 +626,13 @@ export async function renderProjectReady(
 
   const render = hasErrors ? renderWarning : renderSuccess;
 
+  // Dynamically set "Next steps" for success message
+  const nextSteps = [];
+
+  if (true) {
+    nextSteps.push(['Dependencies', 'were installed'])
+  }
+
   render({
     headline:
       `Storefront setup complete` +
@@ -664,39 +671,6 @@ export async function renderProjectReady(
             },
           },
         ],
-      },
-      {
-        title: 'Help\n',
-        body: {
-          list: {
-            items: [
-              {
-                link: {
-                  label: 'Guides',
-                  url: 'https://h2o.fyi/building',
-                },
-              },
-              {
-                link: {
-                  label: 'API reference',
-                  url: 'https://shopify.dev/docs/api/storefront',
-                },
-              },
-              {
-                link: {
-                  label: 'Demo Store code',
-                  url: 'https://github.com/Shopify/hydrogen/tree/HEAD/templates/demo-store',
-                },
-              },
-              [
-                'Run',
-                {
-                  command: `${cliCommand} --help`,
-                },
-              ],
-            ],
-          },
-        },
       },
       {
         title: 'Next steps\n',

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -630,7 +630,7 @@ export async function renderProjectReady(
   const nextSteps = [];
 
   if (true) {
-    nextSteps.push(['Dependencies', 'were installed'])
+    nextSteps.push(['Dependencies', 'were installed']);
   }
 
   render({

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -108,15 +108,22 @@ export async function setupLocalStarterTemplate(
     )
     .catch(abort);
 
+  // Note: Async task titles automatically have '...' appended
+  const initMsg = {
+    create: 'Creating storefront',
+    setup: `Setting up ${options.quickstart ? 'Quickstart ': ''}project`,
+    install: 'Installing dependencies. This could take a few minutes',
+  }
+
   const tasks = [
     {
-      title: 'Creating storefront',
+      title: initMsg.create,
       task: async () => {
         await createStorefrontPromise;
       },
     },
     {
-      title: 'Setting up project',
+      title: initMsg.setup,
       task: async () => {
         await backgroundWorkPromise;
       },
@@ -249,7 +256,7 @@ export async function setupLocalStarterTemplate(
     });
 
     tasks.push({
-      title: 'Installing dependencies. This could take a few minutes',
+      title: initMsg.install,
       task: async () => {
         await installingDepsPromise;
       },
@@ -272,12 +279,17 @@ export async function setupLocalStarterTemplate(
     showShortcutBanner();
   }
 
-  renderSuccess({
-    headline: [
-      {userInput: storefrontInfo?.title ?? project.name},
-      'is ready to build.',
-    ],
-  });
+  // If running in --quickstart mode, skip this success banner
+  if (options.quickstart) {
+    console.log("\n");
+  } else {
+    renderSuccess({
+      headline: [
+        {userInput: storefrontInfo?.title ?? project.name},
+        'is ready to build.',
+      ],
+    });
+  }
 
   const continueWithSetup =
     (options.i18n ?? options.routes) !== undefined ||

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -111,9 +111,9 @@ export async function setupLocalStarterTemplate(
   // Note: Async task titles automatically have '...' appended
   const initMsg = {
     create: 'Creating storefront',
-    setup: `Setting up ${options.quickstart ? 'Quickstart ': ''}project`,
+    setup: `Setting up ${options.quickstart ? 'Quickstart ' : ''}project`,
     install: 'Installing dependencies. This could take a few minutes',
-  }
+  };
 
   const tasks = [
     {
@@ -281,7 +281,7 @@ export async function setupLocalStarterTemplate(
 
   // If running in --quickstart mode, skip this success banner
   if (options.quickstart) {
-    console.log("\n");
+    console.log('\n');
   } else {
     renderSuccess({
       headline: [


### PR DESCRIPTION
### Why are these changes introduced?
We want to make it fast to set up a Hydrogen app with a set of sensible defaults. This is helpful for users who are just kicking the tires and want to see what it's about. It also helps to streamline documentation, eliminating forks in the critical path and reducing decision fatigue.

### What is this pull request doing?
This PR adds a new `--quickstart` flag to the `init` command. With no further user input required, it scaffolds a new Hydrogen project with the following defaults (which are the same ones we currently [recommend](https://shopify.dev/docs/custom-storefronts/hydrogen/getting-started#step-1-create-a-new-hydrogen-app), but which need to be selected manually by the user):

Option | Value
--- | ---
Storefront/data source | Mock.shop
Project name and path | `./hydrogen-quickstart`
Language | JavaScript
CSS library | Tailwind
Install dependencies? | Yes
Install `h2` alias? | Yes
Scaffold standard routes? | Yes
Enable Markets support? | No

While these are the defaults, you can still override each option if you pass their respective flags with the quickstart flag.

### How to test your changes? 🎩 

1. Checkout the branch
2. In the monorepo, run `npx shopify hydrogen init --quickstart`
3. Validate that a new Hydrogen project is scaffolded at `./hydrogen-quickstart`.
4. Also try overrides with individual flags. For example, TypeScript: `npx shopify hydrogen init --quickstart --language ts`

#### 🎬 

https://github.com/Shopify/hydrogen/assets/547470/b2f140e0-2bc8-4f29-8283-d5bb81cf9ea0

**Update:** Also resolved the double-success-banner issue, and removed extraneous help links from the final succcess message:
![image](https://github.com/Shopify/hydrogen/assets/547470/21b05b55-cbfe-4b6e-b75a-a0f69c038d1b)



### Todos
- [x] Tests — probably need an assist here
- [ ] Documentation updates should ship in parallel
