### PR TITLE
Add unstable API for newsletter subscribe functionality

### DIFF
--- a/.changeset/beige-colts-serve.md
+++ b/.changeset/beige-colts-serve.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add `<UNSTABLE_NewsletterSubscribeForm />` utility to create a Newsletter subscribe form UI and `UNSTABLE_newsletterSubscribeHandler` as complementary utility to call the storefront mutation that does the subscribing.

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -162,3 +162,6 @@ export type {
 } from '@shopify/hydrogen-react';
 
 export type {HydrogenSessionData, HydrogenSession} from './types';
+
+export {newsletterSubscribeHandler as UNSTABLE_newsletterSubscribeHandler} from './newsletter-subscribe/newsletterSubscribeHandler';
+export {NewsletterSubscribeForm as UNSTABLE_NewsletterSubscribeForm} from './newsletter-subscribe/NewsletterSubscribeForm';

--- a/packages/hydrogen/src/newsletter-subscribe/NewsletterSubscribeForm.tsx
+++ b/packages/hydrogen/src/newsletter-subscribe/NewsletterSubscribeForm.tsx
@@ -1,0 +1,52 @@
+import {useFetcher, type FetcherWithComponents} from '@remix-run/react';
+import type {ReactNode} from 'react';
+import type {NewsletterSubscribeHandlerResponse} from './newsletterSubscribeHandler';
+
+type NewsletterFormProps = {
+  /**
+   * Children nodes of CartForm.
+   * Children can be a render prop that receives the fetcher.
+   */
+  children:
+    | ((
+        fetcher: FetcherWithComponents<any>,
+        isSuccessful?: NewsletterSubscribeHandlerResponse['isSuccessful'],
+        simplifyError?: NewsletterSubscribeHandlerResponse['simplifyError'],
+        userErrors?: NewsletterSubscribeHandlerResponse['userErrors'],
+        apiErrors?: NewsletterSubscribeHandlerResponse['apiErrors'],
+      ) => ReactNode)
+    | ReactNode;
+  /**
+   * The route to submit the form to.
+   */
+  route?: string;
+  /**
+   * Optional key to use for the fetcher.
+   * @see https://remix.run/hooks/use-fetcher#key
+   */
+  fetcherKey?: string;
+};
+
+export function NewsletterSubscribeForm({
+  children,
+  route = '/api/newsletter-subscribe',
+  fetcherKey = 'newsletter-subscribe',
+}: NewsletterFormProps): JSX.Element {
+  const fetcher = useFetcher<NewsletterSubscribeHandlerResponse>({
+    key: fetcherKey,
+  });
+
+  return (
+    <fetcher.Form action={route} method="post">
+      {typeof children === 'function'
+        ? children(
+            fetcher,
+            fetcher.data?.isSuccessful,
+            fetcher.data?.simplifyError,
+            fetcher.data?.userErrors,
+            fetcher.data?.apiErrors,
+          )
+        : children}
+    </fetcher.Form>
+  );
+}

--- a/packages/hydrogen/src/newsletter-subscribe/newsletter-subscribe.example.tsx
+++ b/packages/hydrogen/src/newsletter-subscribe/newsletter-subscribe.example.tsx
@@ -1,0 +1,51 @@
+import {UNSTABLE_NewsletterSubscribeForm as NewsletterSubscribeForm} from '@shopify/hydrogen';
+
+// place <NewsletterSignUp /> anywhere you want the subscription form to show up
+export function NewsletterSignUp({placeholder = 'Email'}) {
+  return (
+    <NewsletterSubscribeForm>
+      {(fetcher, isSuccessful, error) => {
+        return (
+          <>
+            <p>Subscribe to our emails</p>
+            <input
+              type="email"
+              name="email"
+              aria-required="true"
+              autoCorrect="off"
+              autoCapitalize="off"
+              autoComplete="email"
+              placeholder="Email"
+              required
+            />
+            {isSuccessful ? (
+              <span>✅</span>
+            ) : (
+              <button type="submit" disabled={fetcher.state !== 'idle'}>
+                Sign Up
+              </button>
+            )}
+            {error ? (
+              <p>
+                <em>{error}</em>
+              </p>
+            ) : null}
+          </>
+        );
+      }}
+    </NewsletterSubscribeForm>
+  );
+}
+
+// in app/routes/api.newsletter-subscribe.tsx by default
+import {json, type ActionFunctionArgs} from '@shopify/remix-oxygen';
+import {UNSTABLE_newsletterSubscribeHandler as newsletterSubscribeHandler} from '@shopify/hydrogen';
+
+export async function action({request, context}: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const email = formData.has('email') ? String(formData.get('email')) : null;
+
+  const response = await newsletterSubscribeHandler(context.storefront, email);
+
+  return json(response);
+}

--- a/packages/hydrogen/src/newsletter-subscribe/newsletterSubscribeHandler.ts
+++ b/packages/hydrogen/src/newsletter-subscribe/newsletterSubscribeHandler.ts
@@ -1,0 +1,64 @@
+import type {Storefront, StorefrontApiErrors} from '../storefront';
+import type {CustomerUserError} from '@shopify/hydrogen-react/storefront-api-types';
+export interface NewsletterSubscribeHandlerResponse {
+  isSuccessful: boolean;
+  simplifyError?: string;
+  userErrors?: CustomerUserError[];
+  apiErrors?: StorefrontApiErrors;
+}
+
+export async function newsletterSubscribeHandler(
+  storefront: Storefront,
+  email: string | null,
+): Promise<NewsletterSubscribeHandlerResponse> {
+  if (!email) {
+    return {
+      isSuccessful: false,
+      simplifyError: 'email is required.',
+    };
+  }
+
+  const {errors, customerEmailMarketingSubscribe} = await storefront.mutate(
+    NEWSLETTER_MUTATION,
+    {
+      variables: {email},
+      storefrontApiVersion: 'unstable',
+    },
+  );
+
+  if (!customerEmailMarketingSubscribe || errors?.length) {
+    return {
+      isSuccessful: false,
+      simplifyError: 'The subscription failed.',
+      apiErrors: errors,
+    };
+  }
+
+  const {customer, customerUserErrors} = customerEmailMarketingSubscribe;
+
+  return {
+    isSuccessful: Boolean(customer),
+    simplifyError: customerUserErrors?.length
+      ? customerUserErrors[0].message
+      : undefined,
+    userErrors: customerUserErrors,
+    apiErrors: errors,
+  };
+}
+
+const NEWSLETTER_MUTATION = `#graphql
+mutation customerEmailMarketingSubscribe(
+  $email: String!
+) {
+  customerEmailMarketingSubscribe(email: $email) {
+    customer {
+      email
+    }
+    customerUserErrors {
+      code
+      field
+      message
+    }
+  }
+}
+`;


### PR DESCRIPTION
Close https://github.com/Shopify/hydrogen-internal/issues/122

Add `<UNSTABLE_NewsletterSubscribeForm />` utility to create a Newsletter subscribe form UI and `UNSTABLE_newsletterSubscribeHandler` as complementary utility to call the storefront mutation that does the subscribing.