### PR TITLE
Fix codegen schema resolution

### DIFF
--- a/.changeset/wicked-rocks-draw.md
+++ b/.changeset/wicked-rocks-draw.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-codegen': patch
+---
+
+Import schemas from @shopify/hydrogen instead of @shopify/hydrogen-react to avoid dependency issues.

--- a/packages/hydrogen-codegen/src/schema.ts
+++ b/packages/hydrogen-codegen/src/schema.ts
@@ -23,7 +23,7 @@ export function getSchema(api: Api, options?: Options<boolean>) {
   }
 
   try {
-    return require.resolve(`@shopify/hydrogen-react/${api}.schema.json`);
+    return require.resolve(`@shopify/hydrogen/${api}.schema.json`);
   } catch {
     if (options?.throwIfMissing !== false) {
       throw new Error(


### PR DESCRIPTION
Resolve schemas from `@shopify/hydrogen` instead of `@shopify/hydrogen-react` to avoid dependency errors.

This was originally like this to avoid problems in monorepo tests where Hydrogen wouldn't have copied schemas from Hydrogen React but it is not relevant anymore.