### PR TITLE
Make sure 400-500 level HTTP sub-requests are not cached

### DIFF
--- a/.changeset/shy-houses-rest.md
+++ b/.changeset/shy-houses-rest.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Make sure 400-500 sub-requests are not cached

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -55,7 +55,8 @@ function fromSerializableResponse([body, init]: [any, ResponseInit]) {
 
 // Check if the response body has GraphQL errors
 // https://spec.graphql.org/June2018/#sec-Response-Format
-export const checkGraphQLErrors = (body: any) => !body?.errors;
+export const checkGraphQLErrors = (body: any, response: Response) =>
+  !body?.errors && response.status < 400;
 
 // Lock to prevent revalidating the same sub-request
 // in the same isolate. Note that different isolates


### PR DESCRIPTION
Backfix: https://github.com/Shopify/hydrogen/pull/1902