### PR TITLE
Reduce usage of `new URL(...)` for local paths

### DIFF
--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -20,6 +20,7 @@ import {
   currentProcessIsGlobal,
   inferPackageManagerForGlobalCLI,
 } from '@shopify/cli-kit/node/is-global';
+import {getPkgJsonPath} from '../../lib/build.js';
 
 const FLAG_MAP = {f: 'force'} as Record<string, string>;
 
@@ -132,7 +133,7 @@ export async function runInit(
     // Resolving the CLI package from a local directory might fail because
     // this code could be run from a global dependency (e.g. on `npm create`).
     // Therefore, pass the known path to the package.json directly from here:
-    fileURLToPath(new URL('../../../package.json', import.meta.url)),
+    await getPkgJsonPath(),
     isGlobal ? 'cli' : 'cliHydrogen',
   );
 

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -66,19 +66,12 @@ beforeEach(() => {
   outputMock.clear();
 });
 
-beforeAll(() => {
-  process.env.FORCE_CHANGELOG_SOURCE = 'local';
-});
-
-afterAll(() => {
-  delete process.env.FORCE_CHANGELOG_SOURCE;
-});
-
-function createOutdatedSkeletonPackageJson() {
+async function createOutdatedSkeletonPackageJson() {
   const require = createRequire(import.meta.url);
-  const packageJson = require(fileURLToPath(
-    new URL('../../../../../templates/skeleton/package.json', import.meta.url),
-  )) as PackageJson;
+  const packageJson: PackageJson = require(joinPath(
+    getSkeletonSourceDir(),
+    'package.json',
+  ));
 
   if (!packageJson) throw new Error('Could not parse package.json');
   if (!packageJson?.dependencies)
@@ -159,7 +152,8 @@ function increasePatchVersion(depName: string, deps: Record<string, string>) {
 
 describe('upgrade', async () => {
   // Create an outdated skeleton package.json for all tests
-  const OUTDATED_HYDROGEN_PACKAGE_JSON = createOutdatedSkeletonPackageJson();
+  const OUTDATED_HYDROGEN_PACKAGE_JSON =
+    await createOutdatedSkeletonPackageJson();
 
   describe('checkIsGitRepo', () => {
     it('renders an error message when not in a git repo', async () => {

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -22,6 +22,7 @@ import {
   renderTasks,
 } from '@shopify/cli-kit/node/ui';
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output';
+import {type PackageJson} from '@shopify/cli-kit/node/node-package-manager';
 import {
   buildUpgradeCommandArgs,
   displayConfirmation,
@@ -32,13 +33,12 @@ import {
   getSelectedRelease,
   runUpgrade,
   type CumulativeRelease,
-  type Dependencies,
   type Release,
   upgradeNodeModules,
   getChangelog,
   displayDevUpgradeNotice,
 } from './upgrade.js';
-import {type PackageJson} from 'type-fest';
+import {getSkeletonSourceDir} from '../../lib/build.js';
 
 vi.mock('@shopify/cli-kit/node/session');
 
@@ -107,11 +107,8 @@ async function inTemporaryHydrogenRepo(
     packageJson,
   }: {
     cleanGitRepo?: boolean;
-    packageJson?: null | Record<string, unknown>;
-  } = {
-    cleanGitRepo: true,
-    packageJson: null,
-  },
+    packageJson?: PackageJson;
+  } = {cleanGitRepo: true},
 ) {
   return inTemporaryDirectory(async (tmpDir) => {
     // init the git repo
@@ -193,7 +190,7 @@ describe('upgrade', async () => {
             'valid package.json',
           );
         },
-        {packageJson: null},
+        {packageJson: undefined},
       );
     });
 
@@ -656,7 +653,7 @@ describe('upgrade', async () => {
           const currentDependencies = {
             ...OUTDATED_HYDROGEN_PACKAGE_JSON.dependencies,
             ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
-          } as Dependencies;
+          };
 
           await upgradeNodeModules({
             appPath,
@@ -683,7 +680,7 @@ describe('upgrade', async () => {
       const currentDependencies = {
         ...OUTDATED_HYDROGEN_PACKAGE_JSON.dependencies,
         ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
-      } as Dependencies;
+      };
 
       const result: string[] = [
         '@shopify/hydrogen@2023.10.0',
@@ -715,7 +712,7 @@ describe('upgrade', async () => {
         ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
         '@remix-run/dev': '1.2.0',
         '@remix-run/css-bundle': '1.7.0',
-      } as Dependencies;
+      };
 
       const result: string[] = [
         '@shopify/cli-hydrogen@6.0.0',
@@ -750,7 +747,7 @@ describe('upgrade', async () => {
         ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
         '@remix-run/dev': '1.8.0',
         '@remix-run/css-bundle': '1.8.0',
-      } as Dependencies;
+      };
 
       const result: string[] = [
         '@shopify/cli-hydrogen@6.0.0',
@@ -784,7 +781,7 @@ describe('upgrade', async () => {
         '@remix-run/react': '2.2.0',
         ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
         '@remix-run/dev': '2.2.0',
-      } as Dependencies;
+      };
 
       const result: string[] = [
         '@shopify/cli-hydrogen@6.0.0',
@@ -821,10 +818,9 @@ describe('upgrade', async () => {
         '@remix-run/react': '2.1.0',
         ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
         '@remix-run/dev': '2.1.0',
-      } as Dependencies;
-
-      // simulate a missing required dependency
-      delete currentDependencies['typescript'];
+        // simulate a missing required dependency
+        typescript: '',
+      };
 
       const result: string[] = [
         '@shopify/cli-hydrogen@6.0.0',
@@ -853,10 +849,9 @@ describe('upgrade', async () => {
         '@remix-run/react': '2.1.0',
         ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
         '@remix-run/dev': '2.1.0',
-      } as Dependencies;
-
-      // simulate a missing required dependency
-      delete currentDependencies['typescript'];
+        // simulate a missing required dependency
+        typescript: '',
+      };
 
       const result: string[] = [
         '@shopify/cli-hydrogen@6.0.0',
@@ -889,7 +884,7 @@ describe('upgrade', async () => {
         ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
         '@remix-run/dev': '2.1.0',
         typescript: '5.3.0', // more up-to-date than that of 2023.10.0
-      } as Dependencies;
+      };
 
       const result: string[] = [
         '@shopify/cli-hydrogen@6.0.0',
@@ -918,7 +913,7 @@ describe('upgrade', async () => {
         ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
         '@remix-run/dev': '2.1.0',
         '@shopify/hydrogen': 'next',
-      } as Dependencies;
+      };
 
       const result: string[] = [
         '@shopify/cli-hydrogen@6.0.0',

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -87,7 +87,7 @@ export function getSkeletonSourceDir() {
     );
   }
 
-  return monorepoPackagesPath.replace(/\/packages\/$/, '/templates/skeleton/');
+  return joinPath(dirname(monorepoPackagesPath), 'templates', 'skeleton');
 }
 
 export async function getRepoNodeModules() {
@@ -95,10 +95,7 @@ export async function getRepoNodeModules() {
   let nodeModulesPath = stdout.trim();
 
   if (!nodeModulesPath && isHydrogenMonorepo) {
-    nodeModulesPath = monorepoPackagesPath.replace(
-      /\/packages\/$/,
-      '/node_modules/',
-    );
+    nodeModulesPath = joinPath(dirname(monorepoPackagesPath), 'node_modules');
   }
 
   return nodeModulesPath;

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -31,10 +31,12 @@ export type AssetsDir =
   | 'bundle'
   // These are created at build time:
   | 'virtual-routes'
+  | 'internal-templates'
+  | 'external-templates'
   | typeof ASSETS_STARTER_DIR;
 
 let pkgJsonPath: string | undefined;
-export async function getAssetsDir(feature?: AssetsDir, ...subpaths: string[]) {
+export async function getPkgJsonPath() {
   pkgJsonPath ??= await findPathUp('package.json', {
     cwd: fileURLToPath(import.meta.url),
     type: 'file',
@@ -47,8 +49,12 @@ export async function getAssetsDir(feature?: AssetsDir, ...subpaths: string[]) {
     );
   }
 
+  return pkgJsonPath;
+}
+
+export async function getAssetsDir(feature?: AssetsDir, ...subpaths: string[]) {
   return joinPath(
-    dirname(pkgJsonPath),
+    dirname(await getPkgJsonPath()),
     process.env.SHOPIFY_UNIT_TEST
       ? `assets` // Use source for unit tests
       : `dist/${ASSETS_DIR_PREFIX}`,

--- a/packages/cli/src/lib/onboarding/setup-template.mocks.ts
+++ b/packages/cli/src/lib/onboarding/setup-template.mocks.ts
@@ -1,9 +1,8 @@
-import {fileURLToPath} from 'node:url';
 import {vi} from 'vitest';
 import {createSymlink, remove as rmdir} from 'fs-extra/esm';
 import {writeFile} from '@shopify/cli-kit/node/fs';
-import {joinPath} from '@shopify/cli-kit/node/path';
-import {getRepoNodeModules} from '../build.js';
+import {dirname, joinPath} from '@shopify/cli-kit/node/path';
+import {getRepoNodeModules, getSkeletonSourceDir} from '../build.js';
 
 const {renderTasksHook} = vi.hoisted(() => ({renderTasksHook: vi.fn()}));
 
@@ -11,18 +10,15 @@ vi.mock('../template-downloader.js', async () => ({
   downloadMonorepoTemplates: () =>
     Promise.resolve({
       version: '',
-      templatesDir: fileURLToPath(
-        new URL('../../../../../templates', import.meta.url),
-      ),
-      examplesDir: fileURLToPath(
-        new URL('../../../../../examples', import.meta.url),
+      templatesDir: dirname(getSkeletonSourceDir()),
+      examplesDir: dirname(getSkeletonSourceDir()).replace(
+        'templates',
+        'examples',
       ),
     }),
   downloadExternalRepo: () =>
     Promise.resolve({
-      templateDir: fileURLToPath(
-        new URL('../../../../../templates/skeleton', import.meta.url),
-      ),
+      templateDir: getSkeletonSourceDir(),
     }),
 }));
 

--- a/packages/cli/src/lib/remix-config.ts
+++ b/packages/cli/src/lib/remix-config.ts
@@ -12,6 +12,7 @@ import {REQUIRED_REMIX_VERSION} from './remix-version-check.js';
 import {findFileWithExtension} from './file.js';
 import {getViteConfig} from './vite-config.js';
 import {importLocal} from './import-utils.js';
+import {hydrogenPackagesPath, isHydrogenMonorepo} from './build.js';
 
 type RawRemixConfig = AppConfig;
 
@@ -78,9 +79,9 @@ export async function getRemixConfig(
   ).catch(handleRemixImportFail);
   const config = await readConfig(root, mode);
 
-  if (process.env.LOCAL_DEV) {
+  if (isHydrogenMonorepo && hydrogenPackagesPath) {
     // Watch local packages when developing in Hydrogen repo
-    const packagesPath = fileURLToPath(new URL('../../..', import.meta.url));
+    const packagesPath = hydrogenPackagesPath;
     config.watchPaths ??= [];
 
     config.watchPaths.push(

--- a/packages/cli/src/lib/template-downloader.ts
+++ b/packages/cli/src/lib/template-downloader.ts
@@ -8,7 +8,7 @@ import {parseGitHubRepositoryURL} from '@shopify/cli-kit/node/github';
 import {mkdir, fileExists, rmdir} from '@shopify/cli-kit/node/fs';
 import {AbortError} from '@shopify/cli-kit/node/error';
 import {AbortSignal} from '@shopify/cli-kit/node/abort';
-import {getSkeletonSourceDir} from './build.js';
+import {getAssetsDir, getSkeletonSourceDir} from './build.js';
 import {joinPath} from '@shopify/cli-kit/node/path';
 import {downloadGitRepository} from '@shopify/cli-kit/node/git';
 
@@ -89,9 +89,7 @@ export async function downloadMonorepoTemplates({
 
   try {
     const {version, url} = await getLatestReleaseDownloadUrl(signal);
-    const templateStoragePath = fileURLToPath(
-      new URL('../starter-templates', import.meta.url),
-    );
+    const templateStoragePath = await getAssetsDir('internal-templates');
 
     if (!(await fileExists(templateStoragePath))) {
       await mkdir(templateStoragePath);
@@ -126,16 +124,14 @@ export async function downloadExternalRepo(
     throw new AbortError(parsed.error.message);
   }
 
-  const externalTemplates = fileURLToPath(
-    new URL('../external-templates', import.meta.url),
-  );
-  if (!(await fileExists(externalTemplates))) {
-    await mkdir(externalTemplates);
+  const templateStoragePath = await getAssetsDir('external-templates');
+  if (!(await fileExists(templateStoragePath))) {
+    await mkdir(templateStoragePath);
   }
 
   const result = parsed.value;
   const templateDir = joinPath(
-    externalTemplates,
+    templateStoragePath,
     result.full.replace(/^https?:\/\//, '').replace(/[^\w]+/, '_'),
   );
 

--- a/packages/cli/src/lib/virtual-routes.ts
+++ b/packages/cli/src/lib/virtual-routes.ts
@@ -4,11 +4,10 @@
  * @deprecated
  */
 
-import {fileURLToPath} from 'node:url';
 import {glob} from '@shopify/cli-kit/node/fs';
 import {joinPath, relativePath} from '@shopify/cli-kit/node/path';
 import type {RemixConfig} from './remix-config.js';
-import {getAssetsDir} from './build.js';
+import {getAssetsDir, hydrogenPackagesPath} from './build.js';
 
 export const VIRTUAL_ROUTES_DIR = 'virtual-routes/routes';
 export const VIRTUAL_ROOT = 'virtual-routes/virtual-root';
@@ -21,9 +20,10 @@ type MinimalRemixConfig = {
 export async function addVirtualRoutes<T extends MinimalRemixConfig>(
   config: T,
 ): Promise<T> {
-  const distPath = process.env.SHOPIFY_UNIT_TEST
-    ? fileURLToPath(new URL('../../../hydrogen/src/vite', import.meta.url))
-    : await getAssetsDir();
+  const distPath =
+    process.env.SHOPIFY_UNIT_TEST && hydrogenPackagesPath
+      ? joinPath(hydrogenPackagesPath, 'hydrogen', 'src', 'vite')
+      : await getAssetsDir();
 
   const userRouteList = Object.values(config.routes);
   const virtualRoutesPath = joinPath(distPath, VIRTUAL_ROUTES_DIR);


### PR DESCRIPTION
Continues with #2162 and removes all the other usages of `new URL(...)` to find local paths, since this will fail in a bundled/global CLI scenario.

Also simplifies types in upgrade command.