### PR TITLE
Add reference subcategories for Cart and Caching utilities and Media components

### DIFF
--- a/packages/hydrogen-react/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen-react/docs/generated/generated_docs_data.json
@@ -2,6 +2,7 @@
   {
     "name": "AddToCartButton",
     "category": "components",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "The `AddToCartButton` component renders a button that adds an item to the cart when pressed.\n\nIt must be a descendent of the `CartProvider` component.",
@@ -229,6 +230,7 @@
   {
     "name": "CartCheckoutButton",
     "category": "components",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "The `CartCheckoutButton` component renders a button that redirects to the checkout URL for the cart.\n\nMust be a descendent of a `CartProvider` component.\n  ",
@@ -303,6 +305,7 @@
   {
     "name": "CartCost",
     "category": "components",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "\n    The `CartCost` component renders a `Money` component with the cost associated with the `amountType` prop.\n\nIf no `amountType` prop is specified, then it defaults to `totalAmount`.\n\nDepends on `useCart()` and must be a child of `<CartProvider/>`\n  ",
@@ -402,6 +405,7 @@
   {
     "name": "CartLineProvider",
     "category": "components",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [
       {
@@ -473,6 +477,7 @@
   {
     "name": "CartLineQuantity",
     "category": "components",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [
       {
@@ -535,6 +540,7 @@
   {
     "name": "CartLineQuantityAdjustButton",
     "category": "components",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [
       {
@@ -597,6 +603,7 @@
   {
     "name": "CartProvider",
     "category": "components",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [
       {
@@ -835,6 +842,7 @@
   {
     "name": "ExternalVideo",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -1234,6 +1242,7 @@
   {
     "name": "Image",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -1458,6 +1467,7 @@
   {
     "name": "MediaFile",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -3900,6 +3910,7 @@
   {
     "name": "ModelViewer",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -4629,6 +4640,7 @@
   {
     "name": "Video",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -7660,7 +7672,7 @@
               "name": "void",
               "value": "void"
             },
-            "value": "export function useShopifyCookies(options?: UseShopifyCookiesOptions): void {\n  const {hasUserConsent = false, domain = ''} = options || {};\n  useEffect(() => {\n    const cookies = getShopifyCookies(document.cookie);\n\n    /**\n     * Set user and session cookies and refresh the expiry time\n     */\n    if (hasUserConsent) {\n      setCookie(\n        SHOPIFY_Y,\n        cookies[SHOPIFY_Y] || buildUUID(),\n        longTermLength,\n        domain,\n      );\n      setCookie(\n        SHOPIFY_S,\n        cookies[SHOPIFY_S] || buildUUID(),\n        shortTermLength,\n        domain,\n      );\n    } else {\n      setCookie(SHOPIFY_Y, '', 0, domain);\n      setCookie(SHOPIFY_S, '', 0, domain);\n    }\n  }, [options, hasUserConsent, domain]);\n}"
+            "value": "export function useShopifyCookies(options?: UseShopifyCookiesOptions): void {\n  const {hasUserConsent = false, domain = ''} = options || {};\n  useEffect(() => {\n    const cookies = getShopifyCookies(document.cookie);\n\n    /**\n     * Setting cookie with domain\n     *\n     * If no domain is provided, the cookie will be set for the current host.\n     * For Shopify, we need to ensure this domain is set with a leading dot.\n     */\n\n    // Use override domain or current host\n    let currentDomain = domain || window.document.location.host;\n\n    // Reset domain if localhost\n    if (/^localhost/.test(currentDomain)) currentDomain = '';\n\n    // Shopify checkout only consumes cookies set with leading dot domain\n    const domainWithLeadingDot = currentDomain\n      ? /^\\./.test(currentDomain)\n        ? currentDomain\n        : `.${currentDomain}`\n      : '';\n\n    /**\n     * Set user and session cookies and refresh the expiry time\n     */\n    if (hasUserConsent) {\n      setCookie(\n        SHOPIFY_Y,\n        cookies[SHOPIFY_Y] || buildUUID(),\n        longTermLength,\n        domainWithLeadingDot,\n      );\n      setCookie(\n        SHOPIFY_S,\n        cookies[SHOPIFY_S] || buildUUID(),\n        shortTermLength,\n        domainWithLeadingDot,\n      );\n    } else {\n      setCookie(SHOPIFY_Y, '', 0, domainWithLeadingDot);\n      setCookie(SHOPIFY_S, '', 0, domainWithLeadingDot);\n    }\n  }, [options, hasUserConsent, domain]);\n}"
           },
           "UseShopifyCookiesOptions": {
             "filePath": "/useShopifyCookies.tsx",

--- a/packages/hydrogen-react/src/AddToCartButton.doc.ts
+++ b/packages/hydrogen-react/src/AddToCartButton.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'AddToCartButton',
   category: 'components',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description: `The \`AddToCartButton\` component renders a button that adds an item to the cart when pressed.\n\nIt must be a descendent of the \`CartProvider\` component.`,

--- a/packages/hydrogen-react/src/CartCheckoutButton.doc.ts
+++ b/packages/hydrogen-react/src/CartCheckoutButton.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CartCheckoutButton',
   category: 'components',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description: `The \`CartCheckoutButton\` component renders a button that redirects to the checkout URL for the cart.\n\nMust be a descendent of a \`CartProvider\` component.

--- a/packages/hydrogen-react/src/CartCost.doc.ts
+++ b/packages/hydrogen-react/src/CartCost.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CartCost',
   category: 'components',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description: `

--- a/packages/hydrogen-react/src/CartLineProvider.doc.ts
+++ b/packages/hydrogen-react/src/CartLineProvider.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CartLineProvider',
   category: 'components',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen-react/src/CartLineQuantity.doc.ts
+++ b/packages/hydrogen-react/src/CartLineQuantity.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CartLineQuantity',
   category: 'components',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen-react/src/CartLineQuantityAdjustButton.doc.ts
+++ b/packages/hydrogen-react/src/CartLineQuantityAdjustButton.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CartLineQuantityAdjustButton',
   category: 'components',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen-react/src/CartProvider.doc.ts
+++ b/packages/hydrogen-react/src/CartProvider.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CartProvider',
   category: 'components',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen-react/src/ExternalVideo.doc.ts
+++ b/packages/hydrogen-react/src/ExternalVideo.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'ExternalVideo',
   category: 'components',
+  subCategory: 'media',
   isVisualComponent: false,
   // put a name in for 'image', and it will look in the docs/screenshots/ folder automatically.
   // image: "",

--- a/packages/hydrogen-react/src/Image.doc.ts
+++ b/packages/hydrogen-react/src/Image.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image',
   category: 'components',
+  subCategory: 'media',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen-react/src/MediaFile.doc.ts
+++ b/packages/hydrogen-react/src/MediaFile.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'MediaFile',
   category: 'components',
+  subCategory: 'media',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen-react/src/ModelViewer.doc.ts
+++ b/packages/hydrogen-react/src/ModelViewer.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'ModelViewer',
   category: 'components',
+  subCategory: 'media',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen-react/src/Video.doc.ts
+++ b/packages/hydrogen-react/src/Video.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Video',
   category: 'components',
+  subCategory: 'media',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen/docs/generated/generated_docs_data.json
@@ -2236,6 +2236,7 @@
   {
     "name": "CacheCustom",
     "category": "utilities",
+    "subCategory": "caching",
     "isVisualComponent": false,
     "related": [
       {
@@ -2360,6 +2361,7 @@
   {
     "name": "CacheLong",
     "category": "utilities",
+    "subCategory": "caching",
     "isVisualComponent": false,
     "related": [
       {
@@ -2485,6 +2487,7 @@
   {
     "name": "CacheNone",
     "category": "utilities",
+    "subCategory": "caching",
     "isVisualComponent": false,
     "related": [
       {
@@ -2570,6 +2573,7 @@
   {
     "name": "CacheShort",
     "category": "utilities",
+    "subCategory": "caching",
     "isVisualComponent": false,
     "related": [
       {
@@ -2695,6 +2699,7 @@
   {
     "name": "InMemoryCache",
     "category": "utilities",
+    "subCategory": "caching",
     "isVisualComponent": false,
     "related": [
       {
@@ -2723,6 +2728,7 @@
   {
     "name": "generateCacheControlHeader",
     "category": "utilities",
+    "subCategory": "caching",
     "isVisualComponent": false,
     "related": [],
     "description": "This utility function accepts a `CachingStrategy` object and returns a string with the corresponding `cache-control` header.\n\nLearn more about [data fetching in Hydrogen](/docs/custom-storefronts/hydrogen/data-fetching/fetch-data).",
@@ -2996,7 +3002,7 @@
             "filePath": "/cart/CartForm.tsx",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartLinesAddProps",
-            "value": "{\n  action: 'LinesAdd';\n  inputs?: {\n    lines: CartLineInput[];\n  } & OtherFormData;\n}",
+            "value": "{\n  action: 'LinesAdd';\n  inputs?: {\n    lines: Array<OptimisticCartLine>;\n  } & OtherFormData;\n}",
             "description": "",
             "members": [
               {
@@ -3010,11 +3016,18 @@
                 "filePath": "/cart/CartForm.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "inputs",
-                "value": "{ lines: CartLineInput[]; } & OtherFormData",
+                "value": "{ lines: OptimisticCartLine[]; } & OtherFormData",
                 "description": "",
                 "isOptional": true
               }
             ]
+          },
+          "OptimisticCartLine": {
+            "filePath": "/cart/CartForm.tsx",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "OptimisticCartLine",
+            "value": "CartLineInput & {\n  selectedVariant?: unknown;\n}",
+            "description": ""
           },
           "CartLineInput": {
             "description": "",
@@ -3325,6 +3338,7 @@
   {
     "name": "cartGetIdDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that returns the cart id from request header cookie.",
@@ -3382,6 +3396,7 @@
   {
     "name": "cartSetIdDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that returns a header with a Set-Cookie on the cart ID.",
@@ -3498,6 +3513,7 @@
   {
     "name": "createCartHandler",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates an API that can be used to interact with the cart.",
@@ -4022,7 +4038,7 @@
               {
                 "name": "lines",
                 "description": "",
-                "value": "CartLineInput[]",
+                "value": "OptimisticCartLine[]",
                 "filePath": "/cart/queries/cartLinesAddDefault.ts"
               },
               {
@@ -4039,7 +4055,14 @@
               "name": "Promise<CartQueryDataReturn>",
               "value": "Promise<CartQueryDataReturn>"
             },
-            "value": "export type CartLinesAddFunction = (\n  lines: CartLineInput[],\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+            "value": "export type CartLinesAddFunction = (\n  lines: Array<OptimisticCartLine>,\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+          },
+          "OptimisticCartLine": {
+            "filePath": "/cart/CartForm.tsx",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "OptimisticCartLine",
+            "value": "CartLineInput & {\n  selectedVariant?: unknown;\n}",
+            "description": ""
           },
           "CartLineInput": {
             "description": "",
@@ -4775,8 +4798,98 @@
     }
   },
   {
+    "name": "useOptimisticCart",
+    "category": "hooks",
+    "isVisualComponent": false,
+    "related": [
+      {
+        "name": "CartForm",
+        "type": "components",
+        "url": "/docs/api/hydrogen/2024-04/components/cartform"
+      }
+    ],
+    "description": "The `useOptimisticCart` takes an existing cart object, processes all pending cart actions, and locally mutates the cart with optimistic state. An optimistic cart makes cart actions immediately render in the browser while actions sync to the server. This increases the perceived performance of the application.",
+    "type": "utility",
+    "defaultExample": {
+      "description": "I am the default example",
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "JavaScript",
+            "code": "import {defer} from '@shopify/remix-oxygen';\nimport {Link} from '@remix-run/react';\nimport {CartForm, useOptimisticCart} from '@shopify/hydrogen';\n\n// Root loader returns the cart data\nexport async function loader({context}) {\n  return defer({\n    cart: context.cart.get(),\n  });\n}\n\n// The cart component renders each line item in the cart.\nexport function Cart({cart}) {\n  // `useOptimisticCart` adds optimistic line items to the cart.\n  // These line items are displayed in the cart until the server responds.\n  const optimisticCart = useOptimisticCart(cart);\n\n  if (!optimisticCart?.lines?.nodes?.length) return &lt;p&gt;Nothing in cart&lt;/p&gt;;\n\n  return optimisticCart.lines.nodes.map((line) =&gt; (\n    &lt;div key={line.id}&gt;\n      &lt;Link to={`/products${line.merchandise.product.handle}`}&gt;\n        {line.merchandise.product.title}\n      &lt;/Link&gt;\n      &lt;CartForm\n        route=\"/cart\"\n        action={CartForm.ACTIONS.LinesRemove}\n        inputs={{lineIds: [line.id]}}\n      &gt;\n        {/* Each line item has an `isOptimistic` property. Optimistic line items\n        should have actions disabled */}\n        &lt;button type=\"submit\" disabled={!!line.isOptimistic}&gt;\n          Remove\n        &lt;/button&gt;\n      &lt;/CartForm&gt;\n    &lt;/div&gt;\n  ));\n}\n",
+            "language": "jsx"
+          },
+          {
+            "title": "TypeScript",
+            "code": "import {defer, type LoaderFunctionArgs} from '@shopify/remix-oxygen';\nimport {Link} from '@remix-run/react';\nimport {CartForm, OptimisticCart, useOptimisticCart} from '@shopify/hydrogen';\nimport type {Cart} from '@shopify/hydrogen-react/storefront-api-types';\n\n// Root loader returns the cart data\nexport async function loader({context}: LoaderFunctionArgs) {\n  return defer({\n    cart: context.cart.get(),\n  });\n}\n\n// The cart component renders each line item in the cart.\nexport function Cart({cart}: {cart: OptimisticCart}) {\n  // `useOptimisticCart` adds optimistic line items to the cart.\n  // These line items are displayed in the cart until the server responds.\n  const optimisticCart = useOptimisticCart(cart);\n\n  if (!optimisticCart?.lines?.nodes?.length) return &lt;p&gt;Nothing in cart&lt;/p&gt;;\n\n  return optimisticCart.lines.nodes.map((line) =&gt; (\n    &lt;div key={line.id}&gt;\n      &lt;Link to={`/products${line.merchandise.product.handle}`}&gt;\n        {line.merchandise.product.title}\n      &lt;/Link&gt;\n      &lt;CartForm\n        route=\"/cart\"\n        action={CartForm.ACTIONS.LinesRemove}\n        inputs={{lineIds: [line.id]}}\n      &gt;\n        {/* Each line item has an `isOptimistic` property. Optimistic line items\n        should have actions disabled */}\n        &lt;button type=\"submit\" disabled={!!line.isOptimistic}&gt;\n          Remove\n        &lt;/button&gt;\n      &lt;/CartForm&gt;\n    &lt;/div&gt;\n  ));\n}\n",
+            "language": "tsx"
+          }
+        ],
+        "title": "Example code"
+      }
+    },
+    "definitions": [
+      {
+        "title": "Props",
+        "description": "",
+        "type": "UseOptimisticCartGeneratedType",
+        "typeDefinitions": {
+          "UseOptimisticCartGeneratedType": {
+            "filePath": "/cart/optimistic/useOptimisticCart.tsx",
+            "name": "UseOptimisticCartGeneratedType",
+            "description": "",
+            "params": [
+              {
+                "name": "cart",
+                "description": "The cart object from `context.cart.get()` returned by a server loader.",
+                "value": "DefaultCart",
+                "filePath": "/cart/optimistic/useOptimisticCart.tsx"
+              }
+            ],
+            "returns": {
+              "filePath": "/cart/optimistic/useOptimisticCart.tsx",
+              "description": "A new cart object augmented with optimistic state. Each cart line item that is optimistically added includes an `isOptimistic` property. Also if the cart has _any_ optimistic state, a root property `isOptimistic` will be set to `true`.",
+              "name": "OptimisticCart<DefaultCart = CartReturn>",
+              "value": "OptimisticCart<DefaultCart = CartReturn>"
+            },
+            "value": "export function useOptimisticCart<DefaultCart = CartReturn>(\n  cart: DefaultCart,\n): OptimisticCart<DefaultCart> {\n  const fetchers = useFetchers();\n\n  if (!fetchers || !fetchers.length) return cart as OptimisticCart<DefaultCart>;\n\n  const optimisticCart = (cart as CartReturn)?.lines\n    ? (structuredClone(cart) as OptimisticCart<DefaultCart>)\n    : ({lines: {nodes: []}} as OptimisticCart<DefaultCart>);\n\n  const cartLines = optimisticCart.lines.nodes;\n\n  let isOptimistic = false;\n\n  for (const {formData} of fetchers) {\n    if (!formData) continue;\n\n    const cartFormData = CartForm.getFormInput(formData);\n\n    if (cartFormData.action === CartForm.ACTIONS.LinesAdd) {\n      for (const input of cartFormData.inputs.lines) {\n        if (!input.selectedVariant) {\n          console.error(\n            '[h2:error:useOptimisticCart] No selected variant was passed in the cart action. Make sure to pass the selected variant if you want to use an optimistic cart',\n          );\n          continue;\n        }\n\n        const existingLine = cartLines.find(\n          (line) =>\n            line.merchandise.id ===\n            (input.selectedVariant as ProductVariant)?.id,\n        ) as CartLine & {isOptimistic?: boolean};\n\n        isOptimistic = true;\n\n        if (existingLine) {\n          existingLine.quantity =\n            (existingLine.quantity || 1) + (input.quantity || 1);\n          existingLine.isOptimistic = true;\n        } else {\n          cartLines.unshift({\n            id: getOptimisticLineId((input.selectedVariant as any).id),\n            merchandise: input.selectedVariant,\n            isOptimistic: true,\n            quantity: input.quantity || 1,\n          } as CartLine & {isOptimistic?: boolean});\n        }\n      }\n    } else if (cartFormData.action === CartForm.ACTIONS.LinesRemove) {\n      for (const lineId of cartFormData.inputs.lineIds) {\n        const index = cartLines.findIndex((line) => line.id === lineId);\n\n        if (index !== -1) {\n          if (isOptimisticLineId(cartLines[index].id)) {\n            console.error(\n              '[h2:error:useOptimisticCart] Tried to remove an optimistic line that has not been added to the cart yet',\n            );\n            continue;\n          }\n\n          cartLines.splice(index, 1);\n          isOptimistic = true;\n        } else {\n          console.warn(\n            `[h2:warn:useOptimisticCart] Tried to remove line '${lineId}' but it doesn't exist in the cart`,\n          );\n        }\n      }\n    } else if (cartFormData.action === CartForm.ACTIONS.LinesUpdate) {\n      for (const line of cartFormData.inputs.lines) {\n        const index = cartLines.findIndex(\n          (optimisticLine) => line.id === optimisticLine.id,\n        );\n\n        if (index > -1) {\n          if (isOptimisticLineId(cartLines[index].id)) {\n            console.error(\n              '[h2:error:useOptimisticCart] Tried to update an optimistic line that has not been added to the cart yet',\n            );\n            continue;\n          }\n\n          cartLines[index].quantity = line.quantity as number;\n\n          if (cartLines[index].quantity === 0) {\n            cartLines.splice(index, 1);\n          }\n\n          isOptimistic = true;\n        } else {\n          console.warn(\n            `[h2:warn:useOptimisticCart] Tried to update line '${line.id}' but it doesn't exist in the cart`,\n          );\n        }\n      }\n    }\n  }\n\n  if (isOptimistic) {\n    optimisticCart.isOptimistic = isOptimistic;\n  }\n\n  return optimisticCart;\n}"
+          },
+          "OptimisticCart": {
+            "filePath": "/cart/optimistic/useOptimisticCart.tsx",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "OptimisticCart",
+            "value": "T & {\n  isOptimistic?: boolean;\n  lines: {nodes: Array<CartLine & {isOptimistic?: boolean}>};\n}",
+            "description": ""
+          },
+          "CartReturn": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartReturn",
+            "value": "Cart & {\n  errors?: StorefrontApiErrors;\n}",
+            "description": ""
+          },
+          "Cart": {
+            "description": "",
+            "name": "Cart",
+            "value": "Cart",
+            "members": [],
+            "override": "[Cart](/docs/api/storefront/2024-04/objects/Cart) - Storefront API type"
+          },
+          "StorefrontApiErrors": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontApiErrors",
+            "value": "JsonGraphQLError[] | undefined",
+            "description": ""
+          }
+        }
+      }
+    ]
+  },
+  {
     "name": "cartAttributesUpdateDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that accepts an array of [AttributeInput](/docs/api/storefront/2024-04/input-objects/AttributeInput) and updates attributes to a cart",
@@ -4824,7 +4937,7 @@
             "filePath": "/cart/queries/cart-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
             "description": "",
             "members": [
               {
@@ -4848,2041 +4961,13 @@
                 "value": "string",
                 "description": "The cart fragment to override the one used in this query.",
                 "isOptional": true
-              }
-            ]
-          },
-          "Storefront": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "Storefront",
-            "value": "{\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontQueries,\n      RawGqlString,\n      StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, 'cache'>,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontMutations,\n      RawGqlString,\n      StorefrontCommonExtraParams,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  cache?: Cache;\n  CacheNone: typeof CacheNone;\n  CacheLong: typeof CacheLong;\n  CacheShort: typeof CacheShort;\n  CacheCustom: typeof CacheCustom;\n  generateCacheControlHeader: typeof generateCacheControlHeader;\n  getPublicTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  getPrivateTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  getShopifyDomain: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  getApiUrl: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  i18n: TI18n;\n}",
-            "description": "Interface to interact with the Storefront API.",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "query",
-                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> & StorefrontError>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mutate",
-                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> & StorefrontError>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cache",
-                "value": "Cache",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheNone",
-                "value": "() => NoStoreStrategy",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheLong",
-                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheShort",
-                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheCustom",
-                "value": "(overrideOptions: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "generateCacheControlHeader",
-                "value": "(cacheOptions: AllCacheOptions) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getPublicTokenHeaders",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getPrivateTokenHeaders",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getShopifyDomain",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getApiUrl",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "i18n",
-                "value": "TI18n",
-                "description": ""
-              }
-            ]
-          },
-          "StorefrontQueries": {
-            "filePath": "/storefront.ts",
-            "name": "StorefrontQueries",
-            "description": "Maps all the queries found in the project to variables and return types.",
-            "members": [],
-            "value": "export interface StorefrontQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
-          },
-          "AutoAddedVariableNames": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AutoAddedVariableNames",
-            "value": "'country' | 'language'",
-            "description": ""
-          },
-          "StorefrontCommonExtraParams": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontCommonExtraParams",
-            "value": "{\n  headers?: HeadersInit;\n  storefrontApiVersion?: string;\n  displayName?: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "headers",
-                "value": "HeadersInit",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "storefrontApiVersion",
-                "value": "string",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "displayName",
-                "value": "string",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontQueryOptions": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontQueryOptions",
-            "value": "StorefrontCommonExtraParams & {\n  query: string;\n  mutation?: never;\n  cache?: CachingStrategy;\n}",
-            "description": ""
-          },
-          "CachingStrategy": {
-            "filePath": "/cache/strategies.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CachingStrategy",
-            "value": "AllCacheOptions",
-            "description": "Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the pre-defined caching strategies: CacheNone, CacheShort, CacheLong.",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "maxAge",
-                "value": "number",
-                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleWhileRevalidate",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sMaxAge",
-                "value": "number",
-                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleIfError",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontError": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontError",
-            "value": "{\n  errors?: StorefrontApiErrors;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "errors",
-                "value": "StorefrontApiErrors",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontApiErrors": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontApiErrors",
-            "value": "JsonGraphQLError[] | undefined",
-            "description": ""
-          },
-          "StorefrontMutations": {
-            "filePath": "/storefront.ts",
-            "name": "StorefrontMutations",
-            "description": "Maps all the mutations found in the project to variables and return types.",
-            "members": [],
-            "value": "export interface StorefrontMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
-          },
-          "NoStoreStrategy": {
-            "filePath": "/cache/strategies.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "NoStoreStrategy",
-            "value": "{\n  mode: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": ""
-              }
-            ]
-          },
-          "AllCacheOptions": {
-            "filePath": "/cache/strategies.ts",
-            "name": "AllCacheOptions",
-            "description": "Override options for a cache strategy.",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "maxAge",
-                "value": "number",
-                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleWhileRevalidate",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sMaxAge",
-                "value": "number",
-                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleIfError",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
-          },
-          "CartAttributesUpdateFunction": {
-            "filePath": "/cart/queries/cartAttributesUpdateDefault.ts",
-            "name": "CartAttributesUpdateFunction",
-            "description": "",
-            "params": [
-              {
-                "name": "attributes",
-                "description": "",
-                "value": "AttributeInput[]",
-                "filePath": "/cart/queries/cartAttributesUpdateDefault.ts"
-              },
-              {
-                "name": "optionalParams",
-                "description": "",
-                "value": "CartOptionalInput",
-                "isOptional": true,
-                "filePath": "/cart/queries/cartAttributesUpdateDefault.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "/cart/queries/cartAttributesUpdateDefault.ts",
-              "description": "",
-              "name": "Promise<CartQueryDataReturn>",
-              "value": "Promise<CartQueryDataReturn>"
-            },
-            "value": "export type CartAttributesUpdateFunction = (\n  attributes: AttributeInput[],\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
-          },
-          "AttributeInput": {
-            "description": "",
-            "name": "AttributeInput",
-            "value": "AttributeInput",
-            "members": [],
-            "override": "[AttributeInput](/docs/api/storefront/2024-04/input-objects/AttributeInput) - Storefront API type"
-          },
-          "CartOptionalInput": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartOptionalInput",
-            "value": "{\n  /**\n   * The cart id.\n   * @default cart.getCartId();\n   */\n  cartId?: Scalars['ID']['input'];\n  /**\n   * The country code.\n   * @default storefront.i18n.country\n   */\n  country?: CountryCode;\n  /**\n   * The language code.\n   * @default storefront.i18n.language\n   */\n  language?: LanguageCode;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cartId",
-                "value": "string",
-                "description": "The cart id.",
-                "isOptional": true,
-                "defaultValue": "cart.getCartId();"
               },
               {
                 "filePath": "/cart/queries/cart-types.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "country",
-                "value": "CountryCode",
-                "description": "The country code.",
-                "isOptional": true,
-                "defaultValue": "storefront.i18n.country"
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "language",
-                "value": "LanguageCode",
-                "description": "The language code.",
-                "isOptional": true,
-                "defaultValue": "storefront.i18n.language"
-              }
-            ]
-          },
-          "CartQueryDataReturn": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryDataReturn",
-            "value": "CartQueryData & {\n  errors?: StorefrontApiErrors;\n}",
-            "description": ""
-          },
-          "CartQueryData": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryData",
-            "value": "{\n  cart: Cart;\n  userErrors?:\n    | CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[];\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cart",
-                "value": "Cart",
-                "description": ""
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "userErrors",
-                "value": "CartUserError[] | MetafieldsSetUserError[] | MetafieldDeleteUserError[]",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "Cart": {
-            "description": "",
-            "name": "Cart",
-            "value": "Cart",
-            "members": [],
-            "override": "[Cart](/docs/api/storefront/2024-04/objects/Cart) - Storefront API type"
-          },
-          "CartUserError": {
-            "description": "",
-            "name": "CartUserError",
-            "value": "CartUserError",
-            "members": [],
-            "override": "[CartUserError](/docs/api/storefront/2024-04/objects/CartUserError) - Storefront API type"
-          },
-          "MetafieldsSetUserError": {
-            "description": "",
-            "name": "MetafieldsSetUserError",
-            "value": "MetafieldsSetUserError",
-            "members": [],
-            "override": "[MetafieldsSetUserError](/docs/api/storefront/2024-04/objects/MetafieldsSetUserError) - Storefront API type"
-          },
-          "MetafieldDeleteUserError": {
-            "description": "",
-            "name": "MetafieldDeleteUserError",
-            "value": "MetafieldDeleteUserError",
-            "members": [],
-            "override": "[MetafieldDeleteUserError](/docs/api/storefront/2024-04/objects/MetafieldDeleteUserError) - Storefront API type"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "name": "cartBuyerIdentityUpdateDefault",
-    "category": "utilities",
-    "isVisualComponent": false,
-    "related": [],
-    "description": "Creates a function that accepts an object of [CartBuyerIdentityInput](/docs/api/storefront/2024-04/input-objects/CartBuyerIdentityInput) and updates the buyer identity of a cart",
-    "type": "utility",
-    "defaultExample": {
-      "description": "This is the default example",
-      "codeblock": {
-        "tabs": [
-          {
-            "title": "JavaScript",
-            "code": "import {cartBuyerIdentityUpdateDefault} from '@shopify/hydrogen';\n\nconst cartBuyerIdentity = cartBuyerIdentityUpdateDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartBuyerIdentity({\n  customerAccessToken: '123',\n});\n",
-            "language": "js"
-          }
-        ],
-        "title": "example"
-      }
-    },
-    "definitions": [
-      {
-        "title": "cartBuyerIdentityUpdateDefault",
-        "description": "",
-        "type": "CartBuyerIdentityUpdateDefaultGeneratedType",
-        "typeDefinitions": {
-          "CartBuyerIdentityUpdateDefaultGeneratedType": {
-            "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts",
-            "name": "CartBuyerIdentityUpdateDefaultGeneratedType",
-            "description": "",
-            "params": [
-              {
-                "name": "options",
-                "description": "",
-                "value": "CartQueryOptions",
-                "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts",
-              "description": "",
-              "name": "CartBuyerIdentityUpdateFunction",
-              "value": "CartBuyerIdentityUpdateFunction"
-            },
-            "value": "export function cartBuyerIdentityUpdateDefault(\n  options: CartQueryOptions,\n): CartBuyerIdentityUpdateFunction {\n  return async (buyerIdentity, optionalParams) => {\n    const {cartBuyerIdentityUpdate, errors} = await options.storefront.mutate<{\n      cartBuyerIdentityUpdate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_BUYER_IDENTITY_UPDATE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        buyerIdentity,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartBuyerIdentityUpdate, errors);\n  };\n}"
-          },
-          "CartQueryOptions": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "storefront",
-                "value": "Storefront",
-                "description": "The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient)."
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getCartId",
-                "value": "() => string",
-                "description": "A function that returns the cart ID."
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cartFragment",
-                "value": "string",
-                "description": "The cart fragment to override the one used in this query.",
-                "isOptional": true
-              }
-            ]
-          },
-          "Storefront": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "Storefront",
-            "value": "{\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontQueries,\n      RawGqlString,\n      StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, 'cache'>,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontMutations,\n      RawGqlString,\n      StorefrontCommonExtraParams,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  cache?: Cache;\n  CacheNone: typeof CacheNone;\n  CacheLong: typeof CacheLong;\n  CacheShort: typeof CacheShort;\n  CacheCustom: typeof CacheCustom;\n  generateCacheControlHeader: typeof generateCacheControlHeader;\n  getPublicTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  getPrivateTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  getShopifyDomain: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  getApiUrl: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  i18n: TI18n;\n}",
-            "description": "Interface to interact with the Storefront API.",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "query",
-                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> & StorefrontError>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mutate",
-                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> & StorefrontError>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cache",
-                "value": "Cache",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheNone",
-                "value": "() => NoStoreStrategy",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheLong",
-                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheShort",
-                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheCustom",
-                "value": "(overrideOptions: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "generateCacheControlHeader",
-                "value": "(cacheOptions: AllCacheOptions) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getPublicTokenHeaders",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getPrivateTokenHeaders",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getShopifyDomain",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getApiUrl",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "i18n",
-                "value": "TI18n",
-                "description": ""
-              }
-            ]
-          },
-          "StorefrontQueries": {
-            "filePath": "/storefront.ts",
-            "name": "StorefrontQueries",
-            "description": "Maps all the queries found in the project to variables and return types.",
-            "members": [],
-            "value": "export interface StorefrontQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
-          },
-          "AutoAddedVariableNames": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AutoAddedVariableNames",
-            "value": "'country' | 'language'",
-            "description": ""
-          },
-          "StorefrontCommonExtraParams": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontCommonExtraParams",
-            "value": "{\n  headers?: HeadersInit;\n  storefrontApiVersion?: string;\n  displayName?: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "headers",
-                "value": "HeadersInit",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "storefrontApiVersion",
-                "value": "string",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "displayName",
-                "value": "string",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontQueryOptions": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontQueryOptions",
-            "value": "StorefrontCommonExtraParams & {\n  query: string;\n  mutation?: never;\n  cache?: CachingStrategy;\n}",
-            "description": ""
-          },
-          "CachingStrategy": {
-            "filePath": "/cache/strategies.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CachingStrategy",
-            "value": "AllCacheOptions",
-            "description": "Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the pre-defined caching strategies: CacheNone, CacheShort, CacheLong.",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "maxAge",
-                "value": "number",
-                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleWhileRevalidate",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sMaxAge",
-                "value": "number",
-                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleIfError",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontError": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontError",
-            "value": "{\n  errors?: StorefrontApiErrors;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "errors",
-                "value": "StorefrontApiErrors",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontApiErrors": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontApiErrors",
-            "value": "JsonGraphQLError[] | undefined",
-            "description": ""
-          },
-          "StorefrontMutations": {
-            "filePath": "/storefront.ts",
-            "name": "StorefrontMutations",
-            "description": "Maps all the mutations found in the project to variables and return types.",
-            "members": [],
-            "value": "export interface StorefrontMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
-          },
-          "NoStoreStrategy": {
-            "filePath": "/cache/strategies.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "NoStoreStrategy",
-            "value": "{\n  mode: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": ""
-              }
-            ]
-          },
-          "AllCacheOptions": {
-            "filePath": "/cache/strategies.ts",
-            "name": "AllCacheOptions",
-            "description": "Override options for a cache strategy.",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "maxAge",
-                "value": "number",
-                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleWhileRevalidate",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sMaxAge",
-                "value": "number",
-                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleIfError",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
-          },
-          "CartBuyerIdentityUpdateFunction": {
-            "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts",
-            "name": "CartBuyerIdentityUpdateFunction",
-            "description": "",
-            "params": [
-              {
-                "name": "buyerIdentity",
-                "description": "",
-                "value": "CartBuyerIdentityInput",
-                "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts"
-              },
-              {
-                "name": "optionalParams",
-                "description": "",
-                "value": "CartOptionalInput",
-                "isOptional": true,
-                "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts",
-              "description": "",
-              "name": "Promise<CartQueryDataReturn>",
-              "value": "Promise<CartQueryDataReturn>"
-            },
-            "value": "export type CartBuyerIdentityUpdateFunction = (\n  buyerIdentity: CartBuyerIdentityInput,\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
-          },
-          "CartBuyerIdentityInput": {
-            "description": "",
-            "name": "CartBuyerIdentityInput",
-            "value": "CartBuyerIdentityInput",
-            "members": [],
-            "override": "[CartBuyerIdentityInput](/docs/api/storefront/2024-04/input-objects/CartBuyerIdentityInput) - Storefront API type"
-          },
-          "CartOptionalInput": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartOptionalInput",
-            "value": "{\n  /**\n   * The cart id.\n   * @default cart.getCartId();\n   */\n  cartId?: Scalars['ID']['input'];\n  /**\n   * The country code.\n   * @default storefront.i18n.country\n   */\n  country?: CountryCode;\n  /**\n   * The language code.\n   * @default storefront.i18n.language\n   */\n  language?: LanguageCode;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cartId",
-                "value": "string",
-                "description": "The cart id.",
-                "isOptional": true,
-                "defaultValue": "cart.getCartId();"
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "country",
-                "value": "CountryCode",
-                "description": "The country code.",
-                "isOptional": true,
-                "defaultValue": "storefront.i18n.country"
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "language",
-                "value": "LanguageCode",
-                "description": "The language code.",
-                "isOptional": true,
-                "defaultValue": "storefront.i18n.language"
-              }
-            ]
-          },
-          "CartQueryDataReturn": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryDataReturn",
-            "value": "CartQueryData & {\n  errors?: StorefrontApiErrors;\n}",
-            "description": ""
-          },
-          "CartQueryData": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryData",
-            "value": "{\n  cart: Cart;\n  userErrors?:\n    | CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[];\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cart",
-                "value": "Cart",
-                "description": ""
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "userErrors",
-                "value": "CartUserError[] | MetafieldsSetUserError[] | MetafieldDeleteUserError[]",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "Cart": {
-            "description": "",
-            "name": "Cart",
-            "value": "Cart",
-            "members": [],
-            "override": "[Cart](/docs/api/storefront/2024-04/objects/Cart) - Storefront API type"
-          },
-          "CartUserError": {
-            "description": "",
-            "name": "CartUserError",
-            "value": "CartUserError",
-            "members": [],
-            "override": "[CartUserError](/docs/api/storefront/2024-04/objects/CartUserError) - Storefront API type"
-          },
-          "MetafieldsSetUserError": {
-            "description": "",
-            "name": "MetafieldsSetUserError",
-            "value": "MetafieldsSetUserError",
-            "members": [],
-            "override": "[MetafieldsSetUserError](/docs/api/storefront/2024-04/objects/MetafieldsSetUserError) - Storefront API type"
-          },
-          "MetafieldDeleteUserError": {
-            "description": "",
-            "name": "MetafieldDeleteUserError",
-            "value": "MetafieldDeleteUserError",
-            "members": [],
-            "override": "[MetafieldDeleteUserError](/docs/api/storefront/2024-04/objects/MetafieldDeleteUserError) - Storefront API type"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "name": "cartCreateDefault",
-    "category": "utilities",
-    "isVisualComponent": false,
-    "related": [],
-    "description": "Creates a function that accepts an object of [CartInput](/docs/api/storefront/2024-04/input-objects/CartInput) and returns a new cart",
-    "type": "utility",
-    "defaultExample": {
-      "description": "This is the default example",
-      "codeblock": {
-        "tabs": [
-          {
-            "title": "JavaScript",
-            "code": "import {cartCreateDefault} from '@shopify/hydrogen';\n\nconst cartCreate = cartCreateDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartCreate({\n  lines: [\n    {\n      merchandiseId: 'gid://shopify/ProductVariant/123456789',\n      quantity: 1,\n    },\n  ],\n});\n",
-            "language": "js"
-          }
-        ],
-        "title": "example"
-      }
-    },
-    "definitions": [
-      {
-        "title": "cartCreateDefault",
-        "description": "",
-        "type": "CartCreateDefaultGeneratedType",
-        "typeDefinitions": {
-          "CartCreateDefaultGeneratedType": {
-            "filePath": "/cart/queries/cartCreateDefault.ts",
-            "name": "CartCreateDefaultGeneratedType",
-            "description": "",
-            "params": [
-              {
-                "name": "options",
-                "description": "",
-                "value": "CartQueryOptions",
-                "filePath": "/cart/queries/cartCreateDefault.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "/cart/queries/cartCreateDefault.ts",
-              "description": "",
-              "name": "CartCreateFunction",
-              "value": "CartCreateFunction"
-            },
-            "value": "export function cartCreateDefault(\n  options: CartQueryOptions,\n): CartCreateFunction {\n  return async (input, optionalParams) => {\n    const {cartId, ...restOfOptionalParams} = optionalParams || {};\n    const {cartCreate, errors} = await options.storefront.mutate<{\n      cartCreate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_CREATE_MUTATION(options.cartFragment), {\n      variables: {\n        input,\n        ...restOfOptionalParams,\n      },\n    });\n    return formatAPIResult(cartCreate, errors);\n  };\n}"
-          },
-          "CartQueryOptions": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "storefront",
-                "value": "Storefront",
-                "description": "The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient)."
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getCartId",
-                "value": "() => string",
-                "description": "A function that returns the cart ID."
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cartFragment",
-                "value": "string",
-                "description": "The cart fragment to override the one used in this query.",
-                "isOptional": true
-              }
-            ]
-          },
-          "Storefront": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "Storefront",
-            "value": "{\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontQueries,\n      RawGqlString,\n      StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, 'cache'>,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontMutations,\n      RawGqlString,\n      StorefrontCommonExtraParams,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  cache?: Cache;\n  CacheNone: typeof CacheNone;\n  CacheLong: typeof CacheLong;\n  CacheShort: typeof CacheShort;\n  CacheCustom: typeof CacheCustom;\n  generateCacheControlHeader: typeof generateCacheControlHeader;\n  getPublicTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  getPrivateTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  getShopifyDomain: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  getApiUrl: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  i18n: TI18n;\n}",
-            "description": "Interface to interact with the Storefront API.",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "query",
-                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> & StorefrontError>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mutate",
-                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> & StorefrontError>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cache",
-                "value": "Cache",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheNone",
-                "value": "() => NoStoreStrategy",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheLong",
-                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheShort",
-                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheCustom",
-                "value": "(overrideOptions: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "generateCacheControlHeader",
-                "value": "(cacheOptions: AllCacheOptions) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getPublicTokenHeaders",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getPrivateTokenHeaders",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getShopifyDomain",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getApiUrl",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "i18n",
-                "value": "TI18n",
-                "description": ""
-              }
-            ]
-          },
-          "StorefrontQueries": {
-            "filePath": "/storefront.ts",
-            "name": "StorefrontQueries",
-            "description": "Maps all the queries found in the project to variables and return types.",
-            "members": [],
-            "value": "export interface StorefrontQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
-          },
-          "AutoAddedVariableNames": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AutoAddedVariableNames",
-            "value": "'country' | 'language'",
-            "description": ""
-          },
-          "StorefrontCommonExtraParams": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontCommonExtraParams",
-            "value": "{\n  headers?: HeadersInit;\n  storefrontApiVersion?: string;\n  displayName?: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "headers",
-                "value": "HeadersInit",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "storefrontApiVersion",
-                "value": "string",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "displayName",
-                "value": "string",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontQueryOptions": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontQueryOptions",
-            "value": "StorefrontCommonExtraParams & {\n  query: string;\n  mutation?: never;\n  cache?: CachingStrategy;\n}",
-            "description": ""
-          },
-          "CachingStrategy": {
-            "filePath": "/cache/strategies.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CachingStrategy",
-            "value": "AllCacheOptions",
-            "description": "Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the pre-defined caching strategies: CacheNone, CacheShort, CacheLong.",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "maxAge",
-                "value": "number",
-                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleWhileRevalidate",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sMaxAge",
-                "value": "number",
-                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleIfError",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontError": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontError",
-            "value": "{\n  errors?: StorefrontApiErrors;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "errors",
-                "value": "StorefrontApiErrors",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontApiErrors": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontApiErrors",
-            "value": "JsonGraphQLError[] | undefined",
-            "description": ""
-          },
-          "StorefrontMutations": {
-            "filePath": "/storefront.ts",
-            "name": "StorefrontMutations",
-            "description": "Maps all the mutations found in the project to variables and return types.",
-            "members": [],
-            "value": "export interface StorefrontMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
-          },
-          "NoStoreStrategy": {
-            "filePath": "/cache/strategies.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "NoStoreStrategy",
-            "value": "{\n  mode: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": ""
-              }
-            ]
-          },
-          "AllCacheOptions": {
-            "filePath": "/cache/strategies.ts",
-            "name": "AllCacheOptions",
-            "description": "Override options for a cache strategy.",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "maxAge",
-                "value": "number",
-                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleWhileRevalidate",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sMaxAge",
-                "value": "number",
-                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleIfError",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
-          },
-          "CartCreateFunction": {
-            "filePath": "/cart/queries/cartCreateDefault.ts",
-            "name": "CartCreateFunction",
-            "description": "",
-            "params": [
-              {
-                "name": "input",
-                "description": "",
-                "value": "CartInput",
-                "filePath": "/cart/queries/cartCreateDefault.ts"
-              },
-              {
-                "name": "optionalParams",
-                "description": "",
-                "value": "CartOptionalInput",
-                "isOptional": true,
-                "filePath": "/cart/queries/cartCreateDefault.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "/cart/queries/cartCreateDefault.ts",
-              "description": "",
-              "name": "Promise<CartQueryDataReturn>",
-              "value": "Promise<CartQueryDataReturn>"
-            },
-            "value": "export type CartCreateFunction = (\n  input: CartInput,\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
-          },
-          "CartInput": {
-            "description": "",
-            "name": "CartInput",
-            "value": "CartInput",
-            "members": [],
-            "override": "[CartInput](/docs/api/storefront/2024-04/input-objects/CartInput) - Storefront API type"
-          },
-          "CartOptionalInput": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartOptionalInput",
-            "value": "{\n  /**\n   * The cart id.\n   * @default cart.getCartId();\n   */\n  cartId?: Scalars['ID']['input'];\n  /**\n   * The country code.\n   * @default storefront.i18n.country\n   */\n  country?: CountryCode;\n  /**\n   * The language code.\n   * @default storefront.i18n.language\n   */\n  language?: LanguageCode;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cartId",
-                "value": "string",
-                "description": "The cart id.",
-                "isOptional": true,
-                "defaultValue": "cart.getCartId();"
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "country",
-                "value": "CountryCode",
-                "description": "The country code.",
-                "isOptional": true,
-                "defaultValue": "storefront.i18n.country"
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "language",
-                "value": "LanguageCode",
-                "description": "The language code.",
-                "isOptional": true,
-                "defaultValue": "storefront.i18n.language"
-              }
-            ]
-          },
-          "CartQueryDataReturn": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryDataReturn",
-            "value": "CartQueryData & {\n  errors?: StorefrontApiErrors;\n}",
-            "description": ""
-          },
-          "CartQueryData": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryData",
-            "value": "{\n  cart: Cart;\n  userErrors?:\n    | CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[];\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cart",
-                "value": "Cart",
-                "description": ""
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "userErrors",
-                "value": "CartUserError[] | MetafieldsSetUserError[] | MetafieldDeleteUserError[]",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "Cart": {
-            "description": "",
-            "name": "Cart",
-            "value": "Cart",
-            "members": [],
-            "override": "[Cart](/docs/api/storefront/2024-04/objects/Cart) - Storefront API type"
-          },
-          "CartUserError": {
-            "description": "",
-            "name": "CartUserError",
-            "value": "CartUserError",
-            "members": [],
-            "override": "[CartUserError](/docs/api/storefront/2024-04/objects/CartUserError) - Storefront API type"
-          },
-          "MetafieldsSetUserError": {
-            "description": "",
-            "name": "MetafieldsSetUserError",
-            "value": "MetafieldsSetUserError",
-            "members": [],
-            "override": "[MetafieldsSetUserError](/docs/api/storefront/2024-04/objects/MetafieldsSetUserError) - Storefront API type"
-          },
-          "MetafieldDeleteUserError": {
-            "description": "",
-            "name": "MetafieldDeleteUserError",
-            "value": "MetafieldDeleteUserError",
-            "members": [],
-            "override": "[MetafieldDeleteUserError](/docs/api/storefront/2024-04/objects/MetafieldDeleteUserError) - Storefront API type"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "name": "cartDiscountCodesUpdateDefault",
-    "category": "utilities",
-    "isVisualComponent": false,
-    "related": [],
-    "description": "Creates a function that accepts an array of strings and adds the discount codes to a cart",
-    "type": "utility",
-    "defaultExample": {
-      "description": "This is the default example",
-      "codeblock": {
-        "tabs": [
-          {
-            "title": "JavaScript",
-            "code": "import {cartDiscountCodesUpdateDefault} from '@shopify/hydrogen';\n\nconst cartDiscount = cartDiscountCodesUpdateDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartDiscount(['FREE_SHIPPING']);\n",
-            "language": "js"
-          }
-        ],
-        "title": "example"
-      }
-    },
-    "definitions": [
-      {
-        "title": "cartDiscountCodesUpdateDefault",
-        "description": "",
-        "type": "CartDiscountCodesUpdateDefaultGeneratedType",
-        "typeDefinitions": {
-          "CartDiscountCodesUpdateDefaultGeneratedType": {
-            "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts",
-            "name": "CartDiscountCodesUpdateDefaultGeneratedType",
-            "description": "",
-            "params": [
-              {
-                "name": "options",
-                "description": "",
-                "value": "CartQueryOptions",
-                "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts",
-              "description": "",
-              "name": "CartDiscountCodesUpdateFunction",
-              "value": "CartDiscountCodesUpdateFunction"
-            },
-            "value": "export function cartDiscountCodesUpdateDefault(\n  options: CartQueryOptions,\n): CartDiscountCodesUpdateFunction {\n  return async (discountCodes, optionalParams) => {\n    // Ensure the discount codes are unique\n    const uniqueCodes = discountCodes.filter((value, index, array) => {\n      return array.indexOf(value) === index;\n    });\n\n    const {cartDiscountCodesUpdate, errors} = await options.storefront.mutate<{\n      cartDiscountCodesUpdate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_DISCOUNT_CODE_UPDATE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        discountCodes: uniqueCodes,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartDiscountCodesUpdate, errors);\n  };\n}"
-          },
-          "CartQueryOptions": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "storefront",
-                "value": "Storefront",
-                "description": "The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient)."
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getCartId",
-                "value": "() => string",
-                "description": "A function that returns the cart ID."
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cartFragment",
-                "value": "string",
-                "description": "The cart fragment to override the one used in this query.",
-                "isOptional": true
-              }
-            ]
-          },
-          "Storefront": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "Storefront",
-            "value": "{\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontQueries,\n      RawGqlString,\n      StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, 'cache'>,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontMutations,\n      RawGqlString,\n      StorefrontCommonExtraParams,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  cache?: Cache;\n  CacheNone: typeof CacheNone;\n  CacheLong: typeof CacheLong;\n  CacheShort: typeof CacheShort;\n  CacheCustom: typeof CacheCustom;\n  generateCacheControlHeader: typeof generateCacheControlHeader;\n  getPublicTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  getPrivateTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  getShopifyDomain: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  getApiUrl: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  i18n: TI18n;\n}",
-            "description": "Interface to interact with the Storefront API.",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "query",
-                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> & StorefrontError>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mutate",
-                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> & StorefrontError>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cache",
-                "value": "Cache",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheNone",
-                "value": "() => NoStoreStrategy",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheLong",
-                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheShort",
-                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "CacheCustom",
-                "value": "(overrideOptions: AllCacheOptions) => AllCacheOptions",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "generateCacheControlHeader",
-                "value": "(cacheOptions: AllCacheOptions) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getPublicTokenHeaders",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getPrivateTokenHeaders",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getShopifyDomain",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getApiUrl",
-                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
-                "description": ""
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "i18n",
-                "value": "TI18n",
-                "description": ""
-              }
-            ]
-          },
-          "StorefrontQueries": {
-            "filePath": "/storefront.ts",
-            "name": "StorefrontQueries",
-            "description": "Maps all the queries found in the project to variables and return types.",
-            "members": [],
-            "value": "export interface StorefrontQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
-          },
-          "AutoAddedVariableNames": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AutoAddedVariableNames",
-            "value": "'country' | 'language'",
-            "description": ""
-          },
-          "StorefrontCommonExtraParams": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontCommonExtraParams",
-            "value": "{\n  headers?: HeadersInit;\n  storefrontApiVersion?: string;\n  displayName?: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "headers",
-                "value": "HeadersInit",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "storefrontApiVersion",
-                "value": "string",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "displayName",
-                "value": "string",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontQueryOptions": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontQueryOptions",
-            "value": "StorefrontCommonExtraParams & {\n  query: string;\n  mutation?: never;\n  cache?: CachingStrategy;\n}",
-            "description": ""
-          },
-          "CachingStrategy": {
-            "filePath": "/cache/strategies.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CachingStrategy",
-            "value": "AllCacheOptions",
-            "description": "Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the pre-defined caching strategies: CacheNone, CacheShort, CacheLong.",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "maxAge",
-                "value": "number",
-                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleWhileRevalidate",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sMaxAge",
-                "value": "number",
-                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleIfError",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontError": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontError",
-            "value": "{\n  errors?: StorefrontApiErrors;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/storefront.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "errors",
-                "value": "StorefrontApiErrors",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "StorefrontApiErrors": {
-            "filePath": "/storefront.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StorefrontApiErrors",
-            "value": "JsonGraphQLError[] | undefined",
-            "description": ""
-          },
-          "StorefrontMutations": {
-            "filePath": "/storefront.ts",
-            "name": "StorefrontMutations",
-            "description": "Maps all the mutations found in the project to variables and return types.",
-            "members": [],
-            "value": "export interface StorefrontMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
-          },
-          "NoStoreStrategy": {
-            "filePath": "/cache/strategies.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "NoStoreStrategy",
-            "value": "{\n  mode: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": ""
-              }
-            ]
-          },
-          "AllCacheOptions": {
-            "filePath": "/cache/strategies.ts",
-            "name": "AllCacheOptions",
-            "description": "Override options for a cache strategy.",
-            "members": [
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "mode",
-                "value": "string",
-                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "maxAge",
-                "value": "number",
-                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleWhileRevalidate",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sMaxAge",
-                "value": "number",
-                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
-                "isOptional": true
-              },
-              {
-                "filePath": "/cache/strategies.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "staleIfError",
-                "value": "number",
-                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
-          },
-          "CartDiscountCodesUpdateFunction": {
-            "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts",
-            "name": "CartDiscountCodesUpdateFunction",
-            "description": "",
-            "params": [
-              {
-                "name": "discountCodes",
-                "description": "",
-                "value": "string[]",
-                "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts"
-              },
-              {
-                "name": "optionalParams",
-                "description": "",
-                "value": "CartOptionalInput",
-                "isOptional": true,
-                "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts",
-              "description": "",
-              "name": "Promise<CartQueryDataReturn>",
-              "value": "Promise<CartQueryDataReturn>"
-            },
-            "value": "export type CartDiscountCodesUpdateFunction = (\n  discountCodes: string[],\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
-          },
-          "CartOptionalInput": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartOptionalInput",
-            "value": "{\n  /**\n   * The cart id.\n   * @default cart.getCartId();\n   */\n  cartId?: Scalars['ID']['input'];\n  /**\n   * The country code.\n   * @default storefront.i18n.country\n   */\n  country?: CountryCode;\n  /**\n   * The language code.\n   * @default storefront.i18n.language\n   */\n  language?: LanguageCode;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cartId",
-                "value": "string",
-                "description": "The cart id.",
-                "isOptional": true,
-                "defaultValue": "cart.getCartId();"
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "country",
-                "value": "CountryCode",
-                "description": "The country code.",
-                "isOptional": true,
-                "defaultValue": "storefront.i18n.country"
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "language",
-                "value": "LanguageCode",
-                "description": "The language code.",
-                "isOptional": true,
-                "defaultValue": "storefront.i18n.language"
-              }
-            ]
-          },
-          "CartQueryDataReturn": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryDataReturn",
-            "value": "CartQueryData & {\n  errors?: StorefrontApiErrors;\n}",
-            "description": ""
-          },
-          "CartQueryData": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryData",
-            "value": "{\n  cart: Cart;\n  userErrors?:\n    | CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[];\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cart",
-                "value": "Cart",
-                "description": ""
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "userErrors",
-                "value": "CartUserError[] | MetafieldsSetUserError[] | MetafieldDeleteUserError[]",
-                "description": "",
-                "isOptional": true
-              }
-            ]
-          },
-          "Cart": {
-            "description": "",
-            "name": "Cart",
-            "value": "Cart",
-            "members": [],
-            "override": "[Cart](/docs/api/storefront/2024-04/objects/Cart) - Storefront API type"
-          },
-          "CartUserError": {
-            "description": "",
-            "name": "CartUserError",
-            "value": "CartUserError",
-            "members": [],
-            "override": "[CartUserError](/docs/api/storefront/2024-04/objects/CartUserError) - Storefront API type"
-          },
-          "MetafieldsSetUserError": {
-            "description": "",
-            "name": "MetafieldsSetUserError",
-            "value": "MetafieldsSetUserError",
-            "members": [],
-            "override": "[MetafieldsSetUserError](/docs/api/storefront/2024-04/objects/MetafieldsSetUserError) - Storefront API type"
-          },
-          "MetafieldDeleteUserError": {
-            "description": "",
-            "name": "MetafieldDeleteUserError",
-            "value": "MetafieldDeleteUserError",
-            "members": [],
-            "override": "[MetafieldDeleteUserError](/docs/api/storefront/2024-04/objects/MetafieldDeleteUserError) - Storefront API type"
-          }
-        }
-      }
-    ]
-  },
-  {
-    "name": "cartGetDefault",
-    "category": "utilities",
-    "isVisualComponent": false,
-    "related": [],
-    "description": "Creates a function that returns a cart",
-    "type": "utility",
-    "defaultExample": {
-      "description": "This is the default example",
-      "codeblock": {
-        "tabs": [
-          {
-            "title": "JavaScript",
-            "code": "import {cartGetDefault} from '@shopify/hydrogen';\n\nconst cartGet = cartGetDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartGet();\n",
-            "language": "js"
-          }
-        ],
-        "title": "example"
-      }
-    },
-    "definitions": [
-      {
-        "title": "cartGetDefault",
-        "description": "",
-        "type": "CartGetDefaultGeneratedType",
-        "typeDefinitions": {
-          "CartGetDefaultGeneratedType": {
-            "filePath": "/cart/queries/cartGetDefault.ts",
-            "name": "CartGetDefaultGeneratedType",
-            "description": "",
-            "params": [
-              {
-                "name": "input1",
-                "description": "",
-                "value": "CartGetOptions",
-                "filePath": "/cart/queries/cartGetDefault.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "/cart/queries/cartGetDefault.ts",
-              "description": "",
-              "name": "CartGetFunction",
-              "value": "CartGetFunction"
-            },
-            "value": "export function cartGetDefault({\n  storefront,\n  customerAccount,\n  getCartId,\n  cartFragment,\n}: CartGetOptions): CartGetFunction {\n  return async (cartInput?: CartGetProps) => {\n    const cartId = getCartId();\n\n    if (!cartId) return null;\n\n    const [isCustomerLoggedIn, {cart, errors}] = await Promise.all([\n      customerAccount ? customerAccount.isLoggedIn() : false,\n      storefront.query<{\n        cart: Cart;\n        errors: StorefrontApiErrors;\n      }>(CART_QUERY(cartFragment), {\n        variables: {\n          cartId,\n          ...cartInput,\n        },\n        cache: storefront.CacheNone(),\n      }),\n    ]);\n\n    return formatAPIResult(\n      addCustomerLoggedInParam(isCustomerLoggedIn, cart),\n      errors,\n    );\n  };\n}"
-          },
-          "CartGetOptions": {
-            "filePath": "/cart/queries/cartGetDefault.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartGetOptions",
-            "value": "CartQueryOptions & {\n  /**\n   * The customer account client instance created by [`createCustomerAccountClient`](docs/api/hydrogen/latest/utilities/createcustomeraccountclient).\n   */\n  customerAccount?: CustomerAccount;\n}",
-            "description": ""
-          },
-          "CartQueryOptions": {
-            "filePath": "/cart/queries/cart-types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
-            "description": "",
-            "members": [
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "storefront",
-                "value": "Storefront",
-                "description": "The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient)."
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "getCartId",
-                "value": "() => string",
-                "description": "A function that returns the cart ID."
-              },
-              {
-                "filePath": "/cart/queries/cart-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cartFragment",
-                "value": "string",
-                "description": "The cart fragment to override the one used in this query.",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
                 "isOptional": true
               }
             ]
@@ -7190,7 +5275,7 @@
             "filePath": "/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n}",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -7255,6 +5340,2656 @@
                 "name": "mutate",
                 "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
                 "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "CartAttributesUpdateFunction": {
+            "filePath": "/cart/queries/cartAttributesUpdateDefault.ts",
+            "name": "CartAttributesUpdateFunction",
+            "description": "",
+            "params": [
+              {
+                "name": "attributes",
+                "description": "",
+                "value": "AttributeInput[]",
+                "filePath": "/cart/queries/cartAttributesUpdateDefault.ts"
+              },
+              {
+                "name": "optionalParams",
+                "description": "",
+                "value": "CartOptionalInput",
+                "isOptional": true,
+                "filePath": "/cart/queries/cartAttributesUpdateDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/cart/queries/cartAttributesUpdateDefault.ts",
+              "description": "",
+              "name": "Promise<CartQueryDataReturn>",
+              "value": "Promise<CartQueryDataReturn>"
+            },
+            "value": "export type CartAttributesUpdateFunction = (\n  attributes: AttributeInput[],\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+          },
+          "AttributeInput": {
+            "description": "",
+            "name": "AttributeInput",
+            "value": "AttributeInput",
+            "members": [],
+            "override": "[AttributeInput](/docs/api/storefront/2024-04/input-objects/AttributeInput) - Storefront API type"
+          },
+          "CartOptionalInput": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartOptionalInput",
+            "value": "{\n  /**\n   * The cart id.\n   * @default cart.getCartId();\n   */\n  cartId?: Scalars['ID']['input'];\n  /**\n   * The country code.\n   * @default storefront.i18n.country\n   */\n  country?: CountryCode;\n  /**\n   * The language code.\n   * @default storefront.i18n.language\n   */\n  language?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartId",
+                "value": "string",
+                "description": "The cart id.",
+                "isOptional": true,
+                "defaultValue": "cart.getCartId();"
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "country",
+                "value": "CountryCode",
+                "description": "The country code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.country"
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "language",
+                "value": "LanguageCode",
+                "description": "The language code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.language"
+              }
+            ]
+          },
+          "CartQueryDataReturn": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryDataReturn",
+            "value": "CartQueryData & {\n  errors?: StorefrontApiErrors;\n}",
+            "description": ""
+          },
+          "CartQueryData": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryData",
+            "value": "{\n  cart: Cart;\n  userErrors?:\n    | CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[];\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cart",
+                "value": "Cart",
+                "description": ""
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "userErrors",
+                "value": "CartUserError[] | MetafieldsSetUserError[] | MetafieldDeleteUserError[]",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "Cart": {
+            "description": "",
+            "name": "Cart",
+            "value": "Cart",
+            "members": [],
+            "override": "[Cart](/docs/api/storefront/2024-04/objects/Cart) - Storefront API type"
+          },
+          "CartUserError": {
+            "description": "",
+            "name": "CartUserError",
+            "value": "CartUserError",
+            "members": [],
+            "override": "[CartUserError](/docs/api/storefront/2024-04/objects/CartUserError) - Storefront API type"
+          },
+          "MetafieldsSetUserError": {
+            "description": "",
+            "name": "MetafieldsSetUserError",
+            "value": "MetafieldsSetUserError",
+            "members": [],
+            "override": "[MetafieldsSetUserError](/docs/api/storefront/2024-04/objects/MetafieldsSetUserError) - Storefront API type"
+          },
+          "MetafieldDeleteUserError": {
+            "description": "",
+            "name": "MetafieldDeleteUserError",
+            "value": "MetafieldDeleteUserError",
+            "members": [],
+            "override": "[MetafieldDeleteUserError](/docs/api/storefront/2024-04/objects/MetafieldDeleteUserError) - Storefront API type"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "name": "cartBuyerIdentityUpdateDefault",
+    "category": "utilities",
+    "subCategory": "cart",
+    "isVisualComponent": false,
+    "related": [],
+    "description": "Creates a function that accepts an object of [CartBuyerIdentityInput](/docs/api/storefront/2024-04/input-objects/CartBuyerIdentityInput) and updates the buyer identity of a cart",
+    "type": "utility",
+    "defaultExample": {
+      "description": "This is the default example",
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "JavaScript",
+            "code": "import {cartBuyerIdentityUpdateDefault} from '@shopify/hydrogen';\n\nconst cartBuyerIdentity = cartBuyerIdentityUpdateDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartBuyerIdentity({\n  customerAccessToken: '123',\n});\n",
+            "language": "js"
+          }
+        ],
+        "title": "example"
+      }
+    },
+    "definitions": [
+      {
+        "title": "cartBuyerIdentityUpdateDefault",
+        "description": "",
+        "type": "CartBuyerIdentityUpdateDefaultGeneratedType",
+        "typeDefinitions": {
+          "CartBuyerIdentityUpdateDefaultGeneratedType": {
+            "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts",
+            "name": "CartBuyerIdentityUpdateDefaultGeneratedType",
+            "description": "",
+            "params": [
+              {
+                "name": "options",
+                "description": "",
+                "value": "CartQueryOptions",
+                "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts",
+              "description": "",
+              "name": "CartBuyerIdentityUpdateFunction",
+              "value": "CartBuyerIdentityUpdateFunction"
+            },
+            "value": "export function cartBuyerIdentityUpdateDefault(\n  options: CartQueryOptions,\n): CartBuyerIdentityUpdateFunction {\n  return async (buyerIdentity, optionalParams) => {\n    if (buyerIdentity.companyLocationId && options.customerAccount) {\n      options.customerAccount.UNSTABLE_setBuyer({\n        companyLocationId: buyerIdentity.companyLocationId,\n      });\n    }\n\n    const buyer = options.customerAccount\n      ? await options.customerAccount.UNSTABLE_getBuyer()\n      : undefined;\n\n    const {cartBuyerIdentityUpdate, errors} = await options.storefront.mutate<{\n      cartBuyerIdentityUpdate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_BUYER_IDENTITY_UPDATE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        buyerIdentity: {\n          ...buyer,\n          ...buyerIdentity,\n        },\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartBuyerIdentityUpdate, errors);\n  };\n}"
+          },
+          "CartQueryOptions": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryOptions",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefront",
+                "value": "Storefront",
+                "description": "The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient)."
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getCartId",
+                "value": "() => string",
+                "description": "A function that returns the cart ID."
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartFragment",
+                "value": "string",
+                "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
+                "isOptional": true
+              }
+            ]
+          },
+          "Storefront": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "Storefront",
+            "value": "{\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontQueries,\n      RawGqlString,\n      StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, 'cache'>,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontMutations,\n      RawGqlString,\n      StorefrontCommonExtraParams,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  cache?: Cache;\n  CacheNone: typeof CacheNone;\n  CacheLong: typeof CacheLong;\n  CacheShort: typeof CacheShort;\n  CacheCustom: typeof CacheCustom;\n  generateCacheControlHeader: typeof generateCacheControlHeader;\n  getPublicTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  getPrivateTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  getShopifyDomain: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  getApiUrl: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  i18n: TI18n;\n}",
+            "description": "Interface to interact with the Storefront API.",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cache",
+                "value": "Cache",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheNone",
+                "value": "() => NoStoreStrategy",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheLong",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheShort",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheCustom",
+                "value": "(overrideOptions: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "generateCacheControlHeader",
+                "value": "(cacheOptions: AllCacheOptions) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPublicTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPrivateTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getShopifyDomain",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "TI18n",
+                "description": ""
+              }
+            ]
+          },
+          "StorefrontQueries": {
+            "filePath": "/storefront.ts",
+            "name": "StorefrontQueries",
+            "description": "Maps all the queries found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "AutoAddedVariableNames": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AutoAddedVariableNames",
+            "value": "'country' | 'language'",
+            "description": ""
+          },
+          "StorefrontCommonExtraParams": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontCommonExtraParams",
+            "value": "{\n  headers?: HeadersInit;\n  storefrontApiVersion?: string;\n  displayName?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "HeadersInit",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefrontApiVersion",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "displayName",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontQueryOptions": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontQueryOptions",
+            "value": "StorefrontCommonExtraParams & {\n  query: string;\n  mutation?: never;\n  cache?: CachingStrategy;\n}",
+            "description": ""
+          },
+          "CachingStrategy": {
+            "filePath": "/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CachingStrategy",
+            "value": "AllCacheOptions",
+            "description": "Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the pre-defined caching strategies: CacheNone, CacheShort, CacheLong.",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontError": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontError",
+            "value": "{\n  errors?: StorefrontApiErrors;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "errors",
+                "value": "StorefrontApiErrors",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontApiErrors": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontApiErrors",
+            "value": "JsonGraphQLError[] | undefined",
+            "description": ""
+          },
+          "StorefrontMutations": {
+            "filePath": "/storefront.ts",
+            "name": "StorefrontMutations",
+            "description": "Maps all the mutations found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "NoStoreStrategy": {
+            "filePath": "/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "NoStoreStrategy",
+            "value": "{\n  mode: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": ""
+              }
+            ]
+          },
+          "AllCacheOptions": {
+            "filePath": "/cache/strategies.ts",
+            "name": "AllCacheOptions",
+            "description": "Override options for a cache strategy.",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "CartBuyerIdentityUpdateFunction": {
+            "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts",
+            "name": "CartBuyerIdentityUpdateFunction",
+            "description": "",
+            "params": [
+              {
+                "name": "buyerIdentity",
+                "description": "",
+                "value": "CartBuyerIdentityInput",
+                "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts"
+              },
+              {
+                "name": "optionalParams",
+                "description": "",
+                "value": "CartOptionalInput",
+                "isOptional": true,
+                "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/cart/queries/cartBuyerIdentityUpdateDefault.ts",
+              "description": "",
+              "name": "Promise<CartQueryDataReturn>",
+              "value": "Promise<CartQueryDataReturn>"
+            },
+            "value": "export type CartBuyerIdentityUpdateFunction = (\n  buyerIdentity: CartBuyerIdentityInput,\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+          },
+          "CartBuyerIdentityInput": {
+            "description": "",
+            "name": "CartBuyerIdentityInput",
+            "value": "CartBuyerIdentityInput",
+            "members": [],
+            "override": "[CartBuyerIdentityInput](/docs/api/storefront/2024-04/input-objects/CartBuyerIdentityInput) - Storefront API type"
+          },
+          "CartOptionalInput": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartOptionalInput",
+            "value": "{\n  /**\n   * The cart id.\n   * @default cart.getCartId();\n   */\n  cartId?: Scalars['ID']['input'];\n  /**\n   * The country code.\n   * @default storefront.i18n.country\n   */\n  country?: CountryCode;\n  /**\n   * The language code.\n   * @default storefront.i18n.language\n   */\n  language?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartId",
+                "value": "string",
+                "description": "The cart id.",
+                "isOptional": true,
+                "defaultValue": "cart.getCartId();"
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "country",
+                "value": "CountryCode",
+                "description": "The country code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.country"
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "language",
+                "value": "LanguageCode",
+                "description": "The language code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.language"
+              }
+            ]
+          },
+          "CartQueryDataReturn": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryDataReturn",
+            "value": "CartQueryData & {\n  errors?: StorefrontApiErrors;\n}",
+            "description": ""
+          },
+          "CartQueryData": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryData",
+            "value": "{\n  cart: Cart;\n  userErrors?:\n    | CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[];\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cart",
+                "value": "Cart",
+                "description": ""
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "userErrors",
+                "value": "CartUserError[] | MetafieldsSetUserError[] | MetafieldDeleteUserError[]",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "Cart": {
+            "description": "",
+            "name": "Cart",
+            "value": "Cart",
+            "members": [],
+            "override": "[Cart](/docs/api/storefront/2024-04/objects/Cart) - Storefront API type"
+          },
+          "CartUserError": {
+            "description": "",
+            "name": "CartUserError",
+            "value": "CartUserError",
+            "members": [],
+            "override": "[CartUserError](/docs/api/storefront/2024-04/objects/CartUserError) - Storefront API type"
+          },
+          "MetafieldsSetUserError": {
+            "description": "",
+            "name": "MetafieldsSetUserError",
+            "value": "MetafieldsSetUserError",
+            "members": [],
+            "override": "[MetafieldsSetUserError](/docs/api/storefront/2024-04/objects/MetafieldsSetUserError) - Storefront API type"
+          },
+          "MetafieldDeleteUserError": {
+            "description": "",
+            "name": "MetafieldDeleteUserError",
+            "value": "MetafieldDeleteUserError",
+            "members": [],
+            "override": "[MetafieldDeleteUserError](/docs/api/storefront/2024-04/objects/MetafieldDeleteUserError) - Storefront API type"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "name": "cartCreateDefault",
+    "category": "utilities",
+    "subCategory": "cart",
+    "isVisualComponent": false,
+    "related": [],
+    "description": "Creates a function that accepts an object of [CartInput](/docs/api/storefront/2024-04/input-objects/CartInput) and returns a new cart",
+    "type": "utility",
+    "defaultExample": {
+      "description": "This is the default example",
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "JavaScript",
+            "code": "import {cartCreateDefault} from '@shopify/hydrogen';\n\nconst cartCreate = cartCreateDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartCreate({\n  lines: [\n    {\n      merchandiseId: 'gid://shopify/ProductVariant/123456789',\n      quantity: 1,\n    },\n  ],\n});\n",
+            "language": "js"
+          }
+        ],
+        "title": "example"
+      }
+    },
+    "definitions": [
+      {
+        "title": "cartCreateDefault",
+        "description": "",
+        "type": "CartCreateDefaultGeneratedType",
+        "typeDefinitions": {
+          "CartCreateDefaultGeneratedType": {
+            "filePath": "/cart/queries/cartCreateDefault.ts",
+            "name": "CartCreateDefaultGeneratedType",
+            "description": "",
+            "params": [
+              {
+                "name": "options",
+                "description": "",
+                "value": "CartQueryOptions",
+                "filePath": "/cart/queries/cartCreateDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/cart/queries/cartCreateDefault.ts",
+              "description": "",
+              "name": "CartCreateFunction",
+              "value": "CartCreateFunction"
+            },
+            "value": "export function cartCreateDefault(\n  options: CartQueryOptions,\n): CartCreateFunction {\n  return async (input, optionalParams) => {\n    const buyer = options.customerAccount\n      ? await options.customerAccount.UNSTABLE_getBuyer()\n      : undefined;\n    const {cartId, ...restOfOptionalParams} = optionalParams || {};\n    const {buyerIdentity, ...restOfInput} = input;\n    const {cartCreate, errors} = await options.storefront.mutate<{\n      cartCreate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_CREATE_MUTATION(options.cartFragment), {\n      variables: {\n        input: {\n          ...restOfInput,\n          buyerIdentity: {\n            ...buyer,\n            ...buyerIdentity,\n          },\n        },\n        ...restOfOptionalParams,\n      },\n    });\n    return formatAPIResult(cartCreate, errors);\n  };\n}"
+          },
+          "CartQueryOptions": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryOptions",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefront",
+                "value": "Storefront",
+                "description": "The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient)."
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getCartId",
+                "value": "() => string",
+                "description": "A function that returns the cart ID."
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartFragment",
+                "value": "string",
+                "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
+                "isOptional": true
+              }
+            ]
+          },
+          "Storefront": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "Storefront",
+            "value": "{\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontQueries,\n      RawGqlString,\n      StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, 'cache'>,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontMutations,\n      RawGqlString,\n      StorefrontCommonExtraParams,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  cache?: Cache;\n  CacheNone: typeof CacheNone;\n  CacheLong: typeof CacheLong;\n  CacheShort: typeof CacheShort;\n  CacheCustom: typeof CacheCustom;\n  generateCacheControlHeader: typeof generateCacheControlHeader;\n  getPublicTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  getPrivateTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  getShopifyDomain: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  getApiUrl: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  i18n: TI18n;\n}",
+            "description": "Interface to interact with the Storefront API.",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cache",
+                "value": "Cache",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheNone",
+                "value": "() => NoStoreStrategy",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheLong",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheShort",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheCustom",
+                "value": "(overrideOptions: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "generateCacheControlHeader",
+                "value": "(cacheOptions: AllCacheOptions) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPublicTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPrivateTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getShopifyDomain",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "TI18n",
+                "description": ""
+              }
+            ]
+          },
+          "StorefrontQueries": {
+            "filePath": "/storefront.ts",
+            "name": "StorefrontQueries",
+            "description": "Maps all the queries found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "AutoAddedVariableNames": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AutoAddedVariableNames",
+            "value": "'country' | 'language'",
+            "description": ""
+          },
+          "StorefrontCommonExtraParams": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontCommonExtraParams",
+            "value": "{\n  headers?: HeadersInit;\n  storefrontApiVersion?: string;\n  displayName?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "HeadersInit",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefrontApiVersion",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "displayName",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontQueryOptions": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontQueryOptions",
+            "value": "StorefrontCommonExtraParams & {\n  query: string;\n  mutation?: never;\n  cache?: CachingStrategy;\n}",
+            "description": ""
+          },
+          "CachingStrategy": {
+            "filePath": "/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CachingStrategy",
+            "value": "AllCacheOptions",
+            "description": "Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the pre-defined caching strategies: CacheNone, CacheShort, CacheLong.",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontError": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontError",
+            "value": "{\n  errors?: StorefrontApiErrors;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "errors",
+                "value": "StorefrontApiErrors",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontApiErrors": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontApiErrors",
+            "value": "JsonGraphQLError[] | undefined",
+            "description": ""
+          },
+          "StorefrontMutations": {
+            "filePath": "/storefront.ts",
+            "name": "StorefrontMutations",
+            "description": "Maps all the mutations found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "NoStoreStrategy": {
+            "filePath": "/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "NoStoreStrategy",
+            "value": "{\n  mode: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": ""
+              }
+            ]
+          },
+          "AllCacheOptions": {
+            "filePath": "/cache/strategies.ts",
+            "name": "AllCacheOptions",
+            "description": "Override options for a cache strategy.",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "CartCreateFunction": {
+            "filePath": "/cart/queries/cartCreateDefault.ts",
+            "name": "CartCreateFunction",
+            "description": "",
+            "params": [
+              {
+                "name": "input",
+                "description": "",
+                "value": "CartInput",
+                "filePath": "/cart/queries/cartCreateDefault.ts"
+              },
+              {
+                "name": "optionalParams",
+                "description": "",
+                "value": "CartOptionalInput",
+                "isOptional": true,
+                "filePath": "/cart/queries/cartCreateDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/cart/queries/cartCreateDefault.ts",
+              "description": "",
+              "name": "Promise<CartQueryDataReturn>",
+              "value": "Promise<CartQueryDataReturn>"
+            },
+            "value": "export type CartCreateFunction = (\n  input: CartInput,\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+          },
+          "CartInput": {
+            "description": "",
+            "name": "CartInput",
+            "value": "CartInput",
+            "members": [],
+            "override": "[CartInput](/docs/api/storefront/2024-04/input-objects/CartInput) - Storefront API type"
+          },
+          "CartOptionalInput": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartOptionalInput",
+            "value": "{\n  /**\n   * The cart id.\n   * @default cart.getCartId();\n   */\n  cartId?: Scalars['ID']['input'];\n  /**\n   * The country code.\n   * @default storefront.i18n.country\n   */\n  country?: CountryCode;\n  /**\n   * The language code.\n   * @default storefront.i18n.language\n   */\n  language?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartId",
+                "value": "string",
+                "description": "The cart id.",
+                "isOptional": true,
+                "defaultValue": "cart.getCartId();"
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "country",
+                "value": "CountryCode",
+                "description": "The country code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.country"
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "language",
+                "value": "LanguageCode",
+                "description": "The language code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.language"
+              }
+            ]
+          },
+          "CartQueryDataReturn": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryDataReturn",
+            "value": "CartQueryData & {\n  errors?: StorefrontApiErrors;\n}",
+            "description": ""
+          },
+          "CartQueryData": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryData",
+            "value": "{\n  cart: Cart;\n  userErrors?:\n    | CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[];\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cart",
+                "value": "Cart",
+                "description": ""
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "userErrors",
+                "value": "CartUserError[] | MetafieldsSetUserError[] | MetafieldDeleteUserError[]",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "Cart": {
+            "description": "",
+            "name": "Cart",
+            "value": "Cart",
+            "members": [],
+            "override": "[Cart](/docs/api/storefront/2024-04/objects/Cart) - Storefront API type"
+          },
+          "CartUserError": {
+            "description": "",
+            "name": "CartUserError",
+            "value": "CartUserError",
+            "members": [],
+            "override": "[CartUserError](/docs/api/storefront/2024-04/objects/CartUserError) - Storefront API type"
+          },
+          "MetafieldsSetUserError": {
+            "description": "",
+            "name": "MetafieldsSetUserError",
+            "value": "MetafieldsSetUserError",
+            "members": [],
+            "override": "[MetafieldsSetUserError](/docs/api/storefront/2024-04/objects/MetafieldsSetUserError) - Storefront API type"
+          },
+          "MetafieldDeleteUserError": {
+            "description": "",
+            "name": "MetafieldDeleteUserError",
+            "value": "MetafieldDeleteUserError",
+            "members": [],
+            "override": "[MetafieldDeleteUserError](/docs/api/storefront/2024-04/objects/MetafieldDeleteUserError) - Storefront API type"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "name": "cartDiscountCodesUpdateDefault",
+    "category": "utilities",
+    "subCategory": "cart",
+    "isVisualComponent": false,
+    "related": [],
+    "description": "Creates a function that accepts an array of strings and adds the discount codes to a cart",
+    "type": "utility",
+    "defaultExample": {
+      "description": "This is the default example",
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "JavaScript",
+            "code": "import {cartDiscountCodesUpdateDefault} from '@shopify/hydrogen';\n\nconst cartDiscount = cartDiscountCodesUpdateDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartDiscount(['FREE_SHIPPING']);\n",
+            "language": "js"
+          }
+        ],
+        "title": "example"
+      }
+    },
+    "definitions": [
+      {
+        "title": "cartDiscountCodesUpdateDefault",
+        "description": "",
+        "type": "CartDiscountCodesUpdateDefaultGeneratedType",
+        "typeDefinitions": {
+          "CartDiscountCodesUpdateDefaultGeneratedType": {
+            "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts",
+            "name": "CartDiscountCodesUpdateDefaultGeneratedType",
+            "description": "",
+            "params": [
+              {
+                "name": "options",
+                "description": "",
+                "value": "CartQueryOptions",
+                "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts",
+              "description": "",
+              "name": "CartDiscountCodesUpdateFunction",
+              "value": "CartDiscountCodesUpdateFunction"
+            },
+            "value": "export function cartDiscountCodesUpdateDefault(\n  options: CartQueryOptions,\n): CartDiscountCodesUpdateFunction {\n  return async (discountCodes, optionalParams) => {\n    // Ensure the discount codes are unique\n    const uniqueCodes = discountCodes.filter((value, index, array) => {\n      return array.indexOf(value) === index;\n    });\n\n    const {cartDiscountCodesUpdate, errors} = await options.storefront.mutate<{\n      cartDiscountCodesUpdate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_DISCOUNT_CODE_UPDATE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        discountCodes: uniqueCodes,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartDiscountCodesUpdate, errors);\n  };\n}"
+          },
+          "CartQueryOptions": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryOptions",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefront",
+                "value": "Storefront",
+                "description": "The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient)."
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getCartId",
+                "value": "() => string",
+                "description": "A function that returns the cart ID."
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartFragment",
+                "value": "string",
+                "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
+                "isOptional": true
+              }
+            ]
+          },
+          "Storefront": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "Storefront",
+            "value": "{\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontQueries,\n      RawGqlString,\n      StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, 'cache'>,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontMutations,\n      RawGqlString,\n      StorefrontCommonExtraParams,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  cache?: Cache;\n  CacheNone: typeof CacheNone;\n  CacheLong: typeof CacheLong;\n  CacheShort: typeof CacheShort;\n  CacheCustom: typeof CacheCustom;\n  generateCacheControlHeader: typeof generateCacheControlHeader;\n  getPublicTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  getPrivateTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  getShopifyDomain: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  getApiUrl: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  i18n: TI18n;\n}",
+            "description": "Interface to interact with the Storefront API.",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cache",
+                "value": "Cache",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheNone",
+                "value": "() => NoStoreStrategy",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheLong",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheShort",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheCustom",
+                "value": "(overrideOptions: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "generateCacheControlHeader",
+                "value": "(cacheOptions: AllCacheOptions) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPublicTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPrivateTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getShopifyDomain",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "TI18n",
+                "description": ""
+              }
+            ]
+          },
+          "StorefrontQueries": {
+            "filePath": "/storefront.ts",
+            "name": "StorefrontQueries",
+            "description": "Maps all the queries found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "AutoAddedVariableNames": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AutoAddedVariableNames",
+            "value": "'country' | 'language'",
+            "description": ""
+          },
+          "StorefrontCommonExtraParams": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontCommonExtraParams",
+            "value": "{\n  headers?: HeadersInit;\n  storefrontApiVersion?: string;\n  displayName?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "HeadersInit",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefrontApiVersion",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "displayName",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontQueryOptions": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontQueryOptions",
+            "value": "StorefrontCommonExtraParams & {\n  query: string;\n  mutation?: never;\n  cache?: CachingStrategy;\n}",
+            "description": ""
+          },
+          "CachingStrategy": {
+            "filePath": "/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CachingStrategy",
+            "value": "AllCacheOptions",
+            "description": "Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the pre-defined caching strategies: CacheNone, CacheShort, CacheLong.",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontError": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontError",
+            "value": "{\n  errors?: StorefrontApiErrors;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "errors",
+                "value": "StorefrontApiErrors",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontApiErrors": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontApiErrors",
+            "value": "JsonGraphQLError[] | undefined",
+            "description": ""
+          },
+          "StorefrontMutations": {
+            "filePath": "/storefront.ts",
+            "name": "StorefrontMutations",
+            "description": "Maps all the mutations found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "NoStoreStrategy": {
+            "filePath": "/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "NoStoreStrategy",
+            "value": "{\n  mode: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": ""
+              }
+            ]
+          },
+          "AllCacheOptions": {
+            "filePath": "/cache/strategies.ts",
+            "name": "AllCacheOptions",
+            "description": "Override options for a cache strategy.",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "CartDiscountCodesUpdateFunction": {
+            "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts",
+            "name": "CartDiscountCodesUpdateFunction",
+            "description": "",
+            "params": [
+              {
+                "name": "discountCodes",
+                "description": "",
+                "value": "string[]",
+                "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts"
+              },
+              {
+                "name": "optionalParams",
+                "description": "",
+                "value": "CartOptionalInput",
+                "isOptional": true,
+                "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/cart/queries/cartDiscountCodesUpdateDefault.ts",
+              "description": "",
+              "name": "Promise<CartQueryDataReturn>",
+              "value": "Promise<CartQueryDataReturn>"
+            },
+            "value": "export type CartDiscountCodesUpdateFunction = (\n  discountCodes: string[],\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+          },
+          "CartOptionalInput": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartOptionalInput",
+            "value": "{\n  /**\n   * The cart id.\n   * @default cart.getCartId();\n   */\n  cartId?: Scalars['ID']['input'];\n  /**\n   * The country code.\n   * @default storefront.i18n.country\n   */\n  country?: CountryCode;\n  /**\n   * The language code.\n   * @default storefront.i18n.language\n   */\n  language?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartId",
+                "value": "string",
+                "description": "The cart id.",
+                "isOptional": true,
+                "defaultValue": "cart.getCartId();"
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "country",
+                "value": "CountryCode",
+                "description": "The country code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.country"
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "language",
+                "value": "LanguageCode",
+                "description": "The language code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.language"
+              }
+            ]
+          },
+          "CartQueryDataReturn": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryDataReturn",
+            "value": "CartQueryData & {\n  errors?: StorefrontApiErrors;\n}",
+            "description": ""
+          },
+          "CartQueryData": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryData",
+            "value": "{\n  cart: Cart;\n  userErrors?:\n    | CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[];\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cart",
+                "value": "Cart",
+                "description": ""
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "userErrors",
+                "value": "CartUserError[] | MetafieldsSetUserError[] | MetafieldDeleteUserError[]",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "Cart": {
+            "description": "",
+            "name": "Cart",
+            "value": "Cart",
+            "members": [],
+            "override": "[Cart](/docs/api/storefront/2024-04/objects/Cart) - Storefront API type"
+          },
+          "CartUserError": {
+            "description": "",
+            "name": "CartUserError",
+            "value": "CartUserError",
+            "members": [],
+            "override": "[CartUserError](/docs/api/storefront/2024-04/objects/CartUserError) - Storefront API type"
+          },
+          "MetafieldsSetUserError": {
+            "description": "",
+            "name": "MetafieldsSetUserError",
+            "value": "MetafieldsSetUserError",
+            "members": [],
+            "override": "[MetafieldsSetUserError](/docs/api/storefront/2024-04/objects/MetafieldsSetUserError) - Storefront API type"
+          },
+          "MetafieldDeleteUserError": {
+            "description": "",
+            "name": "MetafieldDeleteUserError",
+            "value": "MetafieldDeleteUserError",
+            "members": [],
+            "override": "[MetafieldDeleteUserError](/docs/api/storefront/2024-04/objects/MetafieldDeleteUserError) - Storefront API type"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "name": "cartGetDefault",
+    "category": "utilities",
+    "subCategory": "cart",
+    "isVisualComponent": false,
+    "related": [],
+    "description": "Creates a function that returns a cart",
+    "type": "utility",
+    "defaultExample": {
+      "description": "This is the default example",
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "JavaScript",
+            "code": "import {cartGetDefault} from '@shopify/hydrogen';\n\nconst cartGet = cartGetDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartGet();\n",
+            "language": "js"
+          }
+        ],
+        "title": "example"
+      }
+    },
+    "definitions": [
+      {
+        "title": "cartGetDefault",
+        "description": "",
+        "type": "CartGetDefaultGeneratedType",
+        "typeDefinitions": {
+          "CartGetDefaultGeneratedType": {
+            "filePath": "/cart/queries/cartGetDefault.ts",
+            "name": "CartGetDefaultGeneratedType",
+            "description": "",
+            "params": [
+              {
+                "name": "input1",
+                "description": "",
+                "value": "CartGetOptions",
+                "filePath": "/cart/queries/cartGetDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/cart/queries/cartGetDefault.ts",
+              "description": "",
+              "name": "CartGetFunction",
+              "value": "CartGetFunction"
+            },
+            "value": "export function cartGetDefault({\n  storefront,\n  customerAccount,\n  getCartId,\n  cartFragment,\n}: CartGetOptions): CartGetFunction {\n  return async (cartInput?: CartGetProps) => {\n    const cartId = getCartId();\n\n    if (!cartId) return null;\n\n    const [isCustomerLoggedIn, {cart, errors}] = await Promise.all([\n      customerAccount ? customerAccount.isLoggedIn() : false,\n      storefront.query<{\n        cart: Cart;\n        errors: StorefrontApiErrors;\n      }>(CART_QUERY(cartFragment), {\n        variables: {\n          cartId,\n          ...cartInput,\n        },\n        cache: storefront.CacheNone(),\n      }),\n    ]);\n\n    return formatAPIResult(\n      addCustomerLoggedInParam(isCustomerLoggedIn, cart),\n      errors,\n    );\n  };\n}"
+          },
+          "CartGetOptions": {
+            "filePath": "/cart/queries/cartGetDefault.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartGetOptions",
+            "value": "CartQueryOptions & {\n  /**\n   * The customer account client instance created by [`createCustomerAccountClient`](docs/api/hydrogen/latest/utilities/createcustomeraccountclient).\n   */\n  customerAccount?: CustomerAccount;\n}",
+            "description": ""
+          },
+          "CartQueryOptions": {
+            "filePath": "/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryOptions",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefront",
+                "value": "Storefront",
+                "description": "The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient)."
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getCartId",
+                "value": "() => string",
+                "description": "A function that returns the cart ID."
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartFragment",
+                "value": "string",
+                "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
+                "isOptional": true
+              }
+            ]
+          },
+          "Storefront": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "Storefront",
+            "value": "{\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontQueries,\n      RawGqlString,\n      StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, 'cache'>,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontMutations,\n      RawGqlString,\n      StorefrontCommonExtraParams,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  cache?: Cache;\n  CacheNone: typeof CacheNone;\n  CacheLong: typeof CacheLong;\n  CacheShort: typeof CacheShort;\n  CacheCustom: typeof CacheCustom;\n  generateCacheControlHeader: typeof generateCacheControlHeader;\n  getPublicTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  getPrivateTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  getShopifyDomain: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  getApiUrl: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  i18n: TI18n;\n}",
+            "description": "Interface to interact with the Storefront API.",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)]: ({ [KeyType in keyof StorefrontMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>]: StorefrontMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cache",
+                "value": "Cache",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheNone",
+                "value": "() => NoStoreStrategy",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheLong",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheShort",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheCustom",
+                "value": "(overrideOptions: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "generateCacheControlHeader",
+                "value": "(cacheOptions: AllCacheOptions) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPublicTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPrivateTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getShopifyDomain",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "TI18n",
+                "description": ""
+              }
+            ]
+          },
+          "StorefrontQueries": {
+            "filePath": "/storefront.ts",
+            "name": "StorefrontQueries",
+            "description": "Maps all the queries found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "AutoAddedVariableNames": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AutoAddedVariableNames",
+            "value": "'country' | 'language'",
+            "description": ""
+          },
+          "StorefrontCommonExtraParams": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontCommonExtraParams",
+            "value": "{\n  headers?: HeadersInit;\n  storefrontApiVersion?: string;\n  displayName?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "HeadersInit",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefrontApiVersion",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "displayName",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontQueryOptions": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontQueryOptions",
+            "value": "StorefrontCommonExtraParams & {\n  query: string;\n  mutation?: never;\n  cache?: CachingStrategy;\n}",
+            "description": ""
+          },
+          "CachingStrategy": {
+            "filePath": "/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CachingStrategy",
+            "value": "AllCacheOptions",
+            "description": "Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the pre-defined caching strategies: CacheNone, CacheShort, CacheLong.",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontError": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontError",
+            "value": "{\n  errors?: StorefrontApiErrors;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "errors",
+                "value": "StorefrontApiErrors",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontApiErrors": {
+            "filePath": "/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontApiErrors",
+            "value": "JsonGraphQLError[] | undefined",
+            "description": ""
+          },
+          "StorefrontMutations": {
+            "filePath": "/storefront.ts",
+            "name": "StorefrontMutations",
+            "description": "Maps all the mutations found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "NoStoreStrategy": {
+            "filePath": "/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "NoStoreStrategy",
+            "value": "{\n  mode: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": ""
+              }
+            ]
+          },
+          "AllCacheOptions": {
+            "filePath": "/cache/strategies.ts",
+            "name": "AllCacheOptions",
+            "description": "Override options for a cache strategy.",
+            "members": [
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
               }
             ]
           },
@@ -7400,6 +8135,7 @@
   {
     "name": "cartLinesAddDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that accepts an array of [CartLineInput](/docs/api/storefront/2024-04/input-objects/CartLineInput) and adds the line items to a cart",
@@ -7447,7 +8183,7 @@
             "filePath": "/cart/queries/cart-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
             "description": "",
             "members": [
               {
@@ -7470,6 +8206,14 @@
                 "name": "cartFragment",
                 "value": "string",
                 "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
                 "isOptional": true
               }
             ]
@@ -7773,6 +8517,147 @@
             ],
             "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
           },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
           "CartLinesAddFunction": {
             "filePath": "/cart/queries/cartLinesAddDefault.ts",
             "name": "CartLinesAddFunction",
@@ -7781,7 +8666,7 @@
               {
                 "name": "lines",
                 "description": "",
-                "value": "CartLineInput[]",
+                "value": "OptimisticCartLine[]",
                 "filePath": "/cart/queries/cartLinesAddDefault.ts"
               },
               {
@@ -7798,7 +8683,14 @@
               "name": "Promise<CartQueryDataReturn>",
               "value": "Promise<CartQueryDataReturn>"
             },
-            "value": "export type CartLinesAddFunction = (\n  lines: CartLineInput[],\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+            "value": "export type CartLinesAddFunction = (\n  lines: Array<OptimisticCartLine>,\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+          },
+          "OptimisticCartLine": {
+            "filePath": "/cart/CartForm.tsx",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "OptimisticCartLine",
+            "value": "CartLineInput & {\n  selectedVariant?: unknown;\n}",
+            "description": ""
           },
           "CartLineInput": {
             "description": "",
@@ -7909,6 +8801,7 @@
   {
     "name": "cartLinesRemoveDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that accepts an array of line ids and removes the line items from a cart",
@@ -7950,13 +8843,13 @@
               "name": "CartLinesRemoveFunction",
               "value": "CartLinesRemoveFunction"
             },
-            "value": "export function cartLinesRemoveDefault(\n  options: CartQueryOptions,\n): CartLinesRemoveFunction {\n  return async (lineIds, optionalParams) => {\n    const {cartLinesRemove, errors} = await options.storefront.mutate<{\n      cartLinesRemove: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_LINES_REMOVE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        lineIds,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartLinesRemove, errors);\n  };\n}"
+            "value": "export function cartLinesRemoveDefault(\n  options: CartQueryOptions,\n): CartLinesRemoveFunction {\n  return async (lineIds, optionalParams) => {\n    throwIfLinesAreOptimistic('removeLines', lineIds);\n\n    const {cartLinesRemove, errors} = await options.storefront.mutate<{\n      cartLinesRemove: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_LINES_REMOVE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        lineIds,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartLinesRemove, errors);\n  };\n}"
           },
           "CartQueryOptions": {
             "filePath": "/cart/queries/cart-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
             "description": "",
             "members": [
               {
@@ -7979,6 +8872,14 @@
                 "name": "cartFragment",
                 "value": "string",
                 "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
                 "isOptional": true
               }
             ]
@@ -8281,6 +9182,147 @@
               }
             ],
             "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
           },
           "CartLinesRemoveFunction": {
             "filePath": "/cart/queries/cartLinesRemoveDefault.ts",
@@ -8411,6 +9453,7 @@
   {
     "name": "cartLinesUpdateDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that accepts an array of [CartLineUpdateInput](/docs/api/storefront/2024-04/input-objects/CartLineUpdateInput) and updates the line items in a cart",
@@ -8452,13 +9495,13 @@
               "name": "CartLinesUpdateFunction",
               "value": "CartLinesUpdateFunction"
             },
-            "value": "export function cartLinesUpdateDefault(\n  options: CartQueryOptions,\n): CartLinesUpdateFunction {\n  return async (lines, optionalParams) => {\n    const {cartLinesUpdate, errors} = await options.storefront.mutate<{\n      cartLinesUpdate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_LINES_UPDATE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        lines,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartLinesUpdate, errors);\n  };\n}"
+            "value": "export function cartLinesUpdateDefault(\n  options: CartQueryOptions,\n): CartLinesUpdateFunction {\n  return async (lines, optionalParams) => {\n    throwIfLinesAreOptimistic('updateLines', lines);\n\n    const {cartLinesUpdate, errors} = await options.storefront.mutate<{\n      cartLinesUpdate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_LINES_UPDATE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        lines,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartLinesUpdate, errors);\n  };\n}"
           },
           "CartQueryOptions": {
             "filePath": "/cart/queries/cart-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
             "description": "",
             "members": [
               {
@@ -8481,6 +9524,14 @@
                 "name": "cartFragment",
                 "value": "string",
                 "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
                 "isOptional": true
               }
             ]
@@ -8783,6 +9834,147 @@
               }
             ],
             "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
           },
           "CartLinesUpdateFunction": {
             "filePath": "/cart/queries/cartLinesUpdateDefault.ts",
@@ -8920,6 +10112,7 @@
   {
     "name": "cartMetafieldDeleteDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that accepts a string key and removes the matching metafield from the cart.",
@@ -8967,7 +10160,7 @@
             "filePath": "/cart/queries/cart-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
             "description": "",
             "members": [
               {
@@ -8990,6 +10183,14 @@
                 "name": "cartFragment",
                 "value": "string",
                 "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
                 "isOptional": true
               }
             ]
@@ -9292,6 +10493,147 @@
               }
             ],
             "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
           },
           "CartMetafieldDeleteFunction": {
             "filePath": "/cart/queries/cartMetafieldDeleteDefault.ts",
@@ -9422,6 +10764,7 @@
   {
     "name": "cartMetafieldsSetDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that accepts an array of [CartMetafieldsSetInput](https://shopify.dev/docs/api/storefront/2024-04/input-objects/CartMetafieldsSetInput) without `ownerId` and set the metafields to a cart",
@@ -9469,7 +10812,7 @@
             "filePath": "/cart/queries/cart-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
             "description": "",
             "members": [
               {
@@ -9492,6 +10835,14 @@
                 "name": "cartFragment",
                 "value": "string",
                 "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
                 "isOptional": true
               }
             ]
@@ -9794,6 +11145,147 @@
               }
             ],
             "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
           },
           "CartMetafieldsSetFunction": {
             "filePath": "/cart/queries/cartMetafieldsSetDefault.ts",
@@ -9931,6 +11423,7 @@
   {
     "name": "cartNoteUpdateDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that accepts a string and attaches it as a note to a cart.",
@@ -9978,7 +11471,7 @@
             "filePath": "/cart/queries/cart-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
             "description": "",
             "members": [
               {
@@ -10001,6 +11494,14 @@
                 "name": "cartFragment",
                 "value": "string",
                 "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
                 "isOptional": true
               }
             ]
@@ -10303,6 +11804,147 @@
               }
             ],
             "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
           },
           "CartNoteUpdateFunction": {
             "filePath": "/cart/queries/cartNoteUpdateDefault.ts",
@@ -10433,6 +12075,7 @@
   {
     "name": "cartSelectedDeliveryOptionsUpdateDefault",
     "category": "utilities",
+    "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a function that accepts an object of [CartSelectedDeliveryOptionInput](/docs/api/storefront/2024-04/input-objects/CartSelectedDeliveryOptionInput) and updates the selected delivery option of a cart",
@@ -10480,7 +12123,7 @@
             "filePath": "/cart/queries/cart-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartQueryOptions",
-            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n}",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
             "description": "",
             "members": [
               {
@@ -10503,6 +12146,14 @@
                 "name": "cartFragment",
                 "value": "string",
                 "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
                 "isOptional": true
               }
             ]
@@ -10805,6 +12456,147 @@
               }
             ],
             "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "CustomerAccount": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix action.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** UNSTABLE feature. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** UNSTABLE feature. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix action. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountQueries[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>]: CustomerAccountQueries[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? { [KeyType in keyof ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)]: ({ [KeyType in keyof CustomerAccountMutations[RawGqlString][\"variables\"] as Filter<KeyType, Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>]: CustomerAccountMutations[RawGqlString][\"variables\"][KeyType]; } & Partial<Pick<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>>>)[KeyType]; } : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"name\" | \"message\" | \"path\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "UNSTABLE feature. Set buyer information into session."
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "UNSTABLE feature. Get buyer token and company location id from session."
+              }
+            ]
+          },
+          "LoginOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LogoutOptions": {
+            "filePath": "/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  postLogoutRedirectUri?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountQueries": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "CustomerAccountMutations": {
+            "filePath": "/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
           },
           "CartSelectedDeliveryOptionsUpdateFunction": {
             "filePath": "/cart/queries/cartSelectedDeliveryOptionsUpdateDefault.ts",
@@ -11585,7 +13377,7 @@
             "filePath": "/csp/csp.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CreateContentSecurityPolicy",
-            "value": "{\n  defaultSrc?: DirectiveValues;\n  scriptSrc?: DirectiveValues;\n  styleSrc?: DirectiveValues;\n  imgSrc?: DirectiveValues;\n  connectSrc?: DirectiveValues;\n  fontSrc?: DirectiveValues;\n  objectSrc?: DirectiveValues;\n  mediaSrc?: DirectiveValues;\n  frameSrc?: DirectiveValues;\n  sandbox?: DirectiveValues;\n  reportUri?: DirectiveValues;\n  childSrc?: DirectiveValues;\n  formAction?: DirectiveValues;\n  frameAncestors?: DirectiveValues;\n  pluginTypes?: DirectiveValues;\n  baseUri?: DirectiveValues;\n  reportTo?: DirectiveValues;\n  workerSrc?: DirectiveValues;\n  manifestSrc?: DirectiveValues;\n  prefetchSrc?: DirectiveValues;\n  navigateTo?: DirectiveValues;\n  upgradeInsecureRequests?: boolean;\n  blockAllMixedContent?: boolean;\n}",
+            "value": "{\n  defaultSrc?: DirectiveValues;\n  scriptSrc?: DirectiveValues;\n  scriptSrcElem?: DirectiveValues;\n  styleSrc?: DirectiveValues;\n  imgSrc?: DirectiveValues;\n  connectSrc?: DirectiveValues;\n  fontSrc?: DirectiveValues;\n  objectSrc?: DirectiveValues;\n  mediaSrc?: DirectiveValues;\n  frameSrc?: DirectiveValues;\n  sandbox?: DirectiveValues;\n  reportUri?: DirectiveValues;\n  childSrc?: DirectiveValues;\n  formAction?: DirectiveValues;\n  frameAncestors?: DirectiveValues;\n  pluginTypes?: DirectiveValues;\n  baseUri?: DirectiveValues;\n  reportTo?: DirectiveValues;\n  workerSrc?: DirectiveValues;\n  manifestSrc?: DirectiveValues;\n  prefetchSrc?: DirectiveValues;\n  navigateTo?: DirectiveValues;\n  upgradeInsecureRequests?: boolean;\n  blockAllMixedContent?: boolean;\n}",
             "description": "",
             "members": [
               {
@@ -11600,6 +13392,14 @@
                 "filePath": "/csp/csp.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "scriptSrc",
+                "value": "DirectiveValues",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/csp/csp.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "scriptSrcElem",
                 "value": "DirectiveValues",
                 "description": "",
                 "isOptional": true
@@ -11965,7 +13765,7 @@
               "name": "",
               "value": ""
             },
-            "value": "export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {\n  const {\n    withPrivacyBanner = true,\n    onVisitorConsentCollected,\n    onReady,\n    ...consentConfig\n  } = props;\n  const loadedEvent = useRef(false);\n  const scriptStatus = useLoadScript(\n    withPrivacyBanner ? CONSENT_API_WITH_BANNER : CONSENT_API,\n    {\n      attributes: {\n        id: 'customer-privacy-api',\n      },\n    },\n  );\n\n  if (!consentConfig.checkoutDomain) logMissingConfig('checkoutDomain');\n  if (!consentConfig.storefrontAccessToken)\n    logMissingConfig('storefrontAccessToken');\n\n  useEffect(() => {\n    const consentCollectedHandler = (\n      event: CustomEvent<VisitorConsentCollected>,\n    ) => {\n      if (onVisitorConsentCollected) {\n        onVisitorConsentCollected(event.detail);\n      }\n    };\n\n    document.addEventListener(\n      'visitorConsentCollected',\n      consentCollectedHandler,\n    );\n\n    return () => {\n      document.removeEventListener(\n        'visitorConsentCollected',\n        consentCollectedHandler,\n      );\n    };\n  }, [onVisitorConsentCollected]);\n\n  useEffect(() => {\n    if (scriptStatus !== 'done' || loadedEvent.current) return;\n\n    loadedEvent.current = true;\n\n    if (withPrivacyBanner && window?.privacyBanner) {\n      window?.privacyBanner?.loadBanner({\n        checkoutRootDomain: consentConfig.checkoutDomain,\n        storefrontAccessToken: consentConfig.storefrontAccessToken,\n      });\n    }\n\n    // Override the setTrackingConsent method to include the headless storefront configuration\n    if (window.Shopify?.customerPrivacy) {\n      const originalSetTrackingConsent =\n        window.Shopify.customerPrivacy.setTrackingConsent;\n      window.Shopify.customerPrivacy.setTrackingConsent = (\n        consent: VisitorConsent,\n        callback: () => void,\n      ) => {\n        originalSetTrackingConsent(\n          {\n            ...consent,\n            headlessStorefront: true,\n            checkoutRootDomain: consentConfig.checkoutDomain,\n            storefrontAccessToken: consentConfig.storefrontAccessToken,\n          },\n          callback,\n        );\n      };\n    }\n\n    if (onReady && !withPrivacyBanner) {\n      onReady();\n    }\n  }, [scriptStatus, withPrivacyBanner, consentConfig]);\n\n  return;\n}"
+            "value": "export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {\n  const {\n    withPrivacyBanner = true,\n    onVisitorConsentCollected,\n    onReady,\n    ...consentConfig\n  } = props;\n  const loadedEvent = useRef(false);\n  const scriptStatus = useLoadScript(\n    withPrivacyBanner ? CONSENT_API_WITH_BANNER : CONSENT_API,\n    {\n      attributes: {\n        id: 'customer-privacy-api',\n      },\n    },\n  );\n\n  useEffect(() => {\n    const consentCollectedHandler = (\n      event: CustomEvent<VisitorConsentCollected>,\n    ) => {\n      if (onVisitorConsentCollected) {\n        onVisitorConsentCollected(event.detail);\n      }\n    };\n\n    document.addEventListener(\n      'visitorConsentCollected',\n      consentCollectedHandler,\n    );\n\n    return () => {\n      document.removeEventListener(\n        'visitorConsentCollected',\n        consentCollectedHandler,\n      );\n    };\n  }, [onVisitorConsentCollected]);\n\n  useEffect(() => {\n    if (scriptStatus !== 'done' || loadedEvent.current) return;\n    loadedEvent.current = true;\n\n    if (!consentConfig.checkoutDomain) logMissingConfig('checkoutDomain');\n    if (!consentConfig.storefrontAccessToken)\n      logMissingConfig('storefrontAccessToken');\n\n    // validate that the storefront access token is not a server API token\n    if (\n      consentConfig.storefrontAccessToken.startsWith('shpat_') ||\n      consentConfig.storefrontAccessToken.length !== 32\n    ) {\n      // eslint-disable-next-line no-console\n      console.error(\n        `[h2:error:useCustomerPrivacy] It looks like you passed a private access token, make sure to use the public token`,\n      );\n    }\n\n    if (withPrivacyBanner && window?.privacyBanner) {\n      window?.privacyBanner?.loadBanner({\n        checkoutRootDomain: consentConfig.checkoutDomain,\n        storefrontAccessToken: consentConfig.storefrontAccessToken,\n      });\n    }\n\n    if (!window.Shopify?.customerPrivacy) return;\n\n    // Override the setTrackingConsent method to include the headless storefront configuration\n    const originalSetTrackingConsent =\n      window.Shopify.customerPrivacy.setTrackingConsent;\n\n    function overrideSetTrackingConsent(\n      consent: VisitorConsent,\n      callback: (data: {error: string} | undefined) => void,\n    ) {\n      originalSetTrackingConsent(\n        {\n          ...consent,\n          headlessStorefront: true,\n          checkoutRootDomain: consentConfig.checkoutDomain,\n          storefrontAccessToken: consentConfig.storefrontAccessToken,\n        },\n        callback,\n      );\n    }\n\n    window.Shopify.customerPrivacy.setTrackingConsent =\n      overrideSetTrackingConsent;\n\n    if (onReady && !withPrivacyBanner) {\n      onReady();\n    }\n  }, [scriptStatus, withPrivacyBanner, consentConfig]);\n\n  return;\n}"
           },
           "CustomerPrivacyApiProps": {
             "filePath": "/customer-privacy/ShopifyCustomerPrivacy.tsx",
@@ -12133,7 +13933,7 @@
             "filePath": "/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccountOptions",
-            "value": "{\n  /** The client requires a session to persist the auth and refresh token. By default Hydrogen ships with cookie session storage, but you can use [another session storage](https://remix.run/docs/en/main/utils/sessions) implementation.  */\n  session: HydrogenSession;\n  /** Unique UUID prefixed with `shp_` associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountId. Use `npx shopify hydrogen env pull` to link your store credentials. */\n  customerAccountId: string;\n  /** The account URL associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountUrl. Use `npx shopify hydrogen env pull` to link your store credentials. */\n  customerAccountUrl: string;\n  /** Override the version of the API */\n  customerApiVersion?: string;\n  /** The object for the current Request. It should be provided by your platform. */\n  request: CrossRuntimeRequest;\n  /** The waitUntil function is used to keep the current request/response lifecycle alive even after a response has been sent. It should be provided by your platform. */\n  waitUntil?: ExecutionContext['waitUntil'];\n  /** This is the route in your app that authorizes the customer after logging in. Make sure to call `customer.authorize()` within the loader on this route. It defaults to `/account/authorize`. */\n  authUrl?: string;\n  /** Use this method to overwrite the default logged-out redirect behavior. The default handler [throws a redirect](https://remix.run/docs/en/main/utils/redirect#:~:text=!session) to `/account/login` with current path as `return_to` query param. */\n  customAuthStatusHandler?: () => DataFunctionValue;\n  /** Whether it should print GraphQL errors automatically. Defaults to true */\n  logErrors?: boolean | ((error?: Error) => boolean);\n}",
+            "value": "{\n  /** The client requires a session to persist the auth and refresh token. By default Hydrogen ships with cookie session storage, but you can use [another session storage](https://remix.run/docs/en/main/utils/sessions) implementation.  */\n  session: HydrogenSession;\n  /** Unique UUID prefixed with `shp_` associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountId. Use `npx shopify hydrogen env pull` to link your store credentials. */\n  customerAccountId: string;\n  /** The account URL associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountUrl. Use `npx shopify hydrogen env pull` to link your store credentials. */\n  customerAccountUrl: string;\n  /** Override the version of the API */\n  customerApiVersion?: string;\n  /** The object for the current Request. It should be provided by your platform. */\n  request: CrossRuntimeRequest;\n  /** The waitUntil function is used to keep the current request/response lifecycle alive even after a response has been sent. It should be provided by your platform. */\n  waitUntil?: ExecutionContext['waitUntil'];\n  /** This is the route in your app that authorizes the customer after logging in. Make sure to call `customer.authorize()` within the loader on this route. It defaults to `/account/authorize`. */\n  authUrl?: string;\n  /** Use this method to overwrite the default logged-out redirect behavior. The default handler [throws a redirect](https://remix.run/docs/en/main/utils/redirect#:~:text=!session) to `/account/login` with current path as `return_to` query param. */\n  customAuthStatusHandler?: () => DataFunctionValue;\n  /** Whether it should print GraphQL errors automatically. Defaults to true */\n  logErrors?: boolean | ((error?: Error) => boolean);\n  /** UNSTABLE feature, this will eventually goes away. If true then we will exchange customerAccessToken for storefrontCustomerAccessToken. */\n  unstableB2b?: boolean;\n}",
             "description": "",
             "members": [
               {
@@ -12202,6 +14002,14 @@
                 "name": "logErrors",
                 "value": "boolean | ((error?: Error) => boolean)",
                 "description": "Whether it should print GraphQL errors automatically. Defaults to true",
+                "isOptional": true
+              },
+              {
+                "filePath": "/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "unstableB2b",
+                "value": "boolean",
+                "description": "UNSTABLE feature, this will eventually goes away. If true then we will exchange customerAccessToken for storefrontCustomerAccessToken.",
                 "isOptional": true
               }
             ]
@@ -12830,12 +14638,12 @@
         "tabs": [
           {
             "title": "JavaScript",
-            "code": "import {VariantSelector} from '@shopify/hydrogen';\nimport {Link} from '@remix-run/react';\n\nconst ProductForm = ({product}) =&gt; {\n  return (\n    &lt;VariantSelector\n      handle={product.handle}\n      options={product.options}\n      variants={product.variants}\n    &gt;\n      {({option}) =&gt; (\n        &lt;&gt;\n          &lt;div&gt;{option.name}&lt;/div&gt;\n          &lt;div&gt;\n            {option.values.map(({value, isAvailable, to, isActive}) =&gt; (\n              &lt;Link\n                to={to}\n                prefetch=\"intent\"\n                className={\n                  isActive ? 'active' : isAvailable ? '' : 'opacity-80'\n                }\n              &gt;\n                {value}\n              &lt;/Link&gt;\n            ))}\n          &lt;/div&gt;\n        &lt;/&gt;\n      )}\n    &lt;/VariantSelector&gt;\n  );\n};\n",
+            "code": "import {VariantSelector} from '@shopify/hydrogen';\nimport {Link} from '@remix-run/react';\n\nconst ProductForm = ({product}) =&gt; {\n  return (\n    &lt;VariantSelector\n      handle={product.handle}\n      options={product.options}\n      variants={product.variants}\n    &gt;\n      {({option}) =&gt; (\n        &lt;&gt;\n          &lt;div&gt;{option.name}&lt;/div&gt;\n          &lt;div&gt;\n            {option.values.map(\n              ({value, isAvailable, to, isActive, variant}) =&gt; (\n                &lt;Link\n                  to={to}\n                  prefetch=\"intent\"\n                  className={\n                    isActive ? 'active' : isAvailable ? '' : 'opacity-80'\n                  }\n                &gt;\n                  {value}\n                  &lt;br /&gt;\n                  {variant && `SKU: ${variant.sku}`}\n                &lt;/Link&gt;\n              ),\n            )}\n          &lt;/div&gt;\n        &lt;/&gt;\n      )}\n    &lt;/VariantSelector&gt;\n  );\n};\n",
             "language": "jsx"
           },
           {
             "title": "TypeScript",
-            "code": "import {VariantSelector} from '@shopify/hydrogen';\nimport type {Product} from '@shopify/hydrogen/storefront-api-types';\nimport {Link} from '@remix-run/react';\n\nconst ProductForm = ({product}: {product: Product}) =&gt; {\n  return (\n    &lt;VariantSelector\n      handle={product.handle}\n      options={product.options}\n      variants={product.variants}\n    &gt;\n      {({option}) =&gt; (\n        &lt;&gt;\n          &lt;div&gt;{option.name}&lt;/div&gt;\n          &lt;div&gt;\n            {option.values.map(({value, isAvailable, to, isActive}) =&gt; (\n              &lt;Link\n                to={to}\n                prefetch=\"intent\"\n                className={\n                  isActive ? 'active' : isAvailable ? '' : 'opacity-80'\n                }\n              &gt;\n                {value}\n              &lt;/Link&gt;\n            ))}\n          &lt;/div&gt;\n        &lt;/&gt;\n      )}\n    &lt;/VariantSelector&gt;\n  );\n};\n",
+            "code": "import {VariantSelector} from '@shopify/hydrogen';\nimport type {Product} from '@shopify/hydrogen/storefront-api-types';\nimport {Link} from '@remix-run/react';\n\nconst ProductForm = ({product}: {product: Product}) =&gt; {\n  return (\n    &lt;VariantSelector\n      handle={product.handle}\n      options={product.options}\n      variants={product.variants}\n    &gt;\n      {({option}) =&gt; (\n        &lt;&gt;\n          &lt;div&gt;{option.name}&lt;/div&gt;\n          &lt;div&gt;\n            {option.values.map(\n              ({value, isAvailable, to, isActive, variant}) =&gt; (\n                &lt;Link\n                  to={to}\n                  prefetch=\"intent\"\n                  className={\n                    isActive ? 'active' : isAvailable ? '' : 'opacity-80'\n                  }\n                &gt;\n                  {value}\n                  &lt;br /&gt;\n                  {variant && `SKU: ${variant.sku}`}\n                &lt;/Link&gt;\n              ),\n            )}\n          &lt;/div&gt;\n        &lt;/&gt;\n      )}\n    &lt;/VariantSelector&gt;\n  );\n};\n",
             "language": "tsx"
           }
         ],
@@ -12929,7 +14737,7 @@
             "filePath": "/product/VariantSelector.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "VariantOptionValue",
-            "value": "{\n  value: string;\n  isAvailable: boolean;\n  to: string;\n  search: string;\n  isActive: boolean;\n}",
+            "value": "{\n  value: string;\n  isAvailable: boolean;\n  to: string;\n  search: string;\n  isActive: boolean;\n  variant?: PartialDeep<ProductVariant>;\n}",
             "description": "",
             "members": [
               {
@@ -12966,6 +14774,14 @@
                 "name": "isActive",
                 "value": "boolean",
                 "description": ""
+              },
+              {
+                "filePath": "/product/VariantSelector.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "variant",
+                "value": "PartialDeep<ProductVariant>",
+                "description": "",
+                "isOptional": true
               }
             ]
           }
@@ -13138,7 +14954,7 @@
               "name": "Promise<Response>",
               "value": "Promise<Response>"
             },
-            "value": "export async function storefrontRedirect(\n  options: StorefrontRedirect,\n): Promise<Response> {\n  const {\n    storefront,\n    request,\n    noAdminRedirect,\n    matchQueryParams,\n    response = new Response('Not Found', {status: 404}),\n  } = options;\n\n  const url = new URL(request.url);\n  const {pathname, searchParams} = url;\n  const isSoftNavigation = searchParams.has('_data');\n\n  searchParams.delete('redirect');\n  searchParams.delete('return_to');\n  searchParams.delete('_data');\n\n  const redirectFrom = (\n    matchQueryParams ? url.toString().replace(url.origin, '') : pathname\n  ).toLowerCase();\n\n  if (url.pathname === '/admin' && !noAdminRedirect) {\n    return createRedirectResponse(\n      `${storefront.getShopifyDomain()}/admin`,\n      isSoftNavigation,\n      searchParams,\n      matchQueryParams,\n    );\n  }\n\n  try {\n    const {urlRedirects} = await storefront.query<{\n      urlRedirects: UrlRedirectConnection;\n    }>(REDIRECT_QUERY, {\n      variables: {query: 'path:' + redirectFrom},\n    });\n\n    const location = urlRedirects?.edges?.[0]?.node?.target;\n\n    if (location) {\n      return createRedirectResponse(\n        location,\n        isSoftNavigation,\n        searchParams,\n        matchQueryParams,\n      );\n    }\n\n    const redirectTo = getRedirectUrl(request.url);\n\n    if (redirectTo) {\n      return createRedirectResponse(\n        redirectTo,\n        isSoftNavigation,\n        searchParams,\n        matchQueryParams,\n      );\n    }\n  } catch (error) {\n    console.error(\n      `Failed to fetch redirects from Storefront API for route ${redirectFrom}`,\n      error,\n    );\n  }\n\n  return response;\n}"
+            "value": "export async function storefrontRedirect(\n  options: StorefrontRedirect,\n): Promise<Response> {\n  const {\n    storefront,\n    request,\n    noAdminRedirect,\n    matchQueryParams,\n    response = new Response('Not Found', {status: 404}),\n  } = options;\n\n  const url = new URL(request.url);\n  const {pathname, searchParams} = url;\n  const isSoftNavigation = searchParams.has('_data');\n\n  searchParams.delete('redirect');\n  searchParams.delete('return_to');\n  searchParams.delete('_data');\n\n  const redirectFrom = (\n    matchQueryParams ? url.toString().replace(url.origin, '') : pathname\n  ).toLowerCase();\n\n  if (url.pathname === '/admin' && !noAdminRedirect) {\n    return createRedirectResponse(\n      `${storefront.getShopifyDomain()}/admin`,\n      isSoftNavigation,\n      searchParams,\n      matchQueryParams,\n    );\n  }\n\n  try {\n    const {urlRedirects} = await storefront.query<{\n      urlRedirects: UrlRedirectConnection;\n    }>(REDIRECT_QUERY, {\n      // The admin doesn't allow redirects to have a\n      // trailing slash, so strip them all off\n      variables: {query: 'path:' + redirectFrom.replace(/\\/+$/, '')},\n    });\n\n    const location = urlRedirects?.edges?.[0]?.node?.target;\n\n    if (location) {\n      return createRedirectResponse(\n        location,\n        isSoftNavigation,\n        searchParams,\n        matchQueryParams,\n      );\n    }\n\n    const redirectTo = getRedirectUrl(request.url);\n\n    if (redirectTo) {\n      return createRedirectResponse(\n        redirectTo,\n        isSoftNavigation,\n        searchParams,\n        matchQueryParams,\n      );\n    }\n  } catch (error) {\n    console.error(\n      `Failed to fetch redirects from Storefront API for route ${redirectFrom}`,\n      error,\n    );\n  }\n\n  return response;\n}"
           },
           "StorefrontRedirect": {
             "filePath": "/routing/redirect.ts",
@@ -13920,6 +15736,7 @@
   {
     "name": "createWithCache",
     "category": "utilities",
+    "subCategory": "caching",
     "isVisualComponent": false,
     "related": [],
     "description": "Creates a utility function that executes an asynchronous operation \n like `fetch` and caches the result according to the strategy provided.\nUse this to call any third-party APIs from loaders or actions.\nBy default, it uses the `CacheShort` strategy.",
@@ -14166,6 +15983,7 @@
   {
     "name": "Image",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -14390,6 +16208,7 @@
   {
     "name": "ExternalVideo",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -14789,6 +16608,7 @@
   {
     "name": "MediaFile",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -17327,6 +19147,7 @@
   {
     "name": "ModelViewer",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -17660,6 +19481,7 @@
   {
     "name": "Video",
     "category": "components",
+    "subCategory": "media",
     "isVisualComponent": false,
     "related": [
       {
@@ -18193,7 +20015,7 @@
               "name": "void",
               "value": "void"
             },
-            "value": "export function useShopifyCookies(options?: UseShopifyCookiesOptions): void {\n  const {hasUserConsent = false, domain = ''} = options || {};\n  useEffect(() => {\n    const cookies = getShopifyCookies(document.cookie);\n\n    /**\n     * Set user and session cookies and refresh the expiry time\n     */\n    if (hasUserConsent) {\n      setCookie(\n        SHOPIFY_Y,\n        cookies[SHOPIFY_Y] || buildUUID(),\n        longTermLength,\n        domain,\n      );\n      setCookie(\n        SHOPIFY_S,\n        cookies[SHOPIFY_S] || buildUUID(),\n        shortTermLength,\n        domain,\n      );\n    } else {\n      setCookie(SHOPIFY_Y, '', 0, domain);\n      setCookie(SHOPIFY_S, '', 0, domain);\n    }\n  }, [options, hasUserConsent, domain]);\n}"
+            "value": "export function useShopifyCookies(options?: UseShopifyCookiesOptions): void {\n  const {hasUserConsent = false, domain = ''} = options || {};\n  useEffect(() => {\n    const cookies = getShopifyCookies(document.cookie);\n\n    /**\n     * Setting cookie with domain\n     *\n     * If no domain is provided, the cookie will be set for the current host.\n     * For Shopify, we need to ensure this domain is set with a leading dot.\n     */\n\n    // Use override domain or current host\n    let currentDomain = domain || window.document.location.host;\n\n    // Reset domain if localhost\n    if (/^localhost/.test(currentDomain)) currentDomain = '';\n\n    // Shopify checkout only consumes cookies set with leading dot domain\n    const domainWithLeadingDot = currentDomain\n      ? /^\\./.test(currentDomain)\n        ? currentDomain\n        : `.${currentDomain}`\n      : '';\n\n    /**\n     * Set user and session cookies and refresh the expiry time\n     */\n    if (hasUserConsent) {\n      setCookie(\n        SHOPIFY_Y,\n        cookies[SHOPIFY_Y] || buildUUID(),\n        longTermLength,\n        domainWithLeadingDot,\n      );\n      setCookie(\n        SHOPIFY_S,\n        cookies[SHOPIFY_S] || buildUUID(),\n        shortTermLength,\n        domainWithLeadingDot,\n      );\n    } else {\n      setCookie(SHOPIFY_Y, '', 0, domainWithLeadingDot);\n      setCookie(SHOPIFY_S, '', 0, domainWithLeadingDot);\n    }\n  }, [options, hasUserConsent, domain]);\n}"
           },
           "UseShopifyCookiesOptions": {
             "filePath": "/useShopifyCookies.tsx",

--- a/packages/hydrogen/src/cache/CacheCustom.doc.ts
+++ b/packages/hydrogen/src/cache/CacheCustom.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CacheCustom',
   category: 'utilities',
+  subCategory: 'caching',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen/src/cache/CacheLong.doc.ts
+++ b/packages/hydrogen/src/cache/CacheLong.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CacheLong',
   category: 'utilities',
+  subCategory: 'caching',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen/src/cache/CacheNone.doc.ts
+++ b/packages/hydrogen/src/cache/CacheNone.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CacheNone',
   category: 'utilities',
+  subCategory: 'caching',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen/src/cache/CacheShort.doc.ts
+++ b/packages/hydrogen/src/cache/CacheShort.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CacheShort',
   category: 'utilities',
+  subCategory: 'caching',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen/src/cache/InMemoryCache.doc.ts
+++ b/packages/hydrogen/src/cache/InMemoryCache.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'InMemoryCache',
   category: 'utilities',
+  subCategory: 'caching',
   isVisualComponent: false,
   related: [
     {

--- a/packages/hydrogen/src/cache/generateCacheControlHeader.doc.ts
+++ b/packages/hydrogen/src/cache/generateCacheControlHeader.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'generateCacheControlHeader',
   category: 'utilities',
+  subCategory: 'caching',
   isVisualComponent: false,
   related: [],
   description: `This utility function accepts a \`CachingStrategy\` object and returns a string with the corresponding \`cache-control\` header.

--- a/packages/hydrogen/src/cart/cartGetIdDefault.doc.ts
+++ b/packages/hydrogen/src/cart/cartGetIdDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartGetIdDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/cartSetIdDefault.doc.ts
+++ b/packages/hydrogen/src/cart/cartSetIdDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartSetIdDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/createCartHandler.doc.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'createCartHandler',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description: 'Creates an API that can be used to interact with the cart.',

--- a/packages/hydrogen/src/cart/queries/cartAttributesUpdateDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartAttributesUpdateDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartAttributesUpdateDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartBuyerIdentityUpdateDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartBuyerIdentityUpdateDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartBuyerIdentityUpdateDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartCreateDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartCreateDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartCreateDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartDiscountCodesUpdateDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartDiscountCodesUpdateDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartDiscountCodesUpdateDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartGetDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description: 'Creates a function that returns a cart',

--- a/packages/hydrogen/src/cart/queries/cartLinesAddDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartLinesAddDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartLinesAddDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartLinesRemoveDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartLinesRemoveDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartLinesRemoveDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartLinesUpdateDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartLinesUpdateDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartLinesUpdateDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartMetafieldDeleteDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartMetafieldDeleteDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartMetafieldDeleteDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartMetafieldsSetDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartMetafieldsSetDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartMetafieldsSetDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartNoteUpdateDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartNoteUpdateDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartNoteUpdateDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/cart/queries/cartSelectedDeliveryOptionsUpdateDefault.doc.ts
+++ b/packages/hydrogen/src/cart/queries/cartSelectedDeliveryOptionsUpdateDefault.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'cartSelectedDeliveryOptionsUpdateDefault',
   category: 'utilities',
+  subCategory: 'cart',
   isVisualComponent: false,
   related: [],
   description:

--- a/packages/hydrogen/src/with-cache.doc.ts
+++ b/packages/hydrogen/src/with-cache.doc.ts
@@ -3,6 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'createWithCache',
   category: 'utilities',
+  subCategory: 'caching',
   isVisualComponent: false,
   related: [],
   description: `Creates a utility function that executes an asynchronous operation \n like \`fetch\` and caches the result according to the strategy provided.\nUse this to call any third-party APIs from loaders or actions.\nBy default, it uses the \`CacheShort\` strategy.`,


### PR DESCRIPTION
This PR adds subcategories to group together some related components and utilities in the Hydrogen and Hydrogen React references.

This just adds the necessary metadata in the Hydrogen repo and regenerates the references; getting it into dotdev is a [followup task](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#generate-api-reference-docs-for-hydrogen-and-hydrogen-react).

It's been about six weeks since we regenerated the reference so there's some unrelated new stuff in here as well, not sure if that's an issue.

## 🎩 
Preview the reorganized references here:

🌀 https://shopify-dev.sf.graham-scott.us.spin.dev/docs/api/hydrogen
🌀 https://shopify-dev.sf.graham-scott.us.spin.dev/docs/api/hydrogen-react

### Cart
<img width="296" alt="Screenshot 2024-05-28 at 11 43 14" src="https://github.com/Shopify/hydrogen/assets/547470/134fd013-d5ce-4384-9087-b3c92af491c9">

### Caching
<img width="303" alt="Screenshot 2024-05-28 at 11 42 52" src="https://github.com/Shopify/hydrogen/assets/547470/32e0cce4-2110-4dec-8930-d613769fe719">

### Media
<img width="291" alt="Screenshot 2024-05-28 at 11 42 17" src="https://github.com/Shopify/hydrogen/assets/547470/c44677b5-ec50-4f2b-8783-063a0bcafbdc">
