### PR TITLE
Add `--verbose` flag to dev and preview commands

### DIFF
--- a/.changeset/witty-rockets-guess.md
+++ b/.changeset/witty-rockets-guess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add `--verbose` flag to `h2 dev` and `h2 preview` commands to enable verbose logging. Only CLI logs become verbose by default. If you also want to see verbose logs from Vite as well, use `DEBUG=* h2 dev` instead.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -552,6 +552,14 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "verbose": {
+          "description": "Outputs more information about the command's execution.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
+          "name": "verbose",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -692,6 +700,14 @@
           "description": "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's Oauth flow",
           "env": "SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH",
           "name": "customer-account-push",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Outputs more information about the command's execution.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
+          "name": "verbose",
           "required": false,
           "allowNo": false,
           "type": "boolean"
@@ -1055,6 +1071,14 @@
           "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
           "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
           "name": "debug",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Outputs more information about the command's execution.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
+          "name": "verbose",
+          "required": false,
           "allowNo": false,
           "type": "boolean"
         }

--- a/packages/cli/src/commands/hydrogen/dev-vite.ts
+++ b/packages/cli/src/commands/hydrogen/dev-vite.ts
@@ -1,6 +1,11 @@
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {enhanceH2Logs, muteDevLogs} from '../../lib/log.js';
+import {
+  enhanceH2Logs,
+  isH2Verbose,
+  muteDevLogs,
+  setH2OVerbose,
+} from '../../lib/log.js';
 import {
   commonFlags,
   flagsToCamelObject,
@@ -59,6 +64,7 @@ export default class DevVite extends Command {
     }),
     ...commonFlags.diff,
     ...commonFlags.customerAccountPush,
