### PR TITLE
Fix customer account error when using mock.shop

### DIFF
--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -198,7 +198,8 @@ export function createCustomerAccountClient({
   }
 
   async function isLoggedIn() {
-    ifInvalidCredentialThrowError(customerAccountUrl, customerAccountId);
+    if (!customerAccountUrl || !customerAccountId) return false;
+
     const customerAccount = session.get(CUSTOMER_ACCOUNT_SESSION_KEY);
     const accessToken = customerAccount?.accessToken;
     const expiresAt = customerAccount?.expiresAt;


### PR DESCRIPTION
Customer Account client's isLoggedIn was throwing when using mock.shop in every page. This PR changes it to return false if CAA is not setup so that we can at least see the non-account pages.