### PR TITLE
Update remix to v2.10.0

### DIFF
--- a/.changeset/happy-rabbits-draw.md
+++ b/.changeset/happy-rabbits-draw.md
@@ -1,0 +1,7 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Update remix to v2.10.1

--- a/docs/preview/package.json
+++ b/docs/preview/package.json
@@ -8,10 +8,10 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/css-bundle": "^2.9.2",
-    "@remix-run/node": "^2.9.2",
-    "@remix-run/react": "^2.9.2",
-    "@remix-run/serve": "^2.9.2",
+    "@remix-run/css-bundle": "^2.10.1",
+    "@remix-run/node": "^2.10.1",
+    "@remix-run/react": "^2.10.1",
+    "@remix-run/serve": "^2.10.1",
     "he": "^1.2.0",
     "isbot": "^3.6.8",
     "marked": "^9.1.0",
@@ -20,8 +20,8 @@
     "react-syntax-highlighter": "^15.5.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "^2.9.2",
-    "@remix-run/eslint-config": "^2.9.2",
+    "@remix-run/dev": "^2.10.1",
+    "@remix-run/eslint-config": "^2.10.1",
     "@types/he": "^1.2.1",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -10,11 +10,11 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/css-bundle": "^2.9.2",
-    "@remix-run/express": "^2.9.2",
-    "@remix-run/node": "^2.9.2",
-    "@remix-run/react": "^2.9.2",
-    "@remix-run/server-runtime": "^2.9.2",
+    "@remix-run/css-bundle": "^2.10.1",
+    "@remix-run/express": "^2.10.1",
+    "@remix-run/node": "^2.10.1",
+    "@remix-run/react": "^2.10.1",
+    "@remix-run/server-runtime": "^2.10.1",
     "@shopify/cli": "3.61.2",
     "@shopify/cli-hydrogen": "^8.1.1",
     "@shopify/hydrogen": "2024.4.7",
@@ -27,8 +27,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "^2.9.2",
-    "@remix-run/eslint-config": "^2.9.2",
+    "@remix-run/dev": "^2.10.1",
+    "@remix-run/eslint-config": "^2.10.1",
     "@types/compression": "^1.7.2",
     "@types/express": "^4.17.17",
     "@types/morgan": "^1.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,10 +55,10 @@
     "docs/preview": {
       "name": "docs-preview",
       "dependencies": {
-        "@remix-run/css-bundle": "^2.9.2",
-        "@remix-run/node": "^2.9.2",
-        "@remix-run/react": "^2.9.2",
-        "@remix-run/serve": "^2.9.2",
+        "@remix-run/css-bundle": "^2.10.1",
+        "@remix-run/node": "^2.10.1",
+        "@remix-run/react": "^2.10.1",
+        "@remix-run/serve": "^2.10.1",
         "he": "^1.2.0",
         "isbot": "^3.6.8",
         "marked": "^9.1.0",
@@ -67,8 +67,8 @@
         "react-syntax-highlighter": "^15.5.0"
       },
       "devDependencies": {
-        "@remix-run/dev": "^2.9.2",
-        "@remix-run/eslint-config": "^2.9.2",
+        "@remix-run/dev": "^2.10.1",
+        "@remix-run/eslint-config": "^2.10.1",
         "@types/he": "^1.2.1",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
@@ -109,11 +109,11 @@
     "examples/express": {
       "name": "example-hydrogen-express",
       "dependencies": {
-        "@remix-run/css-bundle": "^2.9.2",
-        "@remix-run/express": "^2.9.2",
-        "@remix-run/node": "^2.9.2",
-        "@remix-run/react": "^2.9.2",
-        "@remix-run/server-runtime": "^2.9.2",
+        "@remix-run/css-bundle": "^2.10.1",
+        "@remix-run/express": "^2.10.1",
+        "@remix-run/node": "^2.10.1",
+        "@remix-run/react": "^2.10.1",
+        "@remix-run/server-runtime": "^2.10.1",
         "@shopify/cli": "3.61.2",
         "@shopify/cli-hydrogen": "^8.1.1",
         "@shopify/hydrogen": "2024.4.7",
@@ -126,8 +126,8 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@remix-run/dev": "^2.9.2",
-        "@remix-run/eslint-config": "^2.9.2",
+        "@remix-run/dev": "^2.10.1",
+        "@remix-run/eslint-config": "^2.10.1",
         "@types/compression": "^1.7.2",
         "@types/express": "^4.17.17",
         "@types/morgan": "^1.9.4",
@@ -1590,17 +1590,17 @@
       "license": "MIT"
     },
     "node_modules/@bugsnag/browser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.22.7.tgz",
-      "integrity": "sha512-70jFkWKscK2osm7bnFbPLevrzHClrygM3UcKetKs/l81Xuzlxnu1SS3onN5OUl9kd9RN4XMFr46Pv5jSqWqImQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.25.0.tgz",
+      "integrity": "sha512-PzzWy5d9Ly1CU1KkxTB6ZaOw/dO+CYSfVtqxVJccy832e6+7rW/dvSw5Jy7rsNhgcKSKjZq86LtNkPSvritOLA==",
       "dependencies": {
-        "@bugsnag/core": "^7.22.7"
+        "@bugsnag/core": "^7.25.0"
       }
     },
     "node_modules/@bugsnag/core": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.22.7.tgz",
-      "integrity": "sha512-9DPWBkkBjhFJc5dCFy/wVC3HE0Aw3ZiLJKjyAxgywSKbILgtpD+qT1Xe8sacWyxU92znamlZ8H8ziQOe7jhhbA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.25.0.tgz",
+      "integrity": "sha512-JZLak1b5BVzy77CPcklViZrppac/pE07L3uSDmfSvFYSCGReXkik2txOgV05VlF9EDe36dtUAIIV7iAPDfFpQQ==",
       "dependencies": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -1624,11 +1624,11 @@
       }
     },
     "node_modules/@bugsnag/node": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.23.0.tgz",
