### PR TITLE
Update oxygen-cli to 4.4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6293,6 +6293,142 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/@oclif/core": {
+      "version": "3.26.5",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.26.5.tgz",
+      "integrity": "sha512-uRmAujGJjLhhgpLylbiuHuPt9Ec7u6aJ72utuSPNTRw47+W5vbQSGnLGPiil1Mt5YDL+zFOyTVH6Uv3NSP2SaQ==",
+      "dependencies": {
+        "@types/cli-progress": "^3.11.5",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.12.0",
+        "color": "^4.2.3",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.10",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "minimatch": "^9.0.4",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/clean-stack": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
+      "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
+      "dependencies": {
+        "escape-string-regexp": "4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
@@ -8214,6 +8350,334 @@
       "resolved": "packages/cli",
       "link": true
     },
+    "node_modules/@shopify/cli-kit": {
+      "version": "3.60.0",
+      "resolved": "https://registry.npmjs.org/@shopify/cli-kit/-/cli-kit-3.60.0.tgz",
+      "integrity": "sha512-+XJmEPqKy+ZBa6EMYr06Z5O8RhgTl/LaCya+rQWdenBNlXkJNkmsQ571nglOZdfPakjuRcFfWKe5jL8yj2vonA==",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@bugsnag/js": "7.21.0",
+        "@iarna/toml": "2.2.5",
+        "@oclif/core": "3.26.5",
+        "@opentelemetry/api": "1.6.0",
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.43.0",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/sdk-metrics": "1.17.1",
+        "@opentelemetry/semantic-conventions": "1.17.1",
+        "@types/archiver": "5.3.2",
+        "ansi-escapes": "6.2.0",
+        "archiver": "5.3.2",
+        "bottleneck": "2.19.5",
+        "chalk": "5.3.0",
+        "change-case": "4.1.2",
+        "color-json": "3.0.5",
+        "commondir": "1.0.1",
+        "conf": "11.0.2",
+        "deepmerge": "4.3.1",
+        "del": "6.1.1",
+        "dotenv": "16.4.5",
+        "env-paths": "3.0.0",
+        "execa": "7.2.0",
+        "fast-glob": "3.3.1",
+        "figures": "5.0.0",
+        "find-process": "1.4.7",
+        "find-up": "6.3.0",
+        "form-data": "4.0.0",
+        "fs-extra": "11.1.0",
+        "get-port-please": "3.0.1",
+        "gradient-string": "2.0.2",
+        "graphql": "16.8.1",
+        "graphql-request": "5.2.0",
+        "ink": "4.4.1",
+        "is-interactive": "2.0.0",
+        "kill-port-process": "3.1.0",
+        "latest-version": "7.0.0",
+        "liquidjs": "10.9.2",
+        "lodash": "4.17.21",
+        "macaddress": "0.5.3",
+        "minimatch": "9.0.3",
+        "mrmime": "1.0.1",
+        "node-abort-controller": "3.1.1",
+        "node-fetch": "3.3.2",
+        "open": "8.4.2",
+        "pathe": "1.1.1",
+        "react": "^18.2.0",
+        "semver": "7.5.4",
+        "simple-git": "3.19.1",
+        "stacktracey": "2.1.8",
+        "strip-ansi": "7.1.0",
+        "supports-hyperlinks": "3.0.0",
+        "tempy": "3.0.0",
+        "terminal-link": "3.0.0",
+        "ts-error": "1.0.6",
+        "zod": "3.22.3"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/ansi-escapes": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
+      "integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
+      "dependencies": {
+        "type-fest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/figures": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "is-unicode-supported": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/fs-extra": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/supports-hyperlinks": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@shopify/cli-kit/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@shopify/cli/node_modules/@esbuild/android-arm": {
       "version": "0.19.8",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.8.tgz",
@@ -8659,6 +9123,41 @@
     "node_modules/@shopify/mini-oxygen": {
       "resolved": "packages/mini-oxygen",
       "link": true
+    },
+    "node_modules/@shopify/oxygen-cli": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.4.9.tgz",
+      "integrity": "sha512-NCpMyRyXaBtLMSSIDuJsX4hYCiudyMCMeoqvtN7HYgjCZNsC5F2dvZLpu0mVOSqXrNB89PG/QnaXlcZZW+3IjQ==",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@bugsnag/core": "^7.19.0",
+        "@bugsnag/js": "^7.22.4",
+        "@bugsnag/node": "^7.23.0",
+        "async": "^3.2.5"
+      },
+      "bin": {
+        "oxygen-cli": "dist/oxygen-cli.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@oclif/core": "^3.15.1",
+        "@shopify/cli-kit": "^3.58.0"
+      }
+    },
+    "node_modules/@shopify/oxygen-cli/node_modules/@bugsnag/js": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.23.0.tgz",
+      "integrity": "sha512-gnCpcv/v6p3CtbwwDuAjVYPPNq4NMVj4hp70MiB3OGJ+LmIS66CwElDiyvRMA8Ar6OzCF4joTeaNG5bD9cM41w==",
+      "dependencies": {
+        "@bugsnag/browser": "^7.22.7",
+        "@bugsnag/node": "^7.23.0"
+      }
     },
     "node_modules/@shopify/oxygen-workers-types": {
       "version": "4.0.0",
@@ -13283,6 +13782,20 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.615",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.615.tgz",
@@ -14868,14 +15381,16 @@
     },
     "node_modules/filelist": {
       "version": "1.0.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dependencies": {
         "minimatch": "^5.0.1"
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -18191,13 +18706,14 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.8.5",
-      "license": "Apache-2.0",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.1.tgz",
+      "integrity": "sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==",
       "dependencies": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
       },
       "bin": {
         "jake": "bin/cli.js"
@@ -32612,7 +33128,7 @@
         "@ast-grep/napi": "0.11.0",
         "@oclif/core": "3.26.5",
         "@shopify/cli-kit": "3.60.0",
-        "@shopify/oxygen-cli": "~4.4.5",
+        "@shopify/oxygen-cli": "4.4.9",
         "@shopify/plugin-cloudflare": "3.60.0",
         "ansi-escapes": "^6.2.0",
         "cli-truncate": "^4.0.0",
@@ -32684,298 +33200,6 @@
         }
       }
     },
