### PR TITLE
Add `--disable-network-filter` to skip workerd network filtering

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -525,6 +525,13 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "disable-network-filter": {
+          "description": "For security, only connections to public domains are allowed in the local runtime by default. Use this flag to disable the network filter.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_BYPASS_NETWORK_FILTER",
+          "name": "disable-network-filter",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -653,6 +660,13 @@
           "env": "SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH",
           "name": "customer-account-push",
           "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "disable-network-filter": {
+          "description": "For security, only connections to public domains are allowed in the local runtime by default. Use this flag to disable the network filter.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_BYPASS_NETWORK_FILTER",
+          "name": "disable-network-filter",
           "allowNo": false,
           "type": "boolean"
         }

--- a/packages/cli/src/commands/hydrogen/dev-vite.ts
+++ b/packages/cli/src/commands/hydrogen/dev-vite.ts
@@ -57,6 +57,7 @@ export default class DevVite extends Command {
     }),
     ...commonFlags.diff,
     ...commonFlags.customerAccountPush,
+    ...commonFlags.disableNetworkFilter,
   };
 
   async run(): Promise<void> {
@@ -92,6 +93,7 @@ type DevOptions = {
   isLocalDev?: boolean;
   customerAccountPush?: boolean;
   cliConfig: Config;
+  disableNetworkFilter?: boolean;
 };
 
 export async function runDev({
@@ -109,6 +111,7 @@ export async function runDev({
   isLocalDev = false,
   customerAccountPush: customerAccountPushFlag = false,
   cliConfig,
+  disableNetworkFilter,
 }: DevOptions) {
   if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development';
 
@@ -153,6 +156,7 @@ export async function runDev({
         ssrEntry,
         envPromise,
         inspectorPort,
+        disableNetworkFilter,
         disableVirtualRoutes,
       },
     }),

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -66,6 +66,7 @@ export default class Dev extends Command {
     }),
     ...commonFlags.diff,
     ...commonFlags.customerAccountPush,
+    ...commonFlags.disableNetworkFilter,
   };
 
   async run(): Promise<void> {
@@ -98,6 +99,7 @@ type DevOptions = {
   inspectorPort: number;
   customerAccountPush?: boolean;
   cliConfig?: Config;
+  disableNetworkFilter?: boolean;
 };
 
 export async function runDev({
@@ -114,6 +116,7 @@ export async function runDev({
   inspectorPort,
   customerAccountPush: customerAccountPushFlag = false,
   cliConfig,
+  disableNetworkFilter,
 }: DevOptions) {
   if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development';
 
@@ -214,6 +217,7 @@ export async function runDev({
         buildPathWorkerFile,
         buildPathClient,
         env: await envPromise,
+        disableNetworkFilter,
       },
       legacyRuntime,
     );

--- a/packages/cli/src/lib/flags.ts
+++ b/packages/cli/src/lib/flags.ts
@@ -177,6 +177,13 @@ export const commonFlags = {
       env: 'SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH',
     }),
   },
+  disableNetworkFilter: {
+    'disable-network-filter': Flags.boolean({
+      description:
+        'For security, only connections to public domains are allowed in the local runtime by default. Use this flag to disable the network filter.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_BYPASS_NETWORK_FILTER',
+    }),
+  },
 } satisfies Record<string, Record<Lowercase<string>, FlagProps>>;
 
 export function flagsToCamelObject<T extends Record<string, any>>(obj: T) {

--- a/packages/cli/src/lib/mini-oxygen/types.ts
+++ b/packages/cli/src/lib/mini-oxygen/types.ts
@@ -9,6 +9,7 @@ export type MiniOxygenOptions = {
   debug?: boolean;
   inspectorPort: number;
   assetsPort: number;
+  disableNetworkFilter?: boolean;
 };
 
 export type MiniOxygenInstance = {

--- a/packages/cli/src/lib/mini-oxygen/workerd.ts
+++ b/packages/cli/src/lib/mini-oxygen/workerd.ts
@@ -51,6 +51,7 @@ export async function startWorkerdServer({
   buildPathWorkerFile,
   buildPathClient,
   env,
+  disableNetworkFilter = false,
 }: MiniOxygenOptions): Promise<MiniOxygenInstance> {
   const privateInspectorPort = await findPort(PRIVATE_WORKERD_INSPECTOR_PORT);
 
@@ -136,6 +137,9 @@ export async function startWorkerdServer({
               transformLocation: () => absoluteBundlePath,
             }),
           },
+          ...(disableNetworkFilter && {
+            outboundService: (request) => fetch(request.url, request),
+          }),
         },
       ],
     } satisfies MiniflareOptions);

--- a/packages/cli/src/lib/vite/plugins.ts
+++ b/packages/cli/src/lib/vite/plugins.ts
@@ -149,6 +149,9 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
             debug: cliOptions?.debug ?? pluginOptions.debug ?? false,
             inspectorPort:
               cliOptions?.inspectorPort ?? pluginOptions.inspectorPort ?? 9229,
+            disableNetworkFilter:
+              cliOptions?.disableNetworkFilter ??
+              pluginOptions.disableNetworkFilter,
           });
         });
 

--- a/packages/cli/src/lib/vite/shared.ts
+++ b/packages/cli/src/lib/vite/shared.ts
@@ -22,6 +22,7 @@ export type OxygenPluginOptions = {
   debug?: boolean;
   inspectorPort?: number;
   env?: Record<string, any>;
+  disableNetworkFilter?: boolean;
 };
 
 // Note: Vite resolves extensions like .js or .ts automatically.


### PR DESCRIPTION
When using Spin, we can't make queries to its private domain from workerd.
This is supposed to bypass the network filter made in workerd but for some reason we don't get `response.body` anymore with this change.

Still WIP.