### PR TITLE
Fix `cartNoteUpdate` mutation

### DIFF
--- a/packages/hydrogen/src/cart/queries/cartNoteUpdateDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartNoteUpdateDefault.ts
@@ -36,7 +36,7 @@ export const CART_NOTE_UPDATE_MUTATION = (
 ) => `#graphql
   mutation cartNoteUpdate(
     $cartId: ID!
-    $note: String
+    $note: String!
     $language: LanguageCode
     $country: CountryCode
   ) @inContext(country: $country, language: $language) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes the `cartNoteUpdate` function for API version `2024-04`.

### WHAT is this pull request doing?

This function breaks when using the latest Hydrogen version.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
