### PR TITLE
Do not overwrite file deps during project initialization

### DIFF
--- a/packages/cli/src/commands/hydrogen/setup.ts
+++ b/packages/cli/src/commands/hydrogen/setup.ts
@@ -115,11 +115,13 @@ export async function runSetup(options: RunSetupOptions) {
         ]),
       )
       .then(async () => {
-        routes = await setupRoutes(
-          rootDirectory,
-          typescript ? 'ts' : 'js',
-          i18n,
-        );
+        routes = await setupRoutes(rootDirectory, typescript ? 'ts' : 'js', {
+          i18nStrategy: i18n,
+          // User might have added files before running this command.
+          // We should overwrite them to ensure the routes are set up correctly.
+          // Relies on Git to restore the files if needed.
+          overwriteFileDeps: true,
+        });
       });
   }
 

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -139,7 +139,7 @@ export async function handleRouteGeneration(
     setupRoutes: async (
       directory: string,
       language: Language,
-      i18nStrategy?: I18nStrategy,
+      options?: {i18nStrategy?: I18nStrategy; overwriteFileDeps?: boolean},
     ) => {
       if (needsRouteGeneration) {
         const result = await generateRoutes(
@@ -148,8 +148,10 @@ export async function handleRouteGeneration(
             directory,
             force: true,
             typescript: language === 'ts',
-            localePrefix: i18nStrategy === 'subfolders' ? 'locale' : false,
+            localePrefix:
+              options?.i18nStrategy === 'subfolders' ? 'locale' : false,
             signal: controller.signal,
+            ...options,
           },
           {
             rootDirectory: directory,

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -335,7 +335,12 @@ export async function setupLocalStarterTemplate(
           setupSummary.i18nError = error as AbortError;
         });
 
-      await setupRoutes(project.directory, language, i18nStrategy)
+      await setupRoutes(project.directory, language, {
+        i18nStrategy,
+        // The init process might have added and modified files. Do not overwrite them.
+        // E.g. CSS imports might have been added to the root.
+        overwriteFileDeps: false,
+      })
         .then((routes) => {
           setupSummary.routes = routes;
 


### PR DESCRIPTION
Closes #2314

Due to a depending on `~/root` in `routes/cart`, the root file is being overwritten after CSS is setup there. This PR avoids overwriting files that are already setup.