### PR TITLE
useOptimisticCart: optimistically calculate totalQuantity

### DIFF
--- a/.changeset/moody-pots-juggle.md
+++ b/.changeset/moody-pots-juggle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+useOptimisticCart: optimistically calculate totalQuantity

--- a/packages/hydrogen/src/cart/optimistic/useOptimisticCart.test.tsx
+++ b/packages/hydrogen/src/cart/optimistic/useOptimisticCart.test.tsx
@@ -625,6 +625,59 @@ describe('useOptimisticCart', () => {
       expect(optimisticCart).toStrictEqual({...EMPTY_CART, isOptimistic: true});
     });
   });
+
+  describe('Total quantity', () => {
+    it('updates the total quantity when adding a line', async () => {
+      addPendingCartAction({
+        action: CartForm.ACTIONS.LinesAdd,
+        inputs: {
+          lines: [
+            {
+              merchandiseId: '1',
+              quantity: 1,
+              selectedVariant: {
+                id: '1',
+              },
+            },
+          ],
+        },
+      });
+
+      const optimisticCart = useOptimisticCart(EMPTY_CART);
+      expect(optimisticCart.totalQuantity).toStrictEqual(1);
+    });
+
+    it('updates the total quantity when removing a line', async () => {
+      addPendingCartAction({
+        action: CartForm.ACTIONS.LinesRemove,
+        inputs: {
+          lineIds: [
+            'gid://shopify/CartLine/53b449e1-6f6d-47ca-94e4-748a055b45e8?cart=Z2NwLXVzLWNlbnRyYWwxOjAxSFdOR0hESkVBUEtQVkoyMFJFMUhTRDFU',
+          ],
+        },
+      });
+
+      const optimisticCart = useOptimisticCart(CART_WITH_TWO_LINES);
+      expect(optimisticCart.totalQuantity).toStrictEqual(1);
+    });
+
+    it('updates the total quantity when updating a line', async () => {
+      addPendingCartAction({
+        action: CartForm.ACTIONS.LinesUpdate,
+        inputs: {
+          lines: [
+            {
+              id: 'gid://shopify/CartLine/53b449e1-6f6d-47ca-94e4-748a055b45e8?cart=Z2NwLXVzLWNlbnRyYWwxOjAxSFdOR0hESkVBUEtQVkoyMFJFMUhTRDFU',
+              quantity: 2,
+            },
+          ],
+        },
+      });
+
+      const optimisticCart = useOptimisticCart(CART_WITH_LINE);
+      expect(optimisticCart.totalQuantity).toStrictEqual(2);
+    });
+  });
 });
 
 const EMPTY_CART = {
@@ -632,7 +685,7 @@ const EMPTY_CART = {
   id: 'gid://shopify/Cart/Z2NwLXVzLWNlbnRyYWwxOjAxSFdOR0hESkVBUEtQVkoyMFJFMUhTRDFU',
   checkoutUrl:
     'https://checkout.hydrogen.shop/cart/c/Z2NwLXVzLWNlbnRyYWwxOjAxSFdOR0hESkVBUEtQVkoyMFJFMUhTRDFU?key=1b6ea717bf3c3bbe68fd26e20c991267',
-  totalQuantity: 1,
+  totalQuantity: 0,
   buyerIdentity: {
     countryCode: 'US',
     customer: null,

--- a/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
+++ b/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
@@ -29,18 +29,20 @@ export type OptimisticCart<T = CartReturn> = T extends undefined | null
       lines: {
         nodes: Array<OptimisticCartLine>;
       };
+      totalQuantity?: number;
     } & Omit<PartialDeep<CartReturn>, 'lines'>
   : Omit<T, 'lines'> & {
       isOptimistic?: boolean;
       lines: {
         nodes: Array<OptimisticCartLine<T>>;
       };
+      totalQuantity?: number;
     };
 
 /**
  * @param cart The cart object from `context.cart.get()` returned by a server loader.
  *
- * @returns A new cart object augmented with optimistic state. Each cart line item that is optimistically added includes an `isOptimistic` property. Also if the cart has _any_ optimistic state, a root property `isOptimistic` will be set to `true`.
+ * @returns A new cart object augmented with optimistic state for `lines` and `totalQuantity`. Each cart line item that is optimistically added includes an `isOptimistic` property. Also if the cart has _any_ optimistic state, a root property `isOptimistic` will be set to `true`.
  */
 export function useOptimisticCart<
   DefaultCart = {
@@ -149,6 +151,12 @@ export function useOptimisticCart<
   if (isOptimistic) {
     optimisticCart.isOptimistic = isOptimistic;
   }
+
+  // Calculate the total quantity of the optimistic cart
+  optimisticCart.totalQuantity = cartLines.reduce(
+    (sum, line) => sum + line.quantity,
+    0,
+  );
 
   return optimisticCart;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Hey @blittle

This update optimistically calculates `cart.totalQuantity`.

| Before  | After  |
|---|---|
| ![21-47-t37u2-jkyk4](https://github.com/user-attachments/assets/fcaf6eb3-3a8b-40d0-a4c5-633c7ed7d1c4)  | ![21-48-jzfnl-0dbrj](https://github.com/user-attachments/assets/e0bd0667-03dc-430c-a3d7-4ef73e0b2927)  |

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation