### PR TITLE
move css option scaffold to be after i18n set up

### DIFF
--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -210,25 +210,6 @@ export async function setupLocalStarterTemplate(
       options.git ? createInitialCommit(project.directory) : undefined,
     );
 
-  const {setupCss, cssStrategy} = await handleCssStrategy(
-    project.directory,
-    controller,
-    options.styling,
-  );
-
-  if (cssStrategy) {
-    backgroundWorkPromise = backgroundWorkPromise
-      .then(() => setupCss().catch(abort))
-      .then(() =>
-        options.git
-          ? commitAll(
-              project.directory,
-              'Setup ' + CSS_STRATEGY_NAME_MAP[cssStrategy],
-            )
-          : undefined,
-      );
-  }
-
   const {packageManager, shouldInstallDeps, installDeps} =
     await handleDependencies(
       project.directory,
@@ -240,7 +221,6 @@ export async function setupLocalStarterTemplate(
   const setupSummary: SetupSummary = {
     language,
     packageManager,
-    cssStrategy,
     depsInstalled: false,
     cliCommand: await getCliCommand('', packageManager),
   };
@@ -350,6 +330,26 @@ export async function setupLocalStarterTemplate(
           setupSummary.routesError = error as AbortError;
         });
     });
+  }
+
+  const {setupCss, cssStrategy} = await handleCssStrategy(
+    project.directory,
+    controller,
+    options.styling,
+  );
+
+  if (cssStrategy) {
+    setupSummary.cssStrategy = cssStrategy;
+    backgroundWorkPromise = backgroundWorkPromise
+      .then(() => setupCss().catch(abort))
+      .then(() =>
+        options.git
+          ? commitAll(
+              project.directory,
+              'Setup ' + CSS_STRATEGY_NAME_MAP[cssStrategy],
+            )
+          : undefined,
+      );
   }
 
   await renderTasks(tasks);


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fix: https://github.com/Shopify/hydrogen/issues/2314
<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

The CSS option for tailwind modify `root.tsx`, but this file is overwrite later on during i18n setup.

Because `h2 setup css` work for existing project and shared the same code for setup during `init` or `setup css`,
I moved the CSS option to be run after the i18n setup.

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->
run `h2 init` and select tailwind option

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
