### PR TITLE
Allow calling the cart `.get()` method right after cart mutation methods

### DIFF
--- a/.changeset/itchy-weeks-search.md
+++ b/.changeset/itchy-weeks-search.md
@@ -1,0 +1,27 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Allow calling the cart `.get()` method right after creating a new cart with
+one of the mutation methods: `create()`, `addLines()`, `updateDiscountCodes()`, `updateBuyerIdentity()`, `updateNote()`, `updateAttributes()`, `setMetafields()`.
+
+```ts
+import {
+  createCartHandler,
+  cartGetIdDefault,
+  cartSetIdDefault,
+} from '@shopify/hydrogen';
+
+const cartHandler = createCartHandler({
+  storefront,
+  getCartId: cartGetIdDefault(request.headers),
+  setCartId: cartSetIdDefault(),
+  cartQueryFragment: CART_QUERY_FRAGMENT,
+  cartMutateFragment: CART_MUTATE_FRAGMENT,
+});
+
+await cartHandler.addLines([{merchandiseId: '...'}]);
+// This change fixes a bug where `cart` would be null, even though a
+// new cart was created when adding a line item
+const cart = await cartHandler.get();
+```

--- a/packages/hydrogen/src/cart/createCartHandler.test.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.test.ts
@@ -399,4 +399,17 @@ describe('createCartHandler', () => {
 
     expect(result.cart).toHaveProperty('id', 'gid://shopify/Cart/c1-456');
   });
+
+  it('stores the cartId in memory when a new cart is created and returns that result if available', async () => {
+    const cart = getCartHandler();
+
+    await cart.addLines([
+      {
+        merchandiseId: '1',
+        quantity: 1,
+      },
+    ]);
+
+    expect(await cart.get()).toHaveProperty('id', 'c1-new-cart-id');
+  });
 });

--- a/packages/hydrogen/src/cart/createCartHandler.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.ts
@@ -96,7 +96,7 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
   options: CartHandlerOptions | CartHandlerOptionsWithCustom<TCustomMethods>,
 ): CartHandlerReturn<TCustomMethods> {
   const {
-    getCartId,
+    getCartId: _getCartId,
     setCartId,
     storefront,
     customerAccount,
@@ -104,14 +104,23 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
     cartMutateFragment,
   } = options;
 
+  let cartId = _getCartId();
+
+  const getCartId = () => cartId || _getCartId();
+
   const mutateOptions = {
     storefront,
     getCartId,
     cartFragment: cartMutateFragment,
   };
 
-  const cartId = getCartId();
-  const cartCreate = cartCreateDefault(mutateOptions);
+  const _cartCreate = cartCreateDefault(mutateOptions);
+
+  const cartCreate: CartCreateFunction = async function (...args) {
+    const result = await _cartCreate(...args);
+    cartId = result?.cart?.id;
+    return result;
+  };
 
   const methods: HydrogenCart = {
     get: cartGetDefault({


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Allow calling `.get()` immediately after cart mutation methods:

```ts
import {
  createCartHandler,
  cartGetIdDefault,
  cartSetIdDefault,
} from '@shopify/hydrogen';

const cartHandler = createCartHandler({
  storefront,
  getCartId: cartGetIdDefault(request.headers),
  setCartId: cartSetIdDefault(),
  cartQueryFragment: CART_QUERY_FRAGMENT,
  cartMutateFragment: CART_MUTATE_FRAGMENT,
});

await cartHandler.addLines([{merchandiseId: '...'}]);
// This change fixes a bug where `cart` would be null, even though a
// new cart was created when adding a line item
const cart = await cartHandler.get();
```



<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

When calling `cart.get()`, we only make a request if a cartId exists. The problem is, someone might call a mutation method that creates the cart, and then want to get the cart. If we know the cart has been created, we can internally store the cartId in memory, and only call `getCartId()` if that internal value is undefined.

### HOW to test your changes?

Add `await cart.get()` right after `await cart.addLines(inputs.lines)` in [cart.ts in the skeleton template.](https://github.com/Shopify/hydrogen/blob/main/templates/skeleton/app/routes/cart.tsx#L29).

Make sure the returned value is defined after adding an item to the cart. Also make sure that no cart exists before adding to the cart (clear cookies).

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
