### PR TITLE
[Hydrogen React] Don't generate srcset if size is above source image dimensions

### DIFF
--- a/.changeset/smart-boats-cough.md
+++ b/.changeset/smart-boats-cough.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': major
+---
+
+Prevent Image component from generating srcset with higher dimensions than source image

--- a/packages/hydrogen-react/src/Image.test.tsx
+++ b/packages/hydrogen-react/src/Image.test.tsx
@@ -143,13 +143,43 @@ describe('<Image />', () => {
       expect(screen.getByRole('img').style.aspectRatio).toBe('600/400');
     });
 
-    it('does not create srcset with greater width or height when using aspect-ratio with no width', () => {
+    it('does not create srcset with greater dimensions than source image', () => {
       const data = {height: 300, width: 400};
 
       render(
         <Image
           {...defaultProps}
-          sizes="100vw"
+          data={data}
+          srcSetOptions={{
+            intervals: 15,
+            startingWidth: 200,
+            incrementSize: 200,
+            placeholderWidth: 100,
+          }}
+        />,
+      );
+
+      expect(screen.getByRole<HTMLImageElement>('img').srcset).not.toContain(
+        '600w',
+      );
+    });
+
+    it('does not create srcset with greater dimensions than source image when using width', () => {
+      const data = {height: 300, width: 400};
+
+      render(<Image {...defaultProps} data={data} width={200} />);
+
+      expect(screen.getByRole<HTMLImageElement>('img').srcset).not.toContain(
+        '3x',
+      );
+    });
+
+    it('does not create srcset with greater dimensions than source image when using aspect-ratio', () => {
+      const data = {height: 300, width: 400};
+
+      render(
+        <Image
+          {...defaultProps}
           data={data}
           aspectRatio={'1/1'}
           srcSetOptions={{
@@ -166,23 +196,11 @@ describe('<Image />', () => {
       );
     });
 
-    it('does not create srcset with greater width or height when using aspect-ratio with width', () => {
+    it('does not create srcset with greater dimensions than source image when using aspect-ratio and width', () => {
       const data = {height: 300, width: 400};
 
       render(
-        <Image
-          {...defaultProps}
-          sizes="100vw"
-          data={data}
-          aspectRatio={'1/1'}
-          srcSetOptions={{
-            intervals: 15,
-            startingWidth: 200,
-            incrementSize: 200,
-            placeholderWidth: 100,
-          }}
-          width={200}
-        />,
+        <Image {...defaultProps} data={data} aspectRatio={'1/1'} width={200} />,
       );
 
       expect(screen.getByRole<HTMLImageElement>('img').srcset).not.toContain(

--- a/packages/hydrogen-react/src/Image.test.tsx
+++ b/packages/hydrogen-react/src/Image.test.tsx
@@ -142,6 +142,53 @@ describe('<Image />', () => {
 
       expect(screen.getByRole('img').style.aspectRatio).toBe('600/400');
     });
+
+    it('does not create srcset with greater width or height when using aspect-ratio with no width', () => {
+      const data = {height: 300, width: 400};
+
+      render(
+        <Image
+          {...defaultProps}
+          sizes="100vw"
+          data={data}
+          aspectRatio={'1/1'}
+          srcSetOptions={{
+            intervals: 15,
+            startingWidth: 200,
+            incrementSize: 200,
+            placeholderWidth: 100,
+          }}
+        />,
+      );
+
+      expect(screen.getByRole<HTMLImageElement>('img').srcset).not.toContain(
+        '400w',
+      );
+    });
+
+    it('does not create srcset with greater width or height when using aspect-ratio with width', () => {
+      const data = {height: 300, width: 400};
+
+      render(
+        <Image
+          {...defaultProps}
+          sizes="100vw"
+          data={data}
+          aspectRatio={'1/1'}
+          srcSetOptions={{
+            intervals: 15,
+            startingWidth: 200,
+            incrementSize: 200,
+            placeholderWidth: 100,
+          }}
+          width={200}
+        />,
+      );
+
+      expect(screen.getByRole<HTMLImageElement>('img').srcset).not.toContain(
+        '2x',
+      );
+    });
   });
 
   describe('warnings', () => {

--- a/packages/hydrogen-react/src/Image.tsx
+++ b/packages/hydrogen-react/src/Image.tsx
@@ -374,7 +374,7 @@ const FixedWidthImage = React.forwardRef<
         : undefined;
 
       /*
-       * The Sizes Array generates an array of all of the parts
+       * The Sizes Array generates an array of all the parts
        * that make up the srcSet, including the width, height, and crop
        */
       const sizesArray =

--- a/packages/hydrogen-react/src/Image.tsx
+++ b/packages/hydrogen-react/src/Image.tsx
@@ -713,7 +713,7 @@ export function generateSizes(
     }[]
   | undefined {
   if (!imageWidths) return;
-  const sizes = imageWidths.map((width: number) => {
+  return imageWidths.map((width: number) => {
     return {
       width,
       height: aspectRatio
@@ -722,7 +722,6 @@ export function generateSizes(
       crop,
     };
   });
-  return sizes;
   /*
     Given:
       ([100, 200], 1/1, 'center')

--- a/packages/hydrogen-react/src/Image.tsx
+++ b/packages/hydrogen-react/src/Image.tsx
@@ -621,10 +621,7 @@ function getNormalizedFixedUnit(value?: string | number): number | undefined {
  */
 function isFixedWidth(width: string | number): boolean {
   const fixedEndings = /\d(px|em|rem)$/;
-  return (
-    typeof width === 'number' ||
-    (typeof width === 'string' && fixedEndings.test(width))
-  );
+  return typeof width === 'number' || fixedEndings.test(width);
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2456 

### WHAT is this pull request doing?

- Prevent `<Image />` from generating a `srcset` image with higher dimensions than source image. This is to prevent the Shopify CDN from just using the original image uncropped.
- Minor changes to functions
- Minor grammar corrections
- Major bump because of changes in exported function `generateSrcSet`

Only downside is when not using `aspectRatio`. In case the image is 750px wide, the srcset goes from 600w to 800w, and will not generate an image for 800w with 750px width. Not sure if we should still generate it?

### HOW to test your changes?

Tests has been added.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
