### PR TITLE
Adds scriptSrcElem to the CreateContentSecurityPolicy type

### DIFF
--- a/.changeset/flat-camels-dress.md
+++ b/.changeset/flat-camels-dress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Adds type support for the script-src-elem directive for CSPs

--- a/packages/hydrogen/src/csp/csp.ts
+++ b/packages/hydrogen/src/csp/csp.ts
@@ -26,6 +26,7 @@ type DirectiveValues = string[] | string | boolean;
 type CreateContentSecurityPolicy = {
   defaultSrc?: DirectiveValues;
   scriptSrc?: DirectiveValues;
+  scriptSrcElem?: DirectiveValues;
   styleSrc?: DirectiveValues;
   imgSrc?: DirectiveValues;
   connectSrc?: DirectiveValues;


### PR DESCRIPTION
### WHY are these changes introduced?

Providing a `scriptSrcElem` list to the `createContentSecurityPolicy` function fails type checking.


### WHAT is this pull request doing?

Adds type support for the script-src-elem directive for CSPs


#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
