### PR TITLE
Fix local CLI usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "templates/hello-world",
         "templates/skeleton"
       ],
+      "dependencies": {
+        "@shopify/cli-hydrogen": "*"
+      },
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,8 +111,8 @@
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
         "compression": "^1.7.4",
         "cross-env": "^7.0.3",
         "express": "^4.19.2",
@@ -165,8 +165,8 @@
       "dependencies": {
         "@remix-run/react": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
         "@shopify/remix-oxygen": "^2.0.4",
         "crypto-js": "^4.2.0",
         "graphql": "^16.6.0",
@@ -179,7 +179,7 @@
       "devDependencies": {
         "@remix-run/dev": "^2.8.0",
         "@remix-run/eslint-config": "^2.8.0",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -209,8 +209,8 @@
         "@builder.io/partytown": "^0.8.1",
         "@remix-run/react": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
         "@shopify/remix-oxygen": "^2.0.4",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
@@ -221,7 +221,7 @@
       "devDependencies": {
         "@remix-run/dev": "^2.8.0",
         "@remix-run/eslint-config": "^2.8.0",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -243,8 +243,8 @@
       "dependencies": {
         "@remix-run/react": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
         "@shopify/remix-oxygen": "^2.0.4",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
@@ -255,7 +255,7 @@
       "devDependencies": {
         "@remix-run/dev": "^2.8.0",
         "@remix-run/eslint-config": "^2.8.0",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@tailwindcss/forms": "^0.5.3",
@@ -30696,7 +30696,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "8.0.3",
+      "version": "8.0.4",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -30748,8 +30748,8 @@
       "peerDependencies": {
         "@graphql-codegen/cli": "^5.0.2",
         "@remix-run/dev": "^2.1.0",
-        "@shopify/hydrogen-codegen": "^0.3.0",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/hydrogen-codegen": "^0.3.1",
+        "@shopify/mini-oxygen": "^3.0.2",
         "graphql-config": "^5.0.3",
         "vite": "^5.1.0"
       },
@@ -30922,10 +30922,10 @@
     },
     "packages/create-hydrogen": {
       "name": "@shopify/create-hydrogen",
-      "version": "4.3.8",
+      "version": "4.3.9",
       "license": "MIT",
       "dependencies": {
-        "@shopify/cli-hydrogen": "^8.0.3"
+        "@shopify/cli-hydrogen": "^8.0.4"
       },
       "bin": {
         "create-hydrogen": "dist/create-app.js"
@@ -30933,10 +30933,10 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2024.4.1",
+      "version": "2024.4.2",
       "license": "MIT",
       "dependencies": {
-        "@shopify/hydrogen-react": "2024.4.1",
+        "@shopify/hydrogen-react": "2024.4.2",
         "content-security-policy-builder": "^2.2.0",
         "source-map-support": "^0.5.21",
         "tiny-invariant": "^1.3.1",
@@ -30970,7 +30970,7 @@
     },
     "packages/hydrogen-codegen": {
       "name": "@shopify/hydrogen-codegen",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@shopify/graphql-codegen": "^0.0.2"
@@ -30997,7 +30997,7 @@
     },
     "packages/hydrogen-react": {
       "name": "@shopify/hydrogen-react",
-      "version": "2024.4.1",
+      "version": "2024.4.2",
       "license": "MIT",
       "dependencies": {
         "@google/model-viewer": "^1.12.1",
@@ -33231,7 +33231,7 @@
     },
     "packages/mini-oxygen": {
       "name": "@shopify/mini-oxygen",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@miniflare/cache": "^2.14.2",
@@ -33350,8 +33350,8 @@
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
         "@shopify/remix-oxygen": "^2.0.4",
         "@total-typescript/ts-reset": "^0.4.2",
         "graphql": "^16.6.0",
@@ -33362,7 +33362,7 @@
       },
       "devDependencies": {
         "@remix-run/dev": "^2.8.0",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@types/eslint": "^8.4.10",
@@ -33378,13 +33378,13 @@
       }
     },
     "templates/skeleton": {
-      "version": "1.0.10",
+      "version": "2024.4.4",
       "dependencies": {
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
         "@shopify/remix-oxygen": "^2.0.4",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
@@ -33396,8 +33396,8 @@
         "@graphql-codegen/cli": "5.0.2",
         "@remix-run/dev": "^2.8.0",
         "@remix-run/eslint-config": "^2.8.0",
-        "@shopify/hydrogen-codegen": "^0.3.0",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/hydrogen-codegen": "^0.3.1",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -39080,7 +39080,7 @@
     "@shopify/create-hydrogen": {
       "version": "file:packages/create-hydrogen",
       "requires": {
-        "@shopify/cli-hydrogen": "^8.0.3"
+        "@shopify/cli-hydrogen": "^8.0.4"
       }
     },
     "@shopify/generate-docs": {
@@ -39127,7 +39127,7 @@
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/generate-docs": "0.11.1",
         "@shopify/hydrogen-codegen": "*",
-        "@shopify/hydrogen-react": "2024.4.1",
+        "@shopify/hydrogen-react": "2024.4.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@types/source-map-support": "^0.5.10",
@@ -44992,8 +44992,8 @@
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
         "@types/compression": "^1.7.2",
         "@types/express": "^4.17.17",
         "@types/morgan": "^1.9.4",
@@ -45041,9 +45041,9 @@
         "@remix-run/eslint-config": "^2.8.0",
         "@remix-run/react": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.4",
@@ -45079,9 +45079,9 @@
         "@remix-run/eslint-config": "^2.8.0",
         "@remix-run/react": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.4",
@@ -45108,9 +45108,9 @@
         "@remix-run/eslint-config": "^2.8.0",
         "@remix-run/react": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.4",
@@ -46657,9 +46657,9 @@
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.4",
@@ -52880,10 +52880,10 @@
         "@remix-run/react": "^2.8.0",
         "@remix-run/server-runtime": "^2.8.0",
         "@shopify/cli": "3.59.2",
-        "@shopify/cli-hydrogen": "^8.0.3",
-        "@shopify/hydrogen": "2024.4.1",
-        "@shopify/hydrogen-codegen": "^0.3.0",
-        "@shopify/mini-oxygen": "^3.0.1",
+        "@shopify/cli-hydrogen": "^8.0.4",
+        "@shopify/hydrogen": "2024.4.2",
+        "@shopify/hydrogen-codegen": "^0.3.1",
+        "@shopify/mini-oxygen": "^3.0.2",
         "@shopify/oxygen-workers-types": "^4.0.0",
         "@shopify/prettier-config": "^1.1.2",
         "@shopify/remix-oxygen": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "templates/skeleton"
   ],
   "prettier": "@shopify/prettier-config",
+  "dependencies": {
+    "@shopify/cli-hydrogen": "*"
+  },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.0",


### PR DESCRIPTION
Related: https://github.com/Shopify/hydrogen/pull/2075

Running `h2 init` in our monorepo currently doesn't work unless it's done in a project directory. This is because a recent change in Oclif stopped searching for plugins like `cli-hydrogen` in `node_modules` and it now only looks for them in `package.json#dependencies`.

This change adds our plugin as a dummy dependency to the monorepo package.json so that at least we can run h2 commands at the root. This is only a partial fix because we can't run `h2 init` within the examples folder anymore, for example (Oclif only looks for package.json in the current dir, not the parent).

I'm adding it as `*` to avoid changing its version with every release, since this is really not used.