-    "packages/cli/node_modules/@oclif/core": {
-      "version": "3.26.5",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.26.5.tgz",
-      "integrity": "sha512-uRmAujGJjLhhgpLylbiuHuPt9Ec7u6aJ72utuSPNTRw47+W5vbQSGnLGPiil1Mt5YDL+zFOyTVH6Uv3NSP2SaQ==",
-      "dependencies": {
-        "@types/cli-progress": "^3.11.5",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.12.0",
-        "color": "^4.2.3",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.10",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "minimatch": "^9.0.4",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.3",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/cli/node_modules/@oclif/core/node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/@oclif/core/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/cli/node_modules/@oclif/core/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "packages/cli/node_modules/@oclif/core/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "packages/cli/node_modules/@oclif/core/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/cli/node_modules/@oclif/core/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "packages/cli/node_modules/@oclif/core/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/cli/node_modules/@oclif/core/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/cli/node_modules/@oclif/core/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/@shopify/cli-kit": {
-      "version": "3.60.0",
-      "resolved": "https://registry.npmjs.org/@shopify/cli-kit/-/cli-kit-3.60.0.tgz",
-      "integrity": "sha512-+XJmEPqKy+ZBa6EMYr06Z5O8RhgTl/LaCya+rQWdenBNlXkJNkmsQ571nglOZdfPakjuRcFfWKe5jL8yj2vonA==",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "dependencies": {
-        "@bugsnag/js": "7.21.0",
-        "@iarna/toml": "2.2.5",
-        "@oclif/core": "3.26.5",
-        "@opentelemetry/api": "1.6.0",
-        "@opentelemetry/core": "1.17.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.43.0",
-        "@opentelemetry/resources": "1.17.1",
-        "@opentelemetry/sdk-metrics": "1.17.1",
-        "@opentelemetry/semantic-conventions": "1.17.1",
-        "@types/archiver": "5.3.2",
-        "ansi-escapes": "6.2.0",
-        "archiver": "5.3.2",
-        "bottleneck": "2.19.5",
-        "chalk": "5.3.0",
-        "change-case": "4.1.2",
-        "color-json": "3.0.5",
-        "commondir": "1.0.1",
-        "conf": "11.0.2",
-        "deepmerge": "4.3.1",
-        "del": "6.1.1",
-        "dotenv": "16.4.5",
-        "env-paths": "3.0.0",
-        "execa": "7.2.0",
-        "fast-glob": "3.3.1",
-        "figures": "5.0.0",
-        "find-process": "1.4.7",
-        "find-up": "6.3.0",
-        "form-data": "4.0.0",
-        "fs-extra": "11.1.0",
-        "get-port-please": "3.0.1",
-        "gradient-string": "2.0.2",
-        "graphql": "16.8.1",
-        "graphql-request": "5.2.0",
-        "ink": "4.4.1",
-        "is-interactive": "2.0.0",
-        "kill-port-process": "3.1.0",
-        "latest-version": "7.0.0",
-        "liquidjs": "10.9.2",
-        "lodash": "4.17.21",
-        "macaddress": "0.5.3",
-        "minimatch": "9.0.3",
-        "mrmime": "1.0.1",
-        "node-abort-controller": "3.1.1",
-        "node-fetch": "3.3.2",
-        "open": "8.4.2",
-        "pathe": "1.1.1",
-        "react": "^18.2.0",
-        "semver": "7.5.4",
-        "simple-git": "3.19.1",
-        "stacktracey": "2.1.8",
-        "strip-ansi": "7.1.0",
-        "supports-hyperlinks": "3.0.0",
-        "tempy": "3.0.0",
-        "terminal-link": "3.0.0",
-        "ts-error": "1.0.6",
-        "zod": "3.22.3"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      }
-    },
-    "packages/cli/node_modules/@shopify/cli-kit/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/cli/node_modules/@shopify/cli-kit/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/cli/node_modules/@shopify/cli-kit/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/cli/node_modules/@shopify/cli-kit/node_modules/supports-hyperlinks": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
-      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "packages/cli/node_modules/@shopify/oxygen-cli": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.4.6.tgz",
-      "integrity": "sha512-GCsp0l/VQxsezNoH7ItUuYBL4DB4yolYSe8z2FY6EyJ9vD7NPxBoBsVF4ZqPqVThjLXC/9hpokLUY0lH1MpPZg==",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "dependencies": {
-        "@bugsnag/core": "^7.19.0",
-        "@bugsnag/js": "^7.22.4",
-        "@bugsnag/node": "^7.23.0",
-        "async": "^3.2.5"
-      },
-      "bin": {
-        "oxygen-cli": "dist/oxygen-cli.js"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "@oclif/core": "^3.15.1",
-        "@shopify/cli-kit": "^3.58.0"
-      }
-    },
-    "packages/cli/node_modules/@shopify/oxygen-cli/node_modules/@bugsnag/js": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.23.0.tgz",
-      "integrity": "sha512-gnCpcv/v6p3CtbwwDuAjVYPPNq4NMVj4hp70MiB3OGJ+LmIS66CwElDiyvRMA8Ar6OzCF4joTeaNG5bD9cM41w==",
-      "dependencies": {
-        "@bugsnag/browser": "^7.22.7",
-        "@bugsnag/node": "^7.23.0"
-      }
-    },
     "packages/cli/node_modules/@shopify/plugin-cloudflare": {
       "version": "3.60.0",
       "resolved": "https://registry.npmjs.org/@shopify/plugin-cloudflare/-/plugin-cloudflare-3.60.0.tgz",
@@ -33040,36 +33264,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "packages/cli/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "packages/cli/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/cli/node_modules/clean-stack": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
-      "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
-      "dependencies": {
-        "escape-string-regexp": "4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/cli/node_modules/cli-truncate": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
@@ -33085,85 +33279,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/cli/node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "packages/cli/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "packages/cli/node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "packages/cli/node_modules/emoji-regex": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
       "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
-    },
-    "packages/cli/node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-      "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/find-up": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-      "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "packages/cli/node_modules/fs-extra": {
       "version": "11.1.0",
@@ -33199,121 +33318,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/is-interactive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "packages/cli/node_modules/locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/cli/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "packages/cli/node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "packages/cli/node_modules/slice-ansi": {
@@ -33361,20 +33365,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "packages/cli/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "packages/cli/node_modules/type-fest": {
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
@@ -33382,17 +33372,6 @@
       "dev": true,
       "engines": {
         "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/cli/node_modules/yocto-queue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -39989,6 +39968,111 @@
         }
       }
     },
+    "@oclif/core": {
+      "version": "3.26.5",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.26.5.tgz",
+      "integrity": "sha512-uRmAujGJjLhhgpLylbiuHuPt9Ec7u6aJ72utuSPNTRw47+W5vbQSGnLGPiil1Mt5YDL+zFOyTVH6Uv3NSP2SaQ==",
+      "requires": {
+        "@types/cli-progress": "^3.11.5",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.12.0",
+        "color": "^4.2.3",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.10",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "minimatch": "^9.0.4",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
+          "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
+          "requires": {
+            "escape-string-regexp": "4.0.0"
+          }
+        },
+        "color": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+          "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+          "requires": {
+            "color-convert": "^2.0.1",
+            "color-string": "^1.9.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@open-draft/deferred-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
@@ -41285,7 +41369,7 @@
         "@parcel/watcher": "^2.3.0",
         "@remix-run/dev": "^2.9.2",
         "@shopify/cli-kit": "3.60.0",
-        "@shopify/oxygen-cli": "~4.4.5",
+        "@shopify/oxygen-cli": "4.4.9",
         "@shopify/plugin-cloudflare": "3.60.0",
         "@types/diff": "^5.0.2",
         "@types/fs-extra": "^11.0.1",
@@ -41316,224 +41400,6 @@
         "vitest": "^1.0.4"
       },
       "dependencies": {
-        "@oclif/core": {
-          "version": "3.26.5",
-          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.26.5.tgz",
-          "integrity": "sha512-uRmAujGJjLhhgpLylbiuHuPt9Ec7u6aJ72utuSPNTRw47+W5vbQSGnLGPiil1Mt5YDL+zFOyTVH6Uv3NSP2SaQ==",
-          "requires": {
-            "@types/cli-progress": "^3.11.5",
-            "ansi-escapes": "^4.3.2",
-            "ansi-styles": "^4.3.0",
-            "cardinal": "^2.1.1",
-            "chalk": "^4.1.2",
-            "clean-stack": "^3.0.1",
-            "cli-progress": "^3.12.0",
-            "color": "^4.2.3",
-            "debug": "^4.3.4",
-            "ejs": "^3.1.10",
-            "get-package-type": "^0.1.0",
-            "globby": "^11.1.0",
-            "hyperlinker": "^1.0.0",
-            "indent-string": "^4.0.0",
-            "is-wsl": "^2.2.0",
-            "js-yaml": "^3.14.1",
-            "minimatch": "^9.0.4",
-            "natural-orderby": "^2.0.3",
-            "object-treeify": "^1.1.33",
-            "password-prompt": "^1.1.3",
-            "slice-ansi": "^4.0.0",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "supports-color": "^8.1.1",
-            "supports-hyperlinks": "^2.2.0",
-            "widest-line": "^3.1.0",
-            "wordwrap": "^1.0.0",
-            "wrap-ansi": "^7.0.0"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "4.3.2",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-              "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-              "requires": {
-                "type-fest": "^0.21.3"
-              }
-            },
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-            },
-            "ansi-styles": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "emoji-regex": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-              "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-            },
-            "slice-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-              "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-              "requires": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
-              }
-            },
-            "string-width": {
-              "version": "4.2.3",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-              "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            },
-            "type-fest": {
-              "version": "0.21.3",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-              "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
-            }
-          }
-        },
-        "@shopify/cli-kit": {
-          "version": "3.60.0",
-          "resolved": "https://registry.npmjs.org/@shopify/cli-kit/-/cli-kit-3.60.0.tgz",
-          "integrity": "sha512-+XJmEPqKy+ZBa6EMYr06Z5O8RhgTl/LaCya+rQWdenBNlXkJNkmsQ571nglOZdfPakjuRcFfWKe5jL8yj2vonA==",
-          "requires": {
-            "@bugsnag/js": "7.21.0",
-            "@iarna/toml": "2.2.5",
-            "@oclif/core": "3.26.5",
-            "@opentelemetry/api": "1.6.0",
-            "@opentelemetry/core": "1.17.1",
-            "@opentelemetry/exporter-metrics-otlp-http": "0.43.0",
-            "@opentelemetry/resources": "1.17.1",
-            "@opentelemetry/sdk-metrics": "1.17.1",
-            "@opentelemetry/semantic-conventions": "1.17.1",
-            "@types/archiver": "5.3.2",
-            "ansi-escapes": "6.2.0",
-            "archiver": "5.3.2",
-            "bottleneck": "2.19.5",
-            "chalk": "5.3.0",
-            "change-case": "4.1.2",
-            "color-json": "3.0.5",
-            "commondir": "1.0.1",
-            "conf": "11.0.2",
-            "deepmerge": "4.3.1",
-            "del": "6.1.1",
-            "dotenv": "16.4.5",
-            "env-paths": "3.0.0",
-            "execa": "7.2.0",
-            "fast-glob": "3.3.1",
-            "figures": "5.0.0",
-            "find-process": "1.4.7",
-            "find-up": "6.3.0",
-            "form-data": "4.0.0",
-            "fs-extra": "11.1.0",
-            "get-port-please": "3.0.1",
-            "gradient-string": "2.0.2",
-            "graphql": "16.8.1",
-            "graphql-request": "5.2.0",
-            "ink": "4.4.1",
-            "is-interactive": "2.0.0",
-            "kill-port-process": "3.1.0",
-            "latest-version": "7.0.0",
-            "liquidjs": "10.9.2",
-            "lodash": "4.17.21",
-            "macaddress": "0.5.3",
-            "minimatch": "9.0.3",
-            "mrmime": "1.0.1",
-            "node-abort-controller": "3.1.1",
-            "node-fetch": "3.3.2",
-            "open": "8.4.2",
-            "pathe": "1.1.1",
-            "react": "^18.2.0",
-            "semver": "7.5.4",
-            "simple-git": "3.19.1",
-            "stacktracey": "2.1.8",
-            "strip-ansi": "7.1.0",
-            "supports-hyperlinks": "3.0.0",
-            "tempy": "3.0.0",
-            "terminal-link": "3.0.0",
-            "ts-error": "1.0.6",
-            "zod": "3.22.3"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-              "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
-            },
-            "minimatch": {
-              "version": "9.0.3",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-              "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            },
-            "supports-hyperlinks": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
-              "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
-              "requires": {
-                "has-flag": "^4.0.0",
-                "supports-color": "^7.0.0"
-              }
-            }
-          }
-        },
-        "@shopify/oxygen-cli": {
-          "version": "4.4.6",
-          "resolved": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.4.6.tgz",
-          "integrity": "sha512-GCsp0l/VQxsezNoH7ItUuYBL4DB4yolYSe8z2FY6EyJ9vD7NPxBoBsVF4ZqPqVThjLXC/9hpokLUY0lH1MpPZg==",
-          "requires": {
-            "@bugsnag/core": "^7.19.0",
-            "@bugsnag/js": "^7.22.4",
-            "@bugsnag/node": "^7.23.0",
-            "async": "^3.2.5"
-          },
-          "dependencies": {
-            "@bugsnag/js": {
-              "version": "7.23.0",
-              "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.23.0.tgz",
-              "integrity": "sha512-gnCpcv/v6p3CtbwwDuAjVYPPNq4NMVj4hp70MiB3OGJ+LmIS66CwElDiyvRMA8Ar6OzCF4joTeaNG5bD9cM41w==",
-              "requires": {
-                "@bugsnag/browser": "^7.22.7",
-                "@bugsnag/node": "^7.23.0"
-              }
-            }
-          }
-        },
         "@shopify/plugin-cloudflare": {
           "version": "3.60.0",
           "resolved": "https://registry.npmjs.org/@shopify/plugin-cloudflare/-/plugin-cloudflare-3.60.0.tgz",
@@ -41568,30 +41434,6 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
           "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
         },
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "clean-stack": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
-          "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
-          "requires": {
-            "escape-string-regexp": "4.0.0"
-          }
-        },
         "cli-truncate": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
