### PR TITLE
Add `--env` & deprecate `--env-branch` flag for Hydrogen CLI commands

### DIFF
--- a/.changeset/lovely-donkeys-destroy.md
+++ b/.changeset/lovely-donkeys-destroy.md
@@ -1,0 +1,10 @@
+---
+'@shopify/cli-hydrogen': minor
+---
+
+`--env` flag has deprecated the `--env-branch` flag for several Hydrogen CLI commands
+
+- `--env` will allow the user to provide an environment's handle when performing Hydrogen CLI commands
+  - Run `env list` to display all the environments and its associated handles
+- All Hydrogen CLI commands that contain the `--env-branch` flag will also contain the `--env` flag
+- `--env-branch` flag will be deprecated on all Hydrogen CLI commands

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -261,10 +261,24 @@
       "args": {},
       "description": "Builds and deploys a Hydrogen storefront to Oxygen.",
       "flags": {
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Run `env list` to view an environment's handle ",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "env-branch": {
-          "description": "Environment branch (tag) for environment to deploy to.",
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
           "name": "env-branch",
-          "required": false,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -494,9 +508,22 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Run `env list` to view an environment's handle ",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "env-branch": {
-          "char": "e",
-          "description": "Specifies the environment to pull variables from using its Git branch name.",
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
           "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
           "name": "env-branch",
           "hasDynamicHelp": false,
@@ -624,9 +651,22 @@
           "multiple": false,
           "type": "option"
         },
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Run `env list` to view an environment's handle ",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "env-branch": {
-          "char": "e",
-          "description": "Specifies the environment to pull variables from using its Git branch name.",
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
           "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
           "name": "env-branch",
           "hasDynamicHelp": false,
@@ -980,9 +1020,22 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Run `env list` to view an environment's handle ",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "env-branch": {
-          "char": "e",
-          "description": "Specifies the environment to pull variables from using its Git branch name.",
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
           "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
           "name": "env-branch",
           "hasDynamicHelp": false,
