### PR TITLE
Avoid naming collisions when creating new storefronts with `link`

### DIFF
--- a/.changeset/twelve-apricots-study.md
+++ b/.changeset/twelve-apricots-study.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Handle duplicate storefront names when running `link` command

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1206,6 +1206,132 @@
         "cpu.js"
       ]
     },
+    "hydrogen:setup:css": {
+      "aliases": [],
+      "args": {
+        "strategy": {
+          "description": "The CSS strategy to setup. One of tailwind,css-modules,vanilla-extract,postcss",
+          "name": "strategy",
+          "options": [
+            "tailwind",
+            "css-modules",
+            "vanilla-extract",
+            "postcss"
+          ]
+        }
+      },
+      "description": "Setup CSS strategies for your project.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "install-deps": {
+          "description": "Auto installs dependencies using the active package manager.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
+          "name": "install-deps",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:setup:css",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "setup",
+        "css.js"
+      ]
+    },
+    "hydrogen:setup:markets": {
+      "aliases": [],
+      "args": {
+        "strategy": {
+          "description": "The URL structure strategy to setup multiple markets. One of subfolders,domains,subdomains",
+          "name": "strategy",
+          "options": [
+            "subfolders",
+            "domains",
+            "subdomains"
+          ]
+        }
+      },
+      "description": "Setup support for multiple markets in your project.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:setup:markets",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "setup",
+        "markets.js"
+      ]
+    },
+    "hydrogen:setup:vite": {
+      "aliases": [],
+      "args": {},
+      "description": "EXPERIMENTAL: Upgrades the project to use Vite.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:setup:vite",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "setup",
+        "vite.js"
+      ]
+    },
     "hydrogen:env:list": {
       "aliases": [],
       "args": {},
@@ -1470,132 +1596,6 @@
         "hydrogen",
         "generate",
         "routes.js"
-      ]
-    },
-    "hydrogen:setup:css": {
-      "aliases": [],
-      "args": {
-        "strategy": {
-          "description": "The CSS strategy to setup. One of tailwind,css-modules,vanilla-extract,postcss",
-          "name": "strategy",
-          "options": [
-            "tailwind",
-            "css-modules",
-            "vanilla-extract",
-            "postcss"
-          ]
-        }
-      },
-      "description": "Setup CSS strategies for your project.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "force": {
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "install-deps": {
-          "description": "Auto installs dependencies using the active package manager.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
-          "name": "install-deps",
-          "allowNo": true,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:setup:css",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "setup",
-        "css.js"
-      ]
-    },
-    "hydrogen:setup:markets": {
-      "aliases": [],
-      "args": {
-        "strategy": {
-          "description": "The URL structure strategy to setup multiple markets. One of subfolders,domains,subdomains",
-          "name": "strategy",
-          "options": [
-            "subfolders",
-            "domains",
-            "subdomains"
-          ]
-        }
-      },
-      "description": "Setup support for multiple markets in your project.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:setup:markets",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "setup",
-        "markets.js"
-      ]
-    },
-    "hydrogen:setup:vite": {
-      "aliases": [],
-      "args": {},
-      "description": "EXPERIMENTAL: Upgrades the project to use Vite.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:setup:vite",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "setup",
-        "vite.js"
       ]
     }
   },

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1206,132 +1206,6 @@
         "cpu.js"
       ]
     },
