### PR TITLE
Fix name and url shown for HIT/STALE items in subrequest profiler

### DIFF
--- a/.changeset/many-cycles-invite.md
+++ b/.changeset/many-cycles-invite.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Fix names and URLs shown for MISS/STALE items in the Subrequest Profiler.
+Fix names and URLs shown for HIT/STALE items in the Subrequest Profiler.

--- a/.changeset/many-cycles-invite.md
+++ b/.changeset/many-cycles-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix names and URLs shown for MISS/STALE items in the Subrequest Profiler.

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -108,9 +108,9 @@ export async function runWithCache<T = unknown>(
     ...(typeof cacheKey === 'string' ? [cacheKey] : cacheKey),
   ]);
 
-  let debugData: DebugInfo;
+  let userDebugInfo: DebugInfo;
   const addDebugData = (info: AddDebugDataParam) => {
-    debugData = {
+    userDebugInfo = {
       displayName: info.displayName,
       url: info.response?.url,
       responseInit: {
@@ -137,7 +137,7 @@ export async function runWithCache<T = unknown>(
             startTime: overrideStartTime || startTime,
             cacheStatus,
             responsePayload: (result && result[0]) || result,
-            responseInit: (result && result[1]) || debugData?.responseInit,
+            responseInit: (result && result[1]) || userDebugInfo?.responseInit,
             cache: {
               status: cacheStatus,
               strategy: generateCacheControlHeader(strategy || {}),
@@ -145,8 +145,8 @@ export async function runWithCache<T = unknown>(
             },
             waitUntil,
             ...debugInfo,
-            url: debugData?.url || debugInfo?.url || getKeyUrl(key),
-            displayName: debugInfo?.displayName || debugData?.displayName,
+            url: userDebugInfo?.url || debugInfo?.url || getKeyUrl(key),
+            displayName: debugInfo?.displayName || userDebugInfo?.displayName,
           });
         }
       : undefined;

--- a/packages/hydrogen/src/cache/fetch.ts
+++ b/packages/hydrogen/src/cache/fetch.ts
@@ -152,6 +152,7 @@ export async function runWithCache<T = unknown>(
             ...mergeDebugInfo(),
             eventType: 'subrequest',
             startTime: overrideStartTime || startTime,
+            endTime: Date.now(),
             cacheStatus,
             responsePayload: (result && result[0]) || result,
             responseInit: (result && result[1]) || userDebugInfo?.responseInit,

--- a/packages/hydrogen/src/cache/sub-request.ts
+++ b/packages/hydrogen/src/cache/sub-request.ts
@@ -35,10 +35,10 @@ export function generateSubRequestCacheControlHeader(
  * as the response itself so it can be checked for staleness.
  * @private
  */
-export async function getItemFromCache(
+export async function getItemFromCache<T = any>(
   cache: Cache,
   key: string,
-): Promise<undefined | [any, Response]> {
+): Promise<undefined | [T | string, Response]> {
   if (!cache) return;
   const url = getKeyUrl(key);
   const request = new Request(url);

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -329,12 +329,12 @@ export function createStorefrontClient<TI18n extends I18nBase>(
       shouldCacheResponse: checkGraphQLErrors,
       waitUntil,
       debugInfo: {
-        url,
-        graphql: graphqlData,
         requestId: requestInit.headers[STOREFRONT_REQUEST_GROUP_ID_HEADER],
-        purpose: storefrontHeaders?.purpose,
-        stackInfo,
         displayName,
+        url,
+        stackInfo,
+        graphql: graphqlData,
+        purpose: storefrontHeaders?.purpose,
       },
     });
 


### PR DESCRIPTION
We support `addDebugInfo` parameter in `withCache` to enhance what we show in the subrequest profiler. However, this function only runs when there's no cached information. Therefore, in HIT/STALE situations we can't show the profer debug info.

This PR adds the debug info to the Cache API so that we can get it later for HIT/STALE.