### PR TITLE
Fix cart noteUpdate scalar to be required

### DIFF
--- a/.changeset/slimy-pets-do.md
+++ b/.changeset/slimy-pets-do.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Fix noteUpdate scalar to be required

--- a/packages/hydrogen-react/src/cart-queries.ts
+++ b/packages/hydrogen-react/src/cart-queries.ts
@@ -72,7 +72,7 @@ export const CartLineUpdate = (cartFragment: string): string => /* GraphQL */ `
 export const CartNoteUpdate = (cartFragment: string): string => /* GraphQL */ `
   mutation CartNoteUpdate(
     $cartId: ID!
-    $note: String
+    $note: String!
     $numCartLines: Int = 250
     $country: CountryCode = ZZ
     $language: LanguageCode


### PR DESCRIPTION
The storefront api 2024.04 has updated the note parameter in cartNoteUpdate to be required (see [here](https://shopify.dev/docs/api/storefront/2024-04/mutations/cartnoteupdate#argument-note)). This is causing an issue with hydrogen/react noteUpdate. I think the fix is changing the scalar [here](https://github.com/Shopify/hydrogen/blob/7e8cf0558248e3bfd0f8299994e3ed2b91ee3d3b/packages/hydrogen-react/src/cart-queries.ts#L75) to be non-nullable.