### PR TITLE
Cleanup `getSelectedProductOptions` implementation and add JSDocs 

### DIFF
--- a/.changeset/orange-snakes-shout.md
+++ b/.changeset/orange-snakes-shout.md
@@ -1,0 +1,6 @@
+---
+'skeleton': patch
+'@shopify/hydrogen': patch
+---
+
+Add JSdoc to `getSelectedProductOptions` utility and cleanup the skeleton implementation

--- a/packages/hydrogen/src/product/VariantSelector.ts
+++ b/packages/hydrogen/src/product/VariantSelector.ts
@@ -133,6 +133,26 @@ export function VariantSelector({
 
 type GetSelectedProductOptions = (request: Request) => SelectedOptionInput[];
 
+/**
+ * Extract searchParams from a Request instance and return an array of selected options.
+ * @param request - The Request instance to extract searchParams from.
+ * @returns An array of selected options.
+ * @example Basic usage:
+ * ```tsx
+ *
+ * import {getSelectedProductOptions} from '@shopify/hydrogen';
+ *
+ * // Given a request url of `/products/product-handle?color=red&size=large`
+ *
+ * const selectedOptions = getSelectedProductOptions(request);
+ *
+ * // selectedOptions will equal:
+ * // [
+ * //   {name: 'color', value: 'red'},
+ * //   {name: 'size', value: 'large'}
+ * // ]
+ * ```
+ **/
 export const getSelectedProductOptions: GetSelectedProductOptions = (
   request,
 ) => {

--- a/templates/skeleton/app/routes/products.$handle.tsx
+++ b/templates/skeleton/app/routes/products.$handle.tsx
@@ -26,7 +26,7 @@ import type {
 } from '@shopify/hydrogen/storefront-api-types';
 import {getVariantUrl} from '~/lib/variants';
 
-export const meta: MetaFunction<typeof loader> = ({data, location}) => {
+export const meta: MetaFunction<typeof loader> = ({data}) => {
   return [{title: `Hydrogen | ${data?.product.title ?? ''}`}];
 };
 
@@ -34,25 +34,13 @@ export async function loader({params, request, context}: LoaderFunctionArgs) {
   const {handle} = params;
   const {storefront} = context;
 
-  const selectedOptions = getSelectedProductOptions(request).filter(
-    (option) =>
-      // Filter out Shopify predictive search query params
-      !option.name.startsWith('_sid') &&
-      !option.name.startsWith('_pos') &&
-      !option.name.startsWith('_psq') &&
-      !option.name.startsWith('_ss') &&
-      !option.name.startsWith('_v') &&
-      // Filter out third party tracking params
-      !option.name.startsWith('fbclid'),
-  );
-
   if (!handle) {
     throw new Error('Expected product handle to be defined');
   }
 
   // await the query for the critical product data
   const {product} = await storefront.query(PRODUCT_QUERY, {
-    variables: {handle, selectedOptions},
+    variables: {handle, selectedOptions: getSelectedProductOptions(request)},
   });
 
   if (!product?.id) {


### PR DESCRIPTION
Removes the no longer necessary `.filter` from `getSelectedProductOptions` product loader implementation

### Ignores irrelevant params

https://github.com/Shopify/hydrogen/assets/12080141/369fd13f-e6df-436f-b7f3-b93a3648b3fb

### Added JSDoc hint for `getSelectedProductOptions`

<img width="631" alt="Screenshot 2024-05-07 at 11 41 00 AM" src="https://github.com/Shopify/hydrogen/assets/12080141/75299540-b615-4489-8a23-9a43957a4dd1">

