### PR TITLE
Make sure 400-500 level HTTP sub-requests are not cached

### DIFF
--- a/.changeset/shy-houses-rest.md
+++ b/.changeset/shy-houses-rest.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Make sure 400-500 sub-requests are not cached

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -83,7 +83,8 @@ function fromSerializableResponse([body, init]: [any, ResponseInit]) {
 
 // Check if the response body has GraphQL errors
 // https://spec.graphql.org/June2018/#sec-Response-Format
-export const checkGraphQLErrors = (body: any) => !body?.errors;
+export const checkGraphQLErrors = (body: any, response: Response) =>
+  !body?.errors && response.status < 400;
 
 // Lock to prevent revalidating the same sub-request
 // in the same isolate. Note that different isolates


### PR DESCRIPTION
Make sure we don't cache sub-requests that should never be cached.

#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