@@ -41601,57 +41443,10 @@
             "string-width": "^7.0.0"
           }
         },
-        "color": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-          "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-          "requires": {
-            "color-convert": "^2.0.1",
-            "color-string": "^1.9.0"
-          }
-        },
-        "data-uri-to-buffer": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
-        },
-        "ejs": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-          "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-          "requires": {
-            "jake": "^10.8.5"
-          }
-        },
         "emoji-regex": {
           "version": "10.3.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
           "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw=="
-        },
-        "figures": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-          "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
-          "requires": {
-            "escape-string-regexp": "^5.0.0",
-            "is-unicode-supported": "^1.2.0"
-          },
-          "dependencies": {
-            "escape-string-regexp": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-              "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-            }
-          }
-        },
-        "find-up": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-          "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-          "requires": {
-            "locate-path": "^7.1.0",
-            "path-exists": "^5.0.0"
-          }
         },
         "fs-extra": {
           "version": "11.1.0",
@@ -41674,6 +41469,168 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
           "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="
         },
+        "slice-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+          "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+          "requires": {
+            "ansi-styles": "^6.0.0",
+            "is-fullwidth-code-point": "^4.0.0"
+          }
+        },
+        "string-width": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+          "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+          "requires": {
+            "emoji-regex": "^10.3.0",
+            "get-east-asian-width": "^1.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "4.18.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+          "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+          "dev": true
+        }
+      }
+    },
+    "@shopify/cli-kit": {
+      "version": "3.60.0",
+      "resolved": "https://registry.npmjs.org/@shopify/cli-kit/-/cli-kit-3.60.0.tgz",
+      "integrity": "sha512-+XJmEPqKy+ZBa6EMYr06Z5O8RhgTl/LaCya+rQWdenBNlXkJNkmsQ571nglOZdfPakjuRcFfWKe5jL8yj2vonA==",
+      "requires": {
+        "@bugsnag/js": "7.21.0",
+        "@iarna/toml": "2.2.5",
+        "@oclif/core": "3.26.5",
+        "@opentelemetry/api": "1.6.0",
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.43.0",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/sdk-metrics": "1.17.1",
+        "@opentelemetry/semantic-conventions": "1.17.1",
+        "@types/archiver": "5.3.2",
+        "ansi-escapes": "6.2.0",
+        "archiver": "5.3.2",
+        "bottleneck": "2.19.5",
+        "chalk": "5.3.0",
+        "change-case": "4.1.2",
+        "color-json": "3.0.5",
+        "commondir": "1.0.1",
+        "conf": "11.0.2",
+        "deepmerge": "4.3.1",
+        "del": "6.1.1",
+        "dotenv": "16.4.5",
+        "env-paths": "3.0.0",
+        "execa": "7.2.0",
+        "fast-glob": "3.3.1",
+        "figures": "5.0.0",
+        "find-process": "1.4.7",
+        "find-up": "6.3.0",
+        "form-data": "4.0.0",
+        "fs-extra": "11.1.0",
+        "get-port-please": "3.0.1",
+        "gradient-string": "2.0.2",
+        "graphql": "16.8.1",
+        "graphql-request": "5.2.0",
+        "ink": "4.4.1",
+        "is-interactive": "2.0.0",
+        "kill-port-process": "3.1.0",
+        "latest-version": "7.0.0",
+        "liquidjs": "10.9.2",
+        "lodash": "4.17.21",
+        "macaddress": "0.5.3",
+        "minimatch": "9.0.3",
+        "mrmime": "1.0.1",
+        "node-abort-controller": "3.1.1",
+        "node-fetch": "3.3.2",
+        "open": "8.4.2",
+        "pathe": "1.1.1",
+        "react": "^18.2.0",
+        "semver": "7.5.4",
+        "simple-git": "3.19.1",
+        "stacktracey": "2.1.8",
+        "strip-ansi": "7.1.0",
+        "supports-hyperlinks": "3.0.0",
+        "tempy": "3.0.0",
+        "terminal-link": "3.0.0",
+        "ts-error": "1.0.6",
+        "zod": "3.22.3"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
+          "integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
+          "requires": {
+            "type-fest": "^3.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "chalk": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+        },
+        "data-uri-to-buffer": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+          "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+        },
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        },
+        "figures": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+          "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+          "requires": {
+            "escape-string-regexp": "^5.0.0",
+            "is-unicode-supported": "^1.2.0"
+          }
+        },
+        "find-up": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+          "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+          "requires": {
+            "locate-path": "^7.1.0",
+            "path-exists": "^5.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "is-interactive": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -41684,15 +41641,6 @@
           "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
           "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
         },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
         "locate-path": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
