### PR TITLE
Add Readmes for public and app/assets directories

### DIFF
--- a/templates/skeleton/app/assets/readme.md
+++ b/templates/skeleton/app/assets/readme.md
@@ -2,7 +2,7 @@ Use the `/app/assets` folder to store static files that **should be processed at
 
 Files in `/app/assets`:
 - Get uploaded to the Shopify CDN on deployment
-  - `/app/assets/logo.png` → `cdn.shopify.com/0000/0000/0000/assets/logo.png`
+  - `/app/assets/logo.png` → `cdn.shopify.com/0000/0000/0000/assets/logo-p7f8c0gh.png`
 - Can be imported in your app files
   - Example: `import logo from '~/app/assets/logo.png'`
 - Get processed by Hydrogen's build tools

--- a/templates/skeleton/app/assets/readme.md
+++ b/templates/skeleton/app/assets/readme.md
@@ -1,0 +1,11 @@
+Use the `/app/assets` folder to store static files that **should be processed at build time**.
+
+Files in `/app/assets`:
+- Get uploaded to the Shopify CDN on deployment
+  - `/app/assets/logo.png` → `cdn.shopify.com/0000/0000/0000/assets/logo.png`
+- Can be imported in your app files
+  - Example: `import logo from '~/app/assets/logo.png'`
+- Get processed by Hydrogen's build tools
+  - File names are likely to be hashed (`/app/assets/logo.svg` -> `/dist/assets/logo-p7f8c0gh.svg`)
+  - SVG images may be inlined
+  - CSS or JavaScript files may be chunked, uglified, and/or minified

--- a/templates/skeleton/public/readme.md
+++ b/templates/skeleton/public/readme.md
@@ -1,0 +1,7 @@
+Use the `/public` folder to store static files that **shouldn't be processed at build time**.
+
+Files in `/public`:
+- Get uploaded to the Shopify CDN on deployment
+  - `/public/image.png` → `cdn.shopify.com/0000/0000/0000/image.png`
+- Can't be imported in your app files (see `/app/assets` instead)
+- Aren't processed by Hydrogen's build tools


### PR DESCRIPTION
We've observed some confusion in the wild about the two directories where Hydrogen projects can keep static assets: `/public` and `/app/assets`.

This PR adds a readme to each directory with some contextual detail on what happens to the assets stored there. Very open to edits, fact-checks, etc. 

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] ~I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes~
- [ ] ~I've added or updated the documentation~