-      "integrity": "sha512-eXA8/h+J2booEMlKsuRl1NAszebwm4KZ9zxCSg/xN4sw5boXia7kMifLf8QTqk+UBtIhNKBsyQQKHXbawKyE6Q==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.25.0.tgz",
+      "integrity": "sha512-KlxBaJ8EREEsfKInybAjTO9LmdDXV3cUH5+XNXyqUZrcRVuPOu4j4xvljh+n24ifok/wbFZTKVXUzrN4iKIeIA==",
       "dependencies": {
-        "@bugsnag/core": "^7.22.7",
+        "@bugsnag/core": "^7.25.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -3952,9 +3952,9 @@
       "devOptional": true
     },
     "node_modules/@graphql-tools/executor-graphql-ws/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "devOptional": true,
       "engines": {
         "node": ">=10.0.0"
@@ -4595,9 +4595,9 @@
       "devOptional": true
     },
     "node_modules/@graphql-tools/url-loader/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "devOptional": true,
       "engines": {
         "node": ">=10.0.0"
@@ -5379,9 +5379,9 @@
       }
     },
     "node_modules/@miniflare/web-sockets/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -6596,17 +6596,17 @@
       }
     },
     "node_modules/@remix-run/css-bundle": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/css-bundle/-/css-bundle-2.9.2.tgz",
-      "integrity": "sha512-q+rfqcM+1Tf+kTpwaGlyBhwAGZyaQtE8sD0cJQBbhP6GZzMrnKUp2KY+w2Xuh04HnKSO3kTp67SvVUCdN+xllg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/css-bundle/-/css-bundle-2.10.1.tgz",
+      "integrity": "sha512-pbI7VxClUCgeUYlK4woRJKjbbvYblJFTZu4vWzPKZUEGV0xk4Up2CKm0H+1EiHmO0+M9emiu1XuZui6vbVCFdg==",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.9.2.tgz",
-      "integrity": "sha512-70dr9HH/mCHP5+uPoQXyS9+r73IL//IDPaFruIhK8kmmLPGAg5bGyFRz/xX6LTa98gPdAwZXxBy7frudeh2Z0Q==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.10.1.tgz",
+      "integrity": "sha512-2in9QkdPjd8BXo7Hp3/9gfpbCH6qaESMrW3ht8RejacPm7b37hSWeUPgWlPyjMEY5H/oHiGmp4GSOnGSvgB2EQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.8",
@@ -6619,9 +6619,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "2.9.2",
-        "@remix-run/router": "1.16.1",
-        "@remix-run/server-runtime": "2.9.2",
+        "@remix-run/node": "2.10.1",
+        "@remix-run/router": "1.17.1",
+        "@remix-run/server-runtime": "2.10.1",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -6635,7 +6635,7 @@
         "esbuild-plugins-node-modules-polyfill": "^1.6.0",
         "execa": "5.1.1",
         "exit-hook": "2.2.1",
-        "express": "^4.17.1",
+        "express": "^4.19.2",
         "fs-extra": "^10.0.0",
         "get-port": "^5.1.1",
         "gunzip-maybe": "^1.4.2",
@@ -6670,8 +6670,8 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@remix-run/react": "^2.9.2",
-        "@remix-run/serve": "^2.9.2",
+        "@remix-run/react": "^2.10.1",
+        "@remix-run/serve": "^2.10.1",
         "typescript": "^5.1.0",
         "vite": "^5.1.0",
         "wrangler": "^3.28.2"
@@ -7206,9 +7206,9 @@
       }
     },
     "node_modules/@remix-run/eslint-config": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-2.9.2.tgz",
-      "integrity": "sha512-tZV98Fz1QHAwIA9MOo48Es0ltAzvOIj/uCjCDsKOEndhEX+qwH1qC7eLIBGJiRDgEO3hIQUtzUuw5S6J8B2B+w==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-2.10.1.tgz",
+      "integrity": "sha512-bPWK5vfdwOHzgNNvqOVHZeNoZbc2aQrwlFDn+gLidEm+4sGhamLV5+zog5WfKEhxjELVO7qJiSR3N2AbMTUoTw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.8",
@@ -7243,17 +7243,17 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.9.2.tgz",
-      "integrity": "sha512-KhGPwX01gopvOzOCc0V2x+TC2UhfbwnDPjBk/KLFjn3z9srYD2X0xVdqGiNp6tXSiUuLDx8NlfHjrfLVwfJYnQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.10.1.tgz",
+      "integrity": "sha512-d7s4Pu36UkC48iPnoKLcttyCG7WjfC14QUeHX9fzI0UKU2sFhe8vhnDhxdMY9IsHo5zVXJv1wHFvN1ohL+5dGg==",
       "dependencies": {
-        "@remix-run/node": "2.9.2"
+        "@remix-run/node": "2.10.1"
       },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "express": "^4.17.1",
+        "express": "^4.19.2",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -7263,17 +7263,17 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.9.2.tgz",
-      "integrity": "sha512-2Mt2107pfelz4T+ziDBef3P4A7kgPqCDshnEYCVGxInivJ3HHwAKUcb7MhGa8uMMMA6LMWxbAPYNHPzC3iKv2A==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.10.1.tgz",
+      "integrity": "sha512-kuKh9bbivrAEbsiYNlm3x03O1Jpgi+Ux8zR2cig5U2DIbG43ylgX9vQiLp2ZNhQ0xoJ0C241x7d7DpdPfyrgEA==",
       "dependencies": {
-        "@remix-run/server-runtime": "2.9.2",
+        "@remix-run/server-runtime": "2.10.1",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
         "source-map-support": "^0.5.21",
         "stream-slice": "^0.1.2",
-        "undici": "^6.10.1"
+        "undici": "^6.11.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -7304,15 +7304,15 @@
       }
     },
     "node_modules/@remix-run/react": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.9.2.tgz",
-      "integrity": "sha512-DcZDzm68MBxGn8hjf/VsuUpjxDYZ8VOOH79P1zWu4hb3hBr90WV1Sa/gIAFUEGpOCcSQ0EG/ci8MaFxcAaPz2Q==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.10.1.tgz",
+      "integrity": "sha512-EIu38mLx0havRDAXrVpJBOm1cXMsMVusdIZHDd43lwcwfKAHArYYYgSVoU09vrnrpW4paKQGzy8joAfOHmHHCw==",
       "dependencies": {
-        "@remix-run/router": "1.16.1",
-        "@remix-run/server-runtime": "2.9.2",
-        "react-router": "6.23.1",
-        "react-router-dom": "6.23.1",
-        "turbo-stream": "^2.0.0"
+        "@remix-run/router": "1.17.1",
+        "@remix-run/server-runtime": "2.10.1",
+        "react-router": "6.24.1",
+        "react-router-dom": "6.24.1",
+        "turbo-stream": "2.2.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -7329,23 +7329,23 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
-      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.17.1.tgz",
+      "integrity": "sha512-mCOMec4BKd6BRGBZeSnGiIgwsbLGp3yhVqAD8H+PxiRNEHgDpZb8J1TnrSDlg97t0ySKMQJTHCWBCmBpSmkF6Q==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/serve": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.9.2.tgz",
-      "integrity": "sha512-wA3mjQcIkkzmr2798mMDDCkVmVraVwFgLiZ0ManlU5mOWZhI0W+b55fxHltJ4gkAMGYaxrk7vq/s8s/r+L3cTQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.10.1.tgz",
+      "integrity": "sha512-ZnabGBQhxpqsdahm2qbl4pIrdPu73T9fMioksPOa2bjbmf2rgTvbU0/PK3aC1Q1857rIWrwux+YB8n82QBdJTQ==",
       "dependencies": {
-        "@remix-run/express": "2.9.2",
-        "@remix-run/node": "2.9.2",
+        "@remix-run/express": "2.10.1",
+        "@remix-run/node": "2.10.1",
         "chokidar": "^3.5.3",
         "compression": "^1.7.4",
-        "express": "^4.17.1",
+        "express": "^4.19.2",
         "get-port": "5.1.1",
         "morgan": "^1.10.0",
         "source-map-support": "^0.5.21"
@@ -7358,17 +7358,17 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.9.2.tgz",
-      "integrity": "sha512-dX37FEeMVVg7KUbpRhX4hD0nUY0Sscz/qAjU4lYCdd6IzwJGariTmz+bQTXKCjploZuXj09OQZHSOS/ydkUVDA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.10.1.tgz",
+      "integrity": "sha512-jINOmovnwPdllhOm2PU0iTDP9MXwKLit9Ifq3EWjdqs+Bu1zwA3TTRDRX6x9V0OGpM3wiByd80zEmHZ5sZy7hQ==",
       "dependencies": {
-        "@remix-run/router": "1.16.1",
+        "@remix-run/router": "1.17.1",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.6.0",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3",
-        "turbo-stream": "^2.0.0"
+        "turbo-stream": "2.2.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -8120,12 +8120,12 @@
       }
     },
     "node_modules/@shopify/oxygen-cli/node_modules/@bugsnag/js": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.23.0.tgz",
-      "integrity": "sha512-gnCpcv/v6p3CtbwwDuAjVYPPNq4NMVj4hp70MiB3OGJ+LmIS66CwElDiyvRMA8Ar6OzCF4joTeaNG5bD9cM41w==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.25.0.tgz",
+      "integrity": "sha512-d8n8SyKdRUz8jMacRW1j/Sj/ckhKbIEp49+Dacp3CS8afRgfMZ//NXhUFFXITsDP5cXouaejR9fx4XVapYXNgg==",
       "dependencies": {
-        "@bugsnag/browser": "^7.22.7",
-        "@bugsnag/node": "^7.23.0"
+        "@bugsnag/browser": "^7.25.0",
+        "@bugsnag/node": "^7.25.0"
       }
     },
     "node_modules/@shopify/oxygen-workers-types": {
@@ -16741,9 +16741,9 @@
       }
     },
     "node_modules/ink/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -21202,9 +21202,9 @@
       }
     },
     "node_modules/miniflare/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -23652,11 +23652,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.23.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
