### PR TITLE
Add commit message to example deploys

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           npx shopify hydrogen deploy --no-lockfile-check --diff --token=$OXYGEN_DEPLOYMENT_TOKEN_${{ matrix.examples.token }}
         env:
+          SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION: ${{ github.event.head_commit.message }}
           OXYGEN_DEPLOYMENT_TOKEN_1000014888: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_1000014888 }}
           OXYGEN_DEPLOYMENT_TOKEN_1000022490: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_1000022490 }}
           OXYGEN_DEPLOYMENT_TOKEN_1000014892: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_1000014892 }}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue where commit messages aren't being added to the deployments due to the `--diff` flag being used for the examples. When we use `--diff` we create a temporary folder outside of the context of the Git repository so the `deploy` command doesn't know what message to use.

### WHAT is this pull request doing?

Modifies the workflow file to use `${{ github.event.head_commit.message }}`.

### HOW to test your changes?

Visit the admin for the deployments generated by this PR.