### PR TITLE
Fix optimizing deps for PNPM

### DIFF
--- a/.changeset/young-dolls-punch.md
+++ b/.changeset/young-dolls-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix optimizing deps when using PNPM.

--- a/packages/hydrogen/src/vite/plugin.ts
+++ b/packages/hydrogen/src/vite/plugin.ts
@@ -46,6 +46,11 @@ export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
       config(_, env) {
         sharedOptions.command = env.command;
 
+        const isHydrogenMonorepo = new URL(
+          '../../..',
+          import.meta.url,
+        ).pathname.endsWith('/hydrogen/packages/');
+
         return {
           ssr: {
             optimizeDeps: {
@@ -58,20 +63,22 @@ export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
                 'react/jsx-dev-runtime',
                 'react-dom',
                 'react-dom/server',
-                // Remix deps:
-                'set-cookie-parser',
-                'cookie',
+                '@remix-run/server-runtime',
               ],
             },
           },
           // Vite performs an initial reload after optimizing these dependencies.
           // Do it early to avoid the initial reload:
           optimizeDeps: {
-            include: [
-              'content-security-policy-builder',
-              'tiny-invariant',
-              'worktop/cookie',
-            ],
+            // Avoid optimizing Hydrogen itself in the monorepo
+            // to prevent caching source code changes:
+            include: isHydrogenMonorepo
+              ? [
+                  'content-security-policy-builder',
+                  'tiny-invariant',
+                  'worktop/cookie',
+                ]
+              : ['@shopify/hydrogen'],
           },
         };
       },

--- a/templates/skeleton/.npmrc
+++ b/templates/skeleton/.npmrc
@@ -1,7 +1,2 @@
 @shopify:registry=https://registry.npmjs.com
 progress=false
-
-# Ensure Vite can optimize these deps in PNPM
-public-hoist-pattern[]=cookie
-public-hoist-pattern[]=set-cookie-parser
-public-hoist-pattern[]=content-security-policy-builder


### PR DESCRIPTION
PNPM doesn't hoist some subdependencies so Vite can't optimize them properly. With this PR, we tell Vite to optimize direct dependencies instead so that it can always find them even with PNPM.