### PR TITLE
Hide non actionable ts-node warning

### DIFF
--- a/.changeset/red-grapes-change.md
+++ b/.changeset/red-grapes-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Hide non actionable warning about ts-node.


### PR DESCRIPTION
Closes https://github.com/Shopify/hydrogen/issues/2122

We've been getting this annoying warning about ts-node for a while and we couldn't do anything about it because it happens in `@shopify/cli` or one of its dependencies. This hides it until it's fixed and released there.

<img width="935" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/f5f8d31b-3833-4346-b449-f392e57324f5">