-    "hydrogen:setup:css": {
-      "aliases": [],
-      "args": {
-        "strategy": {
-          "description": "The CSS strategy to setup. One of tailwind,css-modules,vanilla-extract,postcss",
-          "name": "strategy",
-          "options": [
-            "tailwind",
-            "css-modules",
-            "vanilla-extract",
-            "postcss"
-          ]
-        }
-      },
-      "description": "Setup CSS strategies for your project.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "force": {
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "install-deps": {
-          "description": "Auto installs dependencies using the active package manager.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
-          "name": "install-deps",
-          "allowNo": true,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:setup:css",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "setup",
-        "css.js"
-      ]
-    },
-    "hydrogen:setup:markets": {
-      "aliases": [],
-      "args": {
-        "strategy": {
-          "description": "The URL structure strategy to setup multiple markets. One of subfolders,domains,subdomains",
-          "name": "strategy",
-          "options": [
-            "subfolders",
-            "domains",
-            "subdomains"
-          ]
-        }
-      },
-      "description": "Setup support for multiple markets in your project.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:setup:markets",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "setup",
-        "markets.js"
-      ]
-    },
-    "hydrogen:setup:vite": {
-      "aliases": [],
-      "args": {},
-      "description": "EXPERIMENTAL: Upgrades the project to use Vite.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:setup:vite",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "setup",
-        "vite.js"
-      ]
-    },
     "hydrogen:env:list": {
       "aliases": [],
       "args": {},
@@ -1596,6 +1470,132 @@
         "hydrogen",
         "generate",
         "routes.js"
+      ]
+    },
+    "hydrogen:setup:css": {
+      "aliases": [],
+      "args": {
+        "strategy": {
+          "description": "The CSS strategy to setup. One of tailwind,css-modules,vanilla-extract,postcss",
+          "name": "strategy",
+          "options": [
+            "tailwind",
+            "css-modules",
+            "vanilla-extract",
+            "postcss"
+          ]
+        }
+      },
+      "description": "Setup CSS strategies for your project.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "install-deps": {
+          "description": "Auto installs dependencies using the active package manager.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
+          "name": "install-deps",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:setup:css",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "setup",
+        "css.js"
+      ]
+    },
+    "hydrogen:setup:markets": {
+      "aliases": [],
+      "args": {
+        "strategy": {
+          "description": "The URL structure strategy to setup multiple markets. One of subfolders,domains,subdomains",
+          "name": "strategy",
+          "options": [
+            "subfolders",
+            "domains",
+            "subdomains"
+          ]
+        }
+      },
+      "description": "Setup support for multiple markets in your project.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:setup:markets",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "setup",
+        "markets.js"
+      ]
+    },
+    "hydrogen:setup:vite": {
+      "aliases": [],
+      "args": {},
+      "description": "EXPERIMENTAL: Upgrades the project to use Vite.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:setup:vite",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "setup",
+        "vite.js"
       ]
     }
   },

--- a/packages/cli/src/commands/hydrogen/link.ts
+++ b/packages/cli/src/commands/hydrogen/link.ts
@@ -106,7 +106,7 @@ export async function linkStorefront(
     }
   }
 
-  const storefronts: ParsedHydrogenStorefront[]  = await getStorefronts(session);
+  const storefronts: ParsedHydrogenStorefront[] = await getStorefronts(session);
 
   let selectedStorefront: HydrogenStorefront | undefined;
 
@@ -136,7 +136,11 @@ export async function linkStorefront(
     selectedStorefront = await handleStorefrontSelection(storefronts);
 
     if (!selectedStorefront) {
-      selectedStorefront = await createNewStorefront(root, session, storefronts);
+      selectedStorefront = await createNewStorefront(
+        root,
+        session,
+        storefronts,
+      );
     }
   }
 
@@ -145,15 +149,19 @@ export async function linkStorefront(
   return selectedStorefront;
 }
 
