### PR TITLE
Improve upgrade notice for outdated dependencies

### DIFF
--- a/.changeset/long-emus-cry.md
+++ b/.changeset/long-emus-cry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix Hydrogen upgrade notification when running the dev command.

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -599,6 +599,9 @@ describe('upgrade', async () => {
             /new @shopify\/hydrogen versions? available/i,
           );
           expect(outputMock.info()).toMatch(
+            /Current: [\d.] | Latest: [\d.]+\s{2,}/i,
+          );
+          expect(outputMock.info()).toMatch(
             /The next \d+ version\(s\) include/i,
           );
           expect(outputMock.info()).toMatch('Run `h2 upgrade`');
@@ -614,9 +617,11 @@ describe('upgrade', async () => {
             displayDevUpgradeNotice({targetPath}),
           ).resolves.not.toThrow();
 
-          console.debug(outputMock.info());
           expect(outputMock.info()).toMatch(
             /new @shopify\/hydrogen versions? available/i,
+          );
+          expect(outputMock.info()).toMatch(
+            /Current: [\d.] | Latest: [\d.]+ with updated dependencies\s{1,}/i,
           );
           expect(outputMock.info()).toMatch(/The next 1 version\(s\) include/i);
           expect(outputMock.info()).toMatch('Run `h2 upgrade`');

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -606,6 +606,33 @@ describe('upgrade', async () => {
         {cleanGitRepo: false, packageJson: OUTDATED_HYDROGEN_PACKAGE_JSON},
       );
     });
+
+    it('shows up a notice if there are related dependencies to upgrade', async () => {
+      await inTemporaryHydrogenRepo(
+        async (targetPath) => {
+          await expect(
+            displayDevUpgradeNotice({targetPath}),
+          ).resolves.not.toThrow();
+
+          console.debug(outputMock.info());
+          expect(outputMock.info()).toMatch(
+            /new @shopify\/hydrogen versions? available/i,
+          );
+          expect(outputMock.info()).toMatch(/The next 1 version\(s\) include/i);
+          expect(outputMock.info()).toMatch('Run `h2 upgrade`');
+        },
+        {
+          cleanGitRepo: false,
+          packageJson: {
+            ...OUTDATED_HYDROGEN_PACKAGE_JSON,
+            dependencies: {
+              ...OUTDATED_HYDROGEN_PACKAGE_JSON.dependencies,
+              '@shopify/hydrogen': '2024.4.2',
+            },
+          },
+        },
+      );
+    });
   });
 
   describe('upgradeNodeModules', () => {

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -36,11 +36,13 @@ import {
   type Release,
   upgradeNodeModules,
   getChangelog,
+  displayDevUpgradeNotice,
 } from './upgrade.js';
 import {type PackageJson} from 'type-fest';
 
-vi.mock('../../lib/shell.js');
 vi.mock('@shopify/cli-kit/node/session');
+
+vi.mock('../../lib/shell.js', () => ({getCliCommand: vi.fn(() => 'h2')}));
 
 vi.mock('@shopify/cli-kit/node/ui', async () => {
   const original = await vi.importActual<
@@ -581,6 +583,24 @@ describe('upgrade', async () => {
           cleanGitRepo: true,
           packageJson: OUTDATED_HYDROGEN_PACKAGE_JSON,
         },
+      );
+    });
+  });
+
+  describe('displayDevUpgradeNotice', () => {
+    it('shows up a notice if there are dependencies to upgrade', async () => {
+      await inTemporaryHydrogenRepo(
+        async (targetPath) => {
+          await expect(
+            displayDevUpgradeNotice({targetPath}),
+          ).resolves.not.toThrow();
+
+          expect(outputMock.info()).toMatch(
+            'new @shopify/hydrogen versions available',
+          );
+          expect(outputMock.info()).toMatch('Run `h2 upgrade`');
+        },
+        {cleanGitRepo: false, packageJson: OUTDATED_HYDROGEN_PACKAGE_JSON},
       );
     });
   });

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -611,6 +611,7 @@ describe('upgrade', async () => {
     });
 
     it('shows up a notice if there are related dependencies to upgrade', async () => {
+      const hydrogenVersion = '2024.4.2';
       await inTemporaryHydrogenRepo(
         async (targetPath) => {
           await expect(
@@ -624,7 +625,9 @@ describe('upgrade', async () => {
             /Current: [\d.] | Latest: [\d.]+ with updated dependencies\s{1,}/i,
           );
           expect(outputMock.info()).toMatch(/The next 1 version\(s\) include/i);
-          expect(outputMock.info()).toMatch('Run `h2 upgrade`');
+          expect(outputMock.info()).toMatch(
+            `or \`h2 upgrade --version ${hydrogenVersion}\``,
+          );
         },
         {
           cleanGitRepo: false,
@@ -632,7 +635,7 @@ describe('upgrade', async () => {
             ...OUTDATED_HYDROGEN_PACKAGE_JSON,
             dependencies: {
               ...OUTDATED_HYDROGEN_PACKAGE_JSON.dependencies,
-              '@shopify/hydrogen': '2024.4.2',
+              '@shopify/hydrogen': hydrogenVersion,
             },
           },
         },

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -588,7 +588,7 @@ describe('upgrade', async () => {
   });
 
   describe('displayDevUpgradeNotice', () => {
-    it('shows up a notice if there are dependencies to upgrade', async () => {
+    it('shows up a notice if Hydrogen is outdated', async () => {
       await inTemporaryHydrogenRepo(
         async (targetPath) => {
           await expect(
@@ -596,7 +596,10 @@ describe('upgrade', async () => {
           ).resolves.not.toThrow();
 
           expect(outputMock.info()).toMatch(
-            'new @shopify/hydrogen versions available',
+            /new @shopify\/hydrogen versions? available/i,
+          );
+          expect(outputMock.info()).toMatch(
+            /The next \d+ version\(s\) include/i,
           );
           expect(outputMock.info()).toMatch('Run `h2 upgrade`');
         },

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1060,40 +1060,41 @@ export async function displayDevUpgradeNotice({
     renderInfo({
       headline,
       body: [`Current: ${currentVersion} | Latest: ${pinnedLatestVersion}`],
-      //@ts-ignore will always be an array
-      customSections: nextReleases.length
-        ? [
-            {
-              title: `The next ${nextReleases.length} version(s) include`,
-              body: [
-                {
-                  list: {
-                    items: [
-                      ...nextReleases,
-                      availableUpgrades.length > 5 && `...more`,
-                    ]
-                      .flat()
-                      .filter(Boolean),
+      customSections: [
+        ...(nextReleases.length > 0
+          ? [
+              {
+                title: `The next ${nextReleases.length} version(s) include`,
+                body: [
+                  {
+                    list: {
+                      items: [
+                        ...nextReleases,
+                        availableUpgrades.length > 5 ? `...more` : '',
+                      ]
+                        .flat()
+                        .filter(Boolean),
+                    },
                   },
-                },
-              ].filter(Boolean),
-            },
+                ].filter(Boolean),
+              },
+            ]
+          : []),
+        {
+          title: 'Next steps',
+          body: [
             {
-              title: 'Next steps',
-              body: [
-                {
-                  list: {
-                    items: [
-                      `Run \`${cliCommand} upgrade\` or \`${cliCommand} upgrade --version XXXX.X.XX\``,
-                      ,
-                      `Read release notes at https://hydrogen.shopify.dev/releases`,
-                    ],
-                  },
-                },
-              ],
+              list: {
+                items: [
+                  `Run \`${cliCommand} upgrade\` or \`${cliCommand} upgrade --version XXXX.X.XX\``,
+                  '',
+                  `Read release notes at https://hydrogen.shopify.dev/releases`,
+                ],
+              },
             },
-          ]
-        : [],
+          ],
+        },
+      ],
     });
   } catch (error) {
     const abortError = error as AbortError;

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1026,10 +1026,20 @@ export async function displayDevUpgradeNotice({
       availableUpgrades[0].version,
     );
     const pinnedCurrentVersion = getAbsoluteVersion(currentVersion);
-    const currentReleaseIndex = changelog.releases.findIndex((release) => {
-      const pinnedReleaseVersion = getAbsoluteVersion(release.version);
-      return pinnedReleaseVersion === pinnedCurrentVersion;
-    });
+
+    // If we are on the latest Hydrogen package version and we are still running
+    // this code, it means there's an outdated dependency. Use the first
+    // outdated version as the current release index to show the upgrade info:
+    const currentReleaseIndex =
+      pinnedCurrentVersion === pinnedLatestVersion
+        ? changelog.releases.findIndex(
+            (release) =>
+              getAbsoluteVersion(release.version) !== pinnedCurrentVersion,
+          )
+        : changelog.releases.findIndex(
+            (release) =>
+              getAbsoluteVersion(release.version) === pinnedCurrentVersion,
+          );
 
     const uniqueNextReleases = changelog.releases
       .slice(0, currentReleaseIndex)

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1070,7 +1070,10 @@ export async function displayDevUpgradeNotice({
 
     renderInfo({
       headline,
-      body: [`Current: ${currentVersion} | Latest: ${pinnedLatestVersion}`],
+      body: [
+        `Current: ${currentVersion} | Latest: ${pinnedLatestVersion}` +
+          (isLatestHydrogenPackage ? ' with updated dependencies' : ''),
+      ],
       customSections: [
         ...(nextReleases.length > 0
           ? [

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1042,22 +1042,17 @@ export async function displayDevUpgradeNotice({
             getAbsoluteVersion(release.version) === pinnedCurrentVersion,
         );
 
-    const uniqueNextReleases = changelog.releases
-      .slice(0, currentReleaseIndex)
-      .reverse()
-      .reduce((acc, release) => {
-        if (acc[release.version]) return acc;
-        acc[release.version] = release;
-        return acc;
-      }, {} as Record<string, Release>);
+    const relevantReleases = changelog.releases.slice(0, currentReleaseIndex);
 
-    const nextReleases = Object.keys(uniqueNextReleases).length
-      ? Object.entries(uniqueNextReleases)
-          .map(([version, release]) => {
-            return `${version} - ${release.title}`;
-          })
-          .slice(0, 5)
-      : [];
+    // By reversing the releases array, we give priority to older releases
+    // for the same version. Older releases (the first one of a version) probably
+    // have more information than a newer release that only changes dependencies.
+    const nextReleases = Object.values(
+      [...relevantReleases].reverse().reduce((acc, release) => {
+        acc[release.version] ??= `${release.version} - ${release.title}`;
+        return acc;
+      }, {} as Record<string, string>),
+    ).slice(0, 5);
 
     let headline =
       Object.keys(uniqueAvailableUpgrades).length > 1

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -349,17 +349,15 @@ function hasOutdatedDependencies({
   });
 }
 
-export function isUpgradeableRelease({
+function isUpgradeableRelease({
   currentDependencies,
   currentPinnedVersion,
   release,
 }: {
-  currentDependencies?: Dependencies;
+  currentDependencies: Dependencies;
   currentPinnedVersion: string;
   release: Release;
 }) {
-  if (!currentDependencies) return false;
-
   const isHydrogenOutdated = semver.gt(release.version, currentPinnedVersion);
 
   if (isHydrogenOutdated) return true;
@@ -383,7 +381,7 @@ export function getAvailableUpgrades({
 }: {
   releases: ChangeLog['releases'];
   currentVersion: string;
-  currentDependencies?: Dependencies;
+  currentDependencies: Dependencies;
 }) {
   const currentPinnedVersion = getAbsoluteVersion(currentVersion);
   let currentMajorVersion = '';
@@ -1000,7 +998,9 @@ export async function displayDevUpgradeNotice({
 }) {
   try {
     const appPath = targetPath ? path.resolve(targetPath) : process.cwd();
-    const {currentVersion} = await getHydrogenVersion({appPath});
+    const {currentVersion, currentDependencies} = await getHydrogenVersion({
+      appPath,
+    });
 
     const isPrerelease = semver.prerelease(currentVersion);
 
@@ -1014,6 +1014,7 @@ export async function displayDevUpgradeNotice({
     const {availableUpgrades, uniqueAvailableUpgrades} = getAvailableUpgrades({
       releases: changelog.releases,
       currentVersion,
+      currentDependencies,
     });
 
     if (availableUpgrades.length === 0 || !availableUpgrades[0]?.version) {

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1030,16 +1030,17 @@ export async function displayDevUpgradeNotice({
     // If we are on the latest Hydrogen package version and we are still running
     // this code, it means there's an outdated dependency. Use the first
     // outdated version as the current release index to show the upgrade info:
-    const currentReleaseIndex =
-      pinnedCurrentVersion === pinnedLatestVersion
-        ? changelog.releases.findIndex(
-            (release) =>
-              getAbsoluteVersion(release.version) !== pinnedCurrentVersion,
-          )
-        : changelog.releases.findIndex(
-            (release) =>
-              getAbsoluteVersion(release.version) === pinnedCurrentVersion,
-          );
+    const isLatestHydrogenPackage =
+      pinnedCurrentVersion === pinnedLatestVersion;
+    const currentReleaseIndex = isLatestHydrogenPackage
+      ? changelog.releases.findIndex(
+          (release) =>
+            getAbsoluteVersion(release.version) !== pinnedCurrentVersion,
+        )
+      : changelog.releases.findIndex(
+          (release) =>
+            getAbsoluteVersion(release.version) === pinnedCurrentVersion,
+        );
 
     const uniqueNextReleases = changelog.releases
       .slice(0, currentReleaseIndex)

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1101,7 +1101,6 @@ export async function displayDevUpgradeNotice({
               list: {
                 items: [
                   `Run \`${cliCommand} upgrade\` or \`${cliCommand} upgrade --version XXXX.X.XX\``,
-                  '',
                   `Read release notes at https://hydrogen.shopify.dev/releases`,
                 ],
               },

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1095,7 +1095,9 @@ export async function displayDevUpgradeNotice({
             {
               list: {
                 items: [
-                  `Run \`${cliCommand} upgrade\` or \`${cliCommand} upgrade --version XXXX.X.XX\``,
+                  `Run \`${cliCommand} upgrade\` or \`${cliCommand} upgrade --version ${
+                    relevantReleases[0]?.version ?? '<version>'
+                  }\``,
                   `Read release notes at https://hydrogen.shopify.dev/releases`,
                 ],
               },


### PR DESCRIPTION
Needs #2120 first.

While working on the previous PR I noticed that when the Hydrogen version is updated but some other dependencies (cli, oxygen, etc) are outdated, we were printing a confusing notification. Trying to improve it here.

Before:

<img width="649" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/3c2ba0c3-447a-4451-bbb2-4eeabe2f8c01">

After:

<img width="649" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/a69bf0ce-bb50-44db-9353-3898e24e7e47">