-      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.24.1.tgz",
+      "integrity": "sha512-PTXFXGK2pyXpHzVo3rR9H7ip4lSPZZc0bHG5CARmj65fTT6qG7sTngmb6lcYu1gf3y/8KxORoy9yn59pGpCnpg==",
       "dependencies": {
-        "@remix-run/router": "1.16.1"
+        "@remix-run/router": "1.17.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -23666,12 +23666,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.23.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
-      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.24.1.tgz",
+      "integrity": "sha512-U19KtXqooqw967Vw0Qcn5cOvrX5Ejo9ORmOtJMzYWtCT4/WOfFLIZGGsVLxcd9UkBO0mSTZtXqhZBsWlHr7+Sg==",
       "dependencies": {
-        "@remix-run/router": "1.16.1",
-        "react-router": "6.23.1"
+        "@remix-run/router": "1.17.1",
+        "react-router": "6.24.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -27507,9 +27507,9 @@
       ]
     },
     "node_modules/turbo-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.0.1.tgz",
-      "integrity": "sha512-sm0ZtcX9YWh28p5X8t5McxC2uthrt9p+g0bGE0KTVFhnhNWefpSVCr+67zRNDUOfo4bpXwiOp7otO+dyQ7/y/A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.2.0.tgz",
+      "integrity": "sha512-FKFg7A0To1VU4CH9YmSMON5QphK0BXjSoiC7D9yMh+mEEbXLUP9qJ4hEt1qcjKtzncs1OpcnjZO8NgrlVbZH+g=="
     },
     "node_modules/turbo-windows-64": {
       "version": "1.12.0",
@@ -29432,7 +29432,7 @@
         "cli-hydrogen": "dist/create-app.js"
       },
       "devDependencies": {
-        "@remix-run/dev": "^2.9.2",
+        "@remix-run/dev": "^2.10.1",
         "@types/diff": "^5.0.2",
         "@types/fs-extra": "^11.0.1",
         "@types/gunzip-maybe": "^1.4.0",
@@ -29657,9 +29657,9 @@
         "worktop": "^0.7.3"
       },
       "devDependencies": {
-        "@remix-run/dev": "^2.9.2",
-        "@remix-run/react": "^2.9.2",
-        "@remix-run/server-runtime": "^2.9.2",
+        "@remix-run/dev": "^2.10.1",
+        "@remix-run/react": "^2.10.1",
+        "@remix-run/server-runtime": "^2.10.1",
         "@shopify/generate-docs": "0.11.1",
         "@shopify/hydrogen-codegen": "*",
         "@testing-library/jest-dom": "^5.17.0",
@@ -32038,9 +32038,9 @@
       }
     },
     "packages/mini-oxygen/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -32062,7 +32062,7 @@
       "version": "2.0.4",
       "license": "MIT",
       "devDependencies": {
-        "@remix-run/server-runtime": "^2.9.2",
+        "@remix-run/server-runtime": "^2.10.1",
         "@shopify/oxygen-workers-types": "^4.1.2"
       },
       "peerDependencies": {
@@ -32073,8 +32073,8 @@
     "templates/skeleton": {
       "version": "2024.4.9",
       "dependencies": {
-        "@remix-run/react": "^2.9.2",
-        "@remix-run/server-runtime": "^2.9.2",
+        "@remix-run/react": "^2.10.1",
+        "@remix-run/server-runtime": "^2.10.1",
         "@shopify/cli": "3.61.2",
         "@shopify/cli-hydrogen": "^8.1.1",
         "@shopify/hydrogen": "2024.4.7",
@@ -32087,8 +32087,8 @@
       },
       "devDependencies": {
         "@graphql-codegen/cli": "5.0.2",
-        "@remix-run/dev": "^2.9.2",
-        "@remix-run/eslint-config": "^2.9.2",
+        "@remix-run/dev": "^2.10.1",
+        "@remix-run/eslint-config": "^2.10.1",
         "@shopify/hydrogen-codegen": "^0.3.1",
         "@shopify/mini-oxygen": "^3.0.3",
         "@shopify/oxygen-workers-types": "^4.1.2",
@@ -33015,17 +33015,17 @@
       "dev": true
     },
     "@bugsnag/browser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.22.7.tgz",
-      "integrity": "sha512-70jFkWKscK2osm7bnFbPLevrzHClrygM3UcKetKs/l81Xuzlxnu1SS3onN5OUl9kd9RN4XMFr46Pv5jSqWqImQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.25.0.tgz",
+      "integrity": "sha512-PzzWy5d9Ly1CU1KkxTB6ZaOw/dO+CYSfVtqxVJccy832e6+7rW/dvSw5Jy7rsNhgcKSKjZq86LtNkPSvritOLA==",
       "requires": {
-        "@bugsnag/core": "^7.22.7"
+        "@bugsnag/core": "^7.25.0"
       }
     },
     "@bugsnag/core": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.22.7.tgz",
-      "integrity": "sha512-9DPWBkkBjhFJc5dCFy/wVC3HE0Aw3ZiLJKjyAxgywSKbILgtpD+qT1Xe8sacWyxU92znamlZ8H8ziQOe7jhhbA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.25.0.tgz",
+      "integrity": "sha512-JZLak1b5BVzy77CPcklViZrppac/pE07L3uSDmfSvFYSCGReXkik2txOgV05VlF9EDe36dtUAIIV7iAPDfFpQQ==",
       "requires": {
         "@bugsnag/cuid": "^3.0.0",
         "@bugsnag/safe-json-stringify": "^6.0.0",
@@ -33049,11 +33049,11 @@
       }
     },
     "@bugsnag/node": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.23.0.tgz",
