### PR TITLE
Bump graphql-codegen dependency

### DIFF
--- a/.changeset/four-cougars-rescue.md
+++ b/.changeset/four-cougars-rescue.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-codegen': patch
+---
+
+Use type imports in generated file (`import type` instead of `import`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -8708,9 +8708,9 @@
       }
     },
     "node_modules/@shopify/graphql-codegen": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@shopify/graphql-codegen/-/graphql-codegen-0.0.1.tgz",
-      "integrity": "sha512-A6LwdihfS0DzfiwwFcSC4CSG5laTwEyVySqYlf1uvo2G9fuxb79FjhmO6WY0kP3P1/Ktg/w3H1w6muzOv2n3qA==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@shopify/graphql-codegen/-/graphql-codegen-0.0.2.tgz",
+      "integrity": "sha512-DScSpsQ+ucv6Y4cujXa5ye9r4lZ6Jl7S+90iyfxEgeTW6HVh/0b9PDcSCJ4T1EONc7kmvCx1dd83tTvCmc7X7A==",
       "dependencies": {
         "@graphql-codegen/add": "^5.0.1",
         "@graphql-codegen/typescript": "^4.0.2",
@@ -8725,9 +8725,9 @@
       }
     },
     "node_modules/@shopify/graphql-codegen/node_modules/type-fest": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.0.tgz",
-      "integrity": "sha512-+dbmiyliDY/2TTcjCS7NpI9yV2iEFlUDk5TKnsbkN7ZoRu5s7bT+zvYtNFhFXC2oLwURGT2frACAZvbbyNBI+w==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
       "engines": {
         "node": ">=16"
       },
@@ -30973,7 +30973,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@shopify/graphql-codegen": "^0.0.1"
+        "@shopify/graphql-codegen": "^0.0.2"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^5.0.1",
@@ -39103,9 +39103,9 @@
       }
     },
     "@shopify/graphql-codegen": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@shopify/graphql-codegen/-/graphql-codegen-0.0.1.tgz",
-      "integrity": "sha512-A6LwdihfS0DzfiwwFcSC4CSG5laTwEyVySqYlf1uvo2G9fuxb79FjhmO6WY0kP3P1/Ktg/w3H1w6muzOv2n3qA==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@shopify/graphql-codegen/-/graphql-codegen-0.0.2.tgz",
+      "integrity": "sha512-DScSpsQ+ucv6Y4cujXa5ye9r4lZ6Jl7S+90iyfxEgeTW6HVh/0b9PDcSCJ4T1EONc7kmvCx1dd83tTvCmc7X7A==",
       "requires": {
         "@graphql-codegen/add": "^5.0.1",
         "@graphql-codegen/typescript": "^4.0.2",
@@ -39114,9 +39114,9 @@
       },
       "dependencies": {
         "type-fest": {
-          "version": "4.18.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.0.tgz",
-          "integrity": "sha512-+dbmiyliDY/2TTcjCS7NpI9yV2iEFlUDk5TKnsbkN7ZoRu5s7bT+zvYtNFhFXC2oLwURGT2frACAZvbbyNBI+w=="
+          "version": "4.18.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+          "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg=="
         }
       }
     },
@@ -39154,7 +39154,7 @@
       "requires": {
         "@graphql-codegen/cli": "^5.0.1",
         "@graphql-codegen/plugin-helpers": "^5.0.2",
-        "@shopify/graphql-codegen": "^0.0.1",
+        "@shopify/graphql-codegen": "^0.0.2",
         "dts-bundle-generator": "^9.3.1",
         "type-fest": "^4.5.0",
         "vitest": "^1.0.4"

--- a/packages/hydrogen-codegen/package.json
+++ b/packages/hydrogen-codegen/package.json
@@ -43,6 +43,6 @@
     "vitest": "^1.0.4"
   },
   "dependencies": {
-    "@shopify/graphql-codegen": "^0.0.1"
+    "@shopify/graphql-codegen": "^0.0.2"
   }
 }

--- a/templates/skeleton/customer-accountapi.generated.d.ts
+++ b/templates/skeleton/customer-accountapi.generated.d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable eslint-comments/no-unlimited-disable */
 /* eslint-disable */
-import * as CustomerAccountAPI from '@shopify/hydrogen/customer-account-api-types';
+import type * as CustomerAccountAPI from '@shopify/hydrogen/customer-account-api-types';
 
 export type CustomerAddressUpdateMutationVariables = CustomerAccountAPI.Exact<{
   address: CustomerAccountAPI.CustomerAddressInput;

--- a/templates/skeleton/storefrontapi.generated.d.ts
+++ b/templates/skeleton/storefrontapi.generated.d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable eslint-comments/no-unlimited-disable */
 /* eslint-disable */
-import * as StorefrontAPI from '@shopify/hydrogen/storefront-api-types';
+import type * as StorefrontAPI from '@shopify/hydrogen/storefront-api-types';
 
 export type MoneyFragment = Pick<
   StorefrontAPI.MoneyV2,


### PR DESCRIPTION
I released a new version of `@shopify/graphql-codegen` to fix an issue for the Shopify API JS folks. Updating the version here as well.