### PR TITLE
Fix command order in Oclif manifest

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1,5 +1,87 @@
 {
   "commands": {
+    "hydrogen:build": {
+      "aliases": [],
+      "args": {},
+      "description": "Builds a Hydrogen storefront for production.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sourcemap": {
+          "description": "Controls whether sourcemaps are generated. Default to `true`. Deactivate `--no-sourcemaps`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_SOURCEMAP",
+          "name": "sourcemap",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "bundle-stats": {
+          "description": "Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
+          "name": "bundle-stats",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "lockfile-check": {
+          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
+          "name": "lockfile-check",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "disable-route-warning": {
+          "description": "Disables any warnings about missing standard routes.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_ROUTE_WARNING",
+          "name": "disable-route-warning",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "codegen": {
+          "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
+          "name": "codegen",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "codegen-config-path": {
+          "dependsOn": [
+            "codegen"
+          ],
+          "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
+          "name": "codegen-config-path",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "diff": {
+          "description": "Applies the current files on top of Hydrogen's starter template in a temporary directory.",
+          "hidden": true,
+          "name": "diff",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:build",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "build.js"
+      ]
+    },
     "hydrogen:build-vite": {
       "aliases": [],
       "args": {},
@@ -83,88 +165,6 @@
         "commands",
         "hydrogen",
         "build-vite.js"
-      ]
-    },
-    "hydrogen:build": {
-      "aliases": [],
-      "args": {},
-      "description": "Builds a Hydrogen storefront for production.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "sourcemap": {
-          "description": "Controls whether sourcemaps are generated. Default to `true`. Deactivate `--no-sourcemaps`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_SOURCEMAP",
-          "name": "sourcemap",
-          "allowNo": true,
-          "type": "boolean"
-        },
-        "bundle-stats": {
-          "description": "Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
-          "name": "bundle-stats",
-          "allowNo": true,
-          "type": "boolean"
-        },
-        "lockfile-check": {
-          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
-          "name": "lockfile-check",
-          "allowNo": true,
-          "type": "boolean"
-        },
-        "disable-route-warning": {
-          "description": "Disables any warnings about missing standard routes.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_ROUTE_WARNING",
-          "name": "disable-route-warning",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "codegen": {
-          "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
-          "name": "codegen",
-          "required": false,
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "codegen-config-path": {
-          "dependsOn": [
-            "codegen"
-          ],
-          "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
-          "name": "codegen-config-path",
-          "required": false,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "diff": {
-          "description": "Applies the current files on top of Hydrogen's starter template in a temporary directory.",
-          "hidden": true,
-          "name": "diff",
-          "required": false,
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:build",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "build.js"
       ]
     },
     "hydrogen:check": {
@@ -255,6 +255,104 @@
         "commands",
         "hydrogen",
         "codegen.js"
+      ]
+    },
+    "hydrogen:customer-account:push": {
+      "aliases": [],
+      "args": {},
+      "description": "Push project configuration to admin",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "storefront-id": {
+          "description": "The id of the storefront the configuration should be pushed to. Must start with 'gid://shopify/HydrogenStorefront/'",
+          "name": "storefront-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev-origin": {
+          "description": "The development domain of your application.",
+          "name": "dev-origin",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "relative-redirect-uri": {
+          "description": "The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'",
+          "name": "relative-redirect-uri",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "relative-logout-uri": {
+          "description": "The relative url of allowed url that will be redirected to post-logout for Customer Account API OAuth flow. Default to nothing.",
+          "name": "relative-logout-uri",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:customer-account:push",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "customer-account",
+        "push.js"
+      ]
+    },
+    "hydrogen:debug:cpu": {
+      "aliases": [],
+      "args": {},
+      "description": "Builds and profiles the server startup time the app.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output": {
+          "description": "Specify a path to generate the profile file. Defaults to \"startup.cpuprofile\".",
+          "name": "output",
+          "required": false,
+          "default": "startup.cpuprofile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:debug:cpu",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "debug",
+        "cpu.js"
       ]
     },
     "hydrogen:deploy": {
@@ -439,153 +537,6 @@
         "deploy.js"
       ]
     },
-    "hydrogen:dev-vite": {
-      "aliases": [],
-      "args": {},
-      "description": "Runs Hydrogen storefront in an Oxygen worker for development.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "entry": {
-          "description": "Entry file for the worker. Defaults to `./server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
-          "name": "entry",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "port": {
-          "description": "The port to run the server on. Defaults to 3000.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
-          "name": "port",
-          "required": false,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "codegen": {
-          "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
-          "name": "codegen",
-          "required": false,
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "codegen-config-path": {
-          "dependsOn": [
-            "codegen"
-          ],
-          "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
-          "name": "codegen-config-path",
-          "required": false,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "disable-virtual-routes": {
-          "description": "Disable rendering fallback routes when a route file doesn't exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_VIRTUAL_ROUTES",
-          "name": "disable-virtual-routes",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "debug": {
-          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
-          "name": "debug",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "inspector-port": {
-          "description": "The port where the inspector is available. Defaults to 9229.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
-          "name": "inspector-port",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "host": {
-          "description": "Expose the server to the network",
-          "name": "host",
-          "required": false,
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "env": {
-          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
-          "exclusive": [
-            "env-branch"
-          ],
-          "name": "env",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "env-branch": {
-          "deprecated": {
-            "to": "env",
-            "message": "--env-branch is deprecated. Use --env instead."
-          },
-          "description": "Specifies the environment to perform the operation using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "name": "env-branch",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "disable-version-check": {
-          "description": "Skip the version check when running `hydrogen dev`",
-          "name": "disable-version-check",
-          "required": false,
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "diff": {
-          "description": "Applies the current files on top of Hydrogen's starter template in a temporary directory.",
-          "hidden": true,
-          "name": "diff",
-          "required": false,
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "customer-account-push": {
-          "description": "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's Oauth flow",
-          "env": "SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH",
-          "name": "customer-account-push",
-          "required": false,
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "description": "Outputs more information about the command's execution.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
-          "name": "verbose",
-          "required": false,
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [],
-      "id": "hydrogen:dev-vite",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "dev-vite.js"
-      ]
-    },
     "hydrogen:dev": {
       "aliases": [],
       "args": {},
@@ -735,6 +686,291 @@
         "dev.js"
       ]
     },
+    "hydrogen:dev-vite": {
+      "aliases": [],
+      "args": {},
+      "description": "Runs Hydrogen storefront in an Oxygen worker for development.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "entry": {
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "port": {
+          "description": "The port to run the server on. Defaults to 3000.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
+          "name": "port",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "codegen": {
+          "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
+          "name": "codegen",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "codegen-config-path": {
+          "dependsOn": [
+            "codegen"
+          ],
+          "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
+          "name": "codegen-config-path",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "disable-virtual-routes": {
+          "description": "Disable rendering fallback routes when a route file doesn't exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_VIRTUAL_ROUTES",
+          "name": "disable-virtual-routes",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "debug": {
+          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
+          "name": "debug",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "inspector-port": {
+          "description": "The port where the inspector is available. Defaults to 9229.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
+          "name": "inspector-port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "host": {
+          "description": "Expose the server to the network",
+          "name": "host",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-branch": {
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "disable-version-check": {
+          "description": "Skip the version check when running `hydrogen dev`",
+          "name": "disable-version-check",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "diff": {
+          "description": "Applies the current files on top of Hydrogen's starter template in a temporary directory.",
+          "hidden": true,
+          "name": "diff",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "customer-account-push": {
+          "description": "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's Oauth flow",
+          "env": "SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH",
+          "name": "customer-account-push",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Outputs more information about the command's execution.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
+          "name": "verbose",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "hydrogen:dev-vite",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "dev-vite.js"
+      ]
+    },
+    "hydrogen:env:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the environments on your linked Hydrogen storefront.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:list",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "env",
+        "list.js"
+      ]
+    },
+    "hydrogen:env:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Populate your .env with variables from your Hydrogen storefront.",
+      "flags": {
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-branch": {
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:pull",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "env",
+        "pull.js"
+      ]
+    },
+    "hydrogen:env:push__unstable": {
+      "aliases": [],
+      "args": {},
+      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
+      "flags": {
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-file": {
+          "description": "Path to an environment file to override existing environment variables for the selected environment. Defaults to the '.env' located in your project path `--path`.",
+          "name": "env-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:push__unstable",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "env",
+        "push__unstable.js"
+      ]
+    },
     "hydrogen:g": {
       "aliases": [],
       "args": {},
@@ -754,6 +990,148 @@
         "commands",
         "hydrogen",
         "g.js"
+      ]
+    },
+    "hydrogen:generate:route": {
+      "aliases": [],
+      "args": {
+        "routeName": {
+          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.",
+          "name": "routeName",
+          "options": [
+            "home",
+            "page",
+            "cart",
+            "products",
+            "collections",
+            "policies",
+            "blogs",
+            "account",
+            "search",
+            "robots",
+            "sitemap",
+            "all"
+          ],
+          "required": true
+        }
+      },
+      "description": "Generates a standard Shopify route.",
+      "flags": {
+        "adapter": {
+          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "adapter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "typescript": {
+          "description": "Generate TypeScript files",
+          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
+          "name": "typescript",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "locale-param": {
+          "description": "The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "locale-param",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:generate:route",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "generate",
+        "route.js"
+      ]
+    },
+    "hydrogen:generate:routes": {
+      "aliases": [],
+      "args": {},
+      "description": "Generates all supported standard shopify routes.",
+      "flags": {
+        "adapter": {
+          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "adapter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "typescript": {
+          "description": "Generate TypeScript files",
+          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
+          "name": "typescript",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "locale-param": {
+          "description": "The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "locale-param",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:generate:routes",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "generate",
+        "routes.js"
       ]
     },
     "hydrogen:init": {
@@ -1170,479 +1548,6 @@
         "setup.js"
       ]
     },
-    "hydrogen:shortcut": {
-      "aliases": [],
-      "args": {},
-      "description": "Creates a global `h2` shortcut for the Hydrogen CLI",
-      "flags": {},
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:shortcut",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "shortcut.js"
-      ]
-    },
-    "hydrogen:unlink": {
-      "aliases": [],
-      "args": {},
-      "description": "Unlink a local project from a Hydrogen storefront.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:unlink",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "unlink.js"
-      ]
-    },
-    "hydrogen:upgrade": {
-      "aliases": [],
-      "args": {},
-      "description": "Upgrade Remix and Hydrogen npm dependencies.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "version": {
-          "char": "v",
-          "description": "A target hydrogen version to update to",
-          "name": "version",
-          "required": false,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "force": {
-          "char": "f",
-          "description": "Ignore warnings and force the upgrade to the target version",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:upgrade",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "upgrade.js"
-      ]
-    },
-    "hydrogen:customer-account:push": {
-      "aliases": [],
-      "args": {},
-      "description": "Push project configuration to admin",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "storefront-id": {
-          "description": "The id of the storefront the configuration should be pushed to. Must start with 'gid://shopify/HydrogenStorefront/'",
-          "name": "storefront-id",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dev-origin": {
-          "description": "The development domain of your application.",
-          "name": "dev-origin",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "relative-redirect-uri": {
-          "description": "The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'",
-          "name": "relative-redirect-uri",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "relative-logout-uri": {
-          "description": "The relative url of allowed url that will be redirected to post-logout for Customer Account API OAuth flow. Default to nothing.",
-          "name": "relative-logout-uri",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:customer-account:push",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "customer-account",
-        "push.js"
-      ]
-    },
-    "hydrogen:debug:cpu": {
-      "aliases": [],
-      "args": {},
-      "description": "Builds and profiles the server startup time the app.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "output": {
-          "description": "Specify a path to generate the profile file. Defaults to \"startup.cpuprofile\".",
-          "name": "output",
-          "required": false,
-          "default": "startup.cpuprofile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:debug:cpu",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "debug",
-        "cpu.js"
-      ]
-    },
-    "hydrogen:env:list": {
-      "aliases": [],
-      "args": {},
-      "description": "List the environments on your linked Hydrogen storefront.",
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:env:list",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "env",
-        "list.js"
-      ]
-    },
-    "hydrogen:env:pull": {
-      "aliases": [],
-      "args": {},
-      "description": "Populate your .env with variables from your Hydrogen storefront.",
-      "flags": {
-        "env": {
-          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
-          "exclusive": [
-            "env-branch"
-          ],
-          "name": "env",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "env-branch": {
-          "deprecated": {
-            "to": "env",
-            "message": "--env-branch is deprecated. Use --env instead."
-          },
-          "description": "Specifies the environment to perform the operation using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "name": "env-branch",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "force": {
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:env:pull",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "env",
-        "pull.js"
-      ]
-    },
-    "hydrogen:env:push__unstable": {
-      "aliases": [],
-      "args": {},
-      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
-      "flags": {
-        "env": {
-          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
-          "exclusive": [
-            "env-branch"
-          ],
-          "name": "env",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "env-file": {
-          "description": "Path to an environment file to override existing environment variables for the selected environment. Defaults to the '.env' located in your project path `--path`.",
-          "name": "env-file",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [],
-      "id": "hydrogen:env:push__unstable",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "env",
-        "push__unstable.js"
-      ]
-    },
-    "hydrogen:generate:route": {
-      "aliases": [],
-      "args": {
-        "routeName": {
-          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.",
-          "name": "routeName",
-          "options": [
-            "home",
-            "page",
-            "cart",
-            "products",
-            "collections",
-            "policies",
-            "blogs",
-            "account",
-            "search",
-            "robots",
-            "sitemap",
-            "all"
-          ],
-          "required": true
-        }
-      },
-      "description": "Generates a standard Shopify route.",
-      "flags": {
-        "adapter": {
-          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
-          "name": "adapter",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "typescript": {
-          "description": "Generate TypeScript files",
-          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
-          "name": "typescript",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "locale-param": {
-          "description": "The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
-          "name": "locale-param",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "force": {
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:generate:route",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "generate",
-        "route.js"
-      ]
-    },
-    "hydrogen:generate:routes": {
-      "aliases": [],
-      "args": {},
-      "description": "Generates all supported standard shopify routes.",
-      "flags": {
-        "adapter": {
-          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
-          "name": "adapter",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "typescript": {
-          "description": "Generate TypeScript files",
-          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
-          "name": "typescript",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "locale-param": {
-          "description": "The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
-          "name": "locale-param",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "force": {
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "name": "path",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "hydrogen:generate:routes",
-      "pluginAlias": "@shopify/cli-hydrogen",
-      "pluginName": "@shopify/cli-hydrogen",
-      "pluginType": "core",
-      "strict": true,
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "hydrogen",
-        "generate",
-        "routes.js"
-      ]
-    },
     "hydrogen:setup:css": {
       "aliases": [],
       "args": {
@@ -1767,6 +1672,101 @@
         "hydrogen",
         "setup",
         "vite.js"
+      ]
+    },
+    "hydrogen:shortcut": {
+      "aliases": [],
+      "args": {},
+      "description": "Creates a global `h2` shortcut for the Hydrogen CLI",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:shortcut",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "shortcut.js"
+      ]
+    },
+    "hydrogen:unlink": {
+      "aliases": [],
+      "args": {},
+      "description": "Unlink a local project from a Hydrogen storefront.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:unlink",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "unlink.js"
+      ]
+    },
+    "hydrogen:upgrade": {
+      "aliases": [],
+      "args": {},
+      "description": "Upgrade Remix and Hydrogen npm dependencies.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "version": {
+          "char": "v",
+          "description": "A target hydrogen version to update to",
+          "name": "version",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Ignore warnings and force the upgrade to the target version",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:upgrade",
+      "pluginAlias": "@shopify/cli-hydrogen",
+      "pluginName": "@shopify/cli-hydrogen",
+      "pluginType": "core",
+      "strict": true,
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "hydrogen",
+        "upgrade.js"
       ]
     }
   },

--- a/packages/cli/scripts/generate-manifest.mjs
+++ b/packages/cli/scripts/generate-manifest.mjs
@@ -28,13 +28,23 @@ const plugin = new Plugin({
   type: 'core',
   ignoreManifest: true,
   errorOnManifestCreate: true,
+  respectNoCacheDefault: true,
 });
 
 await plugin.load(true);
 
+// Oclif resolves commands in parallel, so the order is not guaranteed.
+// Sort commands here alphabetically to avoid Git conflicts:
+const {manifest} = plugin;
+manifest.commands = Object.fromEntries(
+  Object.entries(manifest.commands).sort(([commandA], [commandB]) =>
+    commandA.localeCompare(commandB),
+  ),
+);
+
 await writeFile(
   path.join(cwd, 'oclif.manifest.json'),
-  JSON.stringify(plugin.manifest, null, 2),
+  JSON.stringify(manifest, null, 2),
 );
 
 console.log('', 'Oclif manifest generated.\n');


### PR DESCRIPTION
Oclif resolves commands in parallel so the order is not guaranteed. We are getting a lot of Git conflicts in the Oclif manifest due to this in every PR. This change starts sorting the commands alphabetically to avoid conflicts.