### PR TITLE
Fix upgrade notice in dev command

### DIFF
--- a/.changeset/long-emus-cry.md
+++ b/.changeset/long-emus-cry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix Hydrogen upgrade notification when running the dev command.

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -36,11 +36,13 @@ import {
   type Release,
   upgradeNodeModules,
   getChangelog,
+  displayDevUpgradeNotice,
 } from './upgrade.js';
 import {type PackageJson} from 'type-fest';
 
-vi.mock('../../lib/shell.js');
 vi.mock('@shopify/cli-kit/node/session');
+
+vi.mock('../../lib/shell.js', () => ({getCliCommand: vi.fn(() => 'h2')}));
 
 vi.mock('@shopify/cli-kit/node/ui', async () => {
   const original = await vi.importActual<
@@ -581,6 +583,24 @@ describe('upgrade', async () => {
           cleanGitRepo: true,
           packageJson: OUTDATED_HYDROGEN_PACKAGE_JSON,
         },
+      );
+    });
+  });
+
+  describe('displayDevUpgradeNotice', () => {
+    it('shows up a notice if there are dependencies to upgrade', async () => {
+      await inTemporaryHydrogenRepo(
+        async (targetPath) => {
+          await expect(
+            displayDevUpgradeNotice({targetPath}),
+          ).resolves.not.toThrow();
+
+          expect(outputMock.info()).toMatch(
+            'new @shopify/hydrogen versions available',
+          );
+          expect(outputMock.info()).toMatch('Run `h2 upgrade`');
+        },
+        {cleanGitRepo: false, packageJson: OUTDATED_HYDROGEN_PACKAGE_JSON},
       );
     });
   });

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -349,17 +349,15 @@ function hasOutdatedDependencies({
   });
 }
 
-export function isUpgradeableRelease({
+function isUpgradeableRelease({
   currentDependencies,
   currentPinnedVersion,
   release,
 }: {
-  currentDependencies?: Dependencies;
+  currentDependencies: Dependencies;
   currentPinnedVersion: string;
   release: Release;
 }) {
-  if (!currentDependencies) return false;
-
   const isHydrogenOutdated = semver.gt(release.version, currentPinnedVersion);
 
   if (isHydrogenOutdated) return true;
@@ -383,7 +381,7 @@ export function getAvailableUpgrades({
 }: {
   releases: ChangeLog['releases'];
   currentVersion: string;
-  currentDependencies?: Dependencies;
+  currentDependencies: Dependencies;
 }) {
   const currentPinnedVersion = getAbsoluteVersion(currentVersion);
   let currentMajorVersion = '';
@@ -1000,7 +998,9 @@ export async function displayDevUpgradeNotice({
 }) {
   try {
     const appPath = targetPath ? path.resolve(targetPath) : process.cwd();
-    const {currentVersion} = await getHydrogenVersion({appPath});
+    const {currentVersion, currentDependencies} = await getHydrogenVersion({
+      appPath,
+    });
 
     const isPrerelease = semver.prerelease(currentVersion);
 
@@ -1014,6 +1014,7 @@ export async function displayDevUpgradeNotice({
     const {availableUpgrades, uniqueAvailableUpgrades} = getAvailableUpgrades({
       releases: changelog.releases,
       currentVersion,
+      currentDependencies,
     });
 
     if (availableUpgrades.length === 0 || !availableUpgrades[0]?.version) {


### PR DESCRIPTION
The `h2 dev` command should show an upgrade notice when the Hydrogen version is outdated.

@juanpprieto  I'm not sure how this has ever worked since we we never passing `currentDependencies` down 🤯 

I've added a test for this function now.