### PR TITLE
remove double body in b2b example

### DIFF
--- a/examples/b2b/app/root.tsx
+++ b/examples/b2b/app/root.tsx
@@ -147,19 +147,6 @@ export function Layout({children}: {children?: React.ReactNode}) {
             shop={data.shop}
             consent={data.consent}
           >
-            <B2BLocationProvider>
-              <PageLayout {...data}>{children}</PageLayout>
-            </B2BLocationProvider>
-          </Analytics.Provider>
-        ) : (
-          children
-        )}
-        {data ? (
-          <Analytics.Provider
-            cart={data.cart}
-            shop={data.shop}
-            consent={data.consent}
-          >
             {/***********************************************/
             /**********  EXAMPLE UPDATE STARTS  ************/}
             <B2BLocationProvider>


### PR DESCRIPTION

## The b2b example renders the PageLayout(The entire content of the page) twice, this fixes that

### WHAT is this pull request doing?

It removes the duplicate `<PageLayout {...data}>{children}</PageLayout>` call



#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
