### PR TITLE
Variant selector refactor

### DIFF
--- a/packages/hydrogen/src/product/VariantSelector.example.jsx
+++ b/packages/hydrogen/src/product/VariantSelector.example.jsx
@@ -12,7 +12,7 @@ const ProductForm = ({product}) => {
         <>
           <div>{option.name}</div>
           <div>
-            {option.values.map(({value, isAvailable, to, isActive}) => (
+            {option.values.map(({value, isAvailable, to, isActive, variant}) => (
               <Link
                 to={to}
                 prefetch="intent"
@@ -21,6 +21,8 @@ const ProductForm = ({product}) => {
                 }
               >
                 {value}
+                <br />
+                {variant && `SKU: ${variant.sku}`}
               </Link>
             ))}
           </div>

--- a/packages/hydrogen/src/product/VariantSelector.example.tsx
+++ b/packages/hydrogen/src/product/VariantSelector.example.tsx
@@ -13,7 +13,7 @@ const ProductForm = ({product}: {product: Product}) => {
         <>
           <div>{option.name}</div>
           <div>
-            {option.values.map(({value, isAvailable, to, isActive}) => (
+            {option.values.map(({value, isAvailable, to, isActive, variant}) => (
               <Link
                 to={to}
                 prefetch="intent"
@@ -22,6 +22,8 @@ const ProductForm = ({product}: {product: Product}) => {
                 }
               >
                 {value}
+                <br />
+                {variant && `SKU: ${variant.sku}`}
               </Link>
             ))}
           </div>

--- a/packages/hydrogen/src/product/VariantSelector.test.ts
+++ b/packages/hydrogen/src/product/VariantSelector.test.ts
@@ -522,7 +522,7 @@ describe('<VariantSelector>', () => {
                 },
                 value,
                 createElement('br', null),
-                `SKU: ${variant?.sku}`
+                variant && `SKU: ${variant?.sku}`
               ),
             ),
           ),

--- a/packages/hydrogen/src/product/VariantSelector.test.ts
+++ b/packages/hydrogen/src/product/VariantSelector.test.ts
@@ -488,4 +488,68 @@ describe('<VariantSelector>', () => {
       </DocumentFragment>
     `);
   });
+
+  it('returns variant in option values', () => {
+    const {asFragment} = render(
+      createElement(VariantSelector, {
+        handle: 'snowboard',
+        options: [{name: 'Size', values: ['S', 'M']}],
+        variants: {
+          nodes: [
+            {
+              availableForSale: true,
+              sku: "ABC-01234",
+              selectedOptions: [{name: 'Size', value: 'S'}],
+            } as ProductVariant,
+            {
+              availableForSale: true,
+              sku: "XYZ-56789",
+              selectedOptions: [{name: 'Size', value: 'M'}],
+            } as ProductVariant,
+          ],
+        },
+        children: ({option}) =>
+          createElement(
+            'div',
+            null,
+            option.values.map(({value, to, isAvailable, variant}) =>
+              createElement(
+                'a',
+                {
+                  key: option.name + value,
+                  href: to,
+                  className: isAvailable ? 'available' : 'unavailable',
+                },
+                value,
+                createElement('br', null),
+                `SKU: ${variant?.sku}`
+              ),
+            ),
+          ),
+      }),
+    );
+
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <div>
+          <a
+            class="available"
+            href="/products/snowboard?Size=S"
+          >
+            S
+            <br />
+            SKU: ABC-01234
+          </a>
+          <a
+            class="available"
+            href="/products/snowboard?Size=M"
+          >
+            M
+            <br />
+            SKU: XYZ-56789
+          </a>
+        </div>
+      </DocumentFragment>
+    `);
+  });
 });

--- a/packages/hydrogen/src/product/VariantSelector.ts
+++ b/packages/hydrogen/src/product/VariantSelector.ts
@@ -21,6 +21,7 @@ export type VariantOptionValue = {
   to: string;
   search: string;
   isActive: boolean;
+  variant?: PartialDeep<ProductVariant>;
 };
 
 type VariantSelectorProps = {
@@ -115,6 +116,7 @@ export function VariantSelector({
                 to: path + searchString,
                 search: searchString,
                 isActive: calculatedActiveValue,
+                variant,
               });
             }
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Improve `VariantSelector` to return variant object in option values:

```jsx
<VariantSelector handle={product.handle} options={product.options} variants={product.variants}>
    {({option}) => (
        <>
          <div>{option.name}</div>
          <div>
            /*                          [now accessible as such]     vvvvvvv     */
            {option.values.map(({value, isAvailable, path, isActive, variant}) => (
              <Link
                to={path}
                prefetch="intent"
                className={
                  isActive ? 'active' : isAvailable ? '' : 'opacity-80'
                }
              >
                {value}
                <br />
                {variant && `SKU: ${variant.sku}`}
              </Link>
            ))}
          </div>
        </>
      )}
</VariantSelector>
```
[There has been some small discussion](https://github.com/Shopify/hydrogen/discussions/1198#discussioncomment-8357548) around this issue for a while now and there hasn't been any clear solution. Thus, [like others](https://github.com/Shopify/hydrogen/discussions/1198#discussioncomment-9248875), I had to write a work-around to get the expected results.

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### HOW to test your changes?

I've also created a new test in `VariantSelector.test.ts` which now tests for variant objects returned by option values.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
