### PR TITLE
Add test & note for using method definition in customMethod for `createHydrogenContext`

### DIFF
--- a/examples/custom-cart-method/app/lib/context.ts
+++ b/examples/custom-cart-method/app/lib/context.ts
@@ -43,10 +43,10 @@ export async function createAppLoadContext(
       queryFragment: CART_QUERY_FRAGMENT,
       /***********************************************/
       /**********  EXAMPLE UPDATE STARTS  ************/
+      // Avoid using method definition in customMethods ie. methodDefinition() {}
+      // as TypeScript is unable to correctly infer the type
+      // if method definition is necessary, declaring customMethods separately
       customMethods: {
-        // Avoid using method definition in customMethods ie. methodDefinition() {}
-        // as TypeScript is unable to correctly infer the type
-        // if method definition is necessary, declaring customMethods separately
         updateLineByOptions: async (
           productId: string,
           selectedOptions: SelectedOptionInput[],

--- a/examples/custom-cart-method/app/lib/context.ts
+++ b/examples/custom-cart-method/app/lib/context.ts
@@ -44,6 +44,9 @@ export async function createAppLoadContext(
       /***********************************************/
       /**********  EXAMPLE UPDATE STARTS  ************/
       customMethods: {
+        // Avoid using method definition in customMethods ie. methodDefinition() {}
+        // as TypeScript is unable to correctly infer the type
+        // if method definition is necessary, declaring customMethods separately
         updateLineByOptions: async (
           productId: string,
           selectedOptions: SelectedOptionInput[],

--- a/packages/hydrogen/src/createHydrogenContext.test.ts
+++ b/packages/hydrogen/src/createHydrogenContext.test.ts
@@ -384,7 +384,7 @@ describe('createHydrogenContext', () => {
       });
 
       it('returns cart handler with HydrogenCartCustom if there cart.customMethods is defined', async () => {
-        const customMethods = {testMethod: () => {}};
+        const customMethods = {arrowFunction: () => {}};
 
         const hydrogenContext = createHydrogenContext({
           ...defaultOptions,
@@ -394,6 +394,36 @@ describe('createHydrogenContext', () => {
         expect(hydrogenContext).toHaveProperty('cart');
         expectTypeOf(hydrogenContext.cart).toEqualTypeOf<
           HydrogenCartCustom<typeof customMethods>
+        >();
+      });
+
+      it('returns cart handler with HydrogenCartCustom if there cart.customMethods is defined using method definition', async () => {
+        const customMethods = {methodDefinition() {}};
+
+        const hydrogenContext = createHydrogenContext({
+          ...defaultOptions,
+          cart: {customMethods},
+        });
+
+        expect(hydrogenContext).toHaveProperty('cart');
+        expectTypeOf(hydrogenContext.cart).toEqualTypeOf<
+          HydrogenCartCustom<typeof customMethods>
+        >();
+      });
+
+      it('returns cart handler with HydrogenCartCustom if there cart.customMethods is defined using method definition and declare inline', async () => {
+        const hydrogenContext = createHydrogenContext({
+          ...defaultOptions,
+          cart: {
+            customMethods: {
+              methodDefinition() {},
+            },
+          },
+        });
+
+        expect(hydrogenContext).toHaveProperty('cart');
+        expectTypeOf(hydrogenContext.cart).toEqualTypeOf<
+          HydrogenCartCustom<{methodDefinition(): void}>
         >();
       });
     });

--- a/packages/hydrogen/src/createHydrogenContext.test.ts
+++ b/packages/hydrogen/src/createHydrogenContext.test.ts
@@ -410,22 +410,6 @@ describe('createHydrogenContext', () => {
           HydrogenCartCustom<typeof customMethods>
         >();
       });
-
-      it('returns cart handler with HydrogenCartCustom if there cart.customMethods is defined using method definition and declare inline', async () => {
-        const hydrogenContext = createHydrogenContext({
-          ...defaultOptions,
-          cart: {
-            customMethods: {
-              methodDefinition() {},
-            },
-          },
-        });
-
-        expect(hydrogenContext).toHaveProperty('cart');
-        expectTypeOf(hydrogenContext.cart).toEqualTypeOf<
-          HydrogenCartCustom<{methodDefinition(): void}>
-        >();
-      });
     });
   });
 

--- a/packages/hydrogen/src/createHydrogenContext.test.ts
+++ b/packages/hydrogen/src/createHydrogenContext.test.ts
@@ -410,6 +410,36 @@ describe('createHydrogenContext', () => {
           HydrogenCartCustom<typeof customMethods>
         >();
       });
+
+      it('returns cart handler with HydrogenCartCustom if there cart.customMethods is defined using method definition and declare inline', async () => {
+        // this will pass in ts file but fail in js file.
+        // which is why we still left a note in the custom-cart-method example to avoid using method definition
+        const hydrogenContext = createHydrogenContext({
+          ...defaultOptions,
+          cart: {
+            customMethods: {
+              methodDefinition() {},
+            },
+          },
+        });
+
+        expect(hydrogenContext).toHaveProperty('cart');
+        expectTypeOf(hydrogenContext.cart).toEqualTypeOf<
+          HydrogenCartCustom<{methodDefinition(): void}>
+        >();
+      });
+
+      it('returns cart handler with HydrogenCart if there cart.customMethods is an empty object', async () => {
+        const hydrogenContext = createHydrogenContext({
+          ...defaultOptions,
+          cart: {
+            customMethods: {},
+          },
+        });
+
+        expect(hydrogenContext).toHaveProperty('cart');
+        expectTypeOf(hydrogenContext.cart).toEqualTypeOf<HydrogenCart>();
+      });
     });
   });
 

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -28,7 +28,7 @@ import {type CrossRuntimeRequest, getHeader} from './utils/request';
 
 export type HydrogenContextOptions<
   TSession extends HydrogenSession = HydrogenSession,