-async function createNewStorefront(root: string, session: AdminSession, storefronts: ParsedHydrogenStorefront[]) {
+async function createNewStorefront(
+  root: string,
+  session: AdminSession,
+  storefronts: ParsedHydrogenStorefront[],
+) {
   const projectDirectory = basename(root);
   let defaultProjectName = titleize(projectDirectory);
   const nameAlreadyUsed = storefronts.some(
     ({title}: {title: string}) => title === defaultProjectName,
   );
-  if ( nameAlreadyUsed ) {
+  if (nameAlreadyUsed) {
     defaultProjectName = generateRandomName();
-  };
+  }
 
   const projectName = await renderTextPrompt({
     message: 'New storefront name',

--- a/packages/cli/src/commands/hydrogen/link.ts
+++ b/packages/cli/src/commands/hydrogen/link.ts
@@ -145,10 +145,20 @@ export async function linkStorefront(
 
 async function createNewStorefront(root: string, session: AdminSession) {
   const projectDirectory = basename(root);
+  const storefronts = await getStorefronts(session);
+
+  let defaultProjectName = titleize(projectDirectory);
+  const nameAlreadyUsed = storefronts.some(
+    ({title}) => title === defaultProjectName,
+  );
+  // Append a random hash to the default project name if it's already used
+  if ( nameAlreadyUsed ) {
+    defaultProjectName += ` ${Math.random().toString(36).substring(2, 6)}`;
+  };
 
   const projectName = await renderTextPrompt({
     message: 'New storefront name',
-    defaultValue: titleize(projectDirectory),
+    defaultValue: defaultProjectName,
   });
 
   let storefront: HydrogenStorefront | undefined;

--- a/packages/cli/src/commands/hydrogen/link.ts
+++ b/packages/cli/src/commands/hydrogen/link.ts
@@ -22,6 +22,8 @@ import {login} from '../../lib/auth.js';
 import type {AdminSession} from '../../lib/auth.js';
 import {
   type HydrogenStorefront,
+  type ParsedHydrogenStorefront,
+  generateRandomName,
   handleStorefrontSelection,
 } from '../../lib/onboarding/common.js';
 
@@ -104,7 +106,7 @@ export async function linkStorefront(
     }
   }
 
-  const storefronts = await getStorefronts(session);
+  const storefronts: ParsedHydrogenStorefront[]  = await getStorefronts(session);
 
   let selectedStorefront: HydrogenStorefront | undefined;
 
@@ -134,7 +136,7 @@ export async function linkStorefront(
     selectedStorefront = await handleStorefrontSelection(storefronts);
 
     if (!selectedStorefront) {
-      selectedStorefront = await createNewStorefront(root, session);
+      selectedStorefront = await createNewStorefront(root, session, storefronts);
     }
   }
 
@@ -143,17 +145,14 @@ export async function linkStorefront(
   return selectedStorefront;
 }
 
-async function createNewStorefront(root: string, session: AdminSession) {
+async function createNewStorefront(root: string, session: AdminSession, storefronts: ParsedHydrogenStorefront[]) {
   const projectDirectory = basename(root);
-  const storefronts = await getStorefronts(session);
-
   let defaultProjectName = titleize(projectDirectory);
   const nameAlreadyUsed = storefronts.some(
-    ({title}) => title === defaultProjectName,
+    ({title}: {title: string}) => title === defaultProjectName,
   );
-  // Append a random hash to the default project name if it's already used
   if ( nameAlreadyUsed ) {
-    defaultProjectName += ` ${Math.random().toString(36).substring(2, 6)}`;
+    defaultProjectName = generateRandomName();
   };
 
   const projectName = await renderTextPrompt({

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -268,7 +268,7 @@ export type HydrogenStorefront = {
   productionUrl: string;
 };
 
-export type ParsedHydrogenStorefront = HydrogenStorefront & { parsedId: string };
+export type ParsedHydrogenStorefront = HydrogenStorefront & {parsedId: string};
 
 export async function handleStorefrontSelection(
   storefronts: HydrogenStorefront[],
@@ -762,16 +762,68 @@ export function generateRandomName() {
     return arr[Math.floor(Math.random() * arr.length)];
   }
   const geographicalFeature = getRandomElement([
-    "Bay", "Bend", "Cape", "Cliff", "Cove", "Creek", "Dale", "Dune", "Fjord",
-    "Glade", "Gulf", "Hill", "Isle", "Knoll", "Lake", "Loch", "Mesa", "Peak",
-    "Pond", "Quay", "Reef", "Ridge", "Rise", "River", "Road", "Shore",
-    "Strait", "Stream", "Vale", "Valley", "View", "Vista",
+    'Bay',
+    'Bend',
+    'Cape',
+    'Cliff',
+    'Cove',
+    'Creek',
+    'Dale',
+    'Dune',
+    'Fjord',
+    'Glade',
+    'Gulf',
+    'Hill',
+    'Isle',
+    'Knoll',
+    'Lake',
+    'Loch',
+    'Mesa',
+    'Peak',
+    'Pond',
+    'Quay',
+    'Reef',
+    'Ridge',
+    'Rise',
+    'River',
+    'Road',
+    'Shore',
+    'Strait',
+    'Stream',
+    'Vale',
+    'Valley',
+    'View',
+    'Vista',
   ]);
   const colorNames = getRandomElement([
-    "Crimson", "Azure", "Coral", "Fuchsia", "Indigo", "Ivory", "Lavender",
-    "Lime", "Magenta", "Maroon", "Orchid", "Peach", "Plum", "Quartz",
-    "Salmon", "Teal", "Turquoise", "Violet", "Yellow", "Ebony", "Jade",
-    "Lilac", "Mint", "Onyx", "Pearl", "Ruby", "Sapphire", "Topaz",
-  ])
+    'Crimson',
+    'Azure',
+    'Coral',
+    'Fuchsia',
+    'Indigo',
+    'Ivory',
+    'Lavender',
+    'Lime',
+    'Magenta',
+    'Maroon',
+    'Orchid',
+    'Peach',
+    'Plum',
+    'Quartz',
+    'Salmon',
+    'Teal',
+    'Turquoise',
+    'Violet',
+    'Yellow',
+    'Ebony',
+    'Jade',
+    'Lilac',
+    'Mint',
+    'Onyx',
+    'Pearl',
+    'Ruby',
+    'Sapphire',
+    'Topaz',
+  ]);
   return `${colorNames} ${geographicalFeature}`;
 }

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -268,6 +268,8 @@ export type HydrogenStorefront = {
   productionUrl: string;
 };
 
+export type ParsedHydrogenStorefront = HydrogenStorefront & { parsedId: string };
+
 export async function handleStorefrontSelection(
   storefronts: HydrogenStorefront[],
 ): Promise<HydrogenStorefront | undefined> {
@@ -753,4 +755,23 @@ function normalizeRoutePath(routePath: string) {
     .replace(/\$/g, ':') // Replace dollar signs with colons
     .replace(/[\[\]]/g, '') // Remove brackets
     .replace(/:\w*Handle/i, ':handle'); // Replace arbitrary handle names with a standard `:handle`
+}
+
+export function generateRandomName() {
+  function getRandomElement(arr: string[]) {
+    return arr[Math.floor(Math.random() * arr.length)];
+  }
+  const geographicalFeature = getRandomElement([
+    "Bay", "Bend", "Cape", "Cliff", "Cove", "Creek", "Dale", "Dune", "Fjord",
+    "Glade", "Gulf", "Hill", "Isle", "Knoll", "Lake", "Loch", "Mesa", "Peak",
+    "Pond", "Quay", "Reef", "Ridge", "Rise", "River", "Road", "Shore",
+    "Strait", "Stream", "Vale", "Valley", "View", "Vista",
+  ]);
+  const colorNames = getRandomElement([
+    "Crimson", "Azure", "Coral", "Fuchsia", "Indigo", "Ivory", "Lavender",
+    "Lime", "Magenta", "Maroon", "Orchid", "Peach", "Plum", "Quartz",
+    "Salmon", "Teal", "Turquoise", "Violet", "Yellow", "Ebony", "Jade",
+    "Lilac", "Mint", "Onyx", "Pearl", "Ruby", "Sapphire", "Topaz",
+  ])
+  return `${colorNames} ${geographicalFeature}`;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When running the `link` command and creating a new storefront, we error out if the storefront name already exists in Oxygen:

![image](https://github.com/Shopify/hydrogen/assets/547470/32f60586-7362-4490-80a9-a55ca258e160)

With the new `--quickstart` command, a lot of new users will soon have projects with the directory `hydrogen-quickstart`, and the corresponding name `Hydrogen Quickstart` in Oxygen, because we simply titleize the project directory. There is separate work underway to throw a more descriptive error, but we can also help avoid it in the first place.

### WHAT is this pull request doing?

This refactors `link` to check the titleized directory name against the list of existing storefronts in Oxygen. If the storefront name already exists, it generates a new random name.

<img width="881" alt="Screenshot 2024-03-18 at 11 26 21" src="https://github.com/Shopify/hydrogen/assets/547470/2bbec2ae-6087-4ae3-ac15-096016dbe61b">

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation