### PR TITLE
[CLI] Shell: Add newline in output alias block

### DIFF
--- a/.changeset/short-flowers-enjoy.md
+++ b/.changeset/short-flowers-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add a newline after the `h2` alias created ZSH/Bash profiles.

--- a/packages/cli/src/lib/shell.ts
+++ b/packages/cli/src/lib/shell.ts
@@ -143,7 +143,8 @@ export async function createPlatformShortcut() {
 
 const BASH_ZSH_COMMAND = `
 # Shopify Hydrogen alias to local projects
-alias ${ALIAS_NAME}='$(npm prefix -s)/node_modules/.bin/shopify hydrogen'`;
+alias ${ALIAS_NAME}='$(npm prefix -s)/node_modules/.bin/shopify hydrogen'
+`;
 
 const FISH_FUNCTION = `
 function ${ALIAS_NAME} --wraps='shopify hydrogen' --description 'Shortcut for the Hydrogen CLI'


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed when setting up the `h2` alias that there's no newline added, which makes the _next_ thing added go directly after our hydrogen alias, making both commands fail. 

Here's me installing powerlevel10k after the h2 alias
![](https://screenshot.click/08-52-xp3ty-8icj3.png)

### WHAT is this pull request doing?

Thought I'd add a newline at the end of the zsh block. 