@@ -41702,9 +41650,9 @@
           }
         },
         "minimatch": {
-          "version": "9.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -41740,25 +41688,6 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
           "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="
         },
-        "slice-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-          "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-          "requires": {
-            "ansi-styles": "^6.0.0",
-            "is-fullwidth-code-point": "^4.0.0"
-          }
-        },
-        "string-width": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-          "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
-          "requires": {
-            "emoji-regex": "^10.3.0",
-            "get-east-asian-width": "^1.0.0",
-            "strip-ansi": "^7.1.0"
-          }
-        },
         "strip-ansi": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -41767,19 +41696,19 @@
             "ansi-regex": "^6.0.1"
           }
         },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+        "supports-hyperlinks": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+          "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
           "requires": {
-            "has-flag": "^4.0.0"
+            "has-flag": "^4.0.0",
+            "supports-color": "^7.0.0"
           }
         },
         "type-fest": {
-          "version": "4.18.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
-          "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
-          "dev": true
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+          "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g=="
         },
         "yocto-queue": {
           "version": "1.0.0",
@@ -43448,6 +43377,28 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
           "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
           "requires": {}
+        }
+      }
+    },
+    "@shopify/oxygen-cli": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@shopify/oxygen-cli/-/oxygen-cli-4.4.9.tgz",
+      "integrity": "sha512-NCpMyRyXaBtLMSSIDuJsX4hYCiudyMCMeoqvtN7HYgjCZNsC5F2dvZLpu0mVOSqXrNB89PG/QnaXlcZZW+3IjQ==",
+      "requires": {
+        "@bugsnag/core": "^7.19.0",
+        "@bugsnag/js": "^7.22.4",
+        "@bugsnag/node": "^7.23.0",
+        "async": "^3.2.5"
+      },
+      "dependencies": {
+        "@bugsnag/js": {
+          "version": "7.23.0",
+          "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.23.0.tgz",
+          "integrity": "sha512-gnCpcv/v6p3CtbwwDuAjVYPPNq4NMVj4hp70MiB3OGJ+LmIS66CwElDiyvRMA8Ar6OzCF4joTeaNG5bD9cM41w==",
+          "requires": {
+            "@bugsnag/browser": "^7.22.7",
+            "@bugsnag/node": "^7.23.0"
+          }
         }
       }
     },
@@ -46665,6 +46616,14 @@
     "ee-first": {
       "version": "1.1.1"
     },
+    "ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "requires": {
+        "jake": "^10.8.5"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.615",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.615.tgz",
@@ -47896,12 +47855,16 @@
     },
     "filelist": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "requires": {
         "minimatch": "^5.0.1"
       },
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -50047,12 +50010,14 @@
       }
     },
     "jake": {
-      "version": "10.8.5",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.1.tgz",
+      "integrity": "sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==",
       "requires": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
       }
     },
     "javascript-stringify": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
     "@ast-grep/napi": "0.11.0",
     "@oclif/core": "3.26.5",
     "@shopify/cli-kit": "3.60.0",
-    "@shopify/oxygen-cli": "~4.4.5",
+    "@shopify/oxygen-cli": "4.4.9",
     "@shopify/plugin-cloudflare": "3.60.0",
     "ansi-escapes": "^6.2.0",
     "cli-truncate": "^4.0.0",


### PR DESCRIPTION
Update this dependency to 4.4.9 and pin it. This was done in https://github.com/Shopify/hydrogen/pull/2182 but had some issues with package-lock.
This PR correctly hoists oclif/core so that both Hydrogen and Oxygen CLI plugins use the same version locally.