### PR TITLE
Custom URL for dev tunnels

### DIFF
--- a/packages/cli/src/commands/hydrogen/dev-vite.ts
+++ b/packages/cli/src/commands/hydrogen/dev-vite.ts
@@ -31,6 +31,7 @@ import {
   notifyIssueWithTunnelAndMockShop,
   getDevConfigInBackground,
   getUtilityBannerlines,
+  TUNNEL_DOMAIN,
 } from '../../lib/dev-shared.js';
 import {getCliCommand} from '../../lib/shell.js';
 import {findPort} from '../../lib/find-port.js';
@@ -165,6 +166,27 @@ export async function runDev({
   const viteServer = await vite.createServer({
     root,
     server: {fs, host: host ? true : undefined},
+    plugins: customerAccountPushFlag
+      ? [
+          {
+            name: 'hydrogen:tunnel',
+            configureServer: (viteDevServer) => {
+              viteDevServer.middlewares.use((req, res, next) => {
+                const host = req.headers.host;
+
+                if (host?.includes(TUNNEL_DOMAIN.ORIGINAL)) {
+                  req.headers.host = host.replace(
+                    TUNNEL_DOMAIN.ORIGINAL,
+                    TUNNEL_DOMAIN.REBRANDED,
+                  );
+                }
+
+                next();
+              });
+            },
+          },
+        ]
+      : [],
     ...setH2OPluginContext({
       cliOptions: {
         debug,

--- a/packages/cli/src/lib/dev-shared.ts
+++ b/packages/cli/src/lib/dev-shared.ts
@@ -74,7 +74,10 @@ export async function startTunnelAndPushConfig(
   outputInfo('\nStarting tunnel...\n');
 
   const tunnel = await startTunnelPlugin(cliConfig, port, 'cloudflare');
-  const host = await pollTunnelURL(tunnel);
+  const host = await pollTunnelURL(tunnel).then((host) =>
+    // Replace branded tunnel domain:
+    host.replace('trycloudflare.com', 'tryhydrogen.dev'),
+  );
 
   try {
     await runCustomerAccountPush({

--- a/packages/cli/src/lib/dev-shared.ts
+++ b/packages/cli/src/lib/dev-shared.ts
@@ -65,6 +65,11 @@ export function getDevConfigInBackground(
   });
 }
 
+export const TUNNEL_DOMAIN = Object.freeze({
+  ORIGINAL: '.trycloudflare.com',
+  REBRANDED: '.tryhydrogen.dev',
+});
+
 export async function startTunnelAndPushConfig(
   root: string,
   cliConfig: Config,
@@ -76,7 +81,7 @@ export async function startTunnelAndPushConfig(
   const tunnel = await startTunnelPlugin(cliConfig, port, 'cloudflare');
   const host = await pollTunnelURL(tunnel).then((host) =>
     // Replace branded tunnel domain:
-    host.replace('trycloudflare.com', 'tryhydrogen.dev'),
+    host.replace(TUNNEL_DOMAIN.ORIGINAL, TUNNEL_DOMAIN.REBRANDED),
   );
 
   try {

--- a/packages/cli/src/lib/vite/utils.ts
+++ b/packages/cli/src/lib/vite/utils.ts
@@ -29,6 +29,10 @@ export async function toWeb(
 ) {
   const {Request} = await import('@shopify/mini-oxygen');
 
+  if (!req.headers.host) {
+    throw new Error('Request must contain a host header.');
+  }
+
   return new Request(toURL(req), {
     method: req.method,
     headers: {...headers, ...(req.headers as object)},

--- a/packages/hydrogen/src/csp/csp.ts
+++ b/packages/hydrogen/src/csp/csp.ts
@@ -74,7 +74,7 @@ function createCSPHeader(
       // For HMR:
       'ws://localhost:*',
       'ws://127.0.0.1:*',
-      'ws://*.trycloudflare.com:*',
+      'ws://*.tryhydrogen.dev:*',
     ];
   }
 


### PR DESCRIPTION
When using `--customer-account-push` flag, the tunnel created now uses `.tryhydrogen.dev` as the hostname.