### PR TITLE
Allow ui_locale to be pass to login page

### DIFF
--- a/.changeset/stupid-gifts-drum.md
+++ b/.changeset/stupid-gifts-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Allow ui_locale to be pass to customer account login

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -40,9 +40,8 @@ import type {
   CustomerAccountOptions,
   CustomerAccount,
   CustomerAPIResponse,
-  UiLocales,
 } from './types';
-import { LanguageCode } from '@shopify/hydrogen-react/storefront-api-types';
+import {LanguageCode} from '@shopify/hydrogen-react/storefront-api-types';
 
 const DEFAULT_LOGIN_URL = '/account/login';
 const DEFAULT_AUTH_URL = '/account/authorize';

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -40,6 +40,7 @@ import type {
   CustomerAccountOptions,
   CustomerAccount,
   CustomerAPIResponse,
+  UiLocales,
 } from './types';
 
 const DEFAULT_LOGIN_URL = '/account/login';
@@ -246,7 +247,7 @@ export function createCustomerAccountClient({
   }
 
   return {
-    login: async () => {
+    login: async (uiLocales?: UiLocales) => {
       const loginUrl = new URL(customerAccountUrl + '/auth/oauth/authorize');
 
       const state = await generateState();
@@ -262,6 +263,10 @@ export function createCustomerAccountClient({
       );
       loginUrl.searchParams.append('state', state);
       loginUrl.searchParams.append('nonce', nonce);
+
+      if (uiLocales) {
+        loginUrl.searchParams.append('ui_locales', uiLocales);
+      }
 
       const verifier = await generateCodeVerifier();
       const challenge = await generateCodeChallenge(verifier);

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -42,6 +42,7 @@ import type {
   CustomerAPIResponse,
   UiLocales,
 } from './types';
+import { LanguageCode } from '@shopify/hydrogen-react/storefront-api-types';
 
 const DEFAULT_LOGIN_URL = '/account/login';
 const DEFAULT_AUTH_URL = '/account/authorize';
@@ -247,7 +248,7 @@ export function createCustomerAccountClient({
   }
 
   return {
-    login: async (uiLocales?: UiLocales) => {
+    login: async (uiLocales?: LanguageCode) => {
       const loginUrl = new URL(customerAccountUrl + '/auth/oauth/authorize');
 
       const state = await generateState();
@@ -265,7 +266,12 @@ export function createCustomerAccountClient({
       loginUrl.searchParams.append('nonce', nonce);
 
       if (uiLocales) {
-        loginUrl.searchParams.append('ui_locales', uiLocales);
+        const [language, region] = uiLocales.split('-');
+        let locale = language.toLowerCase();
+        if (region) {
+          locale += `-${region.toUpperCase()}`;
+        }
+        loginUrl.searchParams.append('ui_locales', locale);
       }
 
       const verifier = await generateCodeVerifier();

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -40,6 +40,7 @@ import type {
   CustomerAccountOptions,
   CustomerAccount,
   CustomerAPIResponse,
+  LoginOptions,
 } from './types';
 import {LanguageCode} from '@shopify/hydrogen-react/storefront-api-types';
 
@@ -247,7 +248,7 @@ export function createCustomerAccountClient({
   }
 
   return {
-    login: async (uiLocales?: LanguageCode) => {
+    login: async (options?: LoginOptions) => {
       const loginUrl = new URL(customerAccountUrl + '/auth/oauth/authorize');
 
       const state = await generateState();
@@ -264,8 +265,8 @@ export function createCustomerAccountClient({
       loginUrl.searchParams.append('state', state);
       loginUrl.searchParams.append('nonce', nonce);
 
-      if (uiLocales) {
-        const [language, region] = uiLocales.split('-');
+      if (options?.uiLocales) {
+        const [language, region] = options.uiLocales.split('-');
         let locale = language.toLowerCase();
         if (region) {
           locale += `-${region.toUpperCase()}`;

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -45,9 +45,11 @@ export interface CustomerAccountMutations {
   // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};
 }
 
+export type UiLocales = 'en' | 'fr' | 'cs' | 'da' | 'de' | 'es' | 'fi' | 'it' | 'ja' | 'ko' | 'nb' | 'nl' | 'pl' | 'pt-BR' | 'pt-PT' | 'sv' | 'th' | 'tr' | 'vi' | 'zh-CN' | 'zh-TW';
+
 export type CustomerAccount = {
   /** Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use) */
-  login: () => Promise<Response>;
+  login: (uiLocales?: UiLocales) => Promise<Response>;
   /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */
   authorize: () => Promise<Response>;
   /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -45,7 +45,28 @@ export interface CustomerAccountMutations {
   // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};
 }
 
-export type UiLocales = 'en' | 'fr' | 'cs' | 'da' | 'de' | 'es' | 'fi' | 'it' | 'ja' | 'ko' | 'nb' | 'nl' | 'pl' | 'pt-BR' | 'pt-PT' | 'sv' | 'th' | 'tr' | 'vi' | 'zh-CN' | 'zh-TW';
+export type UiLocales =
+  | 'en'
+  | 'fr'
+  | 'cs'
+  | 'da'
+  | 'de'
+  | 'es'
+  | 'fi'
+  | 'it'
+  | 'ja'
+  | 'ko'
+  | 'nb'
+  | 'nl'
+  | 'pl'
+  | 'pt-BR'
+  | 'pt-PT'
+  | 'sv'
+  | 'th'
+  | 'tr'
+  | 'vi'
+  | 'zh-CN'
+  | 'zh-TW';
 
 export type CustomerAccount = {
   /** Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use) */

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -46,17 +46,21 @@ export interface CustomerAccountMutations {
   // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};
 }
 
+export type LoginOptions = {
+  uiLocales?: LanguageCode;
+};
+
 export type CustomerAccount = {
   /** Start the OAuth login flow. This function should be called and returned from a Remix action.
    * It redirects the customer to a Shopify login domain. It also defined the final path the customer
    * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is
    * automatically setup unless `customAuthStatusHandler` option is in use)
    *
-   * @param uiLocales - The displayed language of the login page. Only support for the following languages:
+   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:
    * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,
    * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.
    * */
-  login: (uiLocales?: LanguageCode) => Promise<Response>;
+  login: (options?: LoginOptions) => Promise<Response>;
   /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */
   authorize: () => Promise<Response>;
   /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */
@@ -136,11 +140,11 @@ export type CustomerAccountForDocs = {
    * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is
    * automatically setup unless `customAuthStatusHandler` option is in use)
    *
-   * @param uiLocales - The displayed language of the login page. Only support for the following languages:
+   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:
    * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,
    * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.
    * */
-  login: (uiLocales?: LanguageCode) => Promise<Response>;
+  login: (options?: LoginOptions) => Promise<Response>;
   /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */
   authorize?: () => Promise<Response>;
   /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -7,7 +7,7 @@ import {type GraphQLError} from '../utils/graphql';
 import type {CrossRuntimeRequest} from '../utils/request';
 
 import type {HydrogenSession} from '../hydrogen';
-import { LanguageCode } from '@shopify/hydrogen-react/storefront-api-types';
+import {LanguageCode} from '@shopify/hydrogen-react/storefront-api-types';
 
 // Return type of unauthorizedHandler = Return type of loader/action function
 // This type is not exported https://github.com/remix-run/react-router/blob/main/packages/router/utils.ts#L167
@@ -131,8 +131,16 @@ export type CustomerAccountOptions = {
 /** Below are types meant for documentation only. Ensure it stay in sync with the type above. */
 
 export type CustomerAccountForDocs = {
-  /** Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use) */
-  login?: () => Promise<Response>;
+  /** Start the OAuth login flow. This function should be called and returned from a Remix action.
+   * It redirects the customer to a Shopify login domain. It also defined the final path the customer
+   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is
+   * automatically setup unless `customAuthStatusHandler` option is in use)
+   *
+   * @param uiLocales - The displayed language of the login page. Only support for the following languages:
+   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,
+   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.
+   * */
+  login: (uiLocales?: LanguageCode) => Promise<Response>;
   /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */
   authorize?: () => Promise<Response>;
   /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -7,6 +7,7 @@ import {type GraphQLError} from '../utils/graphql';
 import type {CrossRuntimeRequest} from '../utils/request';
 
 import type {HydrogenSession} from '../hydrogen';
+import { LanguageCode } from '@shopify/hydrogen-react/storefront-api-types';
 
 // Return type of unauthorizedHandler = Return type of loader/action function
 // This type is not exported https://github.com/remix-run/react-router/blob/main/packages/router/utils.ts#L167
@@ -45,32 +46,17 @@ export interface CustomerAccountMutations {
   // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};
 }
 
-export type UiLocales =
-  | 'en'
-  | 'fr'
-  | 'cs'
-  | 'da'
-  | 'de'
-  | 'es'
-  | 'fi'
-  | 'it'
-  | 'ja'
-  | 'ko'
-  | 'nb'
-  | 'nl'
-  | 'pl'
-  | 'pt-BR'
-  | 'pt-PT'
-  | 'sv'
-  | 'th'
-  | 'tr'
-  | 'vi'
-  | 'zh-CN'
-  | 'zh-TW';
-
 export type CustomerAccount = {
-  /** Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use) */
-  login: (uiLocales?: UiLocales) => Promise<Response>;
+  /** Start the OAuth login flow. This function should be called and returned from a Remix action.
+   * It redirects the customer to a Shopify login domain. It also defined the final path the customer
+   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is
+   * automatically setup unless `customAuthStatusHandler` option is in use)
+   *
+   * @param uiLocales - The displayed language of the login page. Only support for the following languages:
+   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,
+   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.
+   * */
+  login: (uiLocales?: LanguageCode) => Promise<Response>;
   /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */
   authorize: () => Promise<Response>;
   /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */

--- a/templates/skeleton/.env
+++ b/templates/skeleton/.env
@@ -1,8 +1,4 @@
 # These variables are only available locally in MiniOxygen
 
 SESSION_SECRET="foobar"
-PUBLIC_STOREFRONT_API_TOKEN=33ad0f277e864013b8e3c21d19432501
-PUBLIC_STORE_DOMAIN=hydrogen-preview.myshopify.com
-PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID=shp_3cecd990-4824-4e27-beb2-46c8e822ec14
-PUBLIC_CUSTOMER_ACCOUNT_API_URL=https://shopify.com/55145660472
-PUBLIC_CHECKOUT_DOMAIN=checkout.hydrogen.shop
+PUBLIC_STORE_DOMAIN="mock.shop"

--- a/templates/skeleton/.env
+++ b/templates/skeleton/.env
@@ -1,4 +1,8 @@
 # These variables are only available locally in MiniOxygen
 
 SESSION_SECRET="foobar"
-PUBLIC_STORE_DOMAIN="mock.shop"
+PUBLIC_STOREFRONT_API_TOKEN=33ad0f277e864013b8e3c21d19432501
+PUBLIC_STORE_DOMAIN=hydrogen-preview.myshopify.com
+PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID=shp_3cecd990-4824-4e27-beb2-46c8e822ec14
+PUBLIC_CUSTOMER_ACCOUNT_API_URL=https://shopify.com/55145660472
+PUBLIC_CHECKOUT_DOMAIN=checkout.hydrogen.shop


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/hydrogen/issues/1835

### WHAT is this pull request doing?

Allow locale to be passed to customer account login page

### HOW to test your changes?

1. Update `account_.login.tsx` with

    ```tsx
    export async function loader({request, context}: LoaderFunctionArgs) {
      return context.customerAccount.login({uiLocales: 'JA'});
    }
    ```
2. Locally run your project and go to sign n page

Expected: You should see the login interface in Japanese.

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
