### PR TITLE
Fix shop analytics export type

### DIFF
--- a/.changeset/large-flowers-confess.md
+++ b/.changeset/large-flowers-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Export `ShopAnalytics` and `AnalyticsContextValue` types.

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -91,6 +91,8 @@ export {
   Analytics,
   useAnalytics,
   getShopAnalytics,
+  type ShopAnalytics,
+  type AnalyticsContextValue,
 } from './analytics-manager/AnalyticsProvider';
 export {AnalyticsEvent} from './analytics-manager/events';
 export {


### PR DESCRIPTION
Closes https://github.com/Shopify/hydrogen/issues/2386

I guess we should export all the return types of our exposed functions, right?