-      "integrity": "sha512-eXA8/h+J2booEMlKsuRl1NAszebwm4KZ9zxCSg/xN4sw5boXia7kMifLf8QTqk+UBtIhNKBsyQQKHXbawKyE6Q==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.25.0.tgz",
+      "integrity": "sha512-KlxBaJ8EREEsfKInybAjTO9LmdDXV3cUH5+XNXyqUZrcRVuPOu4j4xvljh+n24ifok/wbFZTKVXUzrN4iKIeIA==",
       "requires": {
-        "@bugsnag/core": "^7.22.7",
+        "@bugsnag/core": "^7.25.0",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
@@ -34688,9 +34688,9 @@
           "devOptional": true
         },
         "ws": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
           "devOptional": true,
           "requires": {}
         }
@@ -35189,9 +35189,9 @@
           "devOptional": true
         },
         "ws": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
           "devOptional": true,
           "requires": {}
         }
@@ -35770,9 +35770,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
           "requires": {}
         }
       }
@@ -36546,14 +36546,14 @@
       }
     },
     "@remix-run/css-bundle": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/css-bundle/-/css-bundle-2.9.2.tgz",
-      "integrity": "sha512-q+rfqcM+1Tf+kTpwaGlyBhwAGZyaQtE8sD0cJQBbhP6GZzMrnKUp2KY+w2Xuh04HnKSO3kTp67SvVUCdN+xllg=="
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/css-bundle/-/css-bundle-2.10.1.tgz",
+      "integrity": "sha512-pbI7VxClUCgeUYlK4woRJKjbbvYblJFTZu4vWzPKZUEGV0xk4Up2CKm0H+1EiHmO0+M9emiu1XuZui6vbVCFdg=="
     },
     "@remix-run/dev": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.9.2.tgz",
-      "integrity": "sha512-70dr9HH/mCHP5+uPoQXyS9+r73IL//IDPaFruIhK8kmmLPGAg5bGyFRz/xX6LTa98gPdAwZXxBy7frudeh2Z0Q==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.10.1.tgz",
+      "integrity": "sha512-2in9QkdPjd8BXo7Hp3/9gfpbCH6qaESMrW3ht8RejacPm7b37hSWeUPgWlPyjMEY5H/oHiGmp4GSOnGSvgB2EQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.21.8",
@@ -36566,9 +36566,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "2.9.2",
-        "@remix-run/router": "1.16.1",
-        "@remix-run/server-runtime": "2.9.2",
+        "@remix-run/node": "2.10.1",
+        "@remix-run/router": "1.17.1",
+        "@remix-run/server-runtime": "2.10.1",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -36582,7 +36582,7 @@
         "esbuild-plugins-node-modules-polyfill": "^1.6.0",
         "execa": "5.1.1",
         "exit-hook": "2.2.1",
-        "express": "^4.17.1",
+        "express": "^4.19.2",
         "fs-extra": "^10.0.0",
         "get-port": "^5.1.1",
         "gunzip-maybe": "^1.4.2",
@@ -36881,9 +36881,9 @@
       }
     },
     "@remix-run/eslint-config": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-2.9.2.tgz",
-      "integrity": "sha512-tZV98Fz1QHAwIA9MOo48Es0ltAzvOIj/uCjCDsKOEndhEX+qwH1qC7eLIBGJiRDgEO3hIQUtzUuw5S6J8B2B+w==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/eslint-config/-/eslint-config-2.10.1.tgz",
+      "integrity": "sha512-bPWK5vfdwOHzgNNvqOVHZeNoZbc2aQrwlFDn+gLidEm+4sGhamLV5+zog5WfKEhxjELVO7qJiSR3N2AbMTUoTw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.21.8",
@@ -36905,25 +36905,25 @@
       }
     },
     "@remix-run/express": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.9.2.tgz",
-      "integrity": "sha512-KhGPwX01gopvOzOCc0V2x+TC2UhfbwnDPjBk/KLFjn3z9srYD2X0xVdqGiNp6tXSiUuLDx8NlfHjrfLVwfJYnQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.10.1.tgz",
+      "integrity": "sha512-d7s4Pu36UkC48iPnoKLcttyCG7WjfC14QUeHX9fzI0UKU2sFhe8vhnDhxdMY9IsHo5zVXJv1wHFvN1ohL+5dGg==",
       "requires": {
-        "@remix-run/node": "2.9.2"
+        "@remix-run/node": "2.10.1"
       }
     },
     "@remix-run/node": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.9.2.tgz",
-      "integrity": "sha512-2Mt2107pfelz4T+ziDBef3P4A7kgPqCDshnEYCVGxInivJ3HHwAKUcb7MhGa8uMMMA6LMWxbAPYNHPzC3iKv2A==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.10.1.tgz",
+      "integrity": "sha512-kuKh9bbivrAEbsiYNlm3x03O1Jpgi+Ux8zR2cig5U2DIbG43ylgX9vQiLp2ZNhQ0xoJ0C241x7d7DpdPfyrgEA==",
       "requires": {
-        "@remix-run/server-runtime": "2.9.2",
+        "@remix-run/server-runtime": "2.10.1",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
         "source-map-support": "^0.5.21",
         "stream-slice": "^0.1.2",
-        "undici": "^6.10.1"
+        "undici": "^6.11.1"
       },
       "dependencies": {
         "cookie-signature": {
@@ -36939,49 +36939,49 @@
       }
     },
     "@remix-run/react": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.9.2.tgz",
-      "integrity": "sha512-DcZDzm68MBxGn8hjf/VsuUpjxDYZ8VOOH79P1zWu4hb3hBr90WV1Sa/gIAFUEGpOCcSQ0EG/ci8MaFxcAaPz2Q==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.10.1.tgz",
+      "integrity": "sha512-EIu38mLx0havRDAXrVpJBOm1cXMsMVusdIZHDd43lwcwfKAHArYYYgSVoU09vrnrpW4paKQGzy8joAfOHmHHCw==",
       "requires": {
-        "@remix-run/router": "1.16.1",
-        "@remix-run/server-runtime": "2.9.2",
-        "react-router": "6.23.1",
-        "react-router-dom": "6.23.1",
-        "turbo-stream": "^2.0.0"
+        "@remix-run/router": "1.17.1",
+        "@remix-run/server-runtime": "2.10.1",
+        "react-router": "6.24.1",
+        "react-router-dom": "6.24.1",
+        "turbo-stream": "2.2.0"
       }
     },
     "@remix-run/router": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
-      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig=="
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.17.1.tgz",
+      "integrity": "sha512-mCOMec4BKd6BRGBZeSnGiIgwsbLGp3yhVqAD8H+PxiRNEHgDpZb8J1TnrSDlg97t0ySKMQJTHCWBCmBpSmkF6Q=="
     },
     "@remix-run/serve": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.9.2.tgz",
-      "integrity": "sha512-wA3mjQcIkkzmr2798mMDDCkVmVraVwFgLiZ0ManlU5mOWZhI0W+b55fxHltJ4gkAMGYaxrk7vq/s8s/r+L3cTQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.10.1.tgz",
+      "integrity": "sha512-ZnabGBQhxpqsdahm2qbl4pIrdPu73T9fMioksPOa2bjbmf2rgTvbU0/PK3aC1Q1857rIWrwux+YB8n82QBdJTQ==",
       "requires": {
-        "@remix-run/express": "2.9.2",
-        "@remix-run/node": "2.9.2",
+        "@remix-run/express": "2.10.1",
+        "@remix-run/node": "2.10.1",
         "chokidar": "^3.5.3",
         "compression": "^1.7.4",
-        "express": "^4.17.1",
+        "express": "^4.19.2",
         "get-port": "5.1.1",
         "morgan": "^1.10.0",
         "source-map-support": "^0.5.21"
       }
     },
     "@remix-run/server-runtime": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.9.2.tgz",
