### PR TITLE
Fix upgrade command for outdated dev deps

### DIFF
--- a/.changeset/early-rockets-do.md
+++ b/.changeset/early-rockets-do.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix `h2 upgrade` command to detect outdated devDependencies.

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -327,14 +327,17 @@ export async function getChangelog(): Promise<ChangeLog> {
   );
 }
 
-export function hasOutdatedDependencies({
+function hasOutdatedDependencies({
   release,
   currentDependencies,
 }: {
   release: Release;
   currentDependencies: Dependencies;
 }) {
-  return Object.entries(release.dependencies).some(([name, version]) => {
+  return Object.entries({
+    ...release.dependencies,
+    ...release.devDependencies,
+  }).some(([name, version]) => {
     const currentDependencyVersion = currentDependencies?.[name];
     if (!currentDependencyVersion) return false;
     const isDependencyOutdated = semver.gt(


### PR DESCRIPTION
The upgrade command is supposed to detect outdated dependencies in two releases that have the same Hydrogen version.
This was true for `dependencies` but didn't work for `devDependencies`. I've also added unit tests to cover the whole outdated deps story.

@michenly I think this should fix the issue you were seeing where it didn't show updates for a bump in mini-oxygen 🤔 