@@ -1316,9 +1369,22 @@
       "args": {},
       "description": "Populate your .env with variables from your Hydrogen storefront.",
       "flags": {
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Run `env list` to view an environment's handle ",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "env-branch": {
-          "char": "e",
-          "description": "Specifies the environment to pull variables from using its Git branch name.",
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
           "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
           "name": "env-branch",
           "hasDynamicHelp": false,
@@ -1364,8 +1430,10 @@
       "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
       "flags": {
         "env": {
-          "description": "Specifies an environment's name when using remote environment variables.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_NAME",
+          "description": "Specifies the environment to perform the operation using its handle. Run `env list` to view an environment's handle ",
+          "exclusive": [
+            "env-branch"
+          ],
           "name": "env",
           "hasDynamicHelp": false,
           "multiple": false,

--- a/packages/cli/src/commands/hydrogen/dev-vite.ts
+++ b/packages/cli/src/commands/hydrogen/dev-vite.ts
@@ -50,6 +50,7 @@ export default class DevVite extends Command {
       default: false,
       required: false,
     }),
+    ...commonFlags.env,
     ...commonFlags.envBranch,
     'disable-version-check': Flags.boolean({
       description: 'Skip the version check when running `hydrogen dev`',
@@ -87,6 +88,7 @@ type DevOptions = {
   disableVirtualRoutes?: boolean;
   disableVersionCheck?: boolean;
   envBranch?: string;
+  env?: string;
   debug?: boolean;
   sourcemap?: boolean;
   inspectorPort: number;
@@ -104,6 +106,7 @@ export async function runDev({
   codegenConfigPath,
   disableVirtualRoutes,
   envBranch,
+  env: envHandle,
   debug = false,
   disableVersionCheck = false,
   inspectorPort,
@@ -127,6 +130,7 @@ export async function runDev({
     getAllEnvironmentVariables({
       root,
       envBranch,
+      envHandle,
       fetchRemote,
       localVariables,
     }),

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -59,6 +59,7 @@ export default class Dev extends Command {
     }),
     ...commonFlags.debug,
     ...commonFlags.inspectorPort,
+    ...commonFlags.env,
     ...commonFlags.envBranch,
     'disable-version-check': Flags.boolean({
       description: 'Skip the version check when running `hydrogen dev`',
@@ -93,6 +94,7 @@ type DevOptions = {
   codegenConfigPath?: string;
   disableVirtualRoutes?: boolean;
   disableVersionCheck?: boolean;
+  env?: string;
   envBranch?: string;
   debug?: boolean;
   sourcemap?: boolean;
@@ -108,6 +110,7 @@ export async function runDev({
   legacyRuntime = false,
   codegenConfigPath,
   disableVirtualRoutes,
+  env: envHandle,
   envBranch,
   debug = false,
   sourcemap = true,
@@ -177,7 +180,13 @@ export async function runDev({
   assertOxygenChecks(remixConfig);
 
   const envPromise = backgroundPromise.then(({fetchRemote, localVariables}) =>
-    getAllEnvironmentVariables({root, fetchRemote, envBranch, localVariables}),
+    getAllEnvironmentVariables({
+      root,
+      fetchRemote,
+      envBranch,
+      envHandle,
+      localVariables,
+    }),
   );
 
   const [{watch}, {createFileWatchCache}] = await Promise.all([
@@ -337,6 +346,7 @@ export async function runDev({
               root,
               fetchRemote,
               envBranch,
+              envHandle,
             }),
           });
         }

--- a/packages/cli/src/commands/hydrogen/env/list.test.ts
+++ b/packages/cli/src/commands/hydrogen/env/list.test.ts
@@ -3,10 +3,8 @@ import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output';
 import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs';
 import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui';
 
-import {
-  getStorefrontEnvironments,
-  type Environment,
-} from '../../../lib/graphql/admin/list-environments.js';
+import {getStorefrontEnvironments} from '../../../lib/graphql/admin/list-environments.js';
+import {dummyListEnvironments} from '../../../lib/graphql/admin/test-helper.js';
 import {type AdminSession, login} from '../../../lib/auth.js';
 import {
   renderMissingLink,
@@ -49,48 +47,15 @@ describe('listEnvironments', () => {
     },
   };
 
-  const PRODUCTION_ENVIRONMENT: Environment = {
-    id: 'gid://shopify/HydrogenStorefrontEnvironment/1',
-    branch: 'main',
-    type: 'PRODUCTION',
-    name: 'Production',
-    createdAt: '2023-02-16T22:35:42Z',
-    url: 'https://oxygen-123.example.com',
-  };
-
-  const CUSTOM_ENVIRONMENT: Environment = {
-    id: 'gid://shopify/HydrogenStorefrontEnvironment/3',
-    branch: 'staging',
-    type: 'CUSTOM',
-    name: 'Staging',
-    createdAt: '2023-05-08T20:52:29Z',
-    url: 'https://oxygen-456.example.com',
-  };
-
-  const PREVIEW_ENVIRONMENT: Environment = {
-    id: 'gid://shopify/HydrogenStorefrontEnvironment/2',
-    branch: null,
-    type: 'PREVIEW',
-    name: 'Preview',
-    createdAt: '2023-02-16T22:35:42Z',
-    url: null,
-  };
-
   beforeEach(async () => {
     vi.mocked(login).mockResolvedValue({
       session: ADMIN_SESSION,
       config: SHOPIFY_CONFIG,
     });
 
-    vi.mocked(getStorefrontEnvironments).mockResolvedValue({
-      id: 'gid://shopify/HydrogenStorefront/1',
-      productionUrl: 'https://example.com',
-      environments: [
-        PRODUCTION_ENVIRONMENT,
-        CUSTOM_ENVIRONMENT,
-        PREVIEW_ENVIRONMENT,
-      ],
-    });
+    vi.mocked(getStorefrontEnvironments).mockResolvedValue(
+      dummyListEnvironments(SHOPIFY_CONFIG.storefront.id),
+    );
   });
 
   afterEach(() => {
@@ -119,11 +84,15 @@ describe('listEnvironments', () => {
         /Showing 3 environments for the Hydrogen storefront Existing Link/i,
       );
 
-      expect(output.info()).toMatch(/Production \(Branch: main\)/);
-      expect(output.info()).toMatch(/https:\/\/example\.com/);
-      expect(output.info()).toMatch(/Staging \(Branch: staging\)/);
+      expect(output.info()).toMatch(
+        /Production \(handle: production, branch: main\)/,
+      );
+      expect(output.info()).toMatch(/https:\/\/my-shop\.myshopify\.com/);
+      expect(output.info()).toMatch(
+        /Staging \(handle: staging, branch: staging\)/,
+      );
       expect(output.info()).toMatch(/https:\/\/oxygen-456\.example\.com/);
-      expect(output.info()).toMatch(/Preview/);
+      expect(output.info()).toMatch(/Preview \(handle: preview\)/);
     });
   });
 

--- a/packages/cli/src/commands/hydrogen/env/list.ts
+++ b/packages/cli/src/commands/hydrogen/env/list.ts
@@ -88,8 +88,6 @@ export async function runEnvList({path: root = process.cwd()}: Flags) {
   );
   storefront.environments.push(previewEnvironment[0]!);
 
-  outputNewline();
-
   outputInfo(
     pluralizedEnvironments({
       environments: storefront.environments,
@@ -97,7 +95,7 @@ export async function runEnvList({path: root = process.cwd()}: Flags) {
     }).toString(),
   );
 
-  storefront.environments.forEach(({name, branch, type, url}) => {
+  storefront.environments.forEach(({name, handle, branch, type, url}) => {
     outputNewline();
 
     // If a custom domain is set it will be available on the storefront itself
@@ -105,17 +103,31 @@ export async function runEnvList({path: root = process.cwd()}: Flags) {
     const environmentUrl =
       type === 'PRODUCTION' ? storefront.productionUrl : url;
 
+    const metadata = {
+      handle,
+      branch,
+    };
+
+    const metadataStringified = Object.entries(metadata)
+      .reduce((acc, [key, val]) => {
+        if (val) {
+          acc.push(`${key}: ${val}`);
+        }
+        return acc;
+      }, [] as Array<string>)
+      .join(', ');
+
     outputInfo(
-      outputContent`${colors.whiteBright(name)}${
-        branch ? ` ${colors.dim(`(Branch: ${branch})`)}` : ''
-      }`.value,
+      outputContent`${colors.bold(name)} ${colors.dim(
+        `(${metadataStringified})`,
+      )}`.value,
     );
     if (environmentUrl) {
-      outputInfo(
-        outputContent`    ${colors.whiteBright(environmentUrl)}`.value,
-      );
+      outputInfo(outputContent`    ${environmentUrl}`.value);
     }
   });
+
+  outputNewline();
 }
 
 const pluralizedEnvironments = ({

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -19,6 +19,7 @@ export default class Preview extends Command {
     ...commonFlags.port,
     worker: deprecated('--worker', {isBoolean: true}),
     ...commonFlags.legacyRuntime,
+    ...commonFlags.env,
     ...commonFlags.envBranch,
     ...commonFlags.inspectorPort,
     ...commonFlags.debug,
@@ -37,6 +38,7 @@ type PreviewOptions = {
   port: number;
   path?: string;
   legacyRuntime?: boolean;
+  env?: string;
   envBranch?: string;
   inspectorPort: number;
   debug: boolean;
@@ -46,6 +48,7 @@ export async function runPreview({
   port: appPort,
   path: appPath,
   legacyRuntime = false,
+  env: envHandle,
   envBranch,
   inspectorPort,
   debug,
@@ -63,7 +66,12 @@ export async function runPreview({
 
   const {shop, storefront} = await getConfig(root);
   const fetchRemote = !!shop && !!storefront?.id;
-  const env = await getAllEnvironmentVariables({root, fetchRemote, envBranch});
+  const env = await getAllEnvironmentVariables({
+    root,
+    fetchRemote,
+    envBranch,
+    envHandle,
+  });
 
   appPort = legacyRuntime ? appPort : await findPort(appPort);
   inspectorPort = debug ? await findPort(inspectorPort) : inspectorPort;

--- a/packages/cli/src/lib/common.ts
+++ b/packages/cli/src/lib/common.ts
@@ -1,0 +1,40 @@
+import {AbortError} from '@shopify/cli-kit/node/error';
+
+export function findEnvironmentOrThrow<Environment extends {handle: string}>(
+  environments: Array<Environment>,
+  envHandle: string,
+): Environment {
+  const matchedEnvironment = environments.find(
+    ({handle}) => handle === envHandle,
+  );
+  if (!matchedEnvironment) {
+    throw environmentNotFound('handle', envHandle);
+  }
+
+  return matchedEnvironment;
+}
+
+export function findEnvironmentByBranchOrThrow<
+  Environment extends {branch: string | null},
+>(environments: Array<Environment>, branch: string): Environment {
+  const matchedEnvironment = environments.find(({branch: b}) => b === branch);
+  if (!matchedEnvironment) {
+    throw environmentNotFound('branch', branch);
+  }
+
+  return matchedEnvironment;
+}
+
+function environmentNotFound(criterion: string, value: string) {
+  return new AbortError(
+    'Environment not found',
+    `We could not find an environment matching the ${criterion} '${value}'.`,
+    [
+      [
+        'Run',
+        {command: 'env list'},
+        'to view a list of available environments.',
+      ],
+    ],
+  );
+}

--- a/packages/cli/src/lib/flags.ts
+++ b/packages/cli/src/lib/flags.ts
@@ -59,19 +59,25 @@ export const commonFlags = {
       allowNo: true,
     }),
   },
-  envBranch: {
-    'env-branch': Flags.string({
-      description:
-        'Specifies the environment to pull variables from using its Git branch name.',
-      env: 'SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH',
-      char: 'e',
-    }),
-  },
   env: {
     env: Flags.string({
       description:
-        "Specifies an environment's name when using remote environment variables.",
-      env: 'SHOPIFY_HYDROGEN_ENVIRONMENT_NAME',
+        "Specifies the environment to perform the operation using its handle. Run `env list` to view an environment's handle ",
+      exclusive: ['env-branch'],
+    }),
+  },
+  /**
+   * @deprecated use `env` instead.
+   */
+  envBranch: {
+    'env-branch': Flags.string({
+      description:
+        'Specifies the environment to perform the operation using its Git branch name.',
+      env: 'SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH',
+      deprecated: {
+        to: 'env',
+        message: '--env-branch is deprecated. Use --env instead.',
+      },
     }),
   },
   sourcemap: {

--- a/packages/cli/src/lib/get-oxygen-deployment-data.test.ts
+++ b/packages/cli/src/lib/get-oxygen-deployment-data.test.ts
@@ -32,11 +32,13 @@ describe('getOxygenDeploymentData', () => {
   const environments: OxygenDeploymentData['environments'] = [
     {
       name: 'production',
+      handle: 'production',
       branch: 'main',
       type: 'PRODUCTION',
     },
     {
       name: 'preview',
+      handle: 'preview',
       branch: null,
       type: 'PREVIEW',
     },

--- a/packages/cli/src/lib/graphql/admin/get-oxygen-data.ts
+++ b/packages/cli/src/lib/graphql/admin/get-oxygen-data.ts
@@ -6,6 +6,7 @@ export const GetDeploymentDataQuery = `#graphql
       oxygenDeploymentToken
       environments {
         name
+        handle
         branch
         type
       }
@@ -18,6 +19,7 @@ export interface OxygenDeploymentData {
   environments: Array<{
     name: string;
     branch: string | null;
+    handle: string;
     type: 'PREVIEW' | 'CUSTOM' | 'PRODUCTION';
   }> | null;
 }

--- a/packages/cli/src/lib/graphql/admin/list-environments.test.ts
+++ b/packages/cli/src/lib/graphql/admin/list-environments.test.ts
@@ -4,6 +4,7 @@ import {
   getStorefrontEnvironments,
   type ListEnvironmentsSchema,
 } from './list-environments.js';
+import {dummyListEnvironments} from './test-helper.js';
 
 vi.mock('./client.js');
 
@@ -19,20 +20,9 @@ describe('getStorefrontEnvironments', () => {
 
   it('calls the graphql client and returns Hydrogen storefronts', async () => {
     const mockedResponse: ListEnvironmentsSchema = {
-      hydrogenStorefront: {
-        id: 'gid://shopify/HydrogenStorefront/123',
-        productionUrl: 'https://...',
-        environments: [
-          {
-            createdAt: '2021-01-01T00:00:00Z',
-            id: 'e123',
-            name: 'Staging',
-            type: 'CUSTOM',
-            branch: 'staging',
-            url: 'https://...',
-          },
-        ],
-      },
+      hydrogenStorefront: dummyListEnvironments(
+        'gid://shopify/HydrogenStorefront/1',
+      ),
     };
 
     vi.mocked(adminRequest<ListEnvironmentsSchema>).mockResolvedValue(

--- a/packages/cli/src/lib/graphql/admin/list-environments.ts
+++ b/packages/cli/src/lib/graphql/admin/list-environments.ts
@@ -10,6 +10,7 @@ const ListEnvironmentsQuery = `#graphql
         createdAt
         id
         name
+        handle
         type
         url
       }
@@ -24,11 +25,12 @@ export interface Environment {
   createdAt: string;
   id: string;
   name: string;
+  handle: string;
   type: EnvironmentType;
   url: string | null;
 }
 
-interface HydrogenStorefront {
+export interface HydrogenStorefront {
   id: string;
   environments: Environment[];
   productionUrl: string;

--- a/packages/cli/src/lib/graphql/admin/pull-variables.test.ts
+++ b/packages/cli/src/lib/graphql/admin/pull-variables.test.ts
@@ -38,16 +38,16 @@ describe('getStorefrontEnvVariables', () => {
     );
 
     const id = '123';
-    const branch = 'staging';
+    const envHandle = 'staging';
 
     await expect(
-      getStorefrontEnvVariables(ADMIN_SESSION, id, branch),
+      getStorefrontEnvVariables(ADMIN_SESSION, id, envHandle),
     ).resolves.toStrictEqual(mockedResponse.hydrogenStorefront);
 
     expect(adminRequest).toHaveBeenCalledWith(
       expect.stringMatching(/^#graphql.+query.+hydrogenStorefront\(/s),
       ADMIN_SESSION,
-      {id, branch},
+      {id, handle: envHandle},
     );
   });
 });

--- a/packages/cli/src/lib/graphql/admin/pull-variables.ts
+++ b/packages/cli/src/lib/graphql/admin/pull-variables.ts
@@ -1,10 +1,10 @@
 import {adminRequest, type AdminSession} from './client.js';
 
 const PullVariablesQuery = `#graphql
-  query PullVariables($id: ID!, $branch: String) {
+  query PullVariables($id: ID!, $handle: String) {
     hydrogenStorefront(id: $id) {
       id
-      environmentVariables(branchName: $branch) {
+      environmentVariables(handle: $handle) {
         id
         isSecret
         readOnly
@@ -35,14 +35,14 @@ export interface PullVariablesSchema {
 export async function getStorefrontEnvVariables(
   adminSession: AdminSession,
   storefrontId: string,
-  envBranch?: string,
+  envHandle?: string,
 ) {
   const {hydrogenStorefront} = await adminRequest<PullVariablesSchema>(
     PullVariablesQuery,
     adminSession,
     {
       id: storefrontId,
-      branch: envBranch,
+      handle: envHandle,
     },
   );
 

--- a/packages/cli/src/lib/graphql/admin/test-helper.ts
+++ b/packages/cli/src/lib/graphql/admin/test-helper.ts
@@ -1,0 +1,39 @@
+import {type HydrogenStorefront} from './list-environments.js';
+
+export function dummyListEnvironments(
+  storefrontId: string,
+): HydrogenStorefront {
+  return {
+    id: storefrontId,
+    productionUrl: 'https://my-shop.myshopify.com',
+    environments: [
+      {
+        id: 'gid://shopify/HydrogenStorefrontEnvironment/1',
+        branch: 'main',
+        type: 'PRODUCTION',
+        name: 'Production',
+        handle: 'production',
+        createdAt: '2023-02-16T22:35:42Z',
+        url: 'https://oxygen-123.example.com',
+      },
+      {
+        id: 'gid://shopify/HydrogenStorefrontEnvironment/2',
+        branch: null,
+        type: 'PREVIEW',
+        name: 'Preview',
+        handle: 'preview',
+        createdAt: '2023-02-16T22:35:42Z',
+        url: null,
+      },
+      {
+        id: 'gid://shopify/HydrogenStorefrontEnvironment/3',
+        branch: 'staging',
+        type: 'CUSTOM',
+        name: 'Staging',
+        handle: 'staging',
+        createdAt: '2023-05-08T20:52:29Z',
+        url: 'https://oxygen-456.example.com',
+      },
+    ],
+  };
+}


### PR DESCRIPTION
### WHY are these changes introduced?

- Adding `--env` flag to standardize how we refer to environments in the CLI
  - pass in an environment's handle you can view from running `env list`
  - remove existing `--env` flag which was used to identify environment by name (used only by `env push__unstable`)
  - deprecate `--env-branch` from `env pull`, `env push__unstable`, `deploy`, `preview`, `dev-vite`, `dev`

### WHAT is this pull request doing?


### HOW to test your changes?

- checkout branch
- `npm ci && cd packages/cli & npm run build`
- If you don't have a hydrogen storefront project, `npx shopify hydrogen init` and connect it a repo on Admin
- In `packages/cli` test the following commands:
  - view handles: `npx shopify hydrogen env list --path=/path/to/repo`
  - deploy without specifying env handle: `npx shopify hydrogen deploy --path=/path/to/repo`
  - deploy by specifying env handle: `npx shopify hydrogen deploy --path=/path/to/repo --env-handle=production`
  - deploy by specifying a bad env handle: `npx shopify hydrogen deploy --path=/path/to/repo --env-handle=fake`
  - pull environment variables for preview: `npx shopify hydrogen env pull --path=/path/to/repo`
  - pull environment variables for production: `npx shopify hydrogen env pull --path=/path/to/repo --env-handle=production`
  - pull environment variables using bad env handle: `npx shopify hydrogen env pull --path=/path/to/repo --env-handle=fake`
  - Add an environment variable in the `.env` file in the storefront project
  - push environment variables for preview: `npx shopify hydrogen env push__unstable --path=/path/to/repo`
  - push environment variables for production: `npx shopify hydrogen env push__unstable --path=/path/to/repo --env-handle=production`
  - push environment variables using bad env handle: `npx shopify hydrogen env push__unstable --path=/path/to/repo --env-handle=fake`

#### Screenshots

`env list`
![image](https://github.com/Shopify/hydrogen/assets/2907059/f956b251-d340-4ff5-94f3-06d2d82710a9)

`env pull`
![image](https://github.com/Shopify/hydrogen/assets/2907059/f619ed13-afb8-4fde-9560-4b4d13c62208)

`env push__unstable`
![image](https://github.com/Shopify/hydrogen/assets/2907059/5176c7cb-5d3f-4ac6-9500-ff6a0f521e83)

`deploy`
![image](https://github.com/Shopify/hydrogen/assets/2907059/8b6864d9-e970-4feb-b9ff-b01d53a4576f)


#### Post-merge steps


#### Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
  - This will be a follow-up PR