### PR TITLE
List the uncommitted files that the deploy command errors on

### DIFF
--- a/.changeset/twelve-paws-prove.md
+++ b/.changeset/twelve-paws-prove.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+List the uncommitted files that the deploy command errors on

--- a/packages/cli/src/commands/hydrogen/deploy.test.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.test.ts
@@ -19,6 +19,7 @@ import {
 
 import {deploymentLogger, runDeploy} from './deploy.js';
 import {getOxygenDeploymentData} from '../../lib/get-oxygen-deployment-data.js';
+import {execAsync} from '../../lib/process.js';
 import {createEnvironmentCliChoiceLabel} from '../../lib/common.js';
 import {
   CompletedDeployment,
@@ -33,6 +34,7 @@ vi.mock('@shopify/cli-kit/node/dot-env');
 vi.mock('@shopify/cli-kit/node/fs');
 vi.mock('@shopify/cli-kit/node/context/local');
 vi.mock('../../lib/get-oxygen-deployment-data.js');
+vi.mock('../../lib/process.js');
 vi.mock('./build-vite.js');
 vi.mock('../../lib/auth.js');
 vi.mock('../../lib/shopify-config.js');
@@ -321,11 +323,15 @@ describe('deploy', () => {
   });
 
   it('errors when there are uncommited changes', async () => {
+    vi.mocked(execAsync).mockReturnValue(
+      Promise.resolve({stdout: ' M file.ts\n', stderr: ''}) as any,
+    );
+
     vi.mocked(ensureIsClean).mockRejectedValue(
       new GitDirectoryNotCleanError('Uncommitted changes'),
     );
     await expect(runDeploy(deployParams)).rejects.toThrowError(
-      'Uncommitted changes detected',
+      'Uncommitted changes detected:\n\n M file.ts',
     );
     expect(vi.mocked(createDeploy)).not.toHaveBeenCalled;
   });

--- a/packages/cli/src/lib/check-lockfile.test.ts
+++ b/packages/cli/src/lib/check-lockfile.test.ts
@@ -63,6 +63,12 @@ describe('checkLockfileStatus()', () => {
         expect(outputMock.warn()).toMatch(
           / warning .+ Multiple lockfiles found .+/is,
         );
+        expect(outputMock.warn()).toMatch(
+          /package-lock\.json \(created by npm\)/is,
+        );
+        expect(outputMock.warn()).toMatch(
+          /pnpm-lock\.yaml \(created by pnpm\)/is,
+        );
       });
     });
 

--- a/packages/cli/src/lib/package-managers.ts
+++ b/packages/cli/src/lib/package-managers.ts
@@ -1,0 +1,33 @@
+import {
+  type Lockfile,
+  type PackageManager as Name,
+} from '@shopify/cli-kit/node/node-package-manager';
+
+export interface PackageManager {
+  name: Name;
+  lockfile: Lockfile;
+  installCommand: string;
+}
+
+export const packageManagers: PackageManager[] = [
+  {
+    name: 'npm',
+    lockfile: 'package-lock.json',
+    installCommand: 'npm ci',
+  },
+  {
+    name: 'yarn',
+    lockfile: 'yarn.lock',
+    installCommand: 'yarn install --frozen-lockfile',
+  },
+  {
+    name: 'pnpm',
+    lockfile: 'pnpm-lock.yaml',
+    installCommand: 'pnpm install --frozen-lockfile',
+  },
+  {
+    name: 'bun',
+    lockfile: 'bun.lockb',
+    installCommand: 'bun install --frozen-lockfile',
+  },
+];


### PR DESCRIPTION
### WHY are these changes introduced?

Now that we're guiding merchants to use the `deploy` command a number of them are hitting an error that they haven't seen before:

```
➜  hydrogen git:(main) h2 deploy --preview
╭─ error ──────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Uncommitted changes detected.                                               │
│                                                                              │
│  Next steps                                                                  │
│    • Commit your changes before deploying or use the  `--force`  flag to     │
│      deploy with uncommitted changes.                                        │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

This is easy to debug locally because you can run `git status` to see what has changed but it's cumbersome when it's only happening in your CI environment. The most likely cause of this is that their package manager's lockfile is being updated during the dependency installation process but it's not easy to tell.

### WHAT is this pull request doing?

This PR updates the error message to include all of the file changes by capturing the changes with `git status -s` and adding them to the banner. For example, while working on this change locally I had the following output:

```
➜  skeleton git:(gg-list-uncommitted-changes) h2 deploy --preview
╭─ error ──────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                              │
│  Uncommitted changes detected:                                                               │
│                                                                                              │
│   M ../../packages/cli/oclif.manifest.json                                                   │
│   M ../../packages/cli/src/commands/hydrogen/deploy.test.ts                                  │
│   M ../../packages/cli/src/commands/hydrogen/deploy.ts                                       │
│  ?? bun.lockb                                                                                │
│  ?? pnpm-lock.yaml                                                                           │
│                                                                                              │
│  Next steps                                                                                  │
│    • Commit your changes before deploying or use the `--force` flag to deploy with           │
│      uncommitted changes.                                                                    │
│    • If you are using pnpm, try running `pnpm install --frozen-lockfile` to avoid changes    │
│      to pnpm-lock.yaml.                                                                      │
│    • If you are using bun, try running `bun install --frozen-lockfile` to avoid changes to   │
│      bun.lockb.                                                                              │
│                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────╯
```

Additionally if we find that there are lockfiles present in the diff we'll add an additional item in "next steps" to explain how you might be able to avoid those files changing during a CI deploy.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation