### PR TITLE
Build watch

### DIFF
--- a/.changeset/tiny-pans-help.md
+++ b/.changeset/tiny-pans-help.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': minor
+---
+
+The `h2 preview` command now supports `--build` and `--watch` flags to preview the project using the build process instead of Vite's dev process.
+  

--- a/examples/analytics/package.json
+++ b/examples/analytics/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "nshopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/analytics/package.json
+++ b/examples/analytics/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build --diff",
+    "preview": "shopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/analytics/package.json
+++ b/examples/analytics/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/b2b/package.json
+++ b/examples/b2b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build --diff",
+    "preview": "shopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/b2b/package.json
+++ b/examples/b2b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/b2b/package.json
+++ b/examples/b2b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "nshopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/classic-remix/package.json
+++ b/examples/classic-remix/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "nshopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/classic-remix/package.json
+++ b/examples/classic-remix/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build --diff",
+    "preview": "shopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/classic-remix/package.json
+++ b/examples/classic-remix/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/custom-cart-method/package.json
+++ b/examples/custom-cart-method/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build --diff",
+    "preview": "shopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/custom-cart-method/package.json
+++ b/examples/custom-cart-method/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/custom-cart-method/package.json
+++ b/examples/custom-cart-method/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "nshopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/infinite-scroll/package.json
+++ b/examples/infinite-scroll/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build --diff",
+    "preview": "shopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/infinite-scroll/package.json
+++ b/examples/infinite-scroll/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/infinite-scroll/package.json
+++ b/examples/infinite-scroll/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "nshopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/legacy-customer-account-flow/package.json
+++ b/examples/legacy-customer-account-flow/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build --diff",
+    "preview": "shopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/legacy-customer-account-flow/package.json
+++ b/examples/legacy-customer-account-flow/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/legacy-customer-account-flow/package.json
+++ b/examples/legacy-customer-account-flow/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "nshopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/metaobjects/package.json
+++ b/examples/metaobjects/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build --diff",
+    "preview": "shopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/metaobjects/package.json
+++ b/examples/metaobjects/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/metaobjects/package.json
+++ b/examples/metaobjects/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "nshopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/multipass/package.json
+++ b/examples/multipass/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build",
     "dev": "shopify hydrogen dev --codegen",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/multipass/package.json
+++ b/examples/multipass/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build",
     "dev": "shopify hydrogen dev --codegen",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "shopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/optimistic-cart-ui/package.json
+++ b/examples/optimistic-cart-ui/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build --diff",
+    "preview": "shopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/optimistic-cart-ui/package.json
+++ b/examples/optimistic-cart-ui/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/optimistic-cart-ui/package.json
+++ b/examples/optimistic-cart-ui/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "nshopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/partytown/package.json
+++ b/examples/partytown/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run partytown && shopify hydrogen build",
     "dev": "shopify hydrogen dev --codegen",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen",

--- a/examples/partytown/package.json
+++ b/examples/partytown/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run partytown && shopify hydrogen build",
     "dev": "shopify hydrogen dev --codegen",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "shopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen",

--- a/examples/subscriptions/package.json
+++ b/examples/subscriptions/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build",
     "dev": "shopify hydrogen dev --codegen",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/subscriptions/package.json
+++ b/examples/subscriptions/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build",
     "dev": "shopify hydrogen dev --codegen",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "shopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/third-party-queries-caching/package.json
+++ b/examples/third-party-queries-caching/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --codegen --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/third-party-queries-caching/package.json
+++ b/examples/third-party-queries-caching/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --codegen --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "nshopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/examples/third-party-queries-caching/package.json
+++ b/examples/third-party-queries-caching/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "shopify hydrogen build --codegen --diff",
     "dev": "shopify hydrogen dev --codegen --diff",
-    "preview": "nshopify hydrogen preview --build --diff",
+    "preview": "shopify hydrogen preview --build --diff",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1329,6 +1329,17 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "diff": {
+          "dependsOn": [
+            "build"
+          ],
+          "description": "Applies the current files on top of Hydrogen's starter template in a temporary directory.",
+          "hidden": true,
+          "name": "diff",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1289,6 +1289,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "watch": {
+          "dependsOn": [
+            "build"
+          ],
+          "description": "Watches for changes and rebuilds the project.",
+          "name": "watch",
+          "allowNo": false,
+          "type": "boolean"
+        },
         "entry": {
           "dependsOn": [
             "build"

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1282,6 +1282,44 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "build": {
+          "description": "Builds the app before starting the preview server.",
+          "name": "build",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "entry": {
+          "dependsOn": [
+            "build"
+          ],
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "codegen": {
+          "dependsOn": [
+            "build"
+          ],
+          "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
+          "name": "codegen",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "codegen-config-path": {
+          "dependsOn": [
+            "codegen"
+          ],
+          "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
+          "name": "codegen-config-path",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -68,6 +68,13 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "watch": {
+          "description": "Watches for changes and rebuilds the project writing output to disk.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_WATCH",
+          "name": "watch",
+          "allowNo": false,
+          "type": "boolean"
+        },
         "bundle-stats": {
           "description": "[Classic Remix Compiler] Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
           "name": "bundle-stats",

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -12,7 +12,7 @@ import {findMissingRoutes} from '../../lib/missing-routes.js';
 import {runClassicCompilerBuild} from '../../lib/classic-compiler/build.js';
 import {codegen, spawnCodegenProcess} from '../../lib/codegen.js';
 import {isCI} from '../../lib/is-ci.js';
-import {deferPromise} from '../../lib/defer.js';
+import {deferPromise, type DeferredPromise} from '../../lib/defer.js';
 import {setupResourceCleanup} from '../../lib/resource-cleanup.js';
 
 export default class Build extends Command {
@@ -150,7 +150,7 @@ export async function runBuild({
     customLogger,
   };
 
-  let clientBuildStatus: ReturnType<typeof deferPromise>;
+  let clientBuildStatus: DeferredPromise;
 
   // Client build first
   const clientBuild = await vite.build({
@@ -175,11 +175,17 @@ export async function runBuild({
         writeBundle() {
           clientBuildStatus.resolve();
         },
+        closeWatcher() {
+          // End build process if watcher is closed
+          this.error(new Error('Process exited before client build finished.'));
+        },
       },
     ],
   });
 
   console.log('');
+
+  let serverBuildStatus: DeferredPromise;
 
   // Server/SSR build
   const serverBuild = await vite.build({
@@ -201,9 +207,23 @@ export async function runBuild({
           // before starting the server build to access the
           // Remix manifest from file disk.
           await clientBuildStatus.promise;
+
+          // Keep track of server builds to wait for them to finish
+          // before cleaning up resources in watch mode. Otherwise,
+          // it might complain about missing files and loop infinitely.
+          serverBuildStatus?.resolve();
+          serverBuildStatus = deferPromise();
         },
         async writeBundle() {
-          await onRebuild?.();
+          if (serverBuildStatus?.state !== 'rejected') {
+            await onRebuild?.();
+          }
+
+          serverBuildStatus.resolve();
+        },
+        closeWatcher() {
+          // End build process if watcher is closed
+          this.error(new Error('Process exited before server build finished.'));
         },
       },
     ],
@@ -267,7 +287,21 @@ export async function runBuild({
       const promises: Array<Promise<void>> = [];
       if ('close' in clientBuild) promises.push(clientBuild.close());
       if ('close' in serverBuild) promises.push(serverBuild.close());
+
       await Promise.allSettled(promises);
+
+      if (
+        clientBuildStatus?.state === 'pending' ||
+        serverBuildStatus?.state === 'pending'
+      ) {
+        clientBuildStatus?.promise.catch(() => {});
+        clientBuildStatus?.reject();
+        serverBuildStatus?.promise.catch(() => {});
+        serverBuildStatus?.reject();
+
+        // Give time for Rollup to stop builds before removing files
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
     },
   };
 }

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -10,7 +10,7 @@ import {hasViteConfig, getViteConfig} from '../../lib/vite-config.js';
 import {checkLockfileStatus} from '../../lib/check-lockfile.js';
 import {findMissingRoutes} from '../../lib/missing-routes.js';
 import {runClassicCompilerBuild} from '../../lib/classic-compiler/build.js';
-import {codegen} from '../../lib/codegen.js';
+import {codegen, spawnCodegenProcess} from '../../lib/codegen.js';
 import {isCI} from '../../lib/is-ci.js';
 import {deferPromise} from '../../lib/defer.js';
 
@@ -204,11 +204,17 @@ export async function runBuild({
   }
 
   if (useCodegen) {
-    await codegen({
+    const codegenOptions = {
       rootDirectory: root,
       appDirectory: remixConfig.appDirectory,
       configFilePath: codegenConfigPath,
-    });
+    };
+
+    if (watch) {
+      spawnCodegenProcess(codegenOptions);
+    } else {
+      await codegen(codegenOptions);
+    }
   }
 
   if (!watch && process.env.NODE_ENV !== 'development') {

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -99,6 +99,7 @@ type RunBuildOptions = {
   bundleStats?: boolean;
   lockfileCheck?: boolean;
   watch?: boolean;
+  onRebuild?: () => void | Promise<void>;
 };
 
 export async function runBuild({
@@ -111,6 +112,7 @@ export async function runBuild({
   lockfileCheck = true,
   assetPath = '/',
   watch = false,
+  onRebuild,
 }: RunBuildOptions) {
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'production';
@@ -199,6 +201,9 @@ export async function runBuild({
           // before starting the server build to access the
           // Remix manifest from file disk.
           await clientBuildStatus.promise;
+        },
+        async writeBundle() {
+          await onRebuild?.();
         },
       },
     ],

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -50,7 +50,7 @@ export default class Build extends Command {
     let directory = originalDirectory;
 
     if (flags.diff) {
-      directory = await prepareDiffDirectory(originalDirectory, false);
+      directory = await prepareDiffDirectory(originalDirectory, flags.watch);
     }
 
     const buildParams = {

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -68,7 +68,7 @@ export default class Preview extends Command {
     let directory = originalDirectory;
 
     if (flags.build && flags.diff) {
-      directory = await prepareDiffDirectory(originalDirectory, false);
+      directory = await prepareDiffDirectory(originalDirectory, flags.watch);
     }
 
     const {close} = await runPreview({

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -64,6 +64,7 @@ type PreviewOptions = {
   debug: boolean;
   verbose?: boolean;
   build?: boolean;
+  entry?: string;
   codegen?: boolean;
   codegenConfigPath?: string;
 };
@@ -80,6 +81,7 @@ export async function runPreview({
   build: shouldBuild = false,
   codegen: useCodegen = false,
   codegenConfigPath,
+  entry,
 }: PreviewOptions) {
   if (!process.env.NODE_ENV) process.env.NODE_ENV = 'production';
 
@@ -92,6 +94,7 @@ export async function runPreview({
   if (shouldBuild) {
     await runBuild({
       directory: appPath,
+      entry,
       disableRouteWarning: false,
       lockfileCheck: false,
       sourcemap: true,

--- a/packages/cli/src/commands/hydrogen/preview.ts
+++ b/packages/cli/src/commands/hydrogen/preview.ts
@@ -55,6 +55,10 @@ export default class Preview extends Command {
     ...overrideFlag(commonFlags.codegen, {
       codegen: {dependsOn: ['build']},
     }),
+    // Diff in preview only makes sense when combined with --build.
+    // Without the build flag, preview only needs access to the existing
+    // `dist` directory in the project, so there's no need to merge the
+    // project with the skeleton template in a temporary directory.
     ...overrideFlag(commonFlags.diff, {
       diff: {dependsOn: ['build']},
     }),

--- a/packages/cli/src/lib/defer.ts
+++ b/packages/cli/src/lib/defer.ts
@@ -2,13 +2,24 @@
  * Creates a promise that can be resolved or rejected from the outter scope.
  */
 export function deferPromise() {
-  let resolve = (value?: unknown) => {};
-  let reject = resolve;
+  const deferred = {state: 'pending'} as {
+    promise: Promise<unknown>;
+    resolve: (value?: unknown) => void;
+    reject: (reason?: any) => void;
+    state: 'pending' | 'resolved' | 'rejected';
+  };
 
-  const promise = new Promise((_resolve, _reject) => {
-    resolve = _resolve;
-    reject = _reject;
+  deferred.promise = new Promise((resolve, reject) => {
+    deferred.resolve = (value) => {
+      if (deferred.state === 'pending') deferred.state = 'resolved';
+      return resolve(value);
+    };
+
+    deferred.reject = (reason) => {
+      if (deferred.state === 'pending') deferred.state = 'rejected';
+      return reject(reason);
+    };
   });
 
-  return {promise, resolve, reject};
+  return deferred;
 }

--- a/packages/cli/src/lib/defer.ts
+++ b/packages/cli/src/lib/defer.ts
@@ -1,10 +1,10 @@
 /**
  * Creates a promise that can be resolved or rejected from the outter scope.
  */
-export function deferPromise() {
+export function deferPromise<T = unknown>() {
   const deferred = {state: 'pending'} as {
     promise: Promise<unknown>;
-    resolve: (value?: unknown) => void;
+    resolve: (value?: T) => void;
     reject: (reason?: any) => void;
     state: 'pending' | 'resolved' | 'rejected';
   };
@@ -23,3 +23,5 @@ export function deferPromise() {
 
   return deferred;
 }
+
+export type DeferredPromise<T = unknown> = ReturnType<typeof deferPromise<T>>;

--- a/packages/cli/src/lib/flags.ts
+++ b/packages/cli/src/lib/flags.ts
@@ -92,7 +92,6 @@ export const commonFlags = {
       description:
         'Automatically generates GraphQL types for your project’s Storefront API queries.',
       required: false,
-      default: false,
     }),
     'codegen-config-path': Flags.string({
       description:

--- a/packages/cli/src/lib/flags.ts
+++ b/packages/cli/src/lib/flags.ts
@@ -122,7 +122,6 @@ export const commonFlags = {
       description:
         'Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.',
       env: 'SHOPIFY_HYDROGEN_FLAG_DEBUG',
-      default: false,
     }),
   },
   inspectorPort: {
@@ -135,7 +134,6 @@ export const commonFlags = {
     diff: Flags.boolean({
       description:
         "Applies the current files on top of Hydrogen's starter template in a temporary directory.",
-      default: false,
       required: false,
       hidden: true,
     }),
@@ -167,7 +165,6 @@ export const commonFlags = {
       description:
         "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's Oauth flow",
       required: false,
-      default: false,
       env: 'SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH',
     }),
   },
@@ -175,7 +172,6 @@ export const commonFlags = {
     verbose: Flags.boolean({
       description: "Outputs more information about the command's execution.",
       required: false,
-      default: false,
       env: 'SHOPIFY_HYDROGEN_FLAG_VERBOSE',
     }),
   },

--- a/packages/cli/src/lib/log.ts
+++ b/packages/cli/src/lib/log.ts
@@ -211,6 +211,12 @@ export function muteDevLogs({workerReload}: {workerReload?: boolean} = {}) {
       () => {},
     ],
     [
+      // This log must come from Rollup and does not go through Vite's customLogger
+      ([first]) =>
+        typeof first === 'string' && /^Generated an empty chunk:/i.test(first),
+      () => {},
+    ],
+    [
       // Log new lines between Request logs and other logs
       ([first], existingMatches) => {
         // If this log is not going to be filtered by other replacers:

--- a/packages/cli/src/lib/mini-oxygen/node.ts
+++ b/packages/cli/src/lib/mini-oxygen/node.ts
@@ -67,7 +67,7 @@ export async function startNodeServer({
     });
 
   const miniOxygen = await startServer({
-    script: await readFile(buildPathWorkerFile),
+    script: await readWorkerFile(),
     workerFile: buildPathWorkerFile,
     assetsDir: buildPathClient,
     publicPath: '',

--- a/packages/cli/src/lib/mini-oxygen/workerd.ts
+++ b/packages/cli/src/lib/mini-oxygen/workerd.ts
@@ -3,6 +3,7 @@ import {dirname, resolvePath} from '@shopify/cli-kit/node/path';
 import {readFile, createFileReadStream} from '@shopify/cli-kit/node/fs';
 import {renderSuccess} from '@shopify/cli-kit/node/ui';
 import {outputNewline} from '@shopify/cli-kit/node/output';
+import {AbortError} from '@shopify/cli-kit/node/error';
 import colors from '@shopify/cli-kit/node/colors';
 import type {MiniOxygenInstance, MiniOxygenOptions} from './types.js';
 import {
@@ -52,8 +53,15 @@ export async function startWorkerdServer({
     });
   }
 
-  const absoluteBundlePath = resolvePath(root, buildPathWorkerFile);
   const mainWorkerName = 'hydrogen';
+  const absoluteBundlePath = resolvePath(root, buildPathWorkerFile);
+  const readWorkerFile = () =>
+    readFile(absoluteBundlePath).catch((error) => {
+      throw new AbortError(
+        `Could not read worker file.\n\n` + error.stack,
+        'Did you build the project?',
+      );
+    });
 
   const miniOxygen = createMiniOxygen({
     debug,
@@ -97,7 +105,7 @@ export async function startWorkerdServer({
           {
             type: 'ESModule',
             path: absoluteBundlePath,
-            contents: await readFile(absoluteBundlePath),
+            contents: await readWorkerFile(),
           },
         ],
         bindings: {...env},
@@ -120,7 +128,7 @@ export async function startWorkerdServer({
         const mainWorker = workers.find(({name}) => name === mainWorkerName)!;
 
         if (Array.isArray(mainWorker.modules) && mainWorker.modules[0]) {
-          mainWorker.modules[0].contents = await readFile(absoluteBundlePath);
+          mainWorker.modules[0].contents = await readWorkerFile();
         }
 
         if (nextOptions) {

--- a/packages/cli/src/lib/resource-cleanup.ts
+++ b/packages/cli/src/lib/resource-cleanup.ts
@@ -14,7 +14,13 @@ export function setupResourceCleanup(cleanup: () => Promise<void>) {
     // This function will be called multiple times,
     // but we only want to cleanup resources once.
     closingPromise ??= cleanup();
+
+    // If the cleanup function hangs, we want to ensure the process exits.
+    const timeout = setTimeout(() => processExit(code), 5000);
+
     await closingPromise;
+
+    clearTimeout(timeout);
     return processExit(code);
   };
 }

--- a/packages/cli/src/lib/resource-cleanup.ts
+++ b/packages/cli/src/lib/resource-cleanup.ts
@@ -1,0 +1,20 @@
+/**
+ * Adds a workaround to ensure that the cleanup function is called before the process exits.
+ *
+ * Context: Shopify CLI is hooking into process events and calling process.exit.
+ * This means we are unable to hook into 'beforeExit' or 'SIGINT" events
+ * to cleanup resources. In addition, Miniflare uses `exit-hook` dependency
+ * to do the same thing. This is a workaround to ensure we cleanup resources:
+ */
+export function setupResourceCleanup(cleanup: () => Promise<void>) {
+  let closingPromise: Promise<void>;
+  const processExit = process.exit;
+  // @ts-expect-error - Async function
+  process.exit = async (code?: number | undefined) => {
+    // This function will be called multiple times,
+    // but we only want to cleanup resources once.
+    closingPromise ??= cleanup();
+    await closingPromise;
+    return processExit(code);
+  };
+}

--- a/packages/cli/src/lib/template-diff.ts
+++ b/packages/cli/src/lib/template-diff.ts
@@ -133,7 +133,7 @@ export async function applyTemplateDiff(
           templatePkgJson.dependencies['@shopify/cli-hydrogen'] ?? '*';
       }
 
-      for (const key of ['build', 'dev']) {
+      for (const key of ['build', 'dev', 'preview']) {
         const scriptLine = pkgJson.scripts?.[key];
         if (pkgJson.scripts?.[key] && typeof scriptLine === 'string') {
           pkgJson.scripts[key] = scriptLine.replace(/\s+--diff/, '');

--- a/templates/hello-world/package.json
+++ b/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "shopify hydrogen build",
     "dev": "shopify hydrogen dev",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "nshopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit"
   },

--- a/templates/hello-world/package.json
+++ b/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "shopify hydrogen build",
     "dev": "shopify hydrogen dev",
-    "preview": "nshopify hydrogen preview --build",
+    "preview": "shopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit"
   },

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "shopify hydrogen build --codegen",
     "dev": "shopify hydrogen dev --codegen",
-    "preview": "npm run build && shopify hydrogen preview",
+    "preview": "shopify hydrogen preview --build",
     "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
     "typecheck": "tsc --noEmit",
     "codegen": "shopify hydrogen codegen"


### PR DESCRIPTION
This is a prerequisite for supporting `h2 debug cpu` in Vite. Features:

- Add `--watch` to `h2 build`
- Add `--build --watch --codegen` to `h2 preview`
- Support `--diff` in `h2 preview`

## Note

Miniflare is currently not compatible with CSP nonces and WS connections. Therefore, live reload doesn't work with `h2 preview --build --watch` until that's fixed and you need to refresh the browser manually.
I've reported the problem here: https://github.com/cloudflare/workers-sdk/issues/5829