+    ...commonFlags.verbose,
   };
 
   async run(): Promise<void> {
@@ -95,6 +101,7 @@ type DevOptions = {
   isLocalDev?: boolean;
   customerAccountPush?: boolean;
   cliConfig: Config;
+  verbose?: boolean;
 };
 
 export async function runDev({
@@ -113,10 +120,12 @@ export async function runDev({
   isLocalDev = false,
   customerAccountPush: customerAccountPushFlag = false,
   cliConfig,
+  verbose,
 }: DevOptions) {
   if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development';
 
-  muteDevLogs();
+  if (verbose) setH2OVerbose();
+  if (!isH2Verbose()) muteDevLogs();
 
   const root = appPath ?? process.cwd();
 

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -12,7 +12,13 @@ import {
   handleRemixImportFail,
   type ServerMode,
 } from '../../lib/remix-config.js';
-import {createRemixLogger, enhanceH2Logs, muteDevLogs} from '../../lib/log.js';
+import {
+  createRemixLogger,
+  enhanceH2Logs,
+  isH2Verbose,
+  muteDevLogs,
+  setH2OVerbose,
+} from '../../lib/log.js';
 import {commonFlags, deprecated, flagsToCamelObject} from '../../lib/flags.js';
 import Command from '@shopify/cli-kit/node/base-command';
 import {Flags, Config} from '@oclif/core';
@@ -68,6 +74,7 @@ export default class Dev extends Command {
     }),
     ...commonFlags.diff,
     ...commonFlags.customerAccountPush,
+    ...commonFlags.verbose,
   };
 
   async run(): Promise<void> {
@@ -101,6 +108,7 @@ type DevOptions = {
   inspectorPort: number;
   customerAccountPush?: boolean;
   cliConfig?: Config;
+  verbose?: boolean;
 };
 
 export async function runDev({
@@ -118,10 +126,12 @@ export async function runDev({
   inspectorPort,
   customerAccountPush: customerAccountPushFlag = false,
   cliConfig,
+  verbose,
 }: DevOptions) {
   if (!process.env.NODE_ENV) process.env.NODE_ENV = 'development';
 
-  muteDevLogs();
+  if (verbose) setH2OVerbose();
+  if (!isH2Verbose()) muteDevLogs();
 
   const {root, publicPath, buildPathClient, buildPathWorkerFile} =
     getProjectPaths(appPath);

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -1,5 +1,5 @@
 import Command from '@shopify/cli-kit/node/base-command';
-import {muteDevLogs} from '../../lib/log.js';
+import {isH2Verbose, muteDevLogs, setH2OVerbose} from '../../lib/log.js';
 import {getProjectPaths} from '../../lib/remix-config.js';
 import {commonFlags, deprecated, flagsToCamelObject} from '../../lib/flags.js';
 import {startMiniOxygen} from '../../lib/mini-oxygen/index.js';
@@ -23,6 +23,7 @@ export default class Preview extends Command {
     ...commonFlags.envBranch,
     ...commonFlags.inspectorPort,
     ...commonFlags.debug,
+    ...commonFlags.verbose,
   };
 
   async run(): Promise<void> {
@@ -42,6 +43,7 @@ type PreviewOptions = {
   envBranch?: string;
   inspectorPort: number;
   debug: boolean;
+  verbose?: boolean;
 };
 
 export async function runPreview({
@@ -52,10 +54,12 @@ export async function runPreview({
   envBranch,
   inspectorPort,
   debug,
+  verbose,
 }: PreviewOptions) {
   if (!process.env.NODE_ENV) process.env.NODE_ENV = 'production';
 
-  muteDevLogs({workerReload: false});
+  if (verbose) setH2OVerbose();
+  if (!isH2Verbose()) muteDevLogs();
 
   let {root, buildPathWorkerFile, buildPathClient} = getProjectPaths(appPath);
 

--- a/packages/cli/src/lib/codegen.ts
+++ b/packages/cli/src/lib/codegen.ts
@@ -74,7 +74,9 @@ export function spawnCodegenProcess({
 
     const {message, details} = normalizeCodegenError(dataString, rootDirectory);
 
+    // Filter these logs even on verbose mode because it floods the terminal:
     if (/`punycode`/.test(message)) return;
+    if (/\.body\[\d\]/) return;
 
     console.log('');
     renderWarning({headline: message, body: details});

--- a/packages/cli/src/lib/flags.ts
+++ b/packages/cli/src/lib/flags.ts
@@ -183,6 +183,14 @@ export const commonFlags = {
       env: 'SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH',
     }),
   },
+  verbose: {
+    verbose: Flags.boolean({
+      description: "Outputs more information about the command's execution.",
+      required: false,
+      default: false,
+      env: 'SHOPIFY_HYDROGEN_FLAG_VERBOSE',
+    }),
+  },
 } satisfies Record<string, Record<Lowercase<string>, FlagProps>>;
 
 export function flagsToCamelObject<T extends Record<string, any>>(obj: T) {

--- a/packages/cli/src/lib/log.ts
+++ b/packages/cli/src/lib/log.ts
@@ -423,3 +423,19 @@ export async function muteRemixLogs() {
     // --
   }
 }
+
+export function setH2OVerbose() {
+  if (!process.env.DEBUG || process.env.DEBUG === '*') {
+    process.env.DEBUG = 'h2:*,o2:*';
+  } else {
+    process.env.DEBUG += ',h2:*,o2:*';
+  }
+}
+
+export function isH2Verbose() {
+  return !!(process.env.DEBUG === '*' || process.env.DEBUG?.includes('h2:*'));
+}
+
+export function isO2Verbose() {
+  return !!(process.env.DEBUG === '*' || process.env.DEBUG?.includes('o2:*'));
+}

--- a/packages/cli/src/lib/vite/mini-oxygen.ts
+++ b/packages/cli/src/lib/vite/mini-oxygen.ts
@@ -14,6 +14,7 @@ import {MiniOxygenOptions} from '../mini-oxygen/types.js';
 import {getHmrUrl, pipeFromWeb, toURL, toWeb} from './utils.js';
 
 import type {ViteEnv} from './worker-entry.js';
+import {isO2Verbose} from '../log.js';
 const scriptPath = fileURLToPath(new URL('./worker-entry.js', import.meta.url));
 
 const FETCH_MODULE_PATHNAME = '/__vite_fetch_module';
@@ -56,20 +57,24 @@ export async function startMiniOxygenRuntime({
 
   const mf = new Miniflare({
     cf: false,
-    verbose: false,
-    log: new NoOpLog(),
     inspectorPort: privateInspectorPort,
-    handleRuntimeStdio(stdout, stderr) {
-      // TODO: handle runtime stdio and remove inspector logs
-      // stdout.pipe(process.stdout);
-      // stderr.pipe(process.stderr);
+    ...(isO2Verbose()
+      ? {verbose: true}
+      : {
+          verbose: false,
+          log: new NoOpLog(),
+          handleRuntimeStdio(stdout, stderr) {
+            // TODO: handle runtime stdio and remove inspector logs
+            // stdout.pipe(process.stdout);
+            // stderr.pipe(process.stderr);
 
-      // Destroy these streams to prevent memory leaks
-      // until we start piping them to the terminal.
-      // https://github.com/Shopify/hydrogen/issues/1720
-      stdout.destroy();
-      stderr.destroy();
-    },
+            // Destroy these streams to prevent memory leaks
+            // until we start piping them to the terminal.
+            // https://github.com/Shopify/hydrogen/issues/1720
+            stdout.destroy();
+            stderr.destroy();
+          },
+        }),
     workers: [
       {
         name: 'oxygen',


### PR DESCRIPTION
### WHY are these changes introduced?

We are currently filtering out logs from the workerd runtime itself because they are largely non-actionable. We get app logs via WS, which is enough for most situations.

However, in some circumstances you might want to see the runtime logs, especially when you're doing something that crashes the runtime (http calls outside of request cycles, importing unsupported dependencies, etc.).

So far, this could be debugged using the `--legacy-runtime`. However, when moving to Vite we won't have access to the Node.js sandbox runtime anymore.

### WHAT is this pull request doing?

Introduce a `--verbose` flag that logs all the runtime information for debugging purposes.

This flag is already used by `cli-kit` internally to output its own verbose logs. I'm not sure if we should use a different flag name to only output H2O logs instead, but I think mixing them with cli-kit is not bad either.

A problem I found is that, when `cli-kit` detects `--verbose`, it runs `process.env.DEBUG='*'`... which is later picked up by Vite and it floods the terminal with all the verbose Vite logs. In order to prevent this, I'm replacing `'*'` with `h2:*,o2:*` so that Vite doesn't output its verbose logs.

If, for whatever reason, the user wants Vite verbose logs, they can just run `DEBUG=* h2 dev` directly without our flag and it should all be printed (cli-kit, h2o and Vite).

### HOW to test your changes?

Try `h2 dev`, `h2 dev --verbose` and `DEBUG=* h2 dev` to see the differences in `templates/skeleton` and `examples/vite`.


---

Note: I'm updating #1891 to also check the `o2:*` value in `process.env.DEBUG`.
