### PR TITLE
Fix subsequent profiler by removing the Layout export from virtual root

### DIFF
--- a/.changeset/spicy-toys-share.md
+++ b/.changeset/spicy-toys-share.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Fix subsequent profiler by removing the Layout export from virtual root.
+Fix subrequest profiler by removing the Layout export from virtual root.

--- a/.changeset/spicy-toys-share.md
+++ b/.changeset/spicy-toys-share.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix subsequent profiler by removing the Layout export from virtual root.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29700,7 +29700,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -29935,7 +29935,7 @@
     },
     "packages/create-hydrogen": {
       "name": "@shopify/create-hydrogen",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0"
@@ -32394,7 +32394,7 @@
       }
     },
     "templates/skeleton": {
-      "version": "2024.7.1",
+      "version": "2024.7.2",
       "dependencies": {
         "@remix-run/react": "^2.10.1",
         "@remix-run/server-runtime": "^2.10.1",

--- a/packages/hydrogen/src/vite/virtual-routes/components/Layout.tsx
+++ b/packages/hydrogen/src/vite/virtual-routes/components/Layout.tsx
@@ -1,3 +1,3 @@
-export function PageLayout(props: {children: React.ReactNode}) {
+export function Layout(props: {children: React.ReactNode}) {
   return <div className="hydrogen-virtual-route">{props.children}</div>;
 }

--- a/packages/hydrogen/src/vite/virtual-routes/virtual-root.tsx
+++ b/packages/hydrogen/src/vite/virtual-routes/virtual-root.tsx
@@ -12,7 +12,7 @@ import {
   useRouteError,
 } from '@remix-run/react';
 import favicon from './assets/favicon.svg';
-import {PageLayout} from './components/PageLayout.jsx';
+import {Layout} from './components/Layout.jsx';
 import {useNonce} from '@shopify/hydrogen';
 
 import styles from './assets/styles.css?url';
@@ -24,7 +24,7 @@ export const links: LinksFunction = () => {
   ];
 };
 
-export function Layout({children}: {children?: React.ReactNode}) {
+export default function App() {
   const nonce = useNonce();
   return (
     <html lang="en">
@@ -40,7 +40,9 @@ export function Layout({children}: {children?: React.ReactNode}) {
         <Links />
       </head>
       <body>
-        <PageLayout>{children}</PageLayout>
+        <Layout>
+          <Outlet />
+        </Layout>
         <ScrollRestoration nonce={nonce} />
         <Scripts nonce={nonce} />
       </body>
@@ -61,14 +63,16 @@ export function ErrorBoundary() {
   }
 
   return (
-    <div className="route-error">
-      <h1>Please report this error</h1>
-      <h2>{errorStatus}</h2>
-      {errorMessage && (
-        <fieldset>
-          <pre>{errorMessage}</pre>
-        </fieldset>
-      )}
-    </div>
+    <Layout>
+      <div className="route-error">
+        <h1>Please report this error</h1>
+        <h2>{errorStatus}</h2>
+        {errorMessage && (
+          <fieldset>
+            <pre>{errorMessage}</pre>
+          </fieldset>
+        )}
+      </div>
+    </Layout>
   );
 }


### PR DESCRIPTION
https://github.com/Shopify/hydrogen/pull/2292 end up breaking virtual root.

The wrapping Layout did not get inserted into page, at first I thought it was because I missed the default App export.
However, adding the following back did not do anything.
```.tsx
export default function App() {
  return <Outlet />;
}
```

@frandiox curious what the magic of virtual route is. It looks like it depends on the `Layout` export from a separate file for some reason?