### PR TITLE
Fix Codegen config resolution

### DIFF
--- a/.changeset/brave-falcons-repair.md
+++ b/.changeset/brave-falcons-repair.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix Codegen config resolution when project directory contains dots.

--- a/packages/cli/src/lib/codegen.ts
+++ b/packages/cli/src/lib/codegen.ts
@@ -1,7 +1,7 @@
 import {spawn} from 'node:child_process';
 import {fileURLToPath} from 'node:url';
 import {formatCode, getCodeFormatOptions} from './format-code.js';
-import {renderFatalError, renderWarning} from '@shopify/cli-kit/node/ui';
+import {renderWarning} from '@shopify/cli-kit/node/ui';
 import {
   joinPath,
   relativePath,
@@ -173,8 +173,7 @@ async function generateTypes({
   const {config: codegenConfig} =
     // Load <root>/codegen.ts if available
     (await loadCodegenConfig({
-      configFilePath,
-      searchPlaces: [dirs.rootDirectory],
+      configFilePath: configFilePath ?? dirs.rootDirectory,
     })) ||
     // Fall back to default config
     (await generateDefaultConfig(dirs, forceSfapiVersion));


### PR DESCRIPTION
When the project directory contains `.`, the GraphQL config dependencies try to load it as a file with unknown extension, resulting in an unhandled exception.

<img width="789" alt="image" src="https://github.com/Shopify/hydrogen/assets/1634092/378e3a95-6751-4811-b87a-c33c1bc04b5a">

This issue was also reported here: https://community.shopify.com/c/shopify-apps/how-can-i-fix-the-missing-loader-for-extension-error-in-hydrogen/td-p/2368900