### PR TITLE
Remove `mock.shop` from env vars in new projects

### DIFF
--- a/.changeset/tall-elephants-drum.md
+++ b/.changeset/tall-elephants-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Remove `PUBLIC_STORE_DOMAIN` environment variable from `.env` when creating new projects with mock.shop.

--- a/packages/cli/src/lib/onboarding/local.test.ts
+++ b/packages/cli/src/lib/onboarding/local.test.ts
@@ -60,9 +60,9 @@ describe('local templates', () => {
         `"name": "${basename(tmpDir)}"`,
       );
 
-      // Creates .env
-      await expect(readFile(`${tmpDir}/.env`)).resolves.toMatch(
-        `PUBLIC_STORE_DOMAIN="mock.shop"`,
+      // Creates .env without mock.shop
+      await expect(readFile(`${tmpDir}/.env`)).resolves.not.toMatch(
+        `mock.shop`,
       );
 
       const output = outputMock.info();

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -177,10 +177,7 @@ export async function setupLocalStarterTemplate(
           joinPath(project.directory, '.env'),
           envLeadingComment +
             '\n' +
-            [
-              ['SESSION_SECRET', 'foobar'],
-              ['PUBLIC_STORE_DOMAIN', 'mock.shop'],
-            ]
+            [['SESSION_SECRET', 'foobar']]
               .map(([key, value]) => `${key}="${value}"`)
               .join('\n') +
             '\n',


### PR DESCRIPTION
We removed it from the skeleton `.env`. However, this file is not used when creating new projects in some situations.