### PR TITLE
Invalidate entry point on change in dev server

### DIFF
--- a/.changeset/purple-carrots-melt.md
+++ b/.changeset/purple-carrots-melt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/mini-oxygen': patch
+---
+
+Update server in development when entry point (`<root>/server.js`) changes.

--- a/packages/mini-oxygen/src/vite/worker-entry.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry.ts
@@ -108,7 +108,8 @@ function fetchEntryModule(publicUrl: URL, env: ViteEnv) {
             // module to avoid hanging promises in workerd
             for (const update of data.updates) {
               runtime.moduleCache.invalidateDepTree([
-                update.path,
+                // Module IDs are absolute from root
+                update.path.replace(/^\.\//, '/'),
                 ...(update.ssrInvalidates ?? []),
               ]);
             }


### PR DESCRIPTION
Related to HMR fixes, I noticed that changes to `server.ts` doesn't reflect in the terminal unless the server is restarted. This PR should fix that.

🎩 :
1. Add a `console.debug(1)` to the fetch handler in `server.ts`
2. Start the dev server and trigger a request to see `1` logged
3. Change the code to `console.debug(2)` and save the file
4. Trigger another request: without this PR, it will log `1` again. With this PR, it should log `2`.