### PR TITLE
Improve performance of currency formatting by caching underlying IntlNumberFormat objects

### DIFF
--- a/.changeset/eleven-wasps-mix.md
+++ b/.changeset/eleven-wasps-mix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Improve performance of currency formatting


### PR DESCRIPTION

### WHY are these changes introduced?
Previously the memoization inside Hydrogen React's money component was broken, so many instances of `Intl.NumberFormat` were getting created.

Fixes [#2330](https://github.com/Shopify/hydrogen/issues/2330) <!-- link to issue if one exists -->

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

This fix has two parts:

1. Improve the outer memoization to prevent `getLazyFormatter` from being called as often.
2. Change `useLazyFormatter` to `getLazyFormatter` and no longer use React memoization. Instead setup a global manual cache of values for money formatters. This means that a money component in one area of the dom will reuse the same formatter as another money component in the dom if they use the same locale and options. The cache key uses `JSON.stringify`, but comparing the cost of calling JSON.stringify many times versus calling `new Intl.NumberFormat`:

|                                                         | **Time executing 10 million times in Node** |
|---------------------------------------------------------|---------------------------------------------|
| `JSON.stringify([string, Record<string, string>])`      | 2.33s                                       |
| `new Intl.NumberFormat(string, Record<string, string>)` | 59.6s                                       |



### HOW to test your changes?

Load a page that displays currency. Make sure the currency renders properly with different locales.

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
