### PR TITLE
Warn about React version mismatch during project creation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -124,15 +124,5 @@
     "plugins": [
       "@shopify/plugin-cloudflare"
     ]
-  },
-  "overrides": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "react": "18.2.0",
-      "react-dom": "18.2.0"
-    }
   }
 }

--- a/packages/create-hydrogen/package.json
+++ b/packages/create-hydrogen/package.json
@@ -18,15 +18,5 @@
   "bin": "dist/create-app.js",
   "files": [
     "dist"
-  ],
-  "overrides": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "react": "18.2.0",
-      "react-dom": "18.2.0"
-    }
-  }
+  ]
 }

--- a/packages/create-hydrogen/src/create-app.ts
+++ b/packages/create-hydrogen/src/create-app.ts
@@ -1,5 +1,40 @@
 #!/usr/bin/env node
 
+import {join} from 'node:path';
+import {tmpdir} from 'node:os';
 import {runInit} from '@shopify/cli-hydrogen/commands/hydrogen/init';
+
+let isReactError = false;
+const reactErrorRE = /(useState|Invalid hook call)/gims;
+
+const stdoutWrite = process.stdout.write.bind(process.stdout);
+process.stdout.write = <typeof stdoutWrite>function (item, encoding, cb) {
+  if (reactErrorRE.test(item?.toString() ?? '')) {
+    isReactError = true;
+  } else {
+    stdoutWrite(item, encoding, cb);
+  }
+};
+
+const stderrWrite = process.stderr.write.bind(process.stderr);
+process.stderr.write = <typeof stderrWrite>function (item, encoding, cb) {
+  if (reactErrorRE.test(item?.toString() ?? '')) {
+    isReactError = true;
+  } else {
+    stderrWrite(item, encoding, cb);
+  }
+};
+
+process.on('beforeExit', () => {
+  if (isReactError) {
+    const randomTmpDir = join(tmpdir(), Math.random().toString(36).slice(2));
+    const message =
+      'There is a React version mismatch. If this command failed, try the following:\n\n' +
+      `npm create @shopify/hydrogen@latest --legacy-peer-deps --cache ${randomTmpDir}` +
+      '\n\nLearn more in https://github.com/Shopify/hydrogen/discussions/2055';
+
+    console.warn('\n\x1b[30m\x1b[43m WARNING \x1b[0m', message);
+  }
+});
 
 runInit();


### PR DESCRIPTION
The `overrides` unfortunately doesn't work with NPM because it ignores it when installing globally.

This PR shows a better warning when there is a React version mismatch and provides a workaround command that should allow creating new projects.