### PR TITLE
Improve logs in Vite dev server

### DIFF
--- a/.changeset/clean-rocks-camp.md
+++ b/.changeset/clean-rocks-camp.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Improve development logs when using Vite.

--- a/packages/cli/src/commands/hydrogen/dev-vite.ts
+++ b/packages/cli/src/commands/hydrogen/dev-vite.ts
@@ -8,7 +8,7 @@ import {
 } from '../../lib/flags.js';
 import Command from '@shopify/cli-kit/node/base-command';
 import colors from '@shopify/cli-kit/node/colors';
-import {renderInfo} from '@shopify/cli-kit/node/ui';
+import {renderSuccess} from '@shopify/cli-kit/node/ui';
 import {AbortError} from '@shopify/cli-kit/node/error';
 import {Flags, Config} from '@oclif/core';
 import {spawnCodegenProcess} from '../../lib/codegen.js';
@@ -250,7 +250,7 @@ export async function runDev({
   if (customSections.length > 0) {
     const {storefrontTitle} = await backgroundPromise;
 
-    renderInfo({
+    renderSuccess({
       body: [
         `View ${
           storefrontTitle ? colors.cyan(storefrontTitle) : 'Hydrogen'

--- a/packages/cli/src/commands/hydrogen/dev-vite.ts
+++ b/packages/cli/src/commands/hydrogen/dev-vite.ts
@@ -150,7 +150,7 @@ export async function runDev({
       cliOptions: {
         debug,
         ssrEntry,
-        envPromise,
+        envPromise: envPromise.then(({allVariables}) => allVariables),
         inspectorPort,
         disableVirtualRoutes,
       },
@@ -220,7 +220,9 @@ export async function runDev({
     cliCommand,
   });
 
-  const envVariables = await envPromise; // Prints the injected env vars
+  const {logInjectedVariables, localVariables} = await envPromise;
+
+  logInjectedVariables();
   console.log('');
   viteServer.printUrls();
   viteServer.bindCLIShortcuts({print: true});
@@ -266,7 +268,7 @@ export async function runDev({
     displayDevUpgradeNotice({targetPath: root});
   }
 
-  if (customerAccountPushFlag && isMockShop(envVariables)) {
+  if (customerAccountPushFlag && isMockShop(localVariables)) {
     notifyIssueWithTunnelAndMockShop(cliCommand);
   }
 

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -66,12 +66,14 @@ export async function runPreview({
 
   const {shop, storefront} = await getConfig(root);
   const fetchRemote = !!shop && !!storefront?.id;
-  const env = await getAllEnvironmentVariables({
-    root,
-    fetchRemote,
-    envBranch,
-    envHandle,
-  });
+  const {allVariables, logInjectedVariables} = await getAllEnvironmentVariables(
+    {
+      root,
+      fetchRemote,
+      envBranch,
+      envHandle,
+    },
+  );
 
   appPort = legacyRuntime ? appPort : await findPort(appPort);
   inspectorPort = debug ? await findPort(inspectorPort) : inspectorPort;
@@ -81,12 +83,14 @@ export async function runPreview({
   // we don't control the build at this point. However, the assets server
   // still need to be started to serve redirections from the worker runtime.
 
+  logInjectedVariables();
+
   const miniOxygen = await startMiniOxygen(
     {
       root,
       port: appPort,
       assetsPort,
-      env,
+      env: allVariables,
       buildPathClient,
       buildPathWorkerFile,
       inspectorPort,

--- a/packages/cli/src/lib/environment-variables.test.ts
+++ b/packages/cli/src/lib/environment-variables.test.ts
@@ -58,6 +58,16 @@ describe('getAllEnvironmentVariables()', () => {
     mockAndCaptureOutput().clear();
   });
 
+  it('returns all variables', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const {allVariables} = await getAllEnvironmentVariables({
+        root: tmpDir,
+      });
+
+      expect(allVariables).toMatchObject({PUBLIC_API_TOKEN: 'abc123'});
+    });
+  });
+
   it('calls pullRemoteEnvironmentVariables using handle', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       await getAllEnvironmentVariables({
@@ -100,23 +110,19 @@ describe('getAllEnvironmentVariables()', () => {
     });
   });
 
-  it('renders a message about injection', async () => {
+  it('returns a logger that renders information about variables', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       const outputMock = mockAndCaptureOutput();
 
-      await getAllEnvironmentVariables({root: tmpDir});
+      const {logInjectedVariables} = await getAllEnvironmentVariables({
+        root: tmpDir,
+      });
+
+      logInjectedVariables();
 
       expect(outputMock.info()).toMatch(
         /Environment variables injected into MiniOxygen:/,
       );
-    });
-  });
-
-  it('lists all of the variables being used', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      const outputMock = mockAndCaptureOutput();
-
-      await getAllEnvironmentVariables({root: tmpDir});
 
       expect(outputMock.info()).toMatch(/PUBLIC_API_TOKEN\s+from Oxygen/);
     });
@@ -130,7 +136,11 @@ describe('getAllEnvironmentVariables()', () => {
 
       const outputMock = mockAndCaptureOutput();
 
-      await getAllEnvironmentVariables({root: tmpDir});
+      const {logInjectedVariables} = await getAllEnvironmentVariables({
+        root: tmpDir,
+      });
+
+      logInjectedVariables();
 
       expect(outputMock.info()).not.toMatch(/PUBLIC_API_TOKEN\s+from Oxygen/);
       expect(outputMock.warn()).toMatch(/failed to load/i);
@@ -157,7 +167,11 @@ describe('getAllEnvironmentVariables()', () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const outputMock = mockAndCaptureOutput();
 
-        await getAllEnvironmentVariables({root: tmpDir});
+        const {logInjectedVariables} = await getAllEnvironmentVariables({
+          root: tmpDir,
+        });
+
+        logInjectedVariables();
 
         expect(outputMock.info()).toMatch(
           /PUBLIC_API_TOKEN\s+from Oxygen \(Marked as secret\)/,
@@ -174,7 +188,11 @@ describe('getAllEnvironmentVariables()', () => {
 
         const outputMock = mockAndCaptureOutput();
 
-        await getAllEnvironmentVariables({root: tmpDir});
+        const {logInjectedVariables} = await getAllEnvironmentVariables({
+          root: tmpDir,
+        });
+
+        logInjectedVariables();
 
         expect(outputMock.info()).toMatch(/LOCAL_TOKEN\s+from local \.env/);
       });
@@ -188,7 +206,11 @@ describe('getAllEnvironmentVariables()', () => {
 
           const outputMock = mockAndCaptureOutput();
 
-          await getAllEnvironmentVariables({root: tmpDir});
+          const {logInjectedVariables} = await getAllEnvironmentVariables({
+            root: tmpDir,
+          });
+
+          logInjectedVariables();
 
           expect(outputMock.info()).not.toMatch(
             /PUBLIC_API_TOKEN\s+from Oxygen/,

--- a/packages/cli/src/lib/environment-variables.ts
+++ b/packages/cli/src/lib/environment-variables.ts
@@ -61,33 +61,41 @@ export async function getAllEnvironmentVariables({
   const remotePublicKeys = Object.keys(remoteVariables);
   const localKeys = Object.keys(localVariables);
 
-  if (
-    localKeys.length > 0 ||
-    remotePublicKeys.length + remoteSecretKeys.length > 0
-  ) {
-    outputInfo('\nEnvironment variables injected into MiniOxygen:\n');
+  function logInjectedVariables() {
+    if (
+      localKeys.length > 0 ||
+      remotePublicKeys.length + remoteSecretKeys.length > 0
+    ) {
+      outputInfo('\nEnvironment variables injected into MiniOxygen:\n');
 
-    outputInfo(
-      linesToColumns([
-        ...remotePublicKeys
-          .filter((key) => !localKeys.includes(key))
-          .map((key) => [key, 'from Oxygen']),
-        ...localKeys.map((key) => [key, 'from local .env']),
-        // Ensure secret variables always get added to the bottom of the list
-        ...remoteSecretKeys
-          .filter((key) => !localKeys.includes(key))
-          .map((key) => [
-            colors.dim(key),
-            colors.dim('from Oxygen (Marked as secret)'),
-          ]),
-      ]),
-    );
+      outputInfo(
+        linesToColumns([
+          ...remotePublicKeys
+            .filter((key) => !localKeys.includes(key))
+            .map((key) => [key, 'from Oxygen']),
+          ...localKeys.map((key) => [key, 'from local .env']),
+          // Ensure secret variables always get added to the bottom of the list
+          ...remoteSecretKeys
+            .filter((key) => !localKeys.includes(key))
+            .map((key) => [
+              colors.dim(key),
+              colors.dim('from Oxygen (Marked as secret)'),
+            ]),
+        ]),
+      );
+    }
   }
 
   return {
-    ...remoteSecrets,
-    ...remoteVariables,
-    ...localVariables,
+    logInjectedVariables,
+    remoteVariables,
+    remoteSecrets,
+    localVariables,
+    allVariables: {
+      ...remoteSecrets,
+      ...remoteVariables,
+      ...localVariables,
+    },
   };
 }
 


### PR DESCRIPTION

### WHY are these changes introduced?

Logs in Vite dev server are quite chaotic at the moment.

### WHAT is this pull request doing?

- Filter out non-actionable Vite logs (most of them come from our Vite<>Workerd integration).
- Adds spacing between Vite logs and Hydrogen logs.
- Ensures most logs are output in order at the beginning.


### HOW to test your changes?

It's easier to review this PR looking at each commit individually.
To test: run the development server in skeleton and Vite projects.

| Before        | After         |
| ------------- | ------------- |
| <img width="793" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/a2f58eac-a5ed-4909-9dc4-97f690aa908a"> | <img width="793" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/faac0d0b-e331-4fcf-8907-3d7354fd8cc8">


