### PR TITLE
Allow `envBranch` to be passed in on CI

### DIFF
--- a/.changeset/chilled-points-give.md
+++ b/.changeset/chilled-points-give.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+[Bug fix] Allow env-branch to be passed when running `h2 deploy` in CI

--- a/packages/cli/src/commands/hydrogen/deploy.test.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.test.ts
@@ -240,7 +240,7 @@ describe('deploy', () => {
     expect(vi.mocked(renderSuccess)).toHaveBeenCalled();
   });
 
-  it('calls createDeploy against a environment selected by env', async () => {
+  it('calls createDeploy against an environment selected by env', async () => {
     vi.mocked(getOxygenDeploymentData).mockResolvedValue({
       oxygenDeploymentToken: 'some-encoded-token',
       environments: [
@@ -271,7 +271,7 @@ describe('deploy', () => {
     expect(vi.mocked(renderSuccess)).toHaveBeenCalled;
   });
 
-  it('calls createDeploy against a environment selected by envBranch', async () => {
+  it('calls createDeploy against an environment selected by envBranch', async () => {
     vi.mocked(getOxygenDeploymentData).mockResolvedValue({
       oxygenDeploymentToken: 'some-encoded-token',
       environments: [
@@ -302,6 +302,30 @@ describe('deploy', () => {
     expect(vi.mocked(renderSuccess)).toHaveBeenCalled;
   });
 
+  it('calls createDeploy against an envBranch in CI', async () => {
+    vi.mocked(ciPlatform).mockReturnValue({
+      isCI: true,
+      name: 'github',
+      metadata: {},
+    });
+
+    await runDeploy({
+      ...deployParams,
+      token: 'some-token',
+      envBranch: 'stage-1',
+    });
+
+    expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
+      config: {
+        ...expectedConfig,
+        environmentTag: 'stage-1',
+      },
+      hooks: expectedHooks,
+      logger: deploymentLogger,
+    });
+    expect(vi.mocked(renderSuccess)).toHaveBeenCalled;
+  });
+
   it("errors when the env provided doesn't match any environment", async () => {
     await expect(
       runDeploy({
@@ -311,7 +335,7 @@ describe('deploy', () => {
     ).rejects.toThrowError('Environment not found');
   });
 
-  it("errors when the env provided doesn't match any environment", async () => {
+  it("errors when the envBranch provided doesn't match any environment", async () => {
     await expect(
       runDeploy({
         ...deployParams,

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -351,6 +351,10 @@ export async function runDeploy(
     );
   }
 
+  if (isCI && envBranch) {
+    userProvidedEnvironmentTag = envBranch;
+  }
+
   if (!isCI) {
     deploymentData = await getOxygenDeploymentData({
       root,


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/hydrogen/issues/2267

### WHAT is this pull request doing?

- We currently don't parse `envBranch` and `env` flags on `npx shopify hydrogen deploy` command in CI environments
  - Assumption: the original intention was that CI environments would ALWAYS just pick up the branch it is on
  - If you pass in an `envBranch` that doesn't exist in CI, we push the deploy to preview (as before)

#### Future task
  - `env` flag will require more effort as it needs to be available on our dependant services
  - the current fix only patches it for the `envBranch` flag

### HOW to test your changes?

- Create a hydrogen repo
  - create a branch "fake-branch" and check it out
- Clone this repo and checkout the branch. Run the following
  - `npm ci`
  - `npm run build`
  - `CI=1 npx shopify hydrogen deploy --env-branch=main --token=<token> --force`

Expected:
- On Admin, the deployment should be created under the "Production" environment since you specified the `main` branch

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