-  TCustomMethods extends CustomMethodsBase | undefined = undefined,
+  TCustomMethods extends CustomMethodsBase | undefined = {},
   TI18n extends I18nBase = I18nBase,
   TEnv extends HydrogenEnv = Env,
 > = {
@@ -90,7 +90,7 @@ export type HydrogenContextOptions<
 
 export interface HydrogenContext<
   TSession extends HydrogenSession = HydrogenSession,
-  TCustomMethods extends CustomMethodsBase | undefined = undefined,
+  TCustomMethods extends CustomMethodsBase | undefined = {},
   TI18n extends I18nBase = I18nBase,
   TEnv extends HydrogenEnv = Env,
 > {
@@ -130,7 +130,7 @@ export interface HydrogenContextOverloads<
 // type for createHydrogenContext methods
 export function createHydrogenContext<
   TSession extends HydrogenSession = HydrogenSession,
-  TCustomMethods extends CustomMethodsBase | undefined = undefined,
+  TCustomMethods extends CustomMethodsBase | undefined = {},
   TI18n extends I18nBase = I18nBase,
   TEnv extends HydrogenEnv = Env,
 >(


### PR DESCRIPTION
When using method definition in customMethod for `createHydrogenContext`, TypeScript is unable to get more specific in the inline declaration scenario because the type is too complex with method definition. 

It is however, fine if customMethods are declare separately and TS is able to isolate customMethods type first and carried it over to use in createHydrogenContext.

This PR add a test to ensure method definition is ok when `customMethod` is definite separately. And add note to avoid using method definition altogether in our custom-cart-method example. 

<details>
  <summary>example when `TCustomMethods` is `undefined` (outdated)</summary>

```.ts
const customMethods = {methodDefinition() {}};
const hydrogenContext = createHydrogenContext({
  ...defaultOptions,
  cart: {customMethods},
});

const {cart} = hydrogenContext; // cart type = HydrogenCartCustom<{methodDefinition(): void}>
const hydrogenContext = createHydrogenContext({
  ...defaultOptions,
  cart: {customMethods:{
    methodDefinition() {}
  }},
});

const {cart} = hydrogenContext; // cart type = HydrogentCart
```
</details>

------------------------------

In order to fix the type definition problem in js file (instead of TS)
the default for `TCustomMethods` is changed to `{}` instead of `undefined`

this somehow fix the type definition problem in TS but not in JS. So I am leaving the example suggestion to avoid method definition.

As it stands now

<details open>
  <summary>✅ example in TS when `TCustomMethods` is `{}` (latest)</summary>

```.ts
const customMethods = {methodDefinition() {}};
const hydrogenContext = createHydrogenContext({
  ...defaultOptions,
  cart: {customMethods},
});

const {cart} = hydrogenContext; // cart type = HydrogenCartCustom<{methodDefinition(): void}>

const hydrogenContext = createHydrogenContext({
  ...defaultOptions,
  cart: {customMethods:{
    methodDefinition() {}
  }},
});

const {cart} = hydrogenContext; // cart type = HydrogenCartCustom<{methodDefinition(): void}>
```

<details open>
  <summary>❌ example in JS when `TCustomMethods` is `{}` (latest)</summary>

```.js
const customMethods = {methodDefinition() {}};
const hydrogenContext = createHydrogenContext({
  ...defaultOptions,
  cart: {customMethods},
});

const {cart} = hydrogenContext; // cart type = HydrogenCartCustom<{methodDefinition(): void}>  while using VS code with type hint


const hydrogenContext = createHydrogenContext({
  ...defaultOptions,
  cart: {customMethods:{
    methodDefinition() {}
  }},
});

const {cart} = hydrogenContext; // cart type = HydrogentCart while using VS code with type hint
```
</details>