### PR TITLE
Fix the `OptimisticCart` type to properly retain the generic of line items

### DIFF
--- a/.changeset/sour-flowers-do.md
+++ b/.changeset/sour-flowers-do.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix the `OptimisticCart` type to properly retain the generic of line items

--- a/.changeset/sour-flowers-do.md
+++ b/.changeset/sour-flowers-do.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Fix the `OptimisticCart` type to properly retain the generic of line items
+Fix the `OptimisticCart` type to properly retain the generic of line items. The `OptimisticCartLine` type now takes a cart or cart line item generic.

--- a/examples/multipass/app/components/Cart.tsx
+++ b/examples/multipass/app/components/Cart.tsx
@@ -16,7 +16,7 @@ import {MultipassCheckoutButton} from './MultipassCheckoutButton';
 /**********   EXAMPLE UPDATE END   ************/
 /***********************************************/
 
-type CartLine = OptimisticCartLine<CartApiQueryFragment['lines']['nodes'][0]>;
+type CartLine = OptimisticCartLine<CartApiQueryFragment>;
 
 type CartMainProps = {
   cart: CartApiQueryFragment | null;

--- a/examples/multipass/app/components/Cart.tsx
+++ b/examples/multipass/app/components/Cart.tsx
@@ -16,6 +16,8 @@ import {MultipassCheckoutButton} from './MultipassCheckoutButton';
 /**********   EXAMPLE UPDATE END   ************/
 /***********************************************/
 
+type CartLine = OptimisticCartLine<CartApiQueryFragment['lines']['nodes'][0]>;
+
 type CartMainProps = {
   cart: CartApiQueryFragment | null;
   layout: 'page' | 'aside';
@@ -65,7 +67,7 @@ function CartLines({
   layout,
 }: {
   layout: CartMainProps['layout'];
-  lines: OptimisticCartLine[];
+  lines: CartLine[];
 }) {
   if (!lines) return null;
 
@@ -85,7 +87,7 @@ function CartLineItem({
   line,
 }: {
   layout: CartMainProps['layout'];
-  line: OptimisticCartLine;
+  line: CartLine;
 }) {
   const {id, merchandise} = line;
   const {product, title, image, selectedOptions} = merchandise;
@@ -199,7 +201,7 @@ function CartLineRemoveButton({
   );
 }
 
-function CartLineQuantity({line}: {line: OptimisticCartLine}) {
+function CartLineQuantity({line}: {line: CartLine}) {
   if (!line || typeof line?.quantity === 'undefined') return null;
   const {id: lineId, quantity, isOptimistic} = line;
   const prevQuantity = Number(Math.max(0, quantity - 1).toFixed(0));
@@ -240,7 +242,7 @@ function CartLinePrice({
   priceType = 'regular',
   ...passthroughProps
 }: {
-  line: OptimisticCartLine;
+  line: CartLine;
   priceType?: 'regular' | 'compareAt';
   [key: string]: any;
 }) {

--- a/examples/subscriptions/app/components/Cart.tsx
+++ b/examples/subscriptions/app/components/Cart.tsx
@@ -86,8 +86,6 @@ function CartLineItem({
 }) {
   /***********************************************/
   /**********  EXAMPLE UPDATE STARTS  ************/
-  // @ts-expect-error - your project should need this expect error.
-  // It's necessary in our mono repo example setup
   const {id, merchandise, sellingPlanAllocation} = line;
   /**********   EXAMPLE UPDATE END   ************/
   /***********************************************/

--- a/examples/subscriptions/app/components/Cart.tsx
+++ b/examples/subscriptions/app/components/Cart.tsx
@@ -11,7 +11,7 @@ import {Link} from '@remix-run/react';
 import type {CartApiQueryFragment} from 'storefrontapi.generated';
 import {useVariantUrl} from '~/lib/variants';
 
-type CartLine = OptimisticCartLine<CartApiQueryFragment['lines']['nodes'][0]>;
+type CartLine = OptimisticCartLine<CartApiQueryFragment>;
 
 type CartMainProps = {
   cart: CartApiQueryFragment;

--- a/examples/subscriptions/app/components/Cart.tsx
+++ b/examples/subscriptions/app/components/Cart.tsx
@@ -11,6 +11,8 @@ import {Link} from '@remix-run/react';
 import type {CartApiQueryFragment} from 'storefrontapi.generated';
 import {useVariantUrl} from '~/lib/variants';
 
+type CartLine = OptimisticCartLine<CartApiQueryFragment['lines']['nodes'][0]>;
+
 type CartMainProps = {
   cart: CartApiQueryFragment;
   layout: 'page' | 'aside';
@@ -60,7 +62,7 @@ function CartLines({
   layout,
 }: {
   layout: CartMainProps['layout'];
-  lines: OptimisticCartLine[];
+  lines: CartLine[];
 }) {
   if (!lines) return null;
 
@@ -80,10 +82,12 @@ function CartLineItem({
   line,
 }: {
   layout: CartMainProps['layout'];
-  line: OptimisticCartLine;
+  line: CartLine;
 }) {
   /***********************************************/
   /**********  EXAMPLE UPDATE STARTS  ************/
+  // @ts-expect-error - your project should need this expect error.
+  // It's necessary in our mono repo example setup
   const {id, merchandise, sellingPlanAllocation} = line;
   /**********   EXAMPLE UPDATE END   ************/
   /***********************************************/
@@ -208,7 +212,7 @@ function CartLineRemoveButton({
   );
 }
 
-function CartLineQuantity({line}: {line: OptimisticCartLine}) {
+function CartLineQuantity({line}: {line: CartLine}) {
   if (!line || typeof line?.quantity === 'undefined') return null;
   const {id: lineId, quantity, isOptimistic} = line;
   const prevQuantity = Number(Math.max(0, quantity - 1).toFixed(0));
@@ -249,7 +253,7 @@ function CartLinePrice({
   priceType = 'regular',
   ...passthroughProps
 }: {
-  line: OptimisticCartLine;
+  line: CartLine;
   priceType?: 'regular' | 'compareAt';
   [key: string]: any;
 }) {

--- a/examples/subscriptions/app/components/CartLineItem.tsx
+++ b/examples/subscriptions/app/components/CartLineItem.tsx
@@ -7,7 +7,7 @@ import {ProductPrice} from '~/components/ProductPrice';
 import {useAside} from '~/components/Aside';
 import type {CartApiQueryFragment} from 'storefrontapi.generated';
 
-type CartLine = OptimisticCartLine<CartApiQueryFragment['lines']['nodes'][0]>;
+type CartLine = OptimisticCartLine<CartApiQueryFragment>;
 
 /**
  * A single line item in the cart. It displays the product image, title, price.

--- a/examples/subscriptions/app/components/CartLineItem.tsx
+++ b/examples/subscriptions/app/components/CartLineItem.tsx
@@ -22,8 +22,6 @@ export function CartLineItem({
 }) {
   /***********************************************/
   /**********  EXAMPLE UPDATE STARTS  ************/
-  // @ts-expect-error - your project should need this expect error.
-  // It's necessary in our mono repo example setup
   const {id, merchandise, sellingPlanAllocation} = line;
   /**********   EXAMPLE UPDATE END   ************/
   /***********************************************/

--- a/examples/subscriptions/app/components/CartLineItem.tsx
+++ b/examples/subscriptions/app/components/CartLineItem.tsx
@@ -5,6 +5,9 @@ import {useVariantUrl} from '~/lib/variants';
 import {Link} from '@remix-run/react';
 import {ProductPrice} from '~/components/ProductPrice';
 import {useAside} from '~/components/Aside';
+import type {CartApiQueryFragment} from 'storefrontapi.generated';
+
+type CartLine = OptimisticCartLine<CartApiQueryFragment['lines']['nodes'][0]>;
 
 /**
  * A single line item in the cart. It displays the product image, title, price.
@@ -15,10 +18,12 @@ export function CartLineItem({
   line,
 }: {
   layout: CartLayout;
-  line: OptimisticCartLine;
+  line: CartLine;
 }) {
   /***********************************************/
   /**********  EXAMPLE UPDATE STARTS  ************/
+  // @ts-expect-error - your project should need this expect error.
+  // It's necessary in our mono repo example setup
   const {id, merchandise, sellingPlanAllocation} = line;
   /**********   EXAMPLE UPDATE END   ************/
   /***********************************************/
@@ -85,7 +90,7 @@ export function CartLineItem({
  * These controls are disabled when the line item is new, and the server
  * hasn't yet responded that it was successfully added to the cart.
  */
-function CartLineQuantity({line}: {line: OptimisticCartLine}) {
+function CartLineQuantity({line}: {line: CartLine}) {
   if (!line || typeof line?.quantity === 'undefined') return null;
   const {id: lineId, quantity, isOptimistic} = line;
   const prevQuantity = Number(Math.max(0, quantity - 1).toFixed(0));

--- a/examples/subscriptions/app/lib/fragments.ts
+++ b/examples/subscriptions/app/lib/fragments.ts
@@ -1,0 +1,183 @@
+// NOTE: https://shopify.dev/docs/api/storefront/latest/queries/cart
+export const CART_QUERY_FRAGMENT = `#graphql
+  fragment Money on MoneyV2 {
+    currencyCode
+    amount
+  }
+  fragment CartLine on CartLine {
+    id
+    quantity
+    attributes {
+      key
+      value
+    }
+    cost {
+      totalAmount {
+        ...Money
+      }
+      amountPerQuantity {
+        ...Money
+      }
+      compareAtAmountPerQuantity {
+        ...Money
+      }
+    }
+    #/***********************************************/
+    #/**********  EXAMPLE UPDATE STARTS  ************/
+    sellingPlanAllocation {
+      sellingPlan {
+         name
+      }
+    }
+    #/***********************************************/
+    #/**********  EXAMPLE UPDATE ENDS  ************/
+    merchandise {
+      ... on ProductVariant {
+        id
+        availableForSale
+        compareAtPrice {
+          ...Money
+        }
+        price {
+          ...Money
+        }
+        requiresShipping
+        title
+        image {
+          id
+          url
+          altText
+          width
+          height
+
+        }
+        product {
+          handle
+          title
+          id
+          vendor
+        }
+        selectedOptions {
+          name
+          value
+        }
+      }
+    }
+  }
+  fragment CartApiQuery on Cart {
+    updatedAt
+    id
+    checkoutUrl
+    totalQuantity
+    buyerIdentity {
+      countryCode
+      customer {
+        id
+        email
+        firstName
+        lastName
+        displayName
+      }
+      email
+      phone
+    }
+    lines(first: $numCartLines) {
+      nodes {
+        ...CartLine
+      }
+    }
+    cost {
+      subtotalAmount {
+        ...Money
+      }
+      totalAmount {
+        ...Money
+      }
+      totalDutyAmount {
+        ...Money
+      }
+      totalTaxAmount {
+        ...Money
+      }
+    }
+    note
+    attributes {
+      key
+      value
+    }
+    discountCodes {
+      code
+      applicable
+    }
+  }
+` as const;
+
+const MENU_FRAGMENT = `#graphql
+  fragment MenuItem on MenuItem {
+    id
+    resourceId
+    tags
+    title
+    type
+    url
+  }
+  fragment ChildMenuItem on MenuItem {
+    ...MenuItem
+  }
+  fragment ParentMenuItem on MenuItem {
+    ...MenuItem
+    items {
+      ...ChildMenuItem
+    }
+  }
+  fragment Menu on Menu {
+    id
+    items {
+      ...ParentMenuItem
+    }
+  }
+` as const;
+
+export const HEADER_QUERY = `#graphql
+  fragment Shop on Shop {
+    id
+    name
+    description
+    primaryDomain {
+      url
+    }
+    brand {
+      logo {
+        image {
+          url
+        }
+      }
+    }
+  }
+  query Header(
+    $country: CountryCode
+    $headerMenuHandle: String!
+    $language: LanguageCode
+  ) @inContext(language: $language, country: $country) {
+    shop {
+      ...Shop
+    }
+    menu(handle: $headerMenuHandle) {
+      ...Menu
+    }
+  }
+  ${MENU_FRAGMENT}
+` as const;
+
+export const FOOTER_QUERY = `#graphql
+  query Footer(
+    $country: CountryCode
+    $footerMenuHandle: String!
+    $language: LanguageCode
+  ) @inContext(language: $language, country: $country) {
+    menu(handle: $footerMenuHandle) {
+      ...Menu
+    }
+  }
+  ${MENU_FRAGMENT}
+` as const;

--- a/examples/subscriptions/storefrontapi.generated.d.ts
+++ b/examples/subscriptions/storefrontapi.generated.d.ts
@@ -20,6 +20,9 @@ export type CartLineFragment = Pick<
       Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
     >;
   };
+  sellingPlanAllocation?: StorefrontAPI.Maybe<{
+    sellingPlan: Pick<StorefrontAPI.SellingPlan, 'name'>;
+  }>;
   merchandise: Pick<
     StorefrontAPI.ProductVariant,
     'id' | 'availableForSale' | 'requiresShipping' | 'title'
@@ -67,6 +70,9 @@ export type CartApiQueryFragment = Pick<
             Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
           >;
         };
+        sellingPlanAllocation?: StorefrontAPI.Maybe<{
+          sellingPlan: Pick<StorefrontAPI.SellingPlan, 'name'>;
+        }>;
         merchandise: Pick<
           StorefrontAPI.ProductVariant,
           'id' | 'availableForSale' | 'requiresShipping' | 'title'

--- a/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
+++ b/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
@@ -25,7 +25,9 @@ export type OptimisticCart<T = CartReturn> = T extends undefined | null
   : Omit<T, 'lines'> & {
       isOptimistic?: boolean;
       lines: {
-        nodes: Array<OptimisticCartLine>;
+        nodes: T extends {lines: {nodes: Array<unknown>}}
+          ? Array<OptimisticCartLine<T['lines']['nodes']['0']>>
+          : Array<OptimisticCartLine>;
       };
     };
 
@@ -49,7 +51,7 @@ export function useOptimisticCart<
     ? (structuredClone(cart) as OptimisticCart<DefaultCart>)
     : ({lines: {nodes: []}} as unknown as OptimisticCart<DefaultCart>);
 
-  const cartLines = optimisticCart.lines.nodes;
+  const cartLines = optimisticCart.lines.nodes as OptimisticCartLine[];
 
   let isOptimistic = false;
 

--- a/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
+++ b/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
@@ -11,10 +11,14 @@ import {
 import type {PartialDeep} from 'type-fest';
 import type {CartReturn} from '../queries/cart-types';
 
-export type OptimisticCartLine<T = CartLine | CartReturn> = T extends {
-  lines: {nodes: Array<unknown>};
-}
-  ? T['lines']['nodes'][0] & {isOptimistic?: boolean}
+type LikeACart = {
+  lines: {
+    nodes: Array<unknown>;
+  };
+};
+
+export type OptimisticCartLine<T = CartLine | CartReturn> = T extends LikeACart
+  ? T['lines']['nodes'][number] & {isOptimistic?: boolean}
   : T & {isOptimistic?: boolean};
 
 export type OptimisticCart<T = CartReturn> = T extends undefined | null
@@ -29,9 +33,7 @@ export type OptimisticCart<T = CartReturn> = T extends undefined | null
   : Omit<T, 'lines'> & {
       isOptimistic?: boolean;
       lines: {
-        nodes: T extends {lines: {nodes: Array<unknown>}}
-          ? Array<OptimisticCartLine<T['lines']['nodes']['0']>>
-          : Array<OptimisticCartLine>;
+        nodes: Array<OptimisticCartLine<T>>;
       };
     };
 

--- a/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
+++ b/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
@@ -11,7 +11,11 @@ import {
 import type {PartialDeep} from 'type-fest';
 import type {CartReturn} from '../queries/cart-types';
 
-export type OptimisticCartLine<T = CartLine> = T & {isOptimistic?: boolean};
+export type OptimisticCartLine<T = CartLine | CartReturn> = T extends {
+  lines: {nodes: Array<unknown>};
+}
+  ? T['lines']['nodes'][0] & {isOptimistic?: boolean}
+  : T & {isOptimistic?: boolean};
 
 export type OptimisticCart<T = CartReturn> = T extends undefined | null
   ? // This is the null/undefined case, where the cart has yet to be created.

--- a/templates/skeleton/app/components/CartLineItem.tsx
+++ b/templates/skeleton/app/components/CartLineItem.tsx
@@ -1,13 +1,14 @@
 import type {CartLineUpdateInput} from '@shopify/hydrogen/storefront-api-types';
 import type {CartLayout} from '~/components/CartMain';
-import {CartForm, Image, type OptimisticCart} from '@shopify/hydrogen';
+import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
 import {useVariantUrl} from '~/lib/variants';
 import {Link} from '@remix-run/react';
 import {ProductPrice} from './ProductPrice';
 import {useAside} from './Aside';
 import type {CartApiQueryFragment} from 'storefrontapi.generated';
 
-type CartLine = OptimisticCart<CartApiQueryFragment>['lines']['nodes'][0];
+type CartLine = OptimisticCartLine<CartApiQueryFragment>;
+
 /**
  * A single line item in the cart. It displays the product image, title, price.
  * It also provides controls to update the quantity or remove the line item.

--- a/templates/skeleton/app/components/CartLineItem.tsx
+++ b/templates/skeleton/app/components/CartLineItem.tsx
@@ -1,11 +1,13 @@
 import type {CartLineUpdateInput} from '@shopify/hydrogen/storefront-api-types';
 import type {CartLayout} from '~/components/CartMain';
-import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
+import {CartForm, Image, type OptimisticCart} from '@shopify/hydrogen';
 import {useVariantUrl} from '~/lib/variants';
 import {Link} from '@remix-run/react';
 import {ProductPrice} from './ProductPrice';
 import {useAside} from './Aside';
+import type {CartApiQueryFragment} from 'storefrontapi.generated';
 
+type CartLine = OptimisticCart<CartApiQueryFragment>['lines']['nodes'][0];
 /**
  * A single line item in the cart. It displays the product image, title, price.
  * It also provides controls to update the quantity or remove the line item.
@@ -15,7 +17,7 @@ export function CartLineItem({
   line,
 }: {
   layout: CartLayout;
-  line: OptimisticCartLine;
+  line: CartLine;
 }) {
   const {id, merchandise} = line;
   const {product, title, image, selectedOptions} = merchandise;
@@ -70,7 +72,7 @@ export function CartLineItem({
  * These controls are disabled when the line item is new, and the server
  * hasn't yet responded that it was successfully added to the cart.
  */
-function CartLineQuantity({line}: {line: OptimisticCartLine}) {
+function CartLineQuantity({line}: {line: CartLine}) {
   if (!line || typeof line?.quantity === 'undefined') return null;
   const {id: lineId, quantity, isOptimistic} = line;
   const prevQuantity = Number(Math.max(0, quantity - 1).toFixed(0));

--- a/templates/skeleton/app/components/CartMain.tsx
+++ b/templates/skeleton/app/components/CartMain.tsx
@@ -1,4 +1,4 @@
-import {type OptimisticCartLine, useOptimisticCart} from '@shopify/hydrogen';
+import {useOptimisticCart} from '@shopify/hydrogen';
 import {Link} from '@remix-run/react';
 import type {CartApiQueryFragment} from 'storefrontapi.generated';
 import {useAside} from '~/components/Aside';

--- a/templates/skeleton/app/components/CartMain.tsx
+++ b/templates/skeleton/app/components/CartMain.tsx
@@ -34,7 +34,7 @@ export function CartMain({layout, cart: originalCart}: CartMainProps) {
       <div className="cart-details">
         <div aria-labelledby="cart-lines">
           <ul>
-            {(cart?.lines?.nodes ?? []).map((line: OptimisticCartLine) => (
+            {(cart?.lines?.nodes ?? []).map((line) => (
               <CartLineItem key={line.id} line={line} layout={layout} />
             ))}
           </ul>


### PR DESCRIPTION

<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

@brookslybrand reported an issue where the the generic on `OptimisticCart` did not propagate to line items. For example, this would produce a type of the default cart lines, not the generic api fragment provided.

```ts
type CartLine = OptimisticCart<CartApiQueryFragment>['lines']['nodes'];
```

With this change, now the `CartAPIQueryFragment` is preserved.

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->


#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
