### PR TITLE
Add Rich Text Component

### DIFF
--- a/.changeset/long-candles-cover.md
+++ b/.changeset/long-candles-cover.md
@@ -7,10 +7,10 @@ Add a RichText component to easily render \`rich_text_field\` metafields. Thank 
 ```tsx
 import {RichText} from '@shopify/hydrogen-react';
 
-export function MainRichText({text}: {text: string}) {
+export function MainRichText({metaFieldData}: {metaFieldData: string}) {
   return (
     <RichText
-      data={JSON.parse(text)}
+      data={metaFieldData}
       components={{
         paragraph({node}) {
           return <p className="customClass">{node.children}</p>;

--- a/.changeset/long-candles-cover.md
+++ b/.changeset/long-candles-cover.md
@@ -2,4 +2,23 @@
 '@shopify/hydrogen-react': minor
 ---
 
-add RichText component
+Add a RichText component to easily render \`rich_text_field\` metafields. Thank you @bastienrobert for the original implementation. Example usage:
+
+```tsx
+import {RichText} from '@shopify/hydrogen-react';
+
+export function MainRichText({text}: {text: string}) {
+  return (
+    <RichText
+      data={JSON.parse(text)}
+      components={{
+        // Customize how a paragraph is rendered. `next` must be called on
+        // children nodes to recursively render the rich text output
+        paragraph({node, next}) {
+          return <p className="customClass">{node.children.map(next)}</p>;
+        },
+      }}
+    />
+  );
+}
+```

--- a/.changeset/long-candles-cover.md
+++ b/.changeset/long-candles-cover.md
@@ -12,10 +12,8 @@ export function MainRichText({text}: {text: string}) {
     <RichText
       data={JSON.parse(text)}
       components={{
-        // Customize how a paragraph is rendered. `next` must be called on
-        // children nodes to recursively render the rich text output
-        paragraph({node, next}) {
-          return <p className="customClass">{node.children.map(next)}</p>;
+        paragraph({node}) {
+          return <p className="customClass">{node.children}</p>;
         },
       }}
     />

--- a/.changeset/long-candles-cover.md
+++ b/.changeset/long-candles-cover.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': minor
+---
+
+add RichText component

--- a/packages/hydrogen-react/src/RichText.components.tsx
+++ b/packages/hydrogen-react/src/RichText.components.tsx
@@ -1,29 +1,19 @@
 import {createElement, type ReactNode} from 'react';
-import type {
-  HeadingASTNode,
-  LinkASTNode,
-  ListASTNode,
-  ListItemASTNode,
-  Next,
-  ParagraphASTNode,
-  RootASTNode,
-  TextASTNode,
-} from './RichText.types.js';
 
 export type CustomComponents = {
-  /** The root node of the rich text. Make sure to map over the children calling `next` on each. Defaults to `<div>` */
+  /** The root node of the rich text. Defaults to `<div>` */
   root?: typeof Root;
-  /** Customize the headings. Each heading has a `level` property from 1-6. Make sure to map over the children calling `next` on each. Defaults to `<h1>` to `<h6>` */
+  /** Customize the headings. Each heading has a `level` property from 1-6. Defaults to `<h1>` to `<h6>` */
   heading?: typeof Heading;
-  /** Customize paragraphs. Make sure to map over the children calling `next` on each. Defaults to `<p>` */
+  /** Customize paragraphs. Defaults to `<p>` */
   paragraph?: typeof Paragraph;
   /** Customize how text nodes. They can either be bold or italic. Defaults to `<em>`, `<strong>` or text. */
   text?: typeof Text;
-  /** Customize links. Make sure to map over the children calling `next` on each. Defaults to `<a>` */
+  /** Customize links. Defaults to a React Router `<Link>` component in Hydrogen and a `<a>` in Hydrogen React. */
   link?: typeof RichTextLink;
-  /** Customize lists. They can be either ordered or unordered. Make sure to map over the children calling `next` on each. Defaults to `<ol>` or `<ul>` */
+  /** Customize lists. They can be either ordered or unordered. Defaults to `<ol>` or `<ul>` */
   list?: typeof List;
-  /** Customize list items. Make sure to map over the children calling `next` on each. Defaults to `<li>`. */
+  /** Customize list items. Defaults to `<li>`. */
   listItem?: typeof ListItem;
 };
 
@@ -37,25 +27,50 @@ export const RichTextComponents = {
   'list-item': ListItem,
 };
 
-function Root({node, next}: {node: RootASTNode; next: Next}): ReactNode {
-  return <div>{node.children?.map(next)}</div>;
+function Root({
+  node,
+}: {
+  node: {
+    type: 'root';
+    children?: ReactNode[];
+  };
+}): ReactNode {
+  return <div>{node.children}</div>;
 }
 
-function Heading({node, next}: {node: HeadingASTNode; next: Next}): ReactNode {
-  return createElement(`h${node.level ?? '1'}`, null, node.children?.map(next));
+function Heading({
+  node,
+}: {
+  node: {
+    type: 'heading';
+    level: number;
+    children?: ReactNode[];
+  };
+}): ReactNode {
+  return createElement(`h${node.level ?? '1'}`, null, node.children);
 }
 
 function Paragraph({
   node,
-  next,
 }: {
-  node: ParagraphASTNode;
-  next: Next;
+  node: {
+    type: 'paragraph';
+    children?: ReactNode[];
+  };
 }): ReactNode {
-  return <p>{node.children?.map(next)}</p>;
+  return <p>{node.children}</p>;
 }
 
-function Text({node}: {node: TextASTNode; next: Next}): ReactNode {
+function Text({
+  node,
+}: {
+  node: {
+    type: 'text';
+    italic?: boolean;
+    bold?: boolean;
+    value?: string;
+  };
+}): ReactNode {
   if (node.bold && node.italic)
     return (
       <em>
@@ -71,29 +86,42 @@ function Text({node}: {node: TextASTNode; next: Next}): ReactNode {
 
 function RichTextLink({
   node,
-  next,
 }: {
-  node: LinkASTNode;
-  next: Next;
+  node: {
+    type: 'link';
+    url: string;
+    title?: string;
+    target?: string;
+    children?: ReactNode[];
+  };
 }): ReactNode {
   return (
     <a href={node.url} title={node.title} target={node.target}>
-      {node.children?.map(next)}
+      {node.children}
     </a>
   );
 }
 
-function List({node, next}: {node: ListASTNode; next: Next}): ReactNode {
+function List({
+  node,
+}: {
+  node: {
+    type: 'list';
+    listType: 'unordered' | 'ordered';
+    children?: ReactNode[];
+  };
+}): ReactNode {
   const List = node.listType === 'unordered' ? 'ul' : 'ol';
-  return <List>{node.children?.map(next)}</List>;
+  return <List>{node.children}</List>;
 }
 
 function ListItem({
   node,
-  next,
 }: {
-  node: ListItemASTNode;
-  next: Next;
+  node: {
+    type: 'list-item';
+    children?: ReactNode[];
+  };
 }): ReactNode {
-  return <li>{node.children?.map(next)}</li>;
+  return <li>{node.children}</li>;
 }

--- a/packages/hydrogen-react/src/RichText.components.tsx
+++ b/packages/hydrogen-react/src/RichText.components.tsx
@@ -1,0 +1,99 @@
+import {createElement, type ReactNode} from 'react';
+import type {
+  HeadingASTNode,
+  LinkASTNode,
+  ListASTNode,
+  ListItemASTNode,
+  Next,
+  ParagraphASTNode,
+  RootASTNode,
+  TextASTNode,
+} from './RichText.types.js';
+
+export type CustomComponents = {
+  /** The root node of the rich text. Defaults to `<div>` */
+  root?: typeof Root;
+  /** Headings, level 1-6. Defaults to `<h1>` to `<h6>` */
+  heading?: typeof Heading;
+  /** Paragraph, defaults to `<p>` */
+  paragraph?: typeof Paragraph;
+  /** Text node that can be either bold or italic. Defaults to `<em>`, `<strong>` or text. */
+  text?: typeof Text;
+  /** Paragraph, defaults to `<a>` */
+  link?: typeof RichTextLink;
+  /** List, either ordered or unordered. Defaults to `<ol>` or `<ul>` */
+  list?: typeof List;
+  /** List items. Defaults to `<li>`. */
+  listItem?: typeof ListItem;
+};
+
+export const RichTextComponents = {
+  root: Root,
+  heading: Heading,
+  paragraph: Paragraph,
+  text: Text,
+  link: RichTextLink,
+  list: List,
+  'list-item': ListItem,
+};
+
+function Root({node, next}: {node: RootASTNode; next: Next}): ReactNode {
+  return <div>{node.children?.map(next)}</div>;
+}
+
+function Heading({node, next}: {node: HeadingASTNode; next: Next}): ReactNode {
+  return createElement(`h${node.level ?? '1'}`, null, node.children?.map(next));
+}
+
+function Paragraph({
+  node,
+  next,
+}: {
+  node: ParagraphASTNode;
+  next: Next;
+}): ReactNode {
+  return <p>{node.children?.map(next)}</p>;
+}
+
+function Text({node}: {node: TextASTNode; next: Next}): ReactNode {
+  if (node.bold && node.italic)
+    return (
+      <em>
+        <strong>{node.value}</strong>
+      </em>
+    );
+
+  if (node.bold) return <strong>{node.value}</strong>;
+  if (node.italic) return <em>{node.value}</em>;
+
+  return node.value;
+}
+
+function RichTextLink({
+  node,
+  next,
+}: {
+  node: LinkASTNode;
+  next: Next;
+}): ReactNode {
+  return (
+    <a href={node.url} title={node.title} target={node.target}>
+      {node.children?.map(next)}
+    </a>
+  );
+}
+
+function List({node, next}: {node: ListASTNode; next: Next}): ReactNode {
+  const List = node.listType === 'unordered' ? 'ul' : 'ol';
+  return <List>{node.children?.map(next)}</List>;
+}
+
+function ListItem({
+  node,
+  next,
+}: {
+  node: ListItemASTNode;
+  next: Next;
+}): ReactNode {
+  return <li>{node.children?.map(next)}</li>;
+}

--- a/packages/hydrogen-react/src/RichText.components.tsx
+++ b/packages/hydrogen-react/src/RichText.components.tsx
@@ -11,19 +11,19 @@ import type {
 } from './RichText.types.js';
 
 export type CustomComponents = {
-  /** The root node of the rich text. Defaults to `<div>` */
+  /** The root node of the rich text. Make sure to map over the children calling `next` on each. Defaults to `<div>` */
   root?: typeof Root;
-  /** Headings, level 1-6. Defaults to `<h1>` to `<h6>` */
+  /** Customize the headings. Each heading has a `level` property from 1-6. Make sure to map over the children calling `next` on each. Defaults to `<h1>` to `<h6>` */
   heading?: typeof Heading;
-  /** Paragraph, defaults to `<p>` */
+  /** Customize paragraphs. Make sure to map over the children calling `next` on each. Defaults to `<p>` */
   paragraph?: typeof Paragraph;
-  /** Text node that can be either bold or italic. Defaults to `<em>`, `<strong>` or text. */
+  /** Customize how text nodes. They can either be bold or italic. Defaults to `<em>`, `<strong>` or text. */
   text?: typeof Text;
-  /** Paragraph, defaults to `<a>` */
+  /** Customize links. Make sure to map over the children calling `next` on each. Defaults to `<a>` */
   link?: typeof RichTextLink;
-  /** List, either ordered or unordered. Defaults to `<ol>` or `<ul>` */
+  /** Customize lists. They can be either ordered or unordered. Make sure to map over the children calling `next` on each. Defaults to `<ol>` or `<ul>` */
   list?: typeof List;
-  /** List items. Defaults to `<li>`. */
+  /** Customize list items. Make sure to map over the children calling `next` on each. Defaults to `<li>`. */
   listItem?: typeof ListItem;
 };
 

--- a/packages/hydrogen-react/src/RichText.doc.ts
+++ b/packages/hydrogen-react/src/RichText.doc.ts
@@ -1,0 +1,38 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'RichText',
+  category: 'components',
+  isVisualComponent: false,
+  related: [],
+  description: `The \`RichText\` component renders a metafield of type \`rich_text_field\`.
+  `,
+  type: 'component',
+  defaultExample: {
+    description: 'I am the default example',
+    codeblock: {
+      tabs: [
+        {
+          title: 'JavaScript',
+          code: './RichText.example.jsx',
+          language: 'jsx',
+        },
+        {
+          title: 'TypeScript',
+          code: './RichText.example.tsx',
+          language: 'tsx',
+        },
+      ],
+      title: 'Example code',
+    },
+  },
+  definitions: [
+    {
+      title: 'Props',
+      type: 'RichTextPropsForDocs',
+      description: '',
+    },
+  ],
+};
+
+export default data;

--- a/packages/hydrogen-react/src/RichText.doc.ts
+++ b/packages/hydrogen-react/src/RichText.doc.ts
@@ -5,8 +5,7 @@ const data: ReferenceEntityTemplateSchema = {
   category: 'components',
   isVisualComponent: false,
   related: [],
-  description: `The \`RichText\` component renders a metafield of type \`rich_text_field\`.
-  `,
+  description: `The \`RichText\` component renders a metafield of type \`rich_text_field\`. By default the rendered output uses semantic HTML tags. Customize how nodes are rendered with the \`components\` prop.`,
   type: 'component',
   defaultExample: {
     description: 'I am the default example',

--- a/packages/hydrogen-react/src/RichText.example.jsx
+++ b/packages/hydrogen-react/src/RichText.example.jsx
@@ -1,0 +1,5 @@
+import {RichText} from '@shopify/hydrogen-react';
+
+export function MainRichText({text}) {
+  return <RichText as="main" data={JSON.parse(text)} />;
+}

--- a/packages/hydrogen-react/src/RichText.example.jsx
+++ b/packages/hydrogen-react/src/RichText.example.jsx
@@ -1,9 +1,9 @@
 import {RichText} from '@shopify/hydrogen-react';
 
-export function MainRichText({text}) {
+export function MainRichText({metaFieldData}) {
   return (
     <RichText
-      data={JSON.parse(text)}
+      data={metaFieldData}
       components={{
         paragraph({node}) {
           return <p className="customClass">{node.children}</p>;

--- a/packages/hydrogen-react/src/RichText.example.jsx
+++ b/packages/hydrogen-react/src/RichText.example.jsx
@@ -5,10 +5,8 @@ export function MainRichText({text}) {
     <RichText
       data={JSON.parse(text)}
       components={{
-        // Customize how a paragraph is rendered. `next` must be called on
-        // children nodes to recursively render the rich text output
-        paragraph({node, next}) {
-          return <p className="customClass">{node.children.map(next)}</p>;
+        paragraph({node}) {
+          return <p className="customClass">{node.children}</p>;
         },
       }}
     />

--- a/packages/hydrogen-react/src/RichText.example.jsx
+++ b/packages/hydrogen-react/src/RichText.example.jsx
@@ -1,5 +1,16 @@
 import {RichText} from '@shopify/hydrogen-react';
 
 export function MainRichText({text}) {
-  return <RichText as="main" data={JSON.parse(text)} />;
+  return (
+    <RichText
+      data={JSON.parse(text)}
+      components={{
+        // Customize how a paragraph is rendered. `next` must be called on
+        // children nodes to recursively render the rich text output
+        paragraph({node, next}) {
+          return <p className="customClass">{node.children.map(next)}</p>;
+        },
+      }}
+    />
+  );
 }

--- a/packages/hydrogen-react/src/RichText.example.tsx
+++ b/packages/hydrogen-react/src/RichText.example.tsx
@@ -5,10 +5,8 @@ export function MainRichText({text}: {text: string}) {
     <RichText
       data={JSON.parse(text)}
       components={{
-        // Customize how a paragraph is rendered. `next` must be called on
-        // children nodes to recursively render the rich text output
-        paragraph({node, next}) {
-          return <p className="customClass">{node.children.map(next)}</p>;
+        paragraph({node}) {
+          return <p className="customClass">{node.children}</p>;
         },
       }}
     />

--- a/packages/hydrogen-react/src/RichText.example.tsx
+++ b/packages/hydrogen-react/src/RichText.example.tsx
@@ -1,5 +1,16 @@
 import {RichText} from '@shopify/hydrogen-react';
 
 export function MainRichText({text}: {text: string}) {
-  return <RichText as="main" data={JSON.parse(text)} />;
+  return (
+    <RichText
+      data={JSON.parse(text)}
+      components={{
+        // Customize how a paragraph is rendered. `next` must be called on
+        // children nodes to recursively render the rich text output
+        paragraph({node, next}) {
+          return <p className="customClass">{node.children.map(next)}</p>;
+        },
+      }}
+    />
+  );
 }

--- a/packages/hydrogen-react/src/RichText.example.tsx
+++ b/packages/hydrogen-react/src/RichText.example.tsx
@@ -1,9 +1,9 @@
 import {RichText} from '@shopify/hydrogen-react';
 
-export function MainRichText({text}: {text: string}) {
+export function MainRichText({metaFieldData}: {metaFieldData: string}) {
   return (
     <RichText
-      data={JSON.parse(text)}
+      data={metaFieldData}
       components={{
         paragraph({node}) {
           return <p className="customClass">{node.children}</p>;

--- a/packages/hydrogen-react/src/RichText.example.tsx
+++ b/packages/hydrogen-react/src/RichText.example.tsx
@@ -1,0 +1,5 @@
+import {RichText} from '@shopify/hydrogen-react';
+
+export function MainRichText({text}: {text: string}) {
+  return <RichText as="main" data={JSON.parse(text)} />;
+}

--- a/packages/hydrogen-react/src/RichText.stories.tsx
+++ b/packages/hydrogen-react/src/RichText.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import type {Story} from '@ladle/react';
+import {RichText} from './RichText.js';
+import {RICH_TEXT_CONTENT} from './RichText.test.helpers.js';
+
+type RichTextProps = React.ComponentProps<typeof RichText>;
+
+const Template: Story<RichTextProps> = (props: RichTextProps) => {
+  return <RichText {...props}>Add to cart</RichText>;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  as: 'div',
+  data: RICH_TEXT_CONTENT,
+};

--- a/packages/hydrogen-react/src/RichText.stories.tsx
+++ b/packages/hydrogen-react/src/RichText.stories.tsx
@@ -12,5 +12,5 @@ const Template: Story<RichTextProps> = (props: RichTextProps) => {
 export const Default = Template.bind({});
 Default.args = {
   as: 'div',
-  data: RICH_TEXT_CONTENT,
+  data: JSON.stringify(RICH_TEXT_CONTENT),
 };

--- a/packages/hydrogen-react/src/RichText.test.helpers.ts
+++ b/packages/hydrogen-react/src/RichText.test.helpers.ts
@@ -88,7 +88,7 @@ export const RICH_TEXT_COMPLEX_PARAGRAPH: RichTextASTNode = {
   ],
 };
 
-export const RICH_TEXT_ORDERED_LIST = {
+export const RICH_TEXT_ORDERED_LIST: RichTextASTNode = {
   listType: 'ordered',
   type: 'list',
   children: [
@@ -113,7 +113,7 @@ export const RICH_TEXT_ORDERED_LIST = {
   ],
 };
 
-export const RICH_TEXT_UNORDERED_LIST = {
+export const RICH_TEXT_UNORDERED_LIST: RichTextASTNode = {
   listType: 'unordered',
   type: 'list',
   children: [

--- a/packages/hydrogen-react/src/RichText.test.helpers.ts
+++ b/packages/hydrogen-react/src/RichText.test.helpers.ts
@@ -1,0 +1,151 @@
+import {type RichTextASTNode} from './RichText.js';
+
+export const RICH_TEXT_HEADING_1: RichTextASTNode = {
+  type: 'heading',
+  children: [
+    {
+      type: 'text',
+      value: 'Heading 1',
+    },
+  ],
+  level: 1,
+};
+
+export const RICH_TEXT_HEADING_2: RichTextASTNode = {
+  type: 'heading',
+  level: 2,
+  children: [
+    {
+      type: 'text',
+      value: 'Heading 2',
+    },
+  ],
+};
+
+export const RICH_TEXT_PARAGRAPH: RichTextASTNode = {
+  type: 'paragraph',
+  children: [
+    {
+      type: 'text',
+      value: 'Paragraph',
+    },
+  ],
+};
+
+export const RICH_TEXT_COMPLEX_PARAGRAPH: RichTextASTNode = {
+  type: 'paragraph',
+  children: [
+    {
+      type: 'text',
+      value: 'This',
+      italic: true,
+    },
+    {
+      type: 'text',
+      value: ' is a ',
+    },
+    {
+      type: 'text',
+      value: 'text',
+      bold: true,
+    },
+    {
+      type: 'text',
+      value: ' and a ',
+    },
+    {
+      url: '/products/foo',
+      title: 'title',
+      target: '_blank',
+      type: 'link',
+      children: [
+        {
+          type: 'text',
+          value: 'link',
+        },
+      ],
+    },
+    {
+      type: 'text',
+      value: ' and an ',
+    },
+    {
+      url: 'https://shopify.com',
+      title: 'Title',
+      target: '_blank',
+      type: 'link',
+      children: [
+        {
+          type: 'text',
+          value: 'external link',
+        },
+      ],
+    },
+    {
+      type: 'text',
+      value: '',
+    },
+  ],
+};
+
+export const RICH_TEXT_ORDERED_LIST = {
+  listType: 'ordered',
+  type: 'list',
+  children: [
+    {
+      type: 'list-item',
+      children: [
+        {
+          type: 'text',
+          value: 'One',
+        },
+      ],
+    },
+    {
+      type: 'list-item',
+      children: [
+        {
+          type: 'text',
+          value: 'Two',
+        },
+      ],
+    },
+  ],
+};
+
+export const RICH_TEXT_UNORDERED_LIST = {
+  listType: 'unordered',
+  type: 'list',
+  children: [
+    {
+      type: 'list-item',
+      children: [
+        {
+          type: 'text',
+          value: 'One',
+        },
+      ],
+    },
+    {
+      type: 'list-item',
+      children: [
+        {
+          type: 'text',
+          value: 'Two',
+        },
+      ],
+    },
+  ],
+};
+
+export const RICH_TEXT_CONTENT: RichTextASTNode = {
+  type: 'root',
+  children: [
+    RICH_TEXT_HEADING_1,
+    RICH_TEXT_HEADING_2,
+    RICH_TEXT_PARAGRAPH,
+    RICH_TEXT_COMPLEX_PARAGRAPH,
+    RICH_TEXT_ORDERED_LIST,
+    RICH_TEXT_UNORDERED_LIST,
+  ],
+};

--- a/packages/hydrogen-react/src/RichText.test.helpers.tsx
+++ b/packages/hydrogen-react/src/RichText.test.helpers.tsx
@@ -1,4 +1,4 @@
-import {type RichTextASTNode} from './RichText.js';
+import {type RichTextASTNode} from './RichText.types.js';
 
 export const RICH_TEXT_HEADING_1: RichTextASTNode = {
   type: 'heading',

--- a/packages/hydrogen-react/src/RichText.test.tsx
+++ b/packages/hydrogen-react/src/RichText.test.tsx
@@ -24,6 +24,11 @@ describe('<RichText />', () => {
     expect(screen.getByText('Heading 1').tagName).toBe('H1');
   });
 
+  it('renders <RichText /> a custom root node', () => {
+    render(<RichText as="span" data={RICH_TEXT_HEADING_1} />);
+    expect(screen.getByText('Heading 1').parentElement?.tagName).toBe('SPAN');
+  });
+
   it('renders <RichText /> with a heading 2 data', () => {
     render(<RichText data={RICH_TEXT_HEADING_2} />);
     expect(screen.getByText('Heading 2').tagName).toBe('H2');
@@ -97,7 +102,7 @@ describe('<RichText />', () => {
   });
 
   describe('Custom components', () => {
-    it('renders <RichText /> with a heading 1 data', () => {
+    it('renders a custom heading component', () => {
       render(
         <RichText
           data={RICH_TEXT_HEADING_1}
@@ -110,7 +115,7 @@ describe('<RichText />', () => {
       expect(screen.getByText('Heading 1').tagName).toBe('THEAD');
     });
 
-    it('renders <RichText /> with a paragraph data', () => {
+    it('renders a custom paragraph component', () => {
       render(
         <RichText
           data={RICH_TEXT_PARAGRAPH}
@@ -122,6 +127,22 @@ describe('<RichText />', () => {
         />,
       );
       expect(screen.getByText('Paragraph').tagName).toBe('TABLE');
+    });
+  });
+
+  describe('Plain text', () => {
+    it('renders plain text paragraph', () => {
+      render(<RichText data={RICH_TEXT_PARAGRAPH} plain />);
+      console.log(screen.debug());
+      expect(screen.getByText('Paragraph').tagName).toBe('DIV');
+    });
+
+    it('renders plain text complex paragraph', () => {
+      render(<RichText data={RICH_TEXT_COMPLEX_PARAGRAPH} plain />);
+      const plain = screen.getByText(
+        'This is a text and a link and an external link',
+      );
+      expect(plain.tagName).toBe('DIV');
     });
   });
 });

--- a/packages/hydrogen-react/src/RichText.test.tsx
+++ b/packages/hydrogen-react/src/RichText.test.tsx
@@ -107,11 +107,10 @@ describe('<RichText />', () => {
         <RichText
           data={RICH_TEXT_HEADING_1}
           components={{
-            heading: ({node, next}) => <thead>{node.children.map(next)}</thead>,
+            heading: ({node}) => <thead>{node.children}</thead>,
           }}
         />,
       );
-      console.log(screen.debug());
       expect(screen.getByText('Heading 1').tagName).toBe('THEAD');
     });
 
@@ -120,9 +119,7 @@ describe('<RichText />', () => {
         <RichText
           data={RICH_TEXT_PARAGRAPH}
           components={{
-            paragraph: ({node, next}) => (
-              <table>{node.children.map(next)}</table>
-            ),
+            paragraph: ({node}) => <table>{node.children}</table>,
           }}
         />,
       );
@@ -133,7 +130,6 @@ describe('<RichText />', () => {
   describe('Plain text', () => {
     it('renders plain text paragraph', () => {
       render(<RichText data={RICH_TEXT_PARAGRAPH} plain />);
-      console.log(screen.debug());
       expect(screen.getByText('Paragraph').tagName).toBe('DIV');
     });
 

--- a/packages/hydrogen-react/src/RichText.test.tsx
+++ b/packages/hydrogen-react/src/RichText.test.tsx
@@ -14,33 +14,38 @@ import {render, screen} from '@testing-library/react';
 
 describe('<RichText />', () => {
   it('renders <RichText /> with an empty node', () => {
-    render(<RichText data={{type: 'root', children: []}} as="main" />);
+    render(
+      <RichText
+        data={JSON.stringify({type: 'root', children: []})}
+        as="main"
+      />,
+    );
 
     expect(screen.getByRole('main')).toBeInTheDocument();
   });
 
   it('renders <RichText /> with a heading 1 data', () => {
-    render(<RichText data={RICH_TEXT_HEADING_1} />);
+    render(<RichText data={JSON.stringify(RICH_TEXT_HEADING_1)} />);
     expect(screen.getByText('Heading 1').tagName).toBe('H1');
   });
 
   it('renders <RichText /> a custom root node', () => {
-    render(<RichText as="span" data={RICH_TEXT_HEADING_1} />);
+    render(<RichText as="span" data={JSON.stringify(RICH_TEXT_HEADING_1)} />);
     expect(screen.getByText('Heading 1').parentElement?.tagName).toBe('SPAN');
   });
 
   it('renders <RichText /> with a heading 2 data', () => {
-    render(<RichText data={RICH_TEXT_HEADING_2} />);
+    render(<RichText data={JSON.stringify(RICH_TEXT_HEADING_2)} />);
     expect(screen.getByText('Heading 2').tagName).toBe('H2');
   });
 
   it('renders <RichText /> with a paragraph data', () => {
-    render(<RichText data={RICH_TEXT_PARAGRAPH} />);
+    render(<RichText data={JSON.stringify(RICH_TEXT_PARAGRAPH)} />);
     expect(screen.getByText('Paragraph').tagName).toBe('P');
   });
 
   it('renders <RichText /> with a complex paragraph data', () => {
-    render(<RichText data={RICH_TEXT_COMPLEX_PARAGRAPH} />);
+    render(<RichText data={JSON.stringify(RICH_TEXT_COMPLEX_PARAGRAPH)} />);
     const textItalic = screen.getByText('This');
     const textBold = screen.getByText('text');
     const externalLink = screen.getByText('external link');
@@ -57,7 +62,7 @@ describe('<RichText />', () => {
   });
 
   it('renders <RichText /> with an ordered list data', () => {
-    render(<RichText data={RICH_TEXT_ORDERED_LIST} />);
+    render(<RichText data={JSON.stringify(RICH_TEXT_ORDERED_LIST)} />);
 
     const listItemOne = screen.getByText('One');
     const listItemTwo = screen.getByText('Two');
@@ -69,7 +74,7 @@ describe('<RichText />', () => {
   });
 
   it('renders <RichText /> with an unordered list data', () => {
-    render(<RichText data={RICH_TEXT_UNORDERED_LIST} />);
+    render(<RichText data={JSON.stringify(RICH_TEXT_UNORDERED_LIST)} />);
 
     const listItemOne = screen.getByText('One');
     const listItemTwo = screen.getByText('Two');
@@ -81,21 +86,23 @@ describe('<RichText />', () => {
   });
 
   it('renders <RichText /> with multiple children in root', () => {
-    render(<RichText data={RICH_TEXT_CONTENT} />);
+    render(<RichText data={JSON.stringify(RICH_TEXT_CONTENT)} />);
 
     expect(screen.getByText('Heading 1')).toBeInTheDocument();
     expect(screen.getByText('Paragraph')).toBeInTheDocument();
   });
 
   it('renders <RichText /> with specified as element', () => {
-    const {container} = render(<RichText data={RICH_TEXT_CONTENT} as="main" />);
+    const {container} = render(
+      <RichText data={JSON.stringify(RICH_TEXT_CONTENT)} as="main" />,
+    );
     const firstChild = container.firstChild as HTMLElement;
     expect(firstChild.tagName).toBe('MAIN');
   });
 
   it('supports passthrough props', () => {
     const {container} = render(
-      <RichText data={RICH_TEXT_CONTENT} className="content" />,
+      <RichText data={JSON.stringify(RICH_TEXT_CONTENT)} className="content" />,
     );
     const firstChild = container.firstChild as HTMLElement;
     expect(firstChild).toHaveClass('content');
@@ -105,7 +112,7 @@ describe('<RichText />', () => {
     it('renders a custom heading component', () => {
       render(
         <RichText
-          data={RICH_TEXT_HEADING_1}
+          data={JSON.stringify(RICH_TEXT_HEADING_1)}
           components={{
             heading: ({node}) => <thead>{node.children}</thead>,
           }}
@@ -117,7 +124,7 @@ describe('<RichText />', () => {
     it('renders a custom paragraph component', () => {
       render(
         <RichText
-          data={RICH_TEXT_PARAGRAPH}
+          data={JSON.stringify(RICH_TEXT_PARAGRAPH)}
           components={{
             paragraph: ({node}) => <table>{node.children}</table>,
           }}
@@ -129,12 +136,14 @@ describe('<RichText />', () => {
 
   describe('Plain text', () => {
     it('renders plain text paragraph', () => {
-      render(<RichText data={RICH_TEXT_PARAGRAPH} plain />);
+      render(<RichText data={JSON.stringify(RICH_TEXT_PARAGRAPH)} plain />);
       expect(screen.getByText('Paragraph').tagName).toBe('DIV');
     });
 
     it('renders plain text complex paragraph', () => {
-      render(<RichText data={RICH_TEXT_COMPLEX_PARAGRAPH} plain />);
+      render(
+        <RichText data={JSON.stringify(RICH_TEXT_COMPLEX_PARAGRAPH)} plain />,
+      );
       const plain = screen.getByText(
         'This is a text and a link and an external link',
       );

--- a/packages/hydrogen-react/src/RichText.test.tsx
+++ b/packages/hydrogen-react/src/RichText.test.tsx
@@ -1,0 +1,106 @@
+import {describe, expect, it} from 'vitest';
+
+import {
+  RICH_TEXT_HEADING_1,
+  RICH_TEXT_HEADING_2,
+  RICH_TEXT_PARAGRAPH,
+  RICH_TEXT_COMPLEX_PARAGRAPH,
+  RICH_TEXT_ORDERED_LIST,
+  RICH_TEXT_UNORDERED_LIST,
+  RICH_TEXT_CONTENT,
+} from './RichText.test.helpers.js';
+import {RichText} from './RichText.js';
+import {render, screen} from '@testing-library/react';
+
+describe('<RichText />', () => {
+  it('renders <RichText /> with an empty node', () => {
+    render(<RichText data={{type: 'root'}} as="main" />);
+
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('renders <RichText /> with a heading 1 data', () => {
+    render(<RichText data={RICH_TEXT_HEADING_1} />);
+
+    const parent = screen.getByText('Heading 1').parentElement as HTMLElement;
+    expect(parent.tagName).toBe('H1');
+  });
+
+  it('renders <RichText /> with a heading 2 data', () => {
+    render(<RichText data={RICH_TEXT_HEADING_2} />);
+
+    const parent = screen.getByText('Heading 2').parentElement as HTMLElement;
+    expect(parent.tagName).toBe('H2');
+  });
+
+  it('renders <RichText /> with a paragraph data', () => {
+    render(<RichText data={RICH_TEXT_PARAGRAPH} />);
+
+    const parent = screen.getByText('Paragraph').parentElement as HTMLElement;
+    expect(parent.tagName).toBe('P');
+  });
+
+  it('renders <RichText /> with a complex paragraph data', () => {
+    render(<RichText data={RICH_TEXT_COMPLEX_PARAGRAPH} />);
+    const textItalic = screen.getByText('This');
+    const textBold = screen.getByText('text');
+    const externalLink = screen.getByText('external link');
+    const externalLinkParent = externalLink.parentElement as HTMLElement;
+    const internalLink = screen.getByText('link');
+    const internalLinkParent = internalLink.parentElement as HTMLElement;
+
+    expect(textItalic).toHaveStyle('font-style: italic');
+    expect(textBold).toHaveStyle('font-weight: bold');
+    expect(externalLinkParent.tagName).toBe('A');
+    expect(externalLinkParent).toHaveAttribute('href', 'https://shopify.com');
+    expect(externalLinkParent).toHaveAttribute('target', '_blank');
+    expect(internalLinkParent.tagName).toBe('A');
+    expect(internalLinkParent).toHaveAttribute('href', '/products/foo');
+    expect(internalLinkParent).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders <RichText /> with an ordered list data', () => {
+    render(<RichText data={RICH_TEXT_ORDERED_LIST} />);
+
+    const listItemOne = screen.getByText('One').parentElement as HTMLElement;
+    const listItemTwo = screen.getByText('Two').parentElement as HTMLElement;
+    const listParent = listItemOne.parentElement as HTMLElement;
+
+    expect(listItemOne.tagName).toBe('LI');
+    expect(listItemTwo.tagName).toBe('LI');
+    expect(listParent.tagName).toBe('OL');
+  });
+
+  it('renders <RichText /> with an unordered list data', () => {
+    render(<RichText data={RICH_TEXT_UNORDERED_LIST} />);
+
+    const listItemOne = screen.getByText('One').parentElement as HTMLElement;
+    const listItemTwo = screen.getByText('Two').parentElement as HTMLElement;
+    const listParent = listItemOne.parentElement as HTMLElement;
+
+    expect(listItemOne.tagName).toBe('LI');
+    expect(listItemTwo.tagName).toBe('LI');
+    expect(listParent.tagName).toBe('UL');
+  });
+
+  it('renders <RichText /> with multiple children in root', () => {
+    render(<RichText data={RICH_TEXT_CONTENT} />);
+
+    expect(screen.getByText('Heading 1')).toBeInTheDocument();
+    expect(screen.getByText('Paragraph')).toBeInTheDocument();
+  });
+
+  it('renders <RichText /> with specified as element', () => {
+    const {container} = render(<RichText data={RICH_TEXT_CONTENT} as="main" />);
+    const firstChild = container.firstChild as HTMLElement;
+    expect(firstChild.tagName).toBe('MAIN');
+  });
+
+  it('supports passthrough props', () => {
+    const {container} = render(
+      <RichText data={RICH_TEXT_CONTENT} className="content" />,
+    );
+    const firstChild = container.firstChild as HTMLElement;
+    expect(firstChild).toHaveClass('content');
+  });
+});

--- a/packages/hydrogen-react/src/RichText.test.tsx
+++ b/packages/hydrogen-react/src/RichText.test.tsx
@@ -14,7 +14,7 @@ import {render, screen} from '@testing-library/react';
 
 describe('<RichText />', () => {
   it('renders <RichText /> with an empty node', () => {
-    render(<RichText data={{type: 'root'}} as="main" />);
+    render(<RichText data={{type: 'root', children: []}} as="main" />);
 
     expect(screen.getByRole('main')).toBeInTheDocument();
   });

--- a/packages/hydrogen-react/src/RichText.test.tsx
+++ b/packages/hydrogen-react/src/RichText.test.tsx
@@ -21,23 +21,17 @@ describe('<RichText />', () => {
 
   it('renders <RichText /> with a heading 1 data', () => {
     render(<RichText data={RICH_TEXT_HEADING_1} />);
-
-    const parent = screen.getByText('Heading 1').parentElement as HTMLElement;
-    expect(parent.tagName).toBe('H1');
+    expect(screen.getByText('Heading 1').tagName).toBe('H1');
   });
 
   it('renders <RichText /> with a heading 2 data', () => {
     render(<RichText data={RICH_TEXT_HEADING_2} />);
-
-    const parent = screen.getByText('Heading 2').parentElement as HTMLElement;
-    expect(parent.tagName).toBe('H2');
+    expect(screen.getByText('Heading 2').tagName).toBe('H2');
   });
 
   it('renders <RichText /> with a paragraph data', () => {
     render(<RichText data={RICH_TEXT_PARAGRAPH} />);
-
-    const parent = screen.getByText('Paragraph').parentElement as HTMLElement;
-    expect(parent.tagName).toBe('P');
+    expect(screen.getByText('Paragraph').tagName).toBe('P');
   });
 
   it('renders <RichText /> with a complex paragraph data', () => {
@@ -45,25 +39,23 @@ describe('<RichText />', () => {
     const textItalic = screen.getByText('This');
     const textBold = screen.getByText('text');
     const externalLink = screen.getByText('external link');
-    const externalLinkParent = externalLink.parentElement as HTMLElement;
     const internalLink = screen.getByText('link');
-    const internalLinkParent = internalLink.parentElement as HTMLElement;
 
-    expect(textItalic).toHaveStyle('font-style: italic');
-    expect(textBold).toHaveStyle('font-weight: bold');
-    expect(externalLinkParent.tagName).toBe('A');
-    expect(externalLinkParent).toHaveAttribute('href', 'https://shopify.com');
-    expect(externalLinkParent).toHaveAttribute('target', '_blank');
-    expect(internalLinkParent.tagName).toBe('A');
-    expect(internalLinkParent).toHaveAttribute('href', '/products/foo');
-    expect(internalLinkParent).toHaveAttribute('target', '_blank');
+    expect(textItalic.tagName).toBe('EM');
+    expect(textBold.tagName).toBe('STRONG');
+    expect(externalLink.tagName).toBe('A');
+    expect(externalLink).toHaveAttribute('href', 'https://shopify.com');
+    expect(externalLink).toHaveAttribute('target', '_blank');
+    expect(internalLink.tagName).toBe('A');
+    expect(internalLink).toHaveAttribute('href', '/products/foo');
+    expect(internalLink).toHaveAttribute('target', '_blank');
   });
 
   it('renders <RichText /> with an ordered list data', () => {
     render(<RichText data={RICH_TEXT_ORDERED_LIST} />);
 
-    const listItemOne = screen.getByText('One').parentElement as HTMLElement;
-    const listItemTwo = screen.getByText('Two').parentElement as HTMLElement;
+    const listItemOne = screen.getByText('One');
+    const listItemTwo = screen.getByText('Two');
     const listParent = listItemOne.parentElement as HTMLElement;
 
     expect(listItemOne.tagName).toBe('LI');
@@ -74,8 +66,8 @@ describe('<RichText />', () => {
   it('renders <RichText /> with an unordered list data', () => {
     render(<RichText data={RICH_TEXT_UNORDERED_LIST} />);
 
-    const listItemOne = screen.getByText('One').parentElement as HTMLElement;
-    const listItemTwo = screen.getByText('Two').parentElement as HTMLElement;
+    const listItemOne = screen.getByText('One');
+    const listItemTwo = screen.getByText('Two');
     const listParent = listItemOne.parentElement as HTMLElement;
 
     expect(listItemOne.tagName).toBe('LI');
@@ -102,5 +94,34 @@ describe('<RichText />', () => {
     );
     const firstChild = container.firstChild as HTMLElement;
     expect(firstChild).toHaveClass('content');
+  });
+
+  describe('Custom components', () => {
+    it('renders <RichText /> with a heading 1 data', () => {
+      render(
+        <RichText
+          data={RICH_TEXT_HEADING_1}
+          components={{
+            heading: ({node, next}) => <thead>{node.children.map(next)}</thead>,
+          }}
+        />,
+      );
+      console.log(screen.debug());
+      expect(screen.getByText('Heading 1').tagName).toBe('THEAD');
+    });
+
+    it('renders <RichText /> with a paragraph data', () => {
+      render(
+        <RichText
+          data={RICH_TEXT_PARAGRAPH}
+          components={{
+            paragraph: ({node, next}) => (
+              <table>{node.children.map(next)}</table>
+            ),
+          }}
+        />,
+      );
+      expect(screen.getByText('Paragraph').tagName).toBe('TABLE');
+    });
   });
 });

--- a/packages/hydrogen-react/src/RichText.tsx
+++ b/packages/hydrogen-react/src/RichText.tsx
@@ -144,33 +144,6 @@ function serializeRichTextASTNode(
         },
       );
   }
-
-  // if (node.type in RichTextComponents) {
-  //   const Component =
-  //     components[node.type === 'list-item' ? 'listItem' : node.type] as FunctionComponent<{
-
-  //     }>;
-
-  //   return createElement(
-  //     (components[
-  //       node.type === 'list-item' ? 'listItem' : node.type
-  //     ] as FunctionComponent<{
-  //       node: RichTextASTNode;
-  //       children: ReactNode[];
-  //     }>) ??
-  //       (RichTextComponents[node.type] as FunctionComponent<{
-  //         node: RichTextASTNode;
-  //         children: ReactNode[];
-  //       }>),
-  //     {
-  //       key: index,
-  //       node,
-  //       children,
-  //     },
-  //   );
-  // }
-
-  return null;
 }
 
 function richTextToString(

--- a/packages/hydrogen-react/src/RichText.tsx
+++ b/packages/hydrogen-react/src/RichText.tsx
@@ -1,0 +1,135 @@
+import {createElement, type ReactNode} from 'react';
+
+export interface RichTextASTNode {
+  type: string;
+  children?: RichTextASTNode[];
+  level?: number;
+  value?: string;
+  bold?: boolean;
+  italic?: boolean;
+  url?: string;
+  title?: string;
+  target?: string;
+  listType?: string;
+}
+
+export interface RichTextPropsBase<ComponentGeneric extends React.ElementType> {
+  /** An HTML tag or React Component to be rendered as the base element wrapper. The default is `div`. */
+  as?: ComponentGeneric;
+  /** An object with fields that correspond to the Storefront API's [RichText format](https://shopify.dev/docs/apps/custom-data/metafields/types#rich-text-formatting). */
+  data: RichTextASTNode;
+}
+
+// This article helps understand the typing here https://www.benmvp.com/blog/polymorphic-react-components-typescript/ Ben is the best :)
+export type RichTextProps<ComponentGeneric extends React.ElementType> =
+  RichTextPropsBase<ComponentGeneric> &
+    Omit<
+      React.ComponentPropsWithoutRef<ComponentGeneric>,
+      keyof RichTextPropsBase<ComponentGeneric>
+    >;
+
+export function RichText<ComponentGeneric extends React.ElementType = 'div'>({
+  as,
+  data,
+  ...passthroughProps
+}: RichTextProps<ComponentGeneric>): JSX.Element {
+  const Wrapper = as ?? 'div';
+
+  return (
+    <Wrapper {...passthroughProps}>{serializeRichTextASTNode(data)}</Wrapper>
+  );
+}
+
+function serializeRichTextASTNode(node: RichTextASTNode, index = 0): ReactNode {
+  switch (node.type) {
+    case 'root':
+      return (
+        <div key={index}>{node.children?.map(serializeRichTextASTNode)}</div>
+      );
+    case 'heading':
+      return createElement(
+        `h${node.level ?? '1'}`,
+        null,
+        node.children?.map(serializeRichTextASTNode),
+      );
+    case 'paragraph':
+      return <p key={index}>{node.children?.map(serializeRichTextASTNode)}</p>;
+    case 'text':
+      return (
+        <span
+          key={index}
+          style={{
+            fontWeight: node.bold ? 'bold' : undefined,
+            fontStyle: node.italic ? 'italic' : undefined,
+          }}
+        >
+          {node.value}
+        </span>
+      );
+    case 'link':
+      return (
+        <a key={index} href={node.url} title={node.title} target={node.target}>
+          {node.children?.map(serializeRichTextASTNode)}
+        </a>
+      );
+    case 'list':
+      // eslint-disable-next-line no-case-declarations
+      const List = node.listType === 'unordered' ? 'ul' : 'ol';
+
+      return (
+        <List key={index}>
+          {node.children?.map((item) => {
+            if (!item.children) {
+              return null;
+            }
+
+            return (
+              <li key={item.children[0].value}>
+                {item.children.map(serializeRichTextASTNode)}
+              </li>
+            );
+          })}
+        </List>
+      );
+    default:
+      return null;
+  }
+}
+
+export function richTextToString(
+  node: RichTextASTNode,
+  result: string[] = [],
+): string {
+  if (node.children && node.children.length > 0) {
+    switch (node.type) {
+      case 'root':
+        node.children.forEach((child) => richTextToString(child, result));
+        break;
+      case 'heading':
+      case 'paragraph':
+        node.children.forEach((child) => richTextToString(child, result));
+        result.push(' ');
+        break;
+      case 'text':
+        result.push(node.value || '');
+        break;
+      case 'link':
+        node.children.forEach((child) => richTextToString(child, result));
+        break;
+      case 'list':
+        node.children.forEach((item) => {
+          if (item.children) {
+            item.children.forEach((child) => richTextToString(child, result));
+          }
+          result.push(' ');
+        });
+        break;
+    }
+  }
+
+  return result.join('').trim();
+}
+
+// This is only for documenation purposes, and it is not used in the code.
+export type RichTextPropsForDocs<AsType extends React.ElementType = 'div'> =
+  RichTextPropsBase<AsType>;

--- a/packages/hydrogen-react/src/RichText.tsx
+++ b/packages/hydrogen-react/src/RichText.tsx
@@ -12,7 +12,7 @@ export interface RichTextPropsBase<ComponentGeneric extends React.ElementType> {
   data: RichTextASTNode;
   /** Customize how Rich Text components are rendered */
   components?: CustomComponents;
-  /** Remove rich text formatting as plain text */
+  /** Remove rich text formatting and render plain text */
   plain?: boolean;
 }
 

--- a/packages/hydrogen-react/src/RichText.tsx
+++ b/packages/hydrogen-react/src/RichText.tsx
@@ -8,8 +8,8 @@ import {
 export interface RichTextPropsBase<ComponentGeneric extends React.ElementType> {
   /** An HTML tag or React Component to be rendered as the base element wrapper. The default is `div`. */
   as?: ComponentGeneric;
-  /** An object with fields that correspond to the Storefront API's [RichText format](https://shopify.dev/docs/apps/custom-data/metafields/types#rich-text-formatting). */
-  data: RichTextASTNode;
+  /** The JSON string that correspond to the Storefront API's [RichText format](https://shopify.dev/docs/apps/custom-data/metafields/types#rich-text-formatting). */
+  data: string;
   /** Customize how rich text components are rendered */
   components?: CustomComponents;
   /** Remove rich text formatting and render plain text */
@@ -25,11 +25,24 @@ export function RichText<ComponentGeneric extends React.ElementType = 'div'>({
 }: RichTextProps<ComponentGeneric>): JSX.Element {
   const Wrapper = as ?? 'div';
 
+  let parsedData;
+
+  try {
+    parsedData = JSON.parse(data) as RichTextASTNode;
+  } catch (e) {
+    throw new Error(
+      'Parsing error. Make sure to pass a JSON string of rich text metafield',
+      {
+        cause: e,
+      },
+    );
+  }
+
   return (
     <Wrapper {...passthroughProps}>
       {plain
-        ? richTextToString(data)
-        : serializeRichTextASTNode(components, data)}
+        ? richTextToString(parsedData)
+        : serializeRichTextASTNode(components, parsedData)}
     </Wrapper>
   );
 }

--- a/packages/hydrogen-react/src/RichText.tsx
+++ b/packages/hydrogen-react/src/RichText.tsx
@@ -62,8 +62,8 @@ function serializeRichTextASTNode(
 ): ReactNode {
   let children;
   if ('children' in node) {
-    children = node.children.map((child) =>
-      serializeRichTextASTNode(components, child, index),
+    children = node.children.map((child, childIndex) =>
+      serializeRichTextASTNode(components, child, childIndex),
     );
   }
 

--- a/packages/hydrogen-react/src/RichText.tsx
+++ b/packages/hydrogen-react/src/RichText.tsx
@@ -1,24 +1,81 @@
-import {createElement, type ReactNode} from 'react';
+import {createElement, FunctionComponent, type ReactNode} from 'react';
 
-export interface RichTextASTNode {
-  type: string;
-  children?: RichTextASTNode[];
-  level?: number;
+type RootASTNode = {
+  type: 'root';
+  children: RichTextASTNode[];
+};
+
+type HeadingASTNode = {
+  type: 'heading';
+  level: number;
+  children: RichTextASTNode[];
+};
+
+type ParagraphASTNode = {
+  type: 'paragraph';
+  children: RichTextASTNode[];
+};
+
+type TextASTNode = {
+  type: 'text';
   value?: string;
   bold?: boolean;
   italic?: boolean;
-  url?: string;
-  title?: string;
-  target?: string;
-  listType?: string;
-}
+};
+
+type LinkASTNode = {
+  type: 'link';
+  url: string;
+  title: string;
+  target: string;
+  children: RichTextASTNode[];
+};
+
+type ListASTNode = {
+  type: 'list';
+  children: ListItemASTNode[];
+  listType: string;
+};
+
+type ListItemASTNode = {
+  type: 'list-item';
+  children: RichTextASTNode[];
+};
+
+export type RichTextASTNode =
+  | RootASTNode
+  | HeadingASTNode
+  | ParagraphASTNode
+  | TextASTNode
+  | LinkASTNode
+  | ListASTNode
+  | ListItemASTNode;
 
 export interface RichTextPropsBase<ComponentGeneric extends React.ElementType> {
   /** An HTML tag or React Component to be rendered as the base element wrapper. The default is `div`. */
   as?: ComponentGeneric;
   /** An object with fields that correspond to the Storefront API's [RichText format](https://shopify.dev/docs/apps/custom-data/metafields/types#rich-text-formatting). */
   data: RichTextASTNode;
+  /** Customize how Rich Text components are rendered */
+  components?: CustomComponents;
 }
+
+type CustomComponents = {
+  /** The root node of the rich text. Defaults to `<div>` */
+  root?: typeof Root;
+  /** Headings, level 1-6. Defaults to `<h1>` to `<h6>` */
+  heading?: typeof Heading;
+  /** Paragraph, defaults to `<p>` */
+  paragraph?: typeof Paragraph;
+  /** Text node that can be either bold or italic. Defaults to `<em>`, `<strong>` or text. */
+  text?: typeof Text;
+  /** Paragraph, defaults to `<a>` */
+  link?: typeof RichTextLink;
+  /** List, either ordered or unordered. Defaults to `<ol>` or `<ul>` */
+  list?: typeof List;
+  /** List items. Defaults to `<li>`. */
+  listItem?: typeof ListItem;
+};
 
 // This article helps understand the typing here https://www.benmvp.com/blog/polymorphic-react-components-typescript/ Ben is the best :)
 export type RichTextProps<ComponentGeneric extends React.ElementType> =
@@ -28,103 +85,153 @@ export type RichTextProps<ComponentGeneric extends React.ElementType> =
       keyof RichTextPropsBase<ComponentGeneric>
     >;
 
+type Next = (node: RichTextASTNode) => ReactNode;
+
+function Root({node, next}: {node: RootASTNode; next: Next}): ReactNode {
+  return <div>{node.children?.map(next)}</div>;
+}
+
+function Heading({node, next}: {node: HeadingASTNode; next: Next}): ReactNode {
+  return createElement(`h${node.level ?? '1'}`, null, node.children?.map(next));
+}
+
+function Paragraph({
+  node,
+  next,
+}: {
+  node: ParagraphASTNode;
+  next: Next;
+}): ReactNode {
+  return <p>{node.children?.map(next)}</p>;
+}
+
+function Text({node}: {node: TextASTNode; next: Next}): ReactNode {
+  if (node.bold && node.italic)
+    return (
+      <em>
+        <strong>{node.value}</strong>
+      </em>
+    );
+
+  if (node.bold) return <strong>{node.value}</strong>;
+  if (node.italic) return <em>{node.value}</em>;
+
+  return node.value;
+}
+
+function RichTextLink({
+  node,
+  next,
+}: {
+  node: LinkASTNode;
+  next: Next;
+}): ReactNode {
+  return (
+    <a href={node.url} title={node.title} target={node.target}>
+      {node.children?.map(next)}
+    </a>
+  );
+}
+
+function List({node, next}: {node: ListASTNode; next: Next}): ReactNode {
+  const List = node.listType === 'unordered' ? 'ul' : 'ol';
+  return <List>{node.children?.map(next)}</List>;
+}
+
+function ListItem({
+  node,
+  next,
+}: {
+  node: ListItemASTNode;
+  next: Next;
+}): ReactNode {
+  return <li>{node.children?.map(next)}</li>;
+}
+
 export function RichText<ComponentGeneric extends React.ElementType = 'div'>({
   as,
   data,
+  components,
   ...passthroughProps
 }: RichTextProps<ComponentGeneric>): JSX.Element {
   const Wrapper = as ?? 'div';
 
   return (
-    <Wrapper {...passthroughProps}>{serializeRichTextASTNode(data)}</Wrapper>
+    <Wrapper {...passthroughProps}>
+      {serializeRichTextASTNode(components, data)}
+    </Wrapper>
   );
 }
 
-function serializeRichTextASTNode(node: RichTextASTNode, index = 0): ReactNode {
-  switch (node.type) {
-    case 'root':
-      return (
-        <div key={index}>{node.children?.map(serializeRichTextASTNode)}</div>
-      );
-    case 'heading':
-      return createElement(
-        `h${node.level ?? '1'}`,
-        null,
-        node.children?.map(serializeRichTextASTNode),
-      );
-    case 'paragraph':
-      return <p key={index}>{node.children?.map(serializeRichTextASTNode)}</p>;
-    case 'text':
-      return (
-        <span
-          key={index}
-          style={{
-            fontWeight: node.bold ? 'bold' : undefined,
-            fontStyle: node.italic ? 'italic' : undefined,
-          }}
-        >
-          {node.value}
-        </span>
-      );
-    case 'link':
-      return (
-        <a key={index} href={node.url} title={node.title} target={node.target}>
-          {node.children?.map(serializeRichTextASTNode)}
-        </a>
-      );
-    case 'list':
-      // eslint-disable-next-line no-case-declarations
-      const List = node.listType === 'unordered' ? 'ul' : 'ol';
+const COMPONENT_MAP = {
+  root: Root,
+  heading: Heading,
+  paragraph: Paragraph,
+  text: Text,
+  link: RichTextLink,
+  list: List,
+  'list-item': ListItem,
+};
 
-      return (
-        <List key={index}>
-          {node.children?.map((item) => {
-            if (!item.children) {
-              return null;
-            }
+function serializeRichTextASTNode(
+  components: CustomComponents = {},
+  node: RichTextASTNode,
+  index = 0,
+): ReactNode {
+  const next = serializeRichTextASTNode.bind(null, components);
 
-            return (
-              <li key={item.children[0].value}>
-                {item.children.map(serializeRichTextASTNode)}
-              </li>
-            );
-          })}
-        </List>
-      );
-    default:
-      return null;
+  if (node.type in COMPONENT_MAP) {
+    return createElement(
+      (components[
+        node.type === 'list-item' ? 'listItem' : node.type
+      ] as FunctionComponent<{
+        node: RichTextASTNode;
+        next: Next;
+      }>) ??
+        (COMPONENT_MAP[node.type] as FunctionComponent<{
+          node: RichTextASTNode;
+          next: Next;
+        }>),
+      {
+        key: index,
+        node,
+        next,
+      },
+    );
   }
+
+  return null;
 }
 
 export function richTextToString(
   node: RichTextASTNode,
   result: string[] = [],
 ): string {
-  if (node.children && node.children.length > 0) {
-    switch (node.type) {
-      case 'root':
-        node.children.forEach((child) => richTextToString(child, result));
-        break;
-      case 'heading':
-      case 'paragraph':
-        node.children.forEach((child) => richTextToString(child, result));
+  switch (node.type) {
+    case 'root':
+      node.children.forEach((child) => richTextToString(child, result));
+      break;
+    case 'heading':
+    case 'paragraph':
+      node.children.forEach((child) => richTextToString(child, result));
+      result.push(' ');
+      break;
+    case 'text':
+      result.push(node.value || '');
+      break;
+    case 'link':
+      node.children.forEach((child) => richTextToString(child, result));
+      break;
+    case 'list':
+      node.children.forEach((item) => {
+        if (item.children) {
+          item.children.forEach((child) => richTextToString(child, result));
+        }
         result.push(' ');
-        break;
-      case 'text':
-        result.push(node.value || '');
-        break;
-      case 'link':
-        node.children.forEach((child) => richTextToString(child, result));
-        break;
-      case 'list':
-        node.children.forEach((item) => {
-          if (item.children) {
-            item.children.forEach((child) => richTextToString(child, result));
-          }
-          result.push(' ');
-        });
-        break;
-    }
+      });
+      break;
+    default:
+      throw new Error(`Unknown node encountered ${node.type}`);
   }
 
   return result.join('').trim();

--- a/packages/hydrogen-react/src/RichText.types.tsx
+++ b/packages/hydrogen-react/src/RichText.types.tsx
@@ -1,7 +1,3 @@
-import type {ReactNode} from 'react';
-
-export type Next = (node: RichTextASTNode) => ReactNode;
-
 export type RootASTNode = {
   type: 'root';
   children: RichTextASTNode[];
@@ -28,15 +24,15 @@ export type TextASTNode = {
 export type LinkASTNode = {
   type: 'link';
   url: string;
-  title: string;
-  target: string;
+  title?: string;
+  target?: string;
   children: RichTextASTNode[];
 };
 
 export type ListASTNode = {
   type: 'list';
   children: ListItemASTNode[];
-  listType: string;
+  listType: 'unordered' | 'ordered';
 };
 
 export type ListItemASTNode = {

--- a/packages/hydrogen-react/src/RichText.types.tsx
+++ b/packages/hydrogen-react/src/RichText.types.tsx
@@ -1,0 +1,54 @@
+import type {ReactNode} from 'react';
+
+export type Next = (node: RichTextASTNode) => ReactNode;
+
+export type RootASTNode = {
+  type: 'root';
+  children: RichTextASTNode[];
+};
+
+export type HeadingASTNode = {
+  type: 'heading';
+  level: number;
+  children: RichTextASTNode[];
+};
+
+export type ParagraphASTNode = {
+  type: 'paragraph';
+  children: RichTextASTNode[];
+};
+
+export type TextASTNode = {
+  type: 'text';
+  value?: string;
+  bold?: boolean;
+  italic?: boolean;
+};
+
+export type LinkASTNode = {
+  type: 'link';
+  url: string;
+  title: string;
+  target: string;
+  children: RichTextASTNode[];
+};
+
+export type ListASTNode = {
+  type: 'list';
+  children: ListItemASTNode[];
+  listType: string;
+};
+
+export type ListItemASTNode = {
+  type: 'list-item';
+  children: RichTextASTNode[];
+};
+
+export type RichTextASTNode =
+  | RootASTNode
+  | HeadingASTNode
+  | ParagraphASTNode
+  | TextASTNode
+  | LinkASTNode
+  | ListASTNode
+  | ListItemASTNode;

--- a/packages/hydrogen-react/src/index.ts
+++ b/packages/hydrogen-react/src/index.ts
@@ -53,7 +53,7 @@ export {Money} from './Money.js';
 export {type ParsedMetafields, parseMetafield} from './parse-metafield.js';
 export {ProductPrice} from './ProductPrice.js';
 export {ProductProvider, useProduct} from './ProductProvider.js';
-export {RichText, richTextToString} from './RichText.js';
+export {RichText} from './RichText.js';
 export {ShopifyProvider, useShop} from './ShopifyProvider.js';
 export {ShopPayButton} from './ShopPayButton.js';
 export type {

--- a/packages/hydrogen-react/src/index.ts
+++ b/packages/hydrogen-react/src/index.ts
@@ -53,6 +53,7 @@ export {Money} from './Money.js';
 export {type ParsedMetafields, parseMetafield} from './parse-metafield.js';
 export {ProductPrice} from './ProductPrice.js';
 export {ProductProvider, useProduct} from './ProductProvider.js';
+export {RichText, richTextToString} from './RichText.js';
 export {ShopifyProvider, useShop} from './ShopifyProvider.js';
 export {ShopPayButton} from './ShopPayButton.js';
 export type {

--- a/packages/hydrogen-react/src/parse-metafield.test.ts
+++ b/packages/hydrogen-react/src/parse-metafield.test.ts
@@ -18,7 +18,7 @@ import type {
 } from './storefront-api-types.js';
 import {faker} from '@faker-js/faker';
 import {RICH_TEXT_CONTENT} from './RichText.test.helpers.js';
-import {type RichTextASTNode} from './RichText.js';
+import {type RichTextASTNode} from './RichText.types.js';
 
 /**
  * The tests in this file are written in the format `parsed.parsedValue? === ''` instead of `(parsed.parsedValue).toEqual()`
@@ -149,6 +149,7 @@ describe(`parseMetafield`, () => {
         type: 'rich_text_field',
         value: JSON.stringify(RICH_TEXT_CONTENT),
       });
+
       expect(parsed.parsedValue?.type === 'root').toBe(true);
       expect(parsed.parsedValue?.children?.length === 6).toBe(true);
       expectType<null | RichTextASTNode>(parsed?.parsedValue);

--- a/packages/hydrogen-react/src/parse-metafield.test.ts
+++ b/packages/hydrogen-react/src/parse-metafield.test.ts
@@ -17,6 +17,8 @@ import type {
   ProductVariant,
 } from './storefront-api-types.js';
 import {faker} from '@faker-js/faker';
+import {RICH_TEXT_CONTENT} from './RichText.test.helpers.js';
+import {type RichTextASTNode} from './RichText.js';
 
 /**
  * The tests in this file are written in the format `parsed.parsedValue? === ''` instead of `(parsed.parsedValue).toEqual()`
@@ -140,6 +142,16 @@ describe(`parseMetafield`, () => {
       expect(parsed?.parsedValue?.amount === '12').toBe(true);
       expect(parsed?.parsedValue?.currencyCode === 'USD').toBe(true);
       expectType<null | MoneyV2>(parsed?.parsedValue);
+    });
+
+    it(`rich_text_field`, () => {
+      const parsed = parseMetafield<ParsedMetafields['rich_text_field']>({
+        type: 'rich_text_field',
+        value: JSON.stringify(RICH_TEXT_CONTENT),
+      });
+      expect(parsed.parsedValue?.type === 'root').toBe(true);
+      expect(parsed.parsedValue?.children?.length === 6).toBe(true);
+      expectType<null | RichTextASTNode>(parsed?.parsedValue);
     });
 
     it(`multi_line_text_field`, () => {

--- a/packages/hydrogen-react/src/parse-metafield.ts
+++ b/packages/hydrogen-react/src/parse-metafield.ts
@@ -9,7 +9,7 @@ import type {
 } from './storefront-api-types.js';
 import type {PartialDeep, Simplify} from 'type-fest';
 import {flattenConnection} from './flatten-connection.js';
-import {type RichTextASTNode} from './RichText.js';
+import {RootASTNode as RichTextRootASTNode} from './RichText.types.js';
 
 /**
  * A function that uses `metafield.type` to parse the Metafield's `value` or `reference` or `references` (depending on the `metafield.type`) and places the result in `metafield.parsedValue`
@@ -366,7 +366,7 @@ type RatingParsedMetafield = MetafieldBaseType & {
 
 type RichTextParsedMetafield = MetafieldBaseType & {
   type: 'rich_text_field';
-  parsedValue: RichTextASTNode | null;
+  parsedValue: RichTextRootASTNode | null;
 };
 
 type VariantParsedRefMetafield = MetafieldBaseType & {

--- a/packages/hydrogen-react/src/parse-metafield.ts
+++ b/packages/hydrogen-react/src/parse-metafield.ts
@@ -9,6 +9,7 @@ import type {
 } from './storefront-api-types.js';
 import type {PartialDeep, Simplify} from 'type-fest';
 import {flattenConnection} from './flatten-connection.js';
+import {type RichTextASTNode} from './RichText.js';
 
 /**
  * A function that uses `metafield.type` to parse the Metafield's `value` or `reference` or `references` (depending on the `metafield.type`) and places the result in `metafield.parsedValue`
@@ -68,6 +69,7 @@ export function parseMetafield<ReturnGeneric>(
     case 'rating':
     case 'volume':
     case 'weight':
+    case 'rich_text_field':
     case 'list.color':
     case 'list.dimension':
     case 'list.number_integer':
@@ -168,6 +170,7 @@ export const allMetafieldTypesArray = [
   'file_reference',
   'json',
   'money',
+  'rich_text_field',
   'multi_line_text_field',
   'number_decimal',
   'number_integer',
@@ -247,6 +250,8 @@ export type ParsedMetafields<ExtraTypeGeneric = void> = {
   product_reference: Simplify<ProductParsedRefMetafield>;
   /** A Metafield that's been parsed, with a `parsedValue` of type `Rating` */
   rating: Simplify<RatingParsedMetafield>;
+  /** A Metafield that's been parsed, with a `parsedValue` of type `Rating` */
+  rich_text_field: Simplify<RichTextParsedMetafield>;
   /** A Metafield that's been parsed, with a `parsedValue` of type `string` */
   single_line_text_field: Simplify<TextParsedMetafield>;
   /** A Metafield that's been parsed, with a `parsedValue` of type `string` */
@@ -357,6 +362,11 @@ type ProductParsedRefMetafield = MetafieldBaseType & {
 type RatingParsedMetafield = MetafieldBaseType & {
   type: 'rating';
   parsedValue: Rating | null;
+};
+
+type RichTextParsedMetafield = MetafieldBaseType & {
+  type: 'rich_text_field';
+  parsedValue: RichTextASTNode | null;
 };
 
 type VariantParsedRefMetafield = MetafieldBaseType & {

--- a/packages/hydrogen/docs/copy-hydrogen-react-docs.cjs
+++ b/packages/hydrogen/docs/copy-hydrogen-react-docs.cjs
@@ -8,6 +8,7 @@ const docsToCopy = [
   'Money',
   'ModelViewer',
   'ShopPayButton',
+  'RichText',
   'Video',
   'useMoney',
   'useLoadScript',

--- a/packages/hydrogen/src/RichText.tsx
+++ b/packages/hydrogen/src/RichText.tsx
@@ -1,0 +1,23 @@
+import {Link} from '@remix-run/react';
+import {RichText as OriginalRichText} from '@shopify/hydrogen-react';
+
+export const RichText: typeof OriginalRichText = function (props) {
+  return (
+    <OriginalRichText
+      {...props}
+      components={{
+        link: ({node}) => (
+          <Link
+            to={node.url}
+            title={node.title}
+            target={node.target}
+            prefetch="intent"
+          >
+            {node.children}
+          </Link>
+        ),
+        ...props.components,
+      }}
+    />
+  );
+};

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -136,6 +136,7 @@ export {
   useMoney,
   useShopifyCookies,
   Video,
+  RichText,
 } from '@shopify/hydrogen-react';
 
 export type {

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -136,8 +136,8 @@ export {
   useMoney,
   useShopifyCookies,
   Video,
-  RichText,
 } from '@shopify/hydrogen-react';
+export {RichText} from './RichText';
 
 export type {
   ClientBrowserParameters,


### PR DESCRIPTION
### WHY are these changes introduced?

Add a RichText component to easily render \`rich_text_field\` metafields. Thank you @bastienrobert for the original implementation. Fixes #621

Example usage:

```tsx
import {RichText} from '@shopify/hydrogen-react';

export function MainRichText({richTextData}: {richTextData: string}) {
  return (
    <RichText
      data={richTextData}
      components={{
        paragraph({node}) {
          return <p className="customClass">{node.children}</p>;
        },
      }}
    />
  );
}
```

See docs at: https://shopify-dev.shopify-dev-8p8h.bret-little.us.spin.dev/docs/api/hydrogen/2024-04/components/richtext


#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
