### PR TITLE
Update Changeset config to link create-hydrogen to dependencies

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,12 @@
   "changelog": ["./hydrogen-changelog-config.js", {"repo": "shopify/hydrogen"}],
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [
+    ["create-hydrogen", "hydrogen"],
+    ["create-hydrogen", "cli"],
+    ["create-hydrogen", "remix-oxygen"],
+    ["create-hydrogen", "mini-oxygen"],
+  ],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
Follow up to #1873 — instead of installing `latest`, this links the `create-hydrogen` package to other packages it depends on.

We don't bump create-hydrogen's version that often because it's so simple, so it can get out of sync with other packages, even though it should basically always be installing the latest dependencies.

[Linking the packages](https://github.com/changesets/changesets/blob/main/docs/linked-packages.md) in Changesets means create-hydrogen will always get bumped when one of its dependencies does, which should lead to the expected behavior.

I'm linking these packages because they're the ones that are included in `@next` releases and create-hydrogen should always be up to date for testing purposes.
![image](https://github.com/Shopify/hydrogen/assets/547470/5e18981a-70d8-4744-b2cb-71ef3e0104d8)
