### PR TITLE
if shopId is passed, use the core url

### DIFF
--- a/packages/hydrogen/src/createHydrogenContext.test.ts
+++ b/packages/hydrogen/src/createHydrogenContext.test.ts
@@ -58,6 +58,7 @@ const mockEnv = {
     'PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID_value',
   PUBLIC_CUSTOMER_ACCOUNT_API_URL: 'PUBLIC_CUSTOMER_ACCOUNT_API_URL_value',
   PUBLIC_CHECKOUT_DOMAIN: 'PUBLIC_CHECKOUT_DOMAIN_value',
+  SHOP_ID: 'SHOP_ID_value',
 };
 
 const defaultOptions = {
@@ -179,7 +180,7 @@ describe('createHydrogenContext', () => {
       expect(vi.mocked(createCustomerAccountClient)).toHaveBeenCalledWith(
         expect.objectContaining({
           customerAccountId: mockEnv.PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID,
-          customerAccountUrl: mockEnv.PUBLIC_CUSTOMER_ACCOUNT_API_URL,
+          shopId: mockEnv.SHOP_ID,
         }),
       );
     });

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -201,7 +201,7 @@ export function createHydrogenContext<
 
     // defaults
     customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID,
-    customerAccountUrl: env.PUBLIC_CUSTOMER_ACCOUNT_API_URL,
+    shopId: env.SHOP_ID,
   });
 
   /*

--- a/packages/hydrogen/src/customer/auth.helpers.test.ts
+++ b/packages/hydrogen/src/customer/auth.helpers.test.ts
@@ -58,7 +58,7 @@ describe('auth.helpers', () => {
         await refreshToken({
           session,
           customerAccountId: 'customerAccountId',
-          customerAccountUrl: 'customerAccountUrl',
+          customerAccountTokenExchangeUrl: 'customerAccountTokenExchangeUrl',
           httpsOrigin: 'https://localhost',
           exchangeForStorefrontCustomerAccessToken,
         });
@@ -78,7 +78,7 @@ describe('auth.helpers', () => {
         await refreshToken({
           session,
           customerAccountId: 'customerAccountId',
-          customerAccountUrl: 'customerAccountUrl',
+          customerAccountTokenExchangeUrl: 'customerAccountTokenExchangeUrl',
           httpsOrigin: 'https://localhost',
           exchangeForStorefrontCustomerAccessToken,
         });
@@ -107,7 +107,7 @@ describe('auth.helpers', () => {
         await refreshToken({
           session,
           customerAccountId: 'customerAccountId',
-          customerAccountUrl: 'customerAccountUrl',
+          customerAccountTokenExchangeUrl: 'customerAccountTokenExchangeUrl',
           httpsOrigin: 'https://localhost',
           exchangeForStorefrontCustomerAccessToken,
         });
@@ -138,7 +138,7 @@ describe('auth.helpers', () => {
       await refreshToken({
         session,
         customerAccountId: 'customerAccountId',
-        customerAccountUrl: 'customerAccountUrl',
+        customerAccountTokenExchangeUrl: 'customerAccountTokenExchangeUrl',
         httpsOrigin: 'https://localhost',
         exchangeForStorefrontCustomerAccessToken,
       });
@@ -197,7 +197,7 @@ describe('auth.helpers', () => {
           expiresAt: new Date().getTime() + 10000 + '',
           session,
           customerAccountId: 'customerAccountId',
-          customerAccountUrl: 'customerAccountUrl',
+          customerAccountTokenExchangeUrl: 'customerAccountTokenExchangeUrl',
           httpsOrigin: 'https://localhost',
           exchangeForStorefrontCustomerAccessToken,
         });
@@ -228,7 +228,7 @@ describe('auth.helpers', () => {
         expiresAt: '100',
         session,
         customerAccountId: 'customerAccountId',
-        customerAccountUrl: 'customerAccountUrl',
+        customerAccountTokenExchangeUrl: 'customerAccountTokenExchangeUrl',
         httpsOrigin: 'https://localhost',
         exchangeForStorefrontCustomerAccessToken,
       });
@@ -269,7 +269,7 @@ describe('auth.helpers', () => {
         expiresAt: '100',
         session,
         customerAccountId: 'customerAccountId',
-        customerAccountUrl: 'customerAccountUrl',
+        customerAccountTokenExchangeUrl: 'customerAccountTokenExchangeUrl',
         httpsOrigin: 'https://localhost',
         exchangeForStorefrontCustomerAccessToken,
       });

--- a/packages/hydrogen/src/customer/auth.helpers.ts
+++ b/packages/hydrogen/src/customer/auth.helpers.ts
@@ -308,7 +308,7 @@ export async function exchangeAccessToken(
 }
 
 export function getNonce(token: string) {
-  return decodeJwt(token).payload.nonce;
+  return decodeJwt(token.replace("shcit_", "")).payload.nonce;
 }
 
 function decodeJwt(token: string) {

--- a/packages/hydrogen/src/customer/auth.helpers.ts
+++ b/packages/hydrogen/src/customer/auth.helpers.ts
@@ -6,6 +6,7 @@ import {
   CUSTOMER_ACCOUNT_SESSION_KEY,
   BUYER_SESSION_KEY,
 } from './constants';
+import {URL_TYPE} from './getCustomerAccountUrl';
 
 type H2OEvent = Parameters<NonNullable<typeof __H2O_LOG_EVENT>>[0];
 
@@ -70,14 +71,14 @@ export interface AccessTokenResponse {
 export async function refreshToken({
   session,
   customerAccountId,
-  customerAccountUrl,
+  customerAccountTokenExchangeUrl,
   httpsOrigin,
   debugInfo,
   exchangeForStorefrontCustomerAccessToken,
 }: {
   session: HydrogenSession;
   customerAccountId: string;
-  customerAccountUrl: string;
+  customerAccountTokenExchangeUrl: string;
   httpsOrigin: string;
   debugInfo?: Partial<H2OEvent>;
   exchangeForStorefrontCustomerAccessToken: () => Promise<void>;
@@ -105,7 +106,7 @@ export async function refreshToken({
   };
 
   const startTime = new Date().getTime();
-  const url = `${customerAccountUrl}/auth/oauth/token`;
+  const url = customerAccountTokenExchangeUrl;
   const response = await fetch(url, {
     method: 'POST',
     headers,
@@ -139,7 +140,7 @@ export async function refreshToken({
   const accessToken = await exchangeAccessToken(
     access_token,
     customerAccountId,
-    customerAccountUrl,
+    customerAccountTokenExchangeUrl,
     httpsOrigin,
     debugInfo,
   );
@@ -166,7 +167,7 @@ export async function checkExpires({
   expiresAt,
   session,
   customerAccountId,
-  customerAccountUrl,
+  customerAccountTokenExchangeUrl,
   httpsOrigin,
   debugInfo,
   exchangeForStorefrontCustomerAccessToken,
@@ -175,7 +176,7 @@ export async function checkExpires({
   expiresAt: string;
   session: HydrogenSession;
   customerAccountId: string;
-  customerAccountUrl: string;
+  customerAccountTokenExchangeUrl: string;
   httpsOrigin: string;
   debugInfo?: Partial<H2OEvent>;
   exchangeForStorefrontCustomerAccessToken: () => Promise<void>;
@@ -187,7 +188,7 @@ export async function checkExpires({
         locks.refresh = refreshToken({
           session,
           customerAccountId,
-          customerAccountUrl,
+          customerAccountTokenExchangeUrl,
           httpsOrigin,
           debugInfo,
           exchangeForStorefrontCustomerAccessToken,
@@ -251,7 +252,7 @@ export function generateState() {
 export async function exchangeAccessToken(
   authAccessToken: string | undefined,
   customerAccountId: string,
-  customerAccountUrl: string,
+  customerAccountTokenExchangeUrl: string,
   httpsOrigin: string,
   debugInfo?: Partial<H2OEvent>,
 ) {
@@ -282,7 +283,7 @@ export async function exchangeAccessToken(
   };
 
   const startTime = new Date().getTime();
-  const url = `${customerAccountUrl}/auth/oauth/token`;
+  const url = customerAccountTokenExchangeUrl;
   const response = await fetch(url, {
     method: 'POST',
     headers,

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -367,7 +367,7 @@ export function createCustomerAccountClient({
       loginUrl.searchParams.append('redirect_uri', redirectUri);
       loginUrl.searchParams.set(
         'scope',
-        'openid email https://api.customers.com/auth/customer.graphql',
+        getCustomerAccountUrl(URL_TYPE.LOGIN_SCOPE),
       );
       loginUrl.searchParams.append('state', state);
       loginUrl.searchParams.append('nonce', nonce);

--- a/packages/hydrogen/src/customer/getCustomerAccountUrl.ts
+++ b/packages/hydrogen/src/customer/getCustomerAccountUrl.ts
@@ -18,7 +18,8 @@ export function createGetCustomerAccountUrl(
     : deprecatedCustomerAccountUrl;
 
   const customerAccountAuthUrl = shopId
-    ? `https://shopify.com/authentication/${shopId}`
+    ? `${deprecatedCustomerAccountUrl}/auth_test`
+    // ? `https://shopify.com/authentication/${shopId}`
     : `${deprecatedCustomerAccountUrl}/auth`;
 
   return function getCustomerAccountUrl(urlType: URL_TYPE): string {

--- a/packages/hydrogen/src/customer/getCustomerAccountUrl.ts
+++ b/packages/hydrogen/src/customer/getCustomerAccountUrl.ts
@@ -1,0 +1,45 @@
+export enum URL_TYPE {
+  CA_BASE_URL = 'CA_BASE_URL',
+  CA_BASE_AUTH_URL = 'CA_BASE_AUTH_URL',
+  GRAPHQL = 'GRAPHQL',
+  AUTH = 'AUTH',
+  LOGIN_SCOPE = 'LOGIN_SCOPE',
+  TOKEN_EXCHANGE = 'TOKEN_EXCHANGE',
+  LOGOUT = 'LOGOUT',
+}
+
+export function createGetCustomerAccountUrl(
+  customerApiVersion: string,
+  deprecatedCustomerAccountUrl?: string,
+  shopId?: string,
+) {
+  const customerAccountUrl = shopId
+    ? `https://shopify.com/${shopId}`
+    : deprecatedCustomerAccountUrl;
+
+  const customerAccountAuthUrl = shopId
+    ? `https://shopify.com/authentication/${shopId}`
+    : `${deprecatedCustomerAccountUrl}/auth`;
+
+  return function getCustomerAccountUrl(urlType: URL_TYPE): string {
+    switch (urlType) {
+      case URL_TYPE.CA_BASE_URL:
+        // @ts-expect-error
+        return customerAccountUrl;
+      case URL_TYPE.CA_BASE_AUTH_URL:
+        return customerAccountAuthUrl;
+      case URL_TYPE.GRAPHQL:
+        return `${customerAccountUrl}/account/customer/api/${customerApiVersion}/graphql`;
+      case URL_TYPE.AUTH:
+        return `${customerAccountAuthUrl}/oauth/authorize`;
+      case URL_TYPE.LOGIN_SCOPE:
+        return shopId
+          ? 'openid email customer-account-api:full'
+          : 'openid email https://api.customers.com/auth/customer.graphql';
+      case URL_TYPE.TOKEN_EXCHANGE:
+        return `${customerAccountAuthUrl}/oauth/token`;
+      case URL_TYPE.LOGOUT:
+        return `${customerAccountAuthUrl}/logout`;
+    }
+  };
+}

--- a/packages/hydrogen/src/customer/getCustomerAccountUrl.ts
+++ b/packages/hydrogen/src/customer/getCustomerAccountUrl.ts
@@ -18,9 +18,8 @@ export function createGetCustomerAccountUrl(
     : deprecatedCustomerAccountUrl;
 
   const customerAccountAuthUrl = shopId
-    ? `${deprecatedCustomerAccountUrl}/auth_test`
-    // ? `https://shopify.com/authentication/${shopId}`
-    : `${deprecatedCustomerAccountUrl}/auth`;
+    ? `http://shopify.com/${shopId}/auth_test`
+    : `https://shopify.com/authentication/${shopId}`;
 
   return function getCustomerAccountUrl(urlType: URL_TYPE): string {
     switch (urlType) {
@@ -34,9 +33,7 @@ export function createGetCustomerAccountUrl(
       case URL_TYPE.AUTH:
         return `${customerAccountAuthUrl}/oauth/authorize`;
       case URL_TYPE.LOGIN_SCOPE:
-        return shopId
-          ? 'openid email customer-account-api:full'
-          : 'openid email https://api.customers.com/auth/customer.graphql';
+        return 'openid email https://api.customers.com/auth/customer.graphql';
       case URL_TYPE.TOKEN_EXCHANGE:
         return `${customerAccountAuthUrl}/oauth/token`;
       case URL_TYPE.LOGOUT:

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -130,8 +130,12 @@ export type CustomerAccountOptions = {
   session: HydrogenSession;
   /** Unique UUID prefixed with `shp_` associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountId. Use `npx shopify hydrogen env pull` to link your store credentials. */
   customerAccountId: string;
-  /** The account URL associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountUrl. Use `npx shopify hydrogen env pull` to link your store credentials. */
-  customerAccountUrl: string;
+  /**
+   * @deprecated use `shopId` instead. The account URL associated with the application, this should be visible in the customer account api settings in the Hydrogen admin channel. Mock.shop doesn't automatically supply customerAccountUrl. Use `npx shopify hydrogen env pull` to link your store credentials.
+   */
+  customerAccountUrl?: string;
+  /** The shop id. Mock.shop doesn't automatically supply shopId. Use `npx shopify hydrogen env pull` to link your store credentials */
+  shopId?: string;
   /** Override the version of the API */
   customerApiVersion?: string;
   /** The object for the current Request. It should be provided by your platform. */

--- a/packages/hydrogen/src/types.d.ts
+++ b/packages/hydrogen/src/types.d.ts
@@ -49,6 +49,7 @@ export interface HydrogenEnv {
   PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID: string;
   PUBLIC_CUSTOMER_ACCOUNT_API_URL: string;
   PUBLIC_CHECKOUT_DOMAIN: string;
+  SHOP_ID: string;
 }
 
 export type StorefrontHeaders = {


### PR DESCRIPTION
Close https://github.com/Shopify/hydrogen-internal/issues/128

This PR changed two utilities

1. `createCustomerAccountClient`
- add a `shopId` option
- make `customerAccountUrl` deprecated and optional

If `shopId` option has value => use the core url, else use `customerAccountUrl`

This utility REQUIRE user update to the code. 
User may need to do a `h2 env pull` to get SHOP_ID into their .env file.
It is NOT a breaking change for now. But we should aim to remove the deprecate option in the next major release.

2. `createAppLoadContext`
This utility does not require user update to the code. 
(They have have to do a `h2 env pull` to get SHOP_ID into their .env file)