### PR TITLE
Bump oxygen-cli to 4.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30453,7 +30453,7 @@
         "@shopify/cli-kit": "3.56.3",
         "@shopify/hydrogen-codegen": "^0.2.2",
         "@shopify/mini-oxygen": "^2.2.5",
-        "@shopify/oxygen-cli": "^4.3.0",
+        "@shopify/oxygen-cli": "^4.3.6",
         "@shopify/plugin-cloudflare": "3.56.3",
         "ansi-escapes": "^6.2.0",
         "cli-truncate": "^4.0.0",
@@ -38099,7 +38099,7 @@
         "@shopify/cli-kit": "3.56.3",
         "@shopify/hydrogen-codegen": "^0.2.2",
         "@shopify/mini-oxygen": "^2.2.5",
-        "@shopify/oxygen-cli": "^4.3.0",
+        "@shopify/oxygen-cli": "^4.3.6",
         "@shopify/plugin-cloudflare": "3.56.3",
         "@types/diff": "^5.0.2",
         "@types/fs-extra": "^11.0.1",
@@ -38175,8 +38175,7 @@
           "optional": true
         },
         "@shopify/oxygen-cli": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.3.0.tgz",
+          "version": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.3.0.tgz",
           "integrity": "sha512-45L3J916wN85EMHzTDpwaiuFWmAd00KY3LIPawpeRcHt0nbJgSAJd01Ijz9M12AOYRiZM5AtlBAE5hjyH5Ppaw==",
           "requires": {
             "@bugsnag/core": "^7.19.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "@shopify/cli-kit": "3.56.3",
     "@shopify/hydrogen-codegen": "^0.2.2",
     "@shopify/mini-oxygen": "^2.2.5",
-    "@shopify/oxygen-cli": "^4.3.0",
+    "@shopify/oxygen-cli": "^4.3.6",
     "@shopify/plugin-cloudflare": "3.56.3",
     "ansi-escapes": "^6.2.0",
     "cli-truncate": "^4.0.0",


### PR DESCRIPTION
### WHY are these changes introduced?

v4.3.6 of `oxygen-cli` introduces a fix that ensures the correct Git branch is used when using the `deploy` command inside a GitHub action triggered by the `pull_request` event.

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
