### PR TITLE
Fix --customer-account-push flag when no domain is set in .env

### DIFF
--- a/packages/cli/src/lib/dev-shared.ts
+++ b/packages/cli/src/lib/dev-shared.ts
@@ -18,9 +18,10 @@ import {getGraphiQLUrl} from './graphiql-url.js';
 
 export function isMockShop(envVariables: Record<string, string>) {
   return (
-    // We fallback to mock.shop if the env var is not set
-    !envVariables.PUBLIC_STORE_DOMAIN ||
-    envVariables.PUBLIC_STORE_DOMAIN === 'mock.shop'
+    envVariables.PUBLIC_STORE_DOMAIN === 'mock.shop' ||
+    // We fallback to mock.shop if the env var is falsy.
+    // When it's undefined, it might be overwritten by remote variables.
+    envVariables.PUBLIC_STORE_DOMAIN === ''
   );
 }
 


### PR DESCRIPTION
Related to #1992 

A bit of a tricky issue:
- Right now, if you pass `--customer-account-push__unstable` and have no `PUBLIC_STORE_DOMAIN` in `.env`, it will think you're using mock.shop and skip the tunnel. This would be correct if we had all the variables at this point, but this is only considering local variables. The domain might be injected later from remote/admin variables.
- A value like `PUBLIC_STORE_DOMAIN=""` in `.env` overwrites remote values and uses mock.shop. We still need to disable tunnel in this case.

To 🎩 , ensure `--customer-account-push__unstable` has the expected behavior when:
-  `PUBLIC_STORE_DOMAIN` is set to a real domain (e.g. `hydrogen-preview.myshopify.com`) in `.env` => starts the tunnel  + no warning.
-  `PUBLIC_STORE_DOMAIN` is undefined in `.env` => starts the tunnel + no warning.
-  `PUBLIC_STORE_DOMAIN` is set to `mock.shop` in `.env` => skips the tunnel + info banner in terminal about mock.shop.
-  `PUBLIC_STORE_DOMAIN` is empty string in `.env` => skips the tunnel + info banner in terminal about mock.shop.