### PR TITLE
Fix unit tests

### DIFF
--- a/packages/cli/src/commands/hydrogen/env/pull.test.ts
+++ b/packages/cli/src/commands/hydrogen/env/pull.test.ts
@@ -264,7 +264,7 @@ describe('pullVariables', () => {
           confirmationMessage: `Yes, confirm changes`,
           cancellationMessage: `No, make changes later`,
           message: expect.stringMatching(
-            /We'll make the following changes to your \.env file:/,
+            /We'll make the following changes to your .*?\.env.*? file:/,
           ),
         });
       });

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -95,7 +95,7 @@ export async function setupLocalStarterTemplate(
       force: true,
       recursive: true,
       filter: (filepath: string) =>
-        !/^(app\/|dist\/|node_modules\/|server\.ts)/i.test(
+        !/^(app\/|dist\/|node_modules\/|server\.ts|\.shopify\/)/i.test(
           relativePath(templateDir, filepath),
         ),
     },


### PR DESCRIPTION
- In our monorepo, when the skeleton template is linked to a storefront and we run tests locally, there's an assertion that won't match `Mock.shop` because the generated template is linked.
- I added a color in https://github.com/Shopify/hydrogen/pull/2392/files and now there's an assertion that doesn't match the characters added for the coloring. I've no idea why the tests didn't fail in that PR, though.