### PR TITLE
move cli & cli-hydrogen to dev dependencies

### DIFF
--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -16,8 +16,6 @@
     "@remix-run/node": "^2.8.0",
     "@remix-run/react": "^2.8.0",
     "@remix-run/server-runtime": "^2.8.0",
-    "@shopify/cli": "3.59.2",
-    "@shopify/cli-hydrogen": "^8.0.3",
     "@shopify/hydrogen": "2024.4.1",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
@@ -30,6 +28,8 @@
   "devDependencies": {
     "@remix-run/dev": "^2.8.0",
     "@remix-run/eslint-config": "^2.8.0",
+    "@shopify/cli": "3.59.2",
+    "@shopify/cli-hydrogen": "^8.0.3",
     "@types/compression": "^1.7.2",
     "@types/express": "^4.17.17",
     "@types/morgan": "^1.9.4",

--- a/examples/multipass/package.json
+++ b/examples/multipass/package.json
@@ -13,8 +13,6 @@
   "prettier": "@shopify/prettier-config",
   "dependencies": {
     "@remix-run/react": "^2.8.0",
-    "@shopify/cli": "3.59.2",
-    "@shopify/cli-hydrogen": "^8.0.3",
     "@shopify/hydrogen": "2024.4.1",
     "@shopify/remix-oxygen": "^2.0.4",
     "crypto-js": "^4.2.0",
@@ -28,6 +26,8 @@
   "devDependencies": {
     "@remix-run/dev": "^2.8.0",
     "@remix-run/eslint-config": "^2.8.0",
+    "@shopify/cli": "3.59.2",
+    "@shopify/cli-hydrogen": "^8.0.3",
     "@shopify/mini-oxygen": "^3.0.1",
     "@shopify/oxygen-workers-types": "^4.0.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/examples/partytown/package.json
+++ b/examples/partytown/package.json
@@ -16,8 +16,6 @@
   "dependencies": {
     "@builder.io/partytown": "^0.8.1",
     "@remix-run/react": "^2.8.0",
-    "@shopify/cli": "3.59.2",
-    "@shopify/cli-hydrogen": "^8.0.3",
     "@shopify/hydrogen": "2024.4.1",
     "@shopify/remix-oxygen": "^2.0.4",
     "graphql": "^16.6.0",
@@ -29,6 +27,8 @@
   "devDependencies": {
     "@remix-run/dev": "^2.8.0",
     "@remix-run/eslint-config": "^2.8.0",
+    "@shopify/cli": "3.59.2",
+    "@shopify/cli-hydrogen": "^8.0.3",
     "@shopify/mini-oxygen": "^3.0.1",
     "@shopify/oxygen-workers-types": "^4.0.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/examples/subscriptions/package.json
+++ b/examples/subscriptions/package.json
@@ -13,8 +13,6 @@
   "prettier": "@shopify/prettier-config",
   "dependencies": {
     "@remix-run/react": "^2.8.0",
-    "@shopify/cli": "3.59.2",
-    "@shopify/cli-hydrogen": "^8.0.3",
     "@shopify/hydrogen": "2024.4.1",
     "@shopify/remix-oxygen": "^2.0.4",
     "graphql": "^16.6.0",
@@ -26,6 +24,8 @@
   "devDependencies": {
     "@remix-run/dev": "^2.8.0",
     "@remix-run/eslint-config": "^2.8.0",
+    "@shopify/cli": "3.59.2",
+    "@shopify/cli-hydrogen": "^8.0.3",
     "@shopify/mini-oxygen": "^3.0.1",
     "@shopify/oxygen-workers-types": "^4.0.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,8 +94,6 @@
         "@remix-run/node": "^2.8.0",
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
-        "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
         "@shopify/hydrogen": "2024.4.1",
         "compression": "^1.7.4",
         "cross-env": "^7.0.3",
@@ -108,6 +106,8 @@
       "devDependencies": {
         "@remix-run/dev": "^2.8.0",
         "@remix-run/eslint-config": "^2.8.0",
+        "@shopify/cli": "3.59.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@types/compression": "^1.7.2",
         "@types/express": "^4.17.17",
         "@types/morgan": "^1.9.4",
@@ -143,8 +143,6 @@
       "name": "example-multipass",
       "dependencies": {
         "@remix-run/react": "^2.8.0",
-        "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/remix-oxygen": "^2.0.4",
         "crypto-js": "^4.2.0",
@@ -158,6 +156,8 @@
       "devDependencies": {
         "@remix-run/dev": "^2.8.0",
         "@remix-run/eslint-config": "^2.8.0",
+        "@shopify/cli": "3.59.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/mini-oxygen": "^3.0.1",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
@@ -184,8 +184,6 @@
       "dependencies": {
         "@builder.io/partytown": "^0.8.1",
         "@remix-run/react": "^2.8.0",
-        "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/remix-oxygen": "^2.0.4",
         "graphql": "^16.6.0",
@@ -197,6 +195,8 @@
       "devDependencies": {
         "@remix-run/dev": "^2.8.0",
         "@remix-run/eslint-config": "^2.8.0",
+        "@shopify/cli": "3.59.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/mini-oxygen": "^3.0.1",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
@@ -218,8 +218,6 @@
       "name": "example-subscriptions",
       "dependencies": {
         "@remix-run/react": "^2.8.0",
-        "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/remix-oxygen": "^2.0.4",
         "graphql": "^16.6.0",
@@ -231,6 +229,8 @@
       "devDependencies": {
         "@remix-run/dev": "^2.8.0",
         "@remix-run/eslint-config": "^2.8.0",
+        "@shopify/cli": "3.59.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/mini-oxygen": "^3.0.1",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
@@ -30665,7 +30665,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "8.0.2",
+      "version": "8.0.3",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -30891,10 +30891,10 @@
     },
     "packages/create-hydrogen": {
       "name": "@shopify/create-hydrogen",
-      "version": "4.3.7",
+      "version": "4.3.8",
       "license": "MIT",
       "dependencies": {
-        "@shopify/cli-hydrogen": "^8.0.2"
+        "@shopify/cli-hydrogen": "^8.0.3"
       },
       "bin": {
         "create-hydrogen": "dist/create-app.js"
@@ -33317,7 +33317,7 @@
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/remix-oxygen": "^2.0.4",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -33345,12 +33345,10 @@
       }
     },
     "templates/skeleton": {
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
-        "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/remix-oxygen": "^2.0.4",
         "graphql": "^16.6.0",
@@ -33363,6 +33361,8 @@
         "@graphql-codegen/cli": "5.0.2",
         "@remix-run/dev": "^2.8.0",
         "@remix-run/eslint-config": "^2.8.0",
+        "@shopify/cli": "3.59.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/hydrogen-codegen": "^0.3.0",
         "@shopify/mini-oxygen": "^3.0.1",
         "@shopify/oxygen-workers-types": "^4.0.0",
@@ -39047,7 +39047,7 @@
     "@shopify/create-hydrogen": {
       "version": "file:packages/create-hydrogen",
       "requires": {
-        "@shopify/cli-hydrogen": "^8.0.2"
+        "@shopify/cli-hydrogen": "^8.0.3"
       }
     },
     "@shopify/generate-docs": {
@@ -44942,7 +44942,7 @@
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/hydrogen": "2024.4.1",
         "@types/compression": "^1.7.2",
         "@types/express": "^4.17.17",
@@ -44986,7 +44986,7 @@
         "@remix-run/eslint-config": "^2.8.0",
         "@remix-run/react": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/mini-oxygen": "^3.0.1",
         "@shopify/oxygen-workers-types": "^4.0.0",
@@ -45021,7 +45021,7 @@
         "@remix-run/eslint-config": "^2.8.0",
         "@remix-run/react": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/mini-oxygen": "^3.0.1",
         "@shopify/oxygen-workers-types": "^4.0.0",
@@ -45050,7 +45050,7 @@
         "@remix-run/eslint-config": "^2.8.0",
         "@remix-run/react": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/mini-oxygen": "^3.0.1",
         "@shopify/oxygen-workers-types": "^4.0.0",
@@ -46596,7 +46596,7 @@
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/mini-oxygen": "^3.0.1",
         "@shopify/oxygen-workers-types": "^4.0.0",
@@ -52819,7 +52819,7 @@
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.2",
+        "@shopify/cli-hydrogen": "^8.0.3",
         "@shopify/hydrogen": "2024.4.1",
         "@shopify/hydrogen-codegen": "^0.3.0",
         "@shopify/mini-oxygen": "^3.0.1",

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -16,8 +16,6 @@
   "dependencies": {
     "@remix-run/react": "^2.8.0",
     "@remix-run/server-runtime": "^2.8.0",
-    "@shopify/cli": "3.59.2",
-    "@shopify/cli-hydrogen": "^8.0.3",
     "@shopify/hydrogen": "2024.4.1",
     "@shopify/remix-oxygen": "^2.0.4",
     "graphql": "^16.6.0",
@@ -30,6 +28,8 @@
     "@graphql-codegen/cli": "5.0.2",
     "@remix-run/dev": "^2.8.0",
     "@remix-run/eslint-config": "^2.8.0",
+    "@shopify/cli": "3.59.2",
+    "@shopify/cli-hydrogen": "^8.0.3",
     "@shopify/hydrogen-codegen": "^0.3.0",
     "@shopify/mini-oxygen": "^3.0.1",
     "@shopify/oxygen-workers-types": "^4.0.0",


### PR DESCRIPTION
Both @shopify/cli & @shopify/cli-hydrogen packages are only something that is required during development. Lets move it in skeleton to reflect that.