### PR TITLE
Pin perfkit to version 1.0.0

### DIFF
--- a/packages/hydrogen/src/analytics-manager/PerfKit.tsx
+++ b/packages/hydrogen/src/analytics-manager/PerfKit.tsx
@@ -13,16 +13,15 @@ declare global {
 }
 
 // Pin to a version that have SPA support.
-// TODO: Update to a stable version when available.
-const PERF_KIT_UNSTABLE =
-  'https://cdn.shopify.com/shopifycloud/perf-kit/shopify-perf-kit-1bd852a.min.js';
+const PERF_KIT_URL =
+  'https://cdn.shopify.com/shopifycloud/perf-kit/shopify-perf-kit-1.0.0.min.js';
 
 export function PerfKit({shop}: {shop: ShopAnalytics}) {
   const loadedEvent = useRef(false);
   const {subscribe, register} = useAnalytics();
   const {ready} = register('Internal_Shopify_Perf_Kit');
 
-  const scriptStatus = useLoadScript(PERF_KIT_UNSTABLE, {
+  const scriptStatus = useLoadScript(PERF_KIT_URL, {
     attributes: {
       id: 'perfkit',
       'data-application': 'hydrogen',


### PR DESCRIPTION
### WHY are these changes introduced?

Pin perfkit to a stable version
- No change set is required atm

### HOW to test your changes?

You can view the preview deployment here: https://01j5bjzh3e7cqnrag18c0vfds6-bdc62392032d96aafe24.myshopify.dev/
- Just check to see if the newer version of perfkit is being used
- Make sure no errors are appearing when sending the monorail event

<img width="1898" alt="image" src="https://github.com/user-attachments/assets/dd594a52-e7ff-400b-b3e5-f7c155f8abd7">

Current perfkit version: https://cdn.shopify.com/shopifycloud/perf-kit/shopify-perf-kit-1.0.0.min.js

#### Post-merge steps

n/a

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

