### PR TITLE
Fix NODE_ENV in test

### DIFF
--- a/packages/cli/src/commands/hydrogen/init.test.ts
+++ b/packages/cli/src/commands/hydrogen/init.test.ts
@@ -356,6 +356,7 @@ describe('init', () => {
 
         // ---- DEV
         outputMock.clear();
+        vi.stubEnv('NODE_ENV', 'development');
 
         const {close, getUrl} = await runClassicDev({
           path: tmpDir,


### PR DESCRIPTION
The `dev` command in tests was loading production files instead of development ones.