### PR TITLE
Announce new releases on Slack

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -124,7 +124,7 @@ jobs:
           url: ${{ secrets.SLACK_NOTIFICATION_URL }}
           method: 'POST'
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"version": "${{ env.HYDROGEN_VERSION }}"}'
+          data: "{\"version\": \"${{ env.HYDROGEN_VERSION }}\"}"
 
   # sync_latest:
   #   needs: changelog


### PR DESCRIPTION
Hey @frandiox!

Here's a PR to announce new releases on the Partner Slack:

![image](https://github.com/user-attachments/assets/9c3375af-9af6-44d9-8492-4c08555f8d9f)

We [did something similar for Discord a while ago](https://github.com/Shopify/hydrogen/pull/1304), but now the Discord has been shut down.

(I've added a `SLACK_NOTIFICATION_URL` secret to the repo).