-      "integrity": "sha512-dX37FEeMVVg7KUbpRhX4hD0nUY0Sscz/qAjU4lYCdd6IzwJGariTmz+bQTXKCjploZuXj09OQZHSOS/ydkUVDA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.10.1.tgz",
+      "integrity": "sha512-jINOmovnwPdllhOm2PU0iTDP9MXwKLit9Ifq3EWjdqs+Bu1zwA3TTRDRX6x9V0OGpM3wiByd80zEmHZ5sZy7hQ==",
       "requires": {
-        "@remix-run/router": "1.16.1",
+        "@remix-run/router": "1.17.1",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.6.0",
         "set-cookie-parser": "^2.4.8",
         "source-map": "^0.7.3",
-        "turbo-stream": "^2.0.0"
+        "turbo-stream": "2.2.0"
       }
     },
     "@remix-run/web-blob": {
@@ -37177,7 +37177,7 @@
         "@ast-grep/napi": "0.11.0",
         "@oclif/core": "3.26.5",
         "@parcel/watcher": "^2.3.0",
-        "@remix-run/dev": "^2.9.2",
+        "@remix-run/dev": "^2.10.1",
         "@shopify/cli-kit": "3.61.2",
         "@shopify/oxygen-cli": "4.4.9",
         "@shopify/plugin-cloudflare": "3.61.2",
@@ -37556,9 +37556,9 @@
     "@shopify/hydrogen": {
       "version": "file:packages/hydrogen",
       "requires": {
-        "@remix-run/dev": "^2.9.2",
-        "@remix-run/react": "^2.9.2",
-        "@remix-run/server-runtime": "^2.9.2",
+        "@remix-run/dev": "^2.10.1",
+        "@remix-run/react": "^2.10.1",
+        "@remix-run/server-runtime": "^2.10.1",
         "@shopify/generate-docs": "0.11.1",
         "@shopify/hydrogen-codegen": "*",
         "@shopify/hydrogen-react": "2024.4.4",
@@ -39173,9 +39173,9 @@
           }
         },
         "ws": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
           "requires": {}
         }
       }
@@ -39192,12 +39192,12 @@
       },
       "dependencies": {
         "@bugsnag/js": {
-          "version": "7.23.0",
-          "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.23.0.tgz",
-          "integrity": "sha512-gnCpcv/v6p3CtbwwDuAjVYPPNq4NMVj4hp70MiB3OGJ+LmIS66CwElDiyvRMA8Ar6OzCF4joTeaNG5bD9cM41w==",
+          "version": "7.25.0",
+          "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.25.0.tgz",
+          "integrity": "sha512-d8n8SyKdRUz8jMacRW1j/Sj/ckhKbIEp49+Dacp3CS8afRgfMZ//NXhUFFXITsDP5cXouaejR9fx4XVapYXNgg==",
           "requires": {
-            "@bugsnag/browser": "^7.22.7",
-            "@bugsnag/node": "^7.23.0"
+            "@bugsnag/browser": "^7.25.0",
+            "@bugsnag/node": "^7.25.0"
           }
         }
       }
@@ -39224,7 +39224,7 @@
     "@shopify/remix-oxygen": {
       "version": "file:packages/remix-oxygen",
       "requires": {
-        "@remix-run/server-runtime": "^2.9.2",
+        "@remix-run/server-runtime": "^2.10.1",
         "@shopify/oxygen-workers-types": "^4.1.2"
       }
     },
@@ -42272,12 +42272,12 @@
     "docs-preview": {
       "version": "file:docs/preview",
       "requires": {
-        "@remix-run/css-bundle": "^2.9.2",
-        "@remix-run/dev": "^2.9.2",
-        "@remix-run/eslint-config": "^2.9.2",
-        "@remix-run/node": "^2.9.2",
-        "@remix-run/react": "^2.9.2",
-        "@remix-run/serve": "^2.9.2",
+        "@remix-run/css-bundle": "^2.10.1",
+        "@remix-run/dev": "^2.10.1",
+        "@remix-run/eslint-config": "^2.10.1",
+        "@remix-run/node": "^2.10.1",
+        "@remix-run/react": "^2.10.1",
+        "@remix-run/serve": "^2.10.1",
         "@types/he": "^1.2.1",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
@@ -43226,13 +43226,13 @@
     "example-hydrogen-express": {
       "version": "file:examples/express",
       "requires": {
-        "@remix-run/css-bundle": "^2.9.2",
-        "@remix-run/dev": "^2.9.2",
-        "@remix-run/eslint-config": "^2.9.2",
-        "@remix-run/express": "^2.9.2",
-        "@remix-run/node": "^2.9.2",
-        "@remix-run/react": "^2.9.2",
-        "@remix-run/server-runtime": "^2.9.2",
+        "@remix-run/css-bundle": "^2.10.1",
+        "@remix-run/dev": "^2.10.1",
+        "@remix-run/eslint-config": "^2.10.1",
+        "@remix-run/express": "^2.10.1",
+        "@remix-run/node": "^2.10.1",
+        "@remix-run/react": "^2.10.1",
+        "@remix-run/server-runtime": "^2.10.1",
         "@shopify/cli": "3.61.2",
         "@shopify/cli-hydrogen": "^8.1.1",
         "@shopify/hydrogen": "2024.4.7",
@@ -45180,9 +45180,9 @@
           }
         },
         "ws": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
           "requires": {}
         }
       }
@@ -48003,9 +48003,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-          "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+          "version": "8.18.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+          "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
           "requires": {}
         }
       }
@@ -49633,20 +49633,20 @@
       "dev": true
     },
     "react-router": {
-      "version": "6.23.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
-      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.24.1.tgz",
+      "integrity": "sha512-PTXFXGK2pyXpHzVo3rR9H7ip4lSPZZc0bHG5CARmj65fTT6qG7sTngmb6lcYu1gf3y/8KxORoy9yn59pGpCnpg==",
       "requires": {
-        "@remix-run/router": "1.16.1"
+        "@remix-run/router": "1.17.1"
       }
     },
     "react-router-dom": {
-      "version": "6.23.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
-      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.24.1.tgz",
+      "integrity": "sha512-U19KtXqooqw967Vw0Qcn5cOvrX5Ejo9ORmOtJMzYWtCT4/WOfFLIZGGsVLxcd9UkBO0mSTZtXqhZBsWlHr7+Sg==",
       "requires": {
-        "@remix-run/router": "1.16.1",
-        "react-router": "6.23.1"
+        "@remix-run/router": "1.17.1",
+        "react-router": "6.24.1"
       }
     },
     "react-syntax-highlighter": {
@@ -50778,10 +50778,10 @@
       "version": "file:templates/skeleton",
       "requires": {
         "@graphql-codegen/cli": "5.0.2",
-        "@remix-run/dev": "^2.9.2",
-        "@remix-run/eslint-config": "^2.9.2",
-        "@remix-run/react": "^2.9.2",
-        "@remix-run/server-runtime": "^2.9.2",
+        "@remix-run/dev": "^2.10.1",
+        "@remix-run/eslint-config": "^2.10.1",
+        "@remix-run/react": "^2.10.1",
+        "@remix-run/server-runtime": "^2.10.1",
         "@shopify/cli": "3.61.2",
         "@shopify/cli-hydrogen": "^8.1.1",
         "@shopify/hydrogen": "2024.4.7",
@@ -52254,9 +52254,9 @@
       "optional": true
     },
     "turbo-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.0.1.tgz",
-      "integrity": "sha512-sm0ZtcX9YWh28p5X8t5McxC2uthrt9p+g0bGE0KTVFhnhNWefpSVCr+67zRNDUOfo4bpXwiOp7otO+dyQ7/y/A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.2.0.tgz",
+      "integrity": "sha512-FKFg7A0To1VU4CH9YmSMON5QphK0BXjSoiC7D9yMh+mEEbXLUP9qJ4hEt1qcjKtzncs1OpcnjZO8NgrlVbZH+g=="
     },
     "turbo-windows-64": {
       "version": "1.12.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "test:watch": "cross-env SHOPIFY_UNIT_TEST=1 vitest --test-timeout=60000"
   },
   "devDependencies": {
-    "@remix-run/dev": "^2.9.2",
+    "@remix-run/dev": "^2.10.1",
     "@types/diff": "^5.0.2",
     "@types/fs-extra": "^11.0.1",
     "@types/gunzip-maybe": "^1.4.0",

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -71,9 +71,9 @@
     "worktop": "^0.7.3"
   },
   "devDependencies": {
-    "@remix-run/dev": "^2.9.2",
-    "@remix-run/react": "^2.9.2",
-    "@remix-run/server-runtime": "^2.9.2",
+    "@remix-run/dev": "^2.10.1",
+    "@remix-run/react": "^2.10.1",
+    "@remix-run/server-runtime": "^2.10.1",
     "@shopify/generate-docs": "0.11.1",
     "@shopify/hydrogen-codegen": "*",
     "@testing-library/jest-dom": "^5.17.0",

--- a/packages/remix-oxygen/package.json
+++ b/packages/remix-oxygen/package.json
@@ -40,7 +40,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@remix-run/server-runtime": "^2.9.2",
+    "@remix-run/server-runtime": "^2.10.1",
     "@shopify/oxygen-workers-types": "^4.1.2"
   },
   "peerDependencies": {

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -14,8 +14,8 @@
   },
   "prettier": "@shopify/prettier-config",
   "dependencies": {
-    "@remix-run/react": "^2.9.2",
-    "@remix-run/server-runtime": "^2.9.2",
+    "@remix-run/react": "^2.10.1",
+    "@remix-run/server-runtime": "^2.10.1",
     "@shopify/cli": "3.61.2",
     "@shopify/cli-hydrogen": "^8.1.1",
     "@shopify/hydrogen": "2024.4.7",
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "5.0.2",
-    "@remix-run/dev": "^2.9.2",
-    "@remix-run/eslint-config": "^2.9.2",
+    "@remix-run/dev": "^2.10.1",
+    "@remix-run/eslint-config": "^2.10.1",
     "@shopify/hydrogen-codegen": "^0.3.1",
     "@shopify/mini-oxygen": "^3.0.3",
     "@shopify/oxygen-workers-types": "^4.1.2",


### PR DESCRIPTION
Update Remix to 2.10.0 which included fixes to [infinite loading error](https://github.com/remix-run/remix/issues/9553). With this we can re-introduce the usage of [Layout Export](https://remix.run/docs/en/main/file-conventions/root#layout-export) safety.  

Other notable changes is the introduction of `future.unstable_fogOfWar` flag, but we wont be using it in base Hydrogen project
2.10.0 https://github.com/remix-run/remix/blob/main/CHANGELOG.md#v2100
2.10.1 https://github.com/remix-run/remix/blob/main/CHANGELOG.md#v2101