### PR TITLE
Make `h2 setup vite` command stable

### DIFF
--- a/.changeset/weak-moons-call.md
+++ b/.changeset/weak-moons-call.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Improve `h2 setup vite` command to cover more migration steps (e.g. vanilla-extract, css-modules, etc.) and keep Remix future flags.

--- a/packages/cli/src/commands/hydrogen/setup/vite.ts
+++ b/packages/cli/src/commands/hydrogen/setup/vite.ts
@@ -355,11 +355,20 @@ export async function runSetupVite({directory}: {directory: string}) {
     },
   ]);
 
+  const rawRemixConfig = await remixConfigPromise;
+  const nextSteps = [
+    `See more information about Vite in Remix at https://remix.run/docs/en/main/future/vite`,
+  ];
+
+  if (rawRemixConfig.mdx) {
+    nextSteps.unshift(
+      'Setup MDX support in Vite: https://remix.run/docs/en/main/future/vite#add-mdx-plugin',
+    );
+  }
+
   renderSuccess({
     headline: `Your Vite project is ready!`,
-    body: `We've modified your project to use Vite.\nPlease use git to review the changes.`,
-    nextSteps: [
-      `See more information about Vite in Remix at https://remix.run/docs/en/main/future/vite`,
-    ],
+    body: `We've modified your project to use Vite.\nPlease use Git to review the changes.`,
+    nextSteps,
   });
 }

--- a/packages/cli/src/commands/hydrogen/setup/vite.ts
+++ b/packages/cli/src/commands/hydrogen/setup/vite.ts
@@ -10,6 +10,7 @@ import {
 import {
   getPackageManager,
   installNodeModules,
+  readAndParsePackageJson,
 } from '@shopify/cli-kit/node/node-package-manager';
 import {commonFlags, flagsToCamelObject} from '../../../lib/flags.js';
 import {getRawRemixConfig} from '../../../lib/remix-config.js';
@@ -45,8 +46,16 @@ export async function runSetupVite({directory}: {directory: string}) {
     throw new AbortError('This project already has a Vite config file.');
   }
 
-  const remixConfigPromise = getRawRemixConfig(directory);
+  const [rawRemixConfig, pkgJson] = await Promise.all([
+    getRawRemixConfig(directory),
+    readAndParsePackageJson(joinPath(directory, 'package.json')),
+  ]);
+
   const codeFormatOptPromise = getCodeFormatOptions(directory);
+  const serverEntry = rawRemixConfig.server || 'server.js';
+  const isTS = serverEntry.endsWith('.ts');
+  const fileExt = isTS ? 'tsx' : 'jsx';
+  const viteAssets = getAssetDir('vite');
 
   const handlePartialIssue = () => {};
 
@@ -64,270 +73,265 @@ export async function runSetupVite({directory}: {directory: string}) {
         ),
       )
       .catch(handlePartialIssue),
+
     moveFile(
       resolvePath(directory, '.eslintrc.js'),
       resolvePath(directory, '.eslintrc.cjs'),
     ).catch(handlePartialIssue),
+
     moveFile(
       resolvePath(directory, 'postcss.config.js'),
       resolvePath(directory, 'postcss.config.cjs'),
     ).catch(handlePartialIssue),
-    remixConfigPromise.then((rawRemixConfig) => {
-      const serverEntry = rawRemixConfig.server || 'server.js';
-      const isTS = serverEntry.endsWith('.ts');
-      const fileExt = isTS ? 'tsx' : 'jsx';
-      const viteAssets = getAssetDir('vite');
 
-      return Promise.all([
-        removeFile(resolvePath(directory, 'remix.config.js')).catch(
-          handlePartialIssue,
-        ),
+    removeFile(resolvePath(directory, 'remix.config.js')).catch(
+      handlePartialIssue,
+    ),
 
-        mergePackageJson(viteAssets, directory, {
-          onResult(pkgJson) {
-            if (pkgJson.dependencies) {
-              // This dependency is not needed in Vite projects:
-              delete pkgJson.dependencies['@remix-run/css-bundle'];
-            }
+    // Adjust dependencies:
+    mergePackageJson(viteAssets, directory, {
+      onResult(pkgJson) {
+        if (pkgJson.dependencies) {
+          // This dependency is not needed in Vite projects:
+          delete pkgJson.dependencies['@remix-run/css-bundle'];
+        }
 
-            if (pkgJson.devDependencies) {
-              if (pkgJson.devDependencies['@vanilla-extract/css']) {
-                // Required vanilla-extract dependency for Vite
-                pkgJson.devDependencies['@vanilla-extract/vite-plugin'] =
-                  '^4.0.0';
+        if (pkgJson.devDependencies) {
+          if (pkgJson.devDependencies['@vanilla-extract/css']) {
+            // Required vanilla-extract dependency for Vite
+            pkgJson.devDependencies['@vanilla-extract/vite-plugin'] = '^4.0.0';
 
-                // Sort dependencies:
-                pkgJson.devDependencies = Object.keys(pkgJson.devDependencies)
-                  .sort()
-                  .reduce((acc, key) => {
-                    acc[key] = pkgJson.devDependencies?.[key]!;
-                    return acc;
-                  }, {} as Record<string, string>);
-              }
-            }
+            // Sort dependencies:
+            pkgJson.devDependencies = Object.keys(pkgJson.devDependencies)
+              .sort()
+              .reduce((acc, key) => {
+                acc[key] = pkgJson.devDependencies?.[key]!;
+                return acc;
+              }, {} as Record<string, string>);
+          }
+        }
 
-            return pkgJson;
-          },
-        }).then((pkgJson) => {
-          return readFile(resolvePath(viteAssets, 'vite.config.js')).then(
-            async (viteConfigContent) => {
-              const hasVanillaExtract =
-                !!pkgJson.devDependencies?.['@vanilla-extract/vite-plugin'];
+        return pkgJson;
+      },
+    }),
 
-              if (hasVanillaExtract) {
-                viteConfigContent = viteConfigContent
-                  .replace(
-                    /\n\n/g,
-                    `\nimport {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin';\n\n`,
-                  )
-                  .replace(/^(\s+)\],/m, '$1  vanillaExtractPlugin(),\n$1],');
-              }
+    // Build `vite.config.js` for the project:
+    readFile(resolvePath(viteAssets, 'vite.config.js')).then(
+      async (viteConfigContent) => {
+        const hasVanillaExtract =
+          !!pkgJson.devDependencies?.['@vanilla-extract/css'];
 
-              const {future, appDirectory, ignoredRouteFiles, routes} =
-                rawRemixConfig;
+        if (hasVanillaExtract) {
+          viteConfigContent = viteConfigContent
+            .replace(
+              /\n\n/g,
+              `\nimport {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin';\n\n`,
+            )
+            .replace(/^(\s+)\],/m, '$1  vanillaExtractPlugin(),\n$1],');
+        }
 
-              // Future flags:
-              for (const flag of [
-                'v3_fetcherPersist',
-                'v3_throwAbortReason',
-                'v3_relativeSplatPath',
-              ] as const) {
-                if (!future?.[flag]) {
-                  viteConfigContent = viteConfigContent.replace(
-                    `${flag}: true`,
-                    `${flag}: false`,
-                  );
-                }
-              }
+        const {future, appDirectory, ignoredRouteFiles, routes} =
+          rawRemixConfig;
 
-              if (appDirectory && appDirectory !== 'app') {
-                viteConfigContent = viteConfigContent.replace(
-                  /^(\s+)(future:)/m,
-                  `$1appDirectory: '${appDirectory}',\n$1$2`,
-                );
-              }
+        // Future flags:
+        for (const flag of [
+          'v3_fetcherPersist',
+          'v3_throwAbortReason',
+          'v3_relativeSplatPath',
+        ] as const) {
+          if (!future?.[flag]) {
+            viteConfigContent = viteConfigContent.replace(
+              `${flag}: true`,
+              `${flag}: false`,
+            );
+          }
+        }
 
-              if (ignoredRouteFiles) {
-                viteConfigContent = viteConfigContent.replace(
-                  /^(\s+)(future:)/m,
-                  `$1ignoredRouteFiles: ${JSON.stringify(
-                    ignoredRouteFiles,
-                  )},\n$1$2`,
-                );
-              }
-
-              if (routes) {
-                viteConfigContent = viteConfigContent.replace(
-                  /^(\s+)(future:)/m,
-                  `$1routes: ${routes.toString()},\n$1$2`,
-                );
-              }
-
-              const viteConfigPath = resolvePath(
-                directory,
-                'vite.config.' + fileExt.slice(0, 2),
-              );
-
-              viteConfigContent = await formatCode(
-                viteConfigContent,
-                await codeFormatOptPromise,
-                viteConfigPath,
-              );
-
-              return writeFile(viteConfigPath, viteConfigContent);
-            },
+        if (appDirectory && appDirectory !== 'app') {
+          viteConfigContent = viteConfigContent.replace(
+            /^(\s+)(future:)/m,
+            `$1appDirectory: '${appDirectory}',\n$1$2`,
           );
-        }),
-        replaceFileContent(
-          resolvePath(directory, serverEntry),
-          false,
-          (content) =>
-            (isTS ? '// @ts-ignore\n' : '') +
-            content.replace(
-              '@remix-run/dev/server-build',
-              'virtual:remix/server-build',
-            ),
-        ),
-        importLangAstGrep(fileExt).then(async (astGrep) => {
-          const appDirectory = resolvePath(
-            directory,
-            rawRemixConfig.appDirectory ?? 'app',
+        }
+
+        if (ignoredRouteFiles) {
+          viteConfigContent = viteConfigContent.replace(
+            /^(\s+)(future:)/m,
+            `$1ignoredRouteFiles: ${JSON.stringify(ignoredRouteFiles)},\n$1$2`,
           );
+        }
 
-          const rootFilepath = joinPath(appDirectory, 'root.' + fileExt);
+        if (routes) {
+          viteConfigContent = viteConfigContent.replace(
+            /^(\s+)(future:)/m,
+            `$1routes: ${routes.toString()},\n$1$2`,
+          );
+        }
 
-          // Add ?url to all CSS imports:
-          await new Promise(async (resolve, reject) => {
-            const fileNumber = await astGrep.findInFiles(
-              {
-                paths: [rootFilepath, joinPath(appDirectory, 'routes')],
-                matcher: {
-                  rule: {
-                    kind: 'string_fragment',
-                    regex: '\\.css$',
-                    inside: {
-                      kind: 'import_statement',
-                      stopBy: 'end',
-                    },
-                  },
+        const viteConfigPath = resolvePath(
+          directory,
+          'vite.config.' + fileExt.slice(0, 2),
+        );
+
+        viteConfigContent = await formatCode(
+          viteConfigContent,
+          await codeFormatOptPromise,
+          viteConfigPath,
+        );
+
+        return writeFile(viteConfigPath, viteConfigContent);
+      },
+    ),
+
+    replaceFileContent(
+      resolvePath(directory, serverEntry),
+      false,
+      (content) =>
+        (isTS ? '// @ts-ignore\n' : '') +
+        content.replace(
+          '@remix-run/dev/server-build',
+          'virtual:remix/server-build',
+        ),
+    ),
+
+    // Adjust CSS imports in the project:
+    importLangAstGrep(fileExt).then(async (astGrep) => {
+      const appDirectory = resolvePath(
+        directory,
+        rawRemixConfig.appDirectory ?? 'app',
+      );
+
+      const rootFilepath = joinPath(appDirectory, 'root.' + fileExt);
+
+      // Add ?url to all CSS imports:
+      await new Promise(async (resolve, reject) => {
+        const fileNumber = await astGrep.findInFiles(
+          {
+            paths: [rootFilepath, joinPath(appDirectory, 'routes')],
+            matcher: {
+              rule: {
+                kind: 'string_fragment',
+                regex: '\\.css$',
+                inside: {
+                  kind: 'import_statement',
+                  stopBy: 'end',
                 },
               },
-              async (err, nodes) => {
-                if (err) reject(err);
-                const nodeMap = {} as Record<
-                  string,
-                  {content: string; positions: number[]}
-                >;
+            },
+          },
+          async (err, nodes) => {
+            if (err) reject(err);
+            const nodeMap = {} as Record<
+              string,
+              {content: string; positions: number[]}
+            >;
 
-                nodes.forEach((node) => {
-                  if (node.text().endsWith('.module.css')) {
-                    // Skip for CSS modules
-                    return;
+            nodes.forEach((node) => {
+              if (node.text().endsWith('.module.css')) {
+                // Skip for CSS modules
+                return;
+              }
+
+              const filename = node.getRoot().filename();
+              const content = node.getRoot().root().text();
+              const position = node.range().end.index;
+
+              const tmp = nodeMap[filename] || {content, positions: []};
+              tmp.positions.push(position);
+              nodeMap[filename] = tmp;
+            });
+
+            await Promise.all(
+              Object.entries(nodeMap).flatMap(
+                ([filename, {content, positions}]) => {
+                  // Start from the end to avoid moving character indexes:
+                  positions.reverse();
+
+                  for (const position of positions) {
+                    content =
+                      content.slice(0, position) +
+                      '?url' +
+                      content.slice(position);
                   }
 
-                  const filename = node.getRoot().filename();
-                  const content = node.getRoot().root().text();
-                  const position = node.range().end.index;
-
-                  const tmp = nodeMap[filename] || {content, positions: []};
-                  tmp.positions.push(position);
-                  nodeMap[filename] = tmp;
-                });
-
-                await Promise.all(
-                  Object.entries(nodeMap).flatMap(
-                    ([filename, {content, positions}]) => {
-                      // Start from the end to avoid moving character indexes:
-                      positions.reverse();
-
-                      for (const position of positions) {
-                        content =
-                          content.slice(0, position) +
-                          '?url' +
-                          content.slice(position);
-                      }
-
-                      return writeFile(filename, content);
-                    },
-                  ),
-                );
-
-                resolve(null);
-              },
+                  return writeFile(filename, content);
+                },
+              ),
             );
 
-            if (fileNumber === 0) resolve(null);
+            resolve(null);
+          },
+        );
+
+        if (fileNumber === 0) resolve(null);
+      });
+
+      // Remove the LiveReload import and usage:
+      await replaceFileContent(
+        rootFilepath,
+        await codeFormatOptPromise,
+        (content) => {
+          const root = astGrep.parse(content).root();
+          const liveReloadRegex = 'LiveReload';
+          const hasLiveReloadRule = {
+            kind: 'identifier',
+            regex: liveReloadRegex,
+          };
+
+          const liveReloadImport = root.find({
+            rule: {
+              kind: 'import_specifier',
+              regex: liveReloadRegex,
+              inside: {
+                kind: 'import_statement',
+                stopBy: 'end',
+              },
+            },
           });
 
-          // Remove the LiveReload import and usage:
-          await replaceFileContent(
-            rootFilepath,
-            await codeFormatOptPromise,
-            (content) => {
-              const root = astGrep.parse(content).root();
-              const liveReloadRegex = 'LiveReload';
-              const hasLiveReloadRule = {
-                kind: 'identifier',
-                regex: liveReloadRegex,
-              };
-
-              const liveReloadImport = root.find({
-                rule: {
-                  kind: 'import_specifier',
-                  regex: liveReloadRegex,
-                  inside: {
-                    kind: 'import_statement',
-                    stopBy: 'end',
+          const liveReloadElements = root.findAll({
+            rule: {
+              any: [
+                {
+                  kind: 'jsx_self_closing_element',
+                  has: hasLiveReloadRule,
+                },
+                {
+                  kind: 'jsx_element',
+                  has: {
+                    kind: 'jsx_opening_element',
+                    has: hasLiveReloadRule,
                   },
                 },
-              });
-
-              const liveReloadElements = root.findAll({
-                rule: {
-                  any: [
-                    {
-                      kind: 'jsx_self_closing_element',
-                      has: hasLiveReloadRule,
-                    },
-                    {
-                      kind: 'jsx_element',
-                      has: {
-                        kind: 'jsx_opening_element',
-                        has: hasLiveReloadRule,
-                      },
-                    },
-                  ],
-                },
-              });
-
-              for (const node of [
-                // From bottom to top
-                ...liveReloadElements.reverse(),
-                liveReloadImport,
-              ]) {
-                if (!node) continue;
-
-                const {start, end} = node.range();
-                content =
-                  content.slice(0, start.index) + content.slice(end.index);
-              }
-
-              return (
-                content
-                  // Remove the trailing comma from the import statement:
-                  .replace(/,\s*,/g, ',')
-                  // Remove cssBundleHref import
-                  .replace(
-                    /import\s+{\s+cssBundleHref\s+}\s+from\s+['"]@remix-run\/css-bundle['"];?\n/,
-                    '',
-                  )
-                  // Remove cssBundleHref usage
-                  .replace(/\.\.\.\(\s*cssBundleHref[^)]+\),?/, '')
-              );
+              ],
             },
+          });
+
+          for (const node of [
+            // From bottom to top
+            ...liveReloadElements.reverse(),
+            liveReloadImport,
+          ]) {
+            if (!node) continue;
+
+            const {start, end} = node.range();
+            content = content.slice(0, start.index) + content.slice(end.index);
+          }
+
+          return (
+            content
+              // Remove the trailing comma from the import statement:
+              .replace(/,\s*,/g, ',')
+              // Remove cssBundleHref import
+              .replace(
+                /import\s+{\s+cssBundleHref\s+}\s+from\s+['"]@remix-run\/css-bundle['"];?\n/,
+                '',
+              )
+              // Remove cssBundleHref usage
+              .replace(/\.\.\.\(\s*cssBundleHref[^)]+\),?/, '')
           );
-        }),
-      ]);
+        },
+      );
     }),
   ]);
 
@@ -350,20 +354,14 @@ export async function runSetupVite({directory}: {directory: string}) {
     },
   ]);
 
-  const rawRemixConfig = await remixConfigPromise;
-  const nextSteps = [
-    `See more information about Vite in Remix at https://remix.run/docs/en/main/future/vite`,
-  ];
-
-  if (rawRemixConfig.mdx) {
-    nextSteps.unshift(
-      'Setup MDX support in Vite: https://remix.run/docs/en/main/future/vite#add-mdx-plugin',
-    );
-  }
-
   renderSuccess({
     headline: `Your Vite project is ready!`,
     body: `We've modified your project to use Vite.\nPlease use Git to review the changes.`,
-    nextSteps,
+    nextSteps: [
+      rawRemixConfig.mdx
+        ? 'Setup MDX support in Vite: https://remix.run/docs/en/main/future/vite#add-mdx-plugin'
+        : '',
+      `See more information about Vite in Remix at https://remix.run/docs/en/main/future/vite`,
+    ].filter(Boolean),
   });
 }

--- a/packages/cli/src/commands/hydrogen/setup/vite.ts
+++ b/packages/cli/src/commands/hydrogen/setup/vite.ts
@@ -170,6 +170,11 @@ export async function runSetupVite({directory}: {directory: string}) {
                 >;
 
                 nodes.forEach((node) => {
+                  if (node.text().endsWith('.module.css')) {
+                    // Skip CSS modules
+                    return;
+                  }
+
                   const filename = node.getRoot().filename();
                   const content = node.getRoot().root().text();
                   const position = node.range().end.index;

--- a/packages/cli/src/lib/file.ts
+++ b/packages/cli/src/lib/file.ts
@@ -87,7 +87,7 @@ export async function mergePackageJson(
     onResult?: (pkgJson: PackageJson) => PackageJson;
   },
 ) {
-  const targetPkgJson: PackageJson = await readAndParsePackageJson(
+  let targetPkgJson: PackageJson = await readAndParsePackageJson(
     joinPath(targetDir, 'package.json'),
   );
   const sourcePkgJson: PackageJson = await readAndParsePackageJson(
@@ -145,8 +145,9 @@ export async function mergePackageJson(
     }
   }
 
-  await writePackageJSON(
-    targetDir,
-    options?.onResult?.(targetPkgJson) ?? targetPkgJson,
-  );
+  targetPkgJson = options?.onResult?.(targetPkgJson) ?? targetPkgJson;
+
+  await writePackageJSON(targetDir, targetPkgJson);
+
+  return targetPkgJson;
 }

--- a/packages/cli/src/lib/file.ts
+++ b/packages/cli/src/lib/file.ts
@@ -87,7 +87,7 @@ export async function mergePackageJson(
     onResult?: (pkgJson: PackageJson) => PackageJson;
   },
 ) {
-  let targetPkgJson: PackageJson = await readAndParsePackageJson(
+  const targetPkgJson: PackageJson = await readAndParsePackageJson(
     joinPath(targetDir, 'package.json'),
   );
   const sourcePkgJson: PackageJson = await readAndParsePackageJson(
@@ -145,9 +145,8 @@ export async function mergePackageJson(
     }
   }
 
-  targetPkgJson = options?.onResult?.(targetPkgJson) ?? targetPkgJson;
-
-  await writePackageJSON(targetDir, targetPkgJson);
-
-  return targetPkgJson;
+  await writePackageJSON(
+    targetDir,
+    options?.onResult?.(targetPkgJson) ?? targetPkgJson,
+  );
 }

--- a/packages/cli/src/lib/vite-config.ts
+++ b/packages/cli/src/lib/vite-config.ts
@@ -1,5 +1,11 @@
 import {joinPath} from '@shopify/cli-kit/node/path';
 import type {RemixPluginContext} from '@remix-run/dev/dist/vite/plugin.js';
+import {findFileWithExtension} from './file.js';
+
+export async function hasViteConfig(root: string) {
+  const result = await findFileWithExtension(root, 'vite.config');
+  return !!result.filepath;
+}
 
 export async function getViteConfig(root: string) {
   const vite = await import('vite');

--- a/packages/cli/src/setup-assets/vite/package.json
+++ b/packages/cli/src/setup-assets/vite/package.json
@@ -5,7 +5,6 @@
     "dev": "shopify hydrogen dev-vite --codegen"
   },
   "dependencies": {
-    "@remix-run/node": "^2.8.0",
     "isbot": "^3.8.0"
   },
   "devDependencies": {

--- a/packages/cli/src/setup-assets/vite/vite.config.js
+++ b/packages/cli/src/setup-assets/vite/vite.config.js
@@ -7,7 +7,14 @@ export default defineConfig({
   plugins: [
     hydrogen(),
     oxygen(),
-    remix({buildDirectory: 'dist'}),
+    remix({
+      buildDirectory: 'dist',
+      future: {
+        v3_fetcherPersist: true,
+        v3_relativeSplatPath: true,
+        v3_throwAbortReason: true,
+      },
+    }),
     tsconfigPaths(),
   ],
 });


### PR DESCRIPTION
### WHY are these changes introduced?

The `h2 setup vite` command was experimental and it had a few issues. This PR makes it more robust and removes the "experimental" confirmation prompt.

### WHAT is this pull request doing?

It now covers most of the steps in the Remix upgrade guide: https://remix.run/docs/en/main/future/vite

- Throw if project is already using Vite
- Remove deprecated Remix css-bundle dependency
- Support CSS Modules
- Support Vanilla Extract
- Improve edge cases for Tailwind support
- Move some `remix.config.js` properties to `vite.config.js` (appDirectory, routes, ignoredRouteFiles, future)
- Notify about MDX support to set it up manually if it was used

### HOW to test your changes?

`h2 setup vite` in project variations with vanilla-extract, modules, changes in remix.config.js etc.

