### PR TITLE
Fix cli version in changelog

### DIFF
--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@remix-run/dev": "^2.10.1",
-        "@shopify/cli": "~3.63.2",
+        "@shopify/cli": "~3.64.1",
         "@shopify/oxygen-workers-types": "^4.1.2",
         "typescript": "^5.2.2"
       },


### PR DESCRIPTION
We should be using the latest CLI version, which already includes fixes for the auth flow.