### PR TITLE
Ignore classic Remix config file in Vite projects

### DIFF
--- a/.changeset/friendly-cheetahs-teach.md
+++ b/.changeset/friendly-cheetahs-teach.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Ignore `remix.config.js` file when `vite.config.js` is present, and warn about it.

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -12,7 +12,7 @@ import {fileSize, removeFile} from '@shopify/cli-kit/node/fs';
 import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager';
 import {commonFlags, flagsToCamelObject} from '../../lib/flags.js';
 import {prepareDiffDirectory} from '../../lib/template-diff.js';
-import {hasViteConfig, getViteConfig} from '../../lib/vite-config.js';
+import {getViteConfig, isViteProject} from '../../lib/vite-config.js';
 import {checkLockfileStatus} from '../../lib/check-lockfile.js';
 import {findMissingRoutes} from '../../lib/missing-routes.js';
 import {runClassicCompilerBuild} from '../../lib/classic-compiler/build.js';
@@ -71,7 +71,7 @@ export default class Build extends Command {
       directory,
     };
 
-    const result = (await hasViteConfig(directory))
+    const result = (await isViteProject(directory))
       ? await runBuild(buildParams)
       : await runClassicCompilerBuild(buildParams);
 

--- a/packages/cli/src/commands/hydrogen/debug/cpu.ts
+++ b/packages/cli/src/commands/hydrogen/debug/cpu.ts
@@ -5,10 +5,7 @@ import {outputInfo} from '@shopify/cli-kit/node/output';
 import {writeFile} from '@shopify/cli-kit/node/fs';
 import colors from '@shopify/cli-kit/node/colors';
 import ansiEscapes from 'ansi-escapes';
-import {
-  getProjectPaths,
-  hasRemixConfigFile,
-} from '../../../lib/remix-config.js';
+import {getProjectPaths, isClassicProject} from '../../../lib/remix-config.js';
 import {muteDevLogs} from '../../../lib/log.js';
 import {commonFlags, flagsToCamelObject} from '../../../lib/flags.js';
 import {prepareDiffDirectory} from '../../../lib/template-diff.js';
@@ -73,8 +70,6 @@ async function runDebugCpu({directory, entry, output}: RunDebugCpuOptions) {
 
   let {buildPath, buildPathWorkerFile} = getProjectPaths(directory);
 
-  const isClassicProject = await hasRemixConfigFile(directory);
-
   outputInfo(
     '⏳️ Starting profiler for CPU startup... Profile will be written to:\n' +
       colors.dim(output),
@@ -110,7 +105,7 @@ async function runDebugCpu({directory, entry, output}: RunDebugCpuOptions) {
     },
   };
 
-  if (isClassicProject) {
+  if (await isClassicProject(directory)) {
     return runClassicCompilerDebugCpu({
       directory,
       output,

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -47,7 +47,7 @@ import {runClassicCompilerBuild} from '../../lib/classic-compiler/build.js';
 import {runBuild} from './build.js';
 import {getViteConfig} from '../../lib/vite-config.js';
 import {prepareDiffDirectory} from '../../lib/template-diff.js';
-import {hasRemixConfigFile} from '../../lib/remix-config.js';
+import {isClassicProject} from '../../lib/remix-config.js';
 import {packageManagers} from '../../lib/package-managers.js';
 import {setupResourceCleanup} from '../../lib/resource-cleanup.js';
 
@@ -449,7 +449,7 @@ export async function runDeploy(
   let assetsDir = 'dist/client';
   let workerDir = 'dist/worker';
 
-  const isClassicCompiler = await hasRemixConfigFile(root);
+  const isClassicCompiler = await isClassicProject(root);
 
   if (!isClassicCompiler) {
     const viteConfig = await getViteConfig(root, ssrEntry).catch(() => null);

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -41,8 +41,11 @@ import {
 import {getCliCommand} from '../../lib/shell.js';
 import {findPort} from '../../lib/find-port.js';
 import {logRequestLine} from '../../lib/mini-oxygen/common.js';
-import {findHydrogenPlugin, findOxygenPlugin} from '../../lib/vite-config.js';
-import {hasViteConfig} from '../../lib/vite-config.js';
+import {
+  findHydrogenPlugin,
+  findOxygenPlugin,
+  isViteProject,
+} from '../../lib/vite-config.js';
 import {runClassicCompilerDev} from '../../lib/classic-compiler/dev.js';
 import {importVite} from '../../lib/import-utils.js';
 import {createEntryPointErrorHandler} from '../../lib/deps-optimizer.js';
@@ -131,7 +134,7 @@ export default class Dev extends Command {
       cliConfig: this.config,
     };
 
-    const {close} = (await hasViteConfig(directory))
+    const {close} = (await isViteProject(directory))
       ? await runDev(devParams)
       : await runClassicCompilerDev(devParams);
 

--- a/packages/cli/src/lib/remix-config.ts
+++ b/packages/cli/src/lib/remix-config.ts
@@ -10,7 +10,7 @@ import {fileExists} from '@shopify/cli-kit/node/fs';
 import {muteRemixLogs} from './log.js';
 import {REQUIRED_REMIX_VERSION} from './remix-version-check.js';
 import {findFileWithExtension} from './file.js';
-import {getViteConfig} from './vite-config.js';
+import {getViteConfig, isViteProject} from './vite-config.js';
 import {importLocal} from './import-utils.js';
 import {hydrogenPackagesPath, isHydrogenMonorepo} from './build.js';
 
@@ -21,6 +21,13 @@ export type {RemixConfig, ServerMode, RawRemixConfig};
 export async function hasRemixConfigFile(root: string) {
   const result = await findFileWithExtension(root, 'remix.config');
   return !!result.filepath;
+}
+
+export async function isClassicProject(root: string) {
+  const isVite = await isViteProject(root);
+  if (isVite) return false;
+
+  return hasRemixConfigFile(root);
 }
 
 const BUILD_DIR = 'dist'; // Hardcoded in Oxygen

--- a/packages/cli/src/lib/vite-config.ts
+++ b/packages/cli/src/lib/vite-config.ts
@@ -10,10 +10,25 @@ import {importVite} from './import-utils.js';
 // Do not import JS from here, only types
 import type {HydrogenPlugin} from '~/hydrogen/vite/plugin.js';
 import type {OxygenPlugin} from '~/mini-oxygen/vite/plugin.js';
+import {hasRemixConfigFile} from './remix-config.js';
+import {renderWarning} from '@shopify/cli-kit/node/ui';
 
 export async function hasViteConfig(root: string) {
   const result = await findFileWithExtension(root, 'vite.config');
   return !!result.filepath;
+}
+
+export async function isViteProject(root: string) {
+  const isVite = await hasViteConfig(root);
+
+  if (isVite && (await hasRemixConfigFile(root))) {
+    renderWarning({
+      headline: 'Both Vite and Remix config files found.',
+      body: 'The remix.config.js file is not used in Vite projects. Please remove it to avoid conflicts.',
+    });
+  }
+
+  return isVite;
 }
 
 export async function getViteConfig(root: string, ssrEntryFlag?: string) {


### PR DESCRIPTION
We were not consistent with our priorities reading from Vite config or Remix config in every command. With this PR, every command gives preference to Vite config when both are present, and warns about it:

<img width="913" alt="image" src="https://github.com/user-attachments/assets/69dabd50-8b09-4ce6-b969-ba5fa17e4d1a">
