### PR TITLE
Remove added tunnel domains to Customer Application on process exit

### DIFF
--- a/packages/cli/src/commands/hydrogen/customer-account/push.ts
+++ b/packages/cli/src/commands/hydrogen/customer-account/push.ts
@@ -175,6 +175,9 @@ export async function runCustomerAccountPush({
   }
 }
 
+/**
+ * Removes existing Customer Application URLs from the storefront.
+ */
 async function cleanupCustomerApplicationUrls(
   session: AdminSession,
   storefrontId: string,

--- a/packages/cli/src/commands/hydrogen/dev-vite.ts
+++ b/packages/cli/src/commands/hydrogen/dev-vite.ts
@@ -323,7 +323,8 @@ export async function runViteDev({
   return {
     getUrl: () => finalHost,
     async close() {
-      codegenProcess?.kill(0);
+      codegenProcess?.removeAllListeners('close');
+      codegenProcess?.kill('SIGINT');
       await Promise.allSettled([viteServer.close(), tunnel?.cleanup?.()]);
     },
   };

--- a/packages/cli/src/commands/hydrogen/dev-vite.ts
+++ b/packages/cli/src/commands/hydrogen/dev-vite.ts
@@ -258,7 +258,7 @@ export async function runViteDev({
   //   process.env.HYDROGEN_ASSET_BASE_URL = buildAssetsUrl(assetsPort);
   // }
 
-  const [tunnelHost, cliCommand] = await Promise.all([
+  const [tunnel, cliCommand] = await Promise.all([
     backgroundPromise.then(({customerAccountPush, storefrontId}) =>
       customerAccountPush
         ? startTunnelAndPushConfig(root, cliConfig, publicPort, storefrontId)
@@ -272,7 +272,7 @@ export async function runViteDev({
     viteServer.resolvedUrls!.local[0] ?? viteServer.resolvedUrls!.network[0]!,
   );
 
-  const finalHost = tunnelHost || publicUrl.toString() || publicUrl.origin;
+  const finalHost = tunnel?.host || publicUrl.toString() || publicUrl.origin;
 
   // Start the public facing server with the port passed by the user.
   enhanceH2Logs({
@@ -324,7 +324,7 @@ export async function runViteDev({
     getUrl: () => finalHost,
     async close() {
       codegenProcess?.kill(0);
-      await viteServer.close();
+      await Promise.allSettled([viteServer.close(), tunnel?.cleanup?.()]);
     },
   };
 }

--- a/packages/cli/src/commands/hydrogen/dev-vite.ts
+++ b/packages/cli/src/commands/hydrogen/dev-vite.ts
@@ -215,14 +215,6 @@ export async function runViteDev({
     ],
   });
 
-  process.once('SIGTERM', async () => {
-    try {
-      await viteServer.close();
-    } finally {
-      process.exit();
-    }
-  });
-
   const h2Plugin = findHydrogenPlugin(viteServer.config);
   if (!h2Plugin) {
     await viteServer.close();

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -422,7 +422,8 @@ export async function runDev({
   return {
     getUrl: () => miniOxygen.listeningAt,
     async close() {
-      codegenProcess?.kill(0);
+      codegenProcess?.removeAllListeners('close');
+      codegenProcess?.kill('SIGINT');
       await Promise.allSettled([
         closeWatcher(),
         miniOxygen?.close(),

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -273,7 +273,7 @@ export async function runDev({
 
     logInjectedVariables();
 
-    const host = (await tunnelPromise) ?? miniOxygen.listeningAt;
+    const host = (await tunnelPromise)?.host ?? miniOxygen.listeningAt;
 
     const cliCommand = await cliCommandPromise;
     enhanceH2Logs({host, cliCommand, ...remixConfig});
@@ -423,7 +423,11 @@ export async function runDev({
     getUrl: () => miniOxygen.listeningAt,
     async close() {
       codegenProcess?.kill(0);
-      await Promise.all([closeWatcher(), miniOxygen?.close()]);
+      await Promise.allSettled([
+        closeWatcher(),
+        miniOxygen?.close(),
+        Promise.resolve(tunnelPromise).then((tunnel) => tunnel?.cleanup?.()),
+      ]);
     },
   };
 }

--- a/packages/cli/src/lib/dev-shared.ts
+++ b/packages/cli/src/lib/dev-shared.ts
@@ -84,13 +84,11 @@ export async function startTunnelAndPushConfig(
     host.replace(TUNNEL_DOMAIN.ORIGINAL, TUNNEL_DOMAIN.REBRANDED),
   );
 
-  try {
-    await runCustomerAccountPush({
-      path: root,
-      devOrigin: host,
-      storefrontId,
-    });
-  } catch (error) {
+  const cleanup = await runCustomerAccountPush({
+    path: root,
+    devOrigin: host,
+    storefrontId,
+  }).catch((error) => {
     if (error instanceof AbortError) {
       renderInfo({
         headline: 'Customer Account Application setup update fail.',
@@ -98,9 +96,9 @@ export async function startTunnelAndPushConfig(
         nextSteps: error.nextSteps,
       });
     }
-  }
+  });
 
-  return host;
+  return {host, cleanup};
 }
 
 export function getDebugBannerLine(publicInspectorPort: number) {

--- a/packages/mini-oxygen/src/vite/server-middleware.ts
+++ b/packages/mini-oxygen/src/vite/server-middleware.ts
@@ -162,6 +162,12 @@ export async function startMiniOxygenRuntime({
     ? warmupWorkerdCache()
     : viteDevServer.httpServer?.once('listening', warmupWorkerdCache);
 
+  // Ensure MiniOxygen is disposed when Vite is closed
+  const viteClose = viteDevServer.close;
+  viteDevServer.close = async () => {
+    await Promise.allSettled([viteClose(), miniOxygen.dispose()]);
+  };
+
   return miniOxygen;
 }
 


### PR DESCRIPTION
- Ensure we copy `.shopify` back to the scaffolded diff examples so that we can cleanup tunnel domains the next time we run the process.
- Ensure resources are cleaned up on process exit.
- Best effort to remove tunnel domains on process exit.

It's easier to review this PR checking commit by commit.

To 🎩 :
1. build packages
2. run skeleton with `npm run dev -- --customer-account-push__unstable`
3. Check that the tunnel domain is added in Admin
4. `ctrl^c` to exit
5. Check that the tunnel domain is removed in Admin