### PR TITLE
Lowercase storefront redirects to make them case insensitive.

### DIFF
--- a/.changeset/big-impalas-brush.md
+++ b/.changeset/big-impalas-brush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Change StorefrontRedirect to base case insensitive in querying redirect URLs from the Storefront API.

--- a/packages/hydrogen/src/routing/redirect.test.ts
+++ b/packages/hydrogen/src/routing/redirect.test.ts
@@ -46,6 +46,28 @@ describe('storefrontRedirect', () => {
     });
   });
 
+  it('queries the SFAPI with the url lower cased', async () => {
+    queryMock.mockResolvedValueOnce({
+      urlRedirects: {edges: [{node: {target: shopifyDomain + '/some-page'}}]},
+    });
+
+    await expect(
+      storefrontRedirect({
+        storefront: storefrontMock,
+        request: new Request('https://domain.com/some-PAGE'),
+      }),
+    ).resolves.toEqual(
+      new Response(null, {
+        status: 301,
+        headers: {location: shopifyDomain + '/some-page'},
+      }),
+    );
+
+    expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+      variables: {query: 'path:/some-page'},
+    });
+  });
+
   it('strips remix _data query parameter on soft navigations', async () => {
     queryMock.mockResolvedValueOnce({
       urlRedirects: {edges: [{node: {target: shopifyDomain + '/some-page'}}]},

--- a/packages/hydrogen/src/routing/redirect.ts
+++ b/packages/hydrogen/src/routing/redirect.ts
@@ -42,9 +42,9 @@ export async function storefrontRedirect(
   searchParams.delete('return_to');
   searchParams.delete('_data');
 
-  const redirectFrom = matchQueryParams
-    ? url.toString().replace(url.origin, '')
-    : pathname;
+  const redirectFrom = (
+    matchQueryParams ? url.toString().replace(url.origin, '') : pathname
+  ).toLowerCase();
 
   if (url.pathname === '/admin' && !noAdminRedirect) {
     return createRedirectResponse(


### PR DESCRIPTION


### WHAT is this pull request doing?

At the moment `StorefrontRedirect` does not match on URLs that are capitalized. This fixes that by `.toLowerCase()` the URL before querying the Storefront API. This also means that redirect URLs defined within the admin with capitalization won't ever be matched.

Fixes #908
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->



#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
