### PR TITLE
Add postal and metro code to oxygen headers

### DIFF
--- a/.changeset/strange-oranges-promise.md
+++ b/.changeset/strange-oranges-promise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/mini-oxygen': patch
+---
+
+Add oxygen-buyer-postal-code and oxygen-buyer-metro-code headers

--- a/packages/mini-oxygen/src/common/headers.ts
+++ b/packages/mini-oxygen/src/common/headers.ts
@@ -8,6 +8,8 @@ export const OXYGEN_HEADERS_MAP = {
   region: {name: 'oxygen-buyer-region', defaultValue: 'California'},
   regionCode: {name: 'oxygen-buyer-region-code', defaultValue: 'CA'},
   city: {name: 'oxygen-buyer-city', defaultValue: 'San Francisco'},
+  postalCode: {name: 'oxygen-buyer-postal-code', defaultValue: '94105'},
+  metroCode: {name: 'oxygen-buyer-metro-code', defaultValue: '807'},
   isEuCountry: {name: 'oxygen-buyer-is-eu-country', defaultValue: ''},
   timezone: {
     name: 'oxygen-buyer-timezone',


### PR DESCRIPTION
### WHY are these changes introduced?

These are now supported, so adding hardcoded values for minioxygen

### WHAT is this pull request doing?

Adds these headers to mini-oxygen so they will be available in the buyer headers

### HOW to test your changes?

- These should be available in the Hydrogen worker when running with miniflare on this branch

#### Post-merge steps

- Documentation updates

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation