### PR TITLE
Add unstable sitemap abstraction

### DIFF
--- a/.changeset/slow-keys-fold.md
+++ b/.changeset/slow-keys-fold.md
@@ -1,0 +1,7 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Introduce a new abstraction for generating sitemap index and child sitemaps.
+
+See the [sitemap example](https://github.com/Shopify/hydrogen/tree/main/examples/sitemap) for how to use it and read the [docs](https://shopify.dev/docs/api/hydrogen/utilities/getSitemapIndex) for more information.

--- a/examples/sitemap/app/routes/[sitemap.xml].tsx
+++ b/examples/sitemap/app/routes/[sitemap.xml].tsx
@@ -1,5 +1,5 @@
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
-import {getSitemapIndex} from '@shopify/hydrogen';
+import {unstable__getSitemapIndex as getSitemapIndex} from '@shopify/hydrogen';
 
 export async function loader({
   request,

--- a/examples/sitemap/app/routes/sitemap.$type.$page[.xml].tsx
+++ b/examples/sitemap/app/routes/sitemap.$type.$page[.xml].tsx
@@ -1,5 +1,5 @@
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
-import {getSitemap} from '@shopify/hydrogen';
+import {unstable__getSitemap as getSitemap} from '@shopify/hydrogen';
 
 export async function loader({
   request,

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -169,3 +169,5 @@ export {
   createHydrogenContext,
   type HydrogenContext,
 } from './createHydrogenContext';
+
+export {getSitemapIndex, getSitemap} from './sitemap/sitemap';

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -170,4 +170,7 @@ export {
   type HydrogenContext,
 } from './createHydrogenContext';
 
-export {getSitemapIndex, getSitemap} from './sitemap/sitemap';
+export {
+  getSitemapIndex as unstable__getSitemapIndex,
+  getSitemap as unstable__getSitemap,
+} from './sitemap/sitemap';

--- a/packages/hydrogen/src/sitemap/getSitemap.doc.ts
+++ b/packages/hydrogen/src/sitemap/getSitemap.doc.ts
@@ -1,0 +1,43 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'getSitemap',
+  category: 'utilities',
+  isVisualComponent: false,
+  related: [
+    {
+      name: 'getSitemapIndex',
+      type: 'utilities',
+      url: '/api/hydrogen/utilities/getSitemapIndex',
+    },
+  ],
+  description: `Generate a sitemap for a specific resource type. Returns a standard Response object.`,
+  type: 'utility',
+  defaultExample: {
+    description: 'I am the default example',
+    codeblock: {
+      tabs: [
+        {
+          title: 'JavaScript',
+          code: './getSitemap.example.jsx',
+          language: 'js',
+        },
+        {
+          title: 'TypeScript',
+          code: './getSitemap.example.tsx',
+          language: 'ts',
+        },
+      ],
+      title: 'Example code',
+    },
+  },
+  definitions: [
+    {
+      title: 'getSitemap',
+      type: 'GetSitemapGeneratedType',
+      description: '',
+    },
+  ],
+};
+
+export default data;

--- a/packages/hydrogen/src/sitemap/getSitemap.doc.ts
+++ b/packages/hydrogen/src/sitemap/getSitemap.doc.ts
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
       url: '/api/hydrogen/utilities/getSitemapIndex',
     },
   ],
-  description: `Generate a sitemap for a specific resource type. Returns a standard Response object.`,
+  description: `> Caution:\n> This component is in an unstable pre-release state and may have breaking changes in a future release.\n\nGenerate a sitemap for a specific resource type. Returns a standard Response object.`,
   type: 'utility',
   defaultExample: {
     description: 'I am the default example',

--- a/packages/hydrogen/src/sitemap/getSitemap.example.jsx
+++ b/packages/hydrogen/src/sitemap/getSitemap.example.jsx
@@ -1,22 +1,20 @@
-import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
 import {getSitemap} from '@shopify/hydrogen';
 
-export async function loader({
-  request,
-  params,
-  context: {storefront},
-}: LoaderFunctionArgs) {
+export async function loader({request, params, context: {storefront}}) {
   const response = await getSitemap({
     storefront,
     request,
     params,
+    // The locales to include in the sitemap
     locales: ['EN-US', 'EN-CA', 'FR-CA'],
+    // A function to generate a link for a given resource
     getLink: ({type, baseUrl, handle, locale}) => {
       if (!locale) return `${baseUrl}/${type}/${handle}`;
       return `${baseUrl}/${locale}/${type}/${handle}`;
     },
   });
 
+  // Set any custom headers on the sitemap response
   response.headers.set('Cache-Control', `max-age=${60 * 60 * 24}`);
 
   return response;

--- a/packages/hydrogen/src/sitemap/getSitemap.example.jsx
+++ b/packages/hydrogen/src/sitemap/getSitemap.example.jsx
@@ -1,4 +1,4 @@
-import {getSitemap} from '@shopify/hydrogen';
+import {unstable__getSitemap as getSitemap} from '@shopify/hydrogen';
 
 export async function loader({request, params, context: {storefront}}) {
   const response = await getSitemap({

--- a/packages/hydrogen/src/sitemap/getSitemap.example.tsx
+++ b/packages/hydrogen/src/sitemap/getSitemap.example.tsx
@@ -10,13 +10,16 @@ export async function loader({
     storefront,
     request,
     params,
+    // The locales to include in the sitemap
     locales: ['EN-US', 'EN-CA', 'FR-CA'],
+    // A function to generate a link for a given resource
     getLink: ({type, baseUrl, handle, locale}) => {
       if (!locale) return `${baseUrl}/${type}/${handle}`;
       return `${baseUrl}/${locale}/${type}/${handle}`;
     },
   });
 
+  // Set any custom headers on the sitemap response
   response.headers.set('Cache-Control', `max-age=${60 * 60 * 24}`);
 
   return response;

--- a/packages/hydrogen/src/sitemap/getSitemap.example.tsx
+++ b/packages/hydrogen/src/sitemap/getSitemap.example.tsx
@@ -1,5 +1,5 @@
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
-import {getSitemap} from '@shopify/hydrogen';
+import {unstable__getSitemap as getSitemap} from '@shopify/hydrogen';
 
 export async function loader({
   request,

--- a/packages/hydrogen/src/sitemap/getSitemapIndex.doc.ts
+++ b/packages/hydrogen/src/sitemap/getSitemapIndex.doc.ts
@@ -11,7 +11,7 @@ const data: ReferenceEntityTemplateSchema = {
       url: '/api/hydrogen/utilities/getSitemap',
     },
   ],
-  description: `Generate a sitemap index that links to separate child sitemaps for different resource types. Returns a standard Response object.`,
+  description: `> Caution:\n> This component is in an unstable pre-release state and may have breaking changes in a future release.\n\nGenerate a sitemap index that links to separate child sitemaps for different resource types. Returns a standard Response object.`,
   type: 'utility',
   defaultExample: {
     description: 'I am the default example',

--- a/packages/hydrogen/src/sitemap/getSitemapIndex.doc.ts
+++ b/packages/hydrogen/src/sitemap/getSitemapIndex.doc.ts
@@ -1,0 +1,43 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'getSitemapIndex',
+  category: 'utilities',
+  isVisualComponent: false,
+  related: [
+    {
+      name: 'getSitemap',
+      type: 'utilities',
+      url: '/api/hydrogen/utilities/getSitemap',
+    },
+  ],
+  description: `Generate a sitemap index that links to separate child sitemaps for different resource types. Returns a standard Response object.`,
+  type: 'utility',
+  defaultExample: {
+    description: 'I am the default example',
+    codeblock: {
+      tabs: [
+        {
+          title: 'JavaScript',
+          code: './getSitemapIndex.example.jsx',
+          language: 'js',
+        },
+        {
+          title: 'TypeScript',
+          code: './getSitemapIndex.example.tsx',
+          language: 'ts',
+        },
+      ],
+      title: 'Example code',
+    },
+  },
+  definitions: [
+    {
+      title: 'getSitemapIndex',
+      type: 'GetSitemapIndexGeneratedType',
+      description: '',
+    },
+  ],
+};
+
+export default data;

--- a/packages/hydrogen/src/sitemap/getSitemapIndex.example.jsx
+++ b/packages/hydrogen/src/sitemap/getSitemapIndex.example.jsx
@@ -1,0 +1,21 @@
+import {getSitemapIndex} from '@shopify/hydrogen';
+
+export async function loader({request, context: {storefront}}) {
+  const response = await getSitemapIndex({
+    storefront,
+    request,
+    types: [
+      'products',
+      'pages',
+      'collections',
+      'metaObjects',
+      'articles',
+      'blogs',
+    ],
+  });
+
+  // Set any custom headers on the sitemap response
+  response.headers.set('Cache-Control', `max-age=${60 * 60 * 24}`);
+
+  return response;
+}

--- a/packages/hydrogen/src/sitemap/getSitemapIndex.example.jsx
+++ b/packages/hydrogen/src/sitemap/getSitemapIndex.example.jsx
@@ -1,4 +1,4 @@
-import {getSitemapIndex} from '@shopify/hydrogen';
+import {unstable__getSitemapIndex as getSitemapIndex} from '@shopify/hydrogen';
 
 export async function loader({request, context: {storefront}}) {
   const response = await getSitemapIndex({

--- a/packages/hydrogen/src/sitemap/getSitemapIndex.example.tsx
+++ b/packages/hydrogen/src/sitemap/getSitemapIndex.example.tsx
@@ -8,8 +8,17 @@ export async function loader({
   const response = await getSitemapIndex({
     storefront,
     request,
+    types: [
+      'products',
+      'pages',
+      'collections',
+      'metaObjects',
+      'articles',
+      'blogs',
+    ],
   });
 
+  // Set any custom headers on the sitemap response
   response.headers.set('Cache-Control', `max-age=${60 * 60 * 24}`);
 
   return response;

--- a/packages/hydrogen/src/sitemap/getSitemapIndex.example.tsx
+++ b/packages/hydrogen/src/sitemap/getSitemapIndex.example.tsx
@@ -1,5 +1,5 @@
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
-import {getSitemapIndex} from '@shopify/hydrogen';
+import {unstable__getSitemapIndex as getSitemapIndex} from '@shopify/hydrogen';
 
 export async function loader({
   request,

--- a/packages/hydrogen/src/sitemap/sitemap.test.ts
+++ b/packages/hydrogen/src/sitemap/sitemap.test.ts
@@ -1,0 +1,354 @@
+import {expect, suite, test} from 'vitest';
+import {getSitemap, getSitemapIndex} from './sitemap';
+
+suite('sitemap', () => {
+  suite('getSitemapIndex', () => {
+    test('renders an empty sitemap index', async () => {
+      const sitemap = await getSitemapIndex({
+        storefront: mockSitemapIndexResponse({}) as any,
+        request: {url: 'https://example.com'} as any,
+        types: [],
+      });
+      expect(await sitemap.text()).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+        </sitemapindex>"
+      `);
+    });
+
+    test('errors when a request object or storefront object are not passed', async () => {
+      async function noRequest() {
+        const sitemap = await getSitemapIndex({
+          storefront: mockSitemapIndexResponse({}),
+        } as any);
+      }
+
+      await expect(noRequest).rejects.toThrowError(
+        'A request object is required to generate a sitemap index',
+      );
+
+      async function noStorefront() {
+        const sitemap = await getSitemapIndex({
+          request: {url: 'https://example.com'},
+        } as any);
+      }
+
+      await expect(noStorefront).rejects.toThrowError(
+        'A storefront client is required to generate a sitemap index',
+      );
+    });
+
+    test('renders a sitemap index', async () => {
+      const sitemap = await getSitemapIndex({
+        storefront: mockSitemapIndexResponse(),
+        request: {url: 'https://example.com'},
+      } as any);
+
+      expect(await sitemap.text()).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <sitemap><loc>https://example.com/sitemap/products/1.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/products/2.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/products/3.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/products/4.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/products/5.xml</loc></sitemap>
+
+          <sitemap><loc>https://example.com/sitemap/pages/1.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/pages/2.xml</loc></sitemap>
+
+          <sitemap><loc>https://example.com/sitemap/collections/1.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/collections/2.xml</loc></sitemap>
+
+          <sitemap><loc>https://example.com/sitemap/metaObjects/1.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/metaObjects/2.xml</loc></sitemap>
+
+          <sitemap><loc>https://example.com/sitemap/articles/1.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/articles/2.xml</loc></sitemap>
+
+          <sitemap><loc>https://example.com/sitemap/blogs/1.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/blogs/2.xml</loc></sitemap>
+
+        </sitemapindex>"
+      `);
+    });
+
+    test('renders links to child sitemap types', async () => {
+      const sitemap = await getSitemapIndex({
+        types: ['collections'],
+        storefront: mockSitemapIndexResponse(),
+        request: {url: 'https://example.com'},
+      } as any);
+
+      expect(await sitemap.text()).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <sitemap><loc>https://example.com/sitemap/collections/1.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/collections/2.xml</loc></sitemap>
+
+        </sitemapindex>"
+      `);
+    });
+
+    test('errors when using unknown types', async () => {
+      async function makeError() {
+        const sitemap = await getSitemapIndex({
+          types: ['jarjar'],
+          storefront: mockSitemapIndexResponse(),
+          request: {url: 'https://example.com'},
+        } as any);
+      }
+
+      await expect(makeError).rejects.toThrowError(
+        '[h2:sitemap:error] No data found for type jarjar. Check types passed to `getSitemapIndex`',
+      );
+    });
+
+    test('adds links to custom child sitemaps', async () => {
+      const sitemap = await getSitemapIndex({
+        types: ['collections'],
+        storefront: mockSitemapIndexResponse() as any,
+        request: {url: 'https://example.com'},
+        customChildSitemaps: ['sitemap/custom.xml', '/sitemap/custom-2.xml'],
+      } as any);
+
+      expect(await sitemap.text()).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <sitemap><loc>https://example.com/sitemap/collections/1.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/collections/2.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/custom.xml</loc></sitemap>
+          <sitemap><loc>https://example.com/sitemap/custom-2.xml</loc></sitemap>
+        </sitemapindex>"
+      `);
+    });
+  });
+
+  suite('getSitemap', () => {
+    test('errors when a request object or storefront object are not passed', async () => {
+      await expect(async function makeError() {
+        const sitemap = await getSitemap({} as any);
+      }).rejects.toThrowError(
+        '[h2:sitemap:error] Remix params object is required',
+      );
+
+      await expect(async function makeError() {
+        const sitemap = await getSitemap({
+          params: {type: 'products', page: '1'},
+        } as any);
+      }).rejects.toThrowError(
+        'A request object is required to generate a sitemap',
+      );
+
+      await expect(async function makeError() {
+        const sitemap = await getSitemap({
+          params: {type: 'products', page: '1'},
+          request: {url: 'https://example.com'},
+        } as any);
+      }).rejects.toThrowError(
+        'A storefront client is required to generate a index',
+      );
+
+      await expect(async function makeError() {
+        const sitemap = await getSitemap({
+          params: {type: 'products', page: '1'},
+          request: {url: 'https://example.com'},
+          storefront: mockSitemapResponse('products', 2),
+        } as any);
+      }).rejects.toThrowError(
+        'A `getLink` function to generate each resource is required to build a sitemap',
+      );
+    });
+
+    test('renders a sitemap', async () => {
+      const sitemap = await getSitemap({
+        params: {type: 'products', page: '1'},
+        storefront: mockSitemapResponse('products', 5),
+        request: {url: 'https://example.com'},
+        getLink: ({handle, baseUrl, type}: any) =>
+          `${baseUrl}/${type}/${handle}`,
+      } as any);
+
+      expect(await sitemap.text()).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml"><url>
+          <loc>https://example.com/products/1</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>weekly</changefreq>
+
+        </url>
+        <url>
+          <loc>https://example.com/products/2</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>weekly</changefreq>
+
+        </url>
+        <url>
+          <loc>https://example.com/products/3</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>weekly</changefreq>
+
+        </url>
+        <url>
+          <loc>https://example.com/products/4</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>weekly</changefreq>
+
+        </url>
+        <url>
+          <loc>https://example.com/products/5</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>weekly</changefreq>
+
+        </url></urlset>"
+      `);
+    });
+
+    test('renders custom links', async () => {
+      const sitemap = await getSitemap({
+        params: {type: 'products', page: '1'},
+        storefront: mockSitemapResponse('products', 2),
+        request: {url: 'https://example.com'},
+        getLink: ({handle, baseUrl, type}: any) =>
+          `${baseUrl}/custom/${type}/${handle}`,
+      } as any);
+
+      expect(await sitemap.text()).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml"><url>
+          <loc>https://example.com/custom/products/1</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>weekly</changefreq>
+
+        </url>
+        <url>
+          <loc>https://example.com/custom/products/2</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>weekly</changefreq>
+
+        </url></urlset>"
+      `);
+    });
+
+    test('renders localized links', async () => {
+      const sitemap = await getSitemap({
+        params: {type: 'products', page: '1'},
+        storefront: mockSitemapResponse('products', 2),
+        request: {url: 'https://example.com'},
+        getLink: ({handle, baseUrl, type, locale}: any) =>
+          locale
+            ? `${baseUrl}/${locale}/${type}/${handle}`
+            : `${baseUrl}/${type}/${handle}`,
+        locales: ['en-CA', 'fr-CA'],
+      } as any);
+
+      expect(await sitemap.text()).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml"><url>
+          <loc>https://example.com/products/1</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <xhtml:link rel="alternate" hreflang="en-CA" href="https://example.com/en-CA/products/1" />
+          <xhtml:link rel="alternate" hreflang="fr-CA" href="https://example.com/fr-CA/products/1" />
+        </url>
+        <url>
+          <loc>https://example.com/products/2</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <xhtml:link rel="alternate" hreflang="en-CA" href="https://example.com/en-CA/products/2" />
+          <xhtml:link rel="alternate" hreflang="fr-CA" href="https://example.com/fr-CA/products/2" />
+        </url></urlset>"
+      `);
+    });
+
+    test('renders custom changefreq', async () => {
+      const sitemap = await getSitemap({
+        params: {type: 'products', page: '1'},
+        storefront: mockSitemapResponse('products', 1),
+        request: {url: 'https://example.com'},
+        getLink: ({handle, baseUrl, type}: any) =>
+          `${baseUrl}/${type}/${handle}`,
+        getChangeFreq: () => 'daily',
+      } as any);
+
+      expect(await sitemap.text()).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml"><url>
+          <loc>https://example.com/products/1</loc>
+          <lastmod>2021-09-01T00:00:00Z</lastmod>
+          <changefreq>daily</changefreq>
+
+        </url></urlset>"
+      `);
+    });
+
+    test('renders a link to the home page if there are no resources', async () => {
+      const sitemap = await getSitemap({
+        params: {type: 'products', page: '1'},
+        storefront: mockSitemapResponse('products', 0),
+        request: {url: 'https://example.com'},
+        getLink: ({handle, baseUrl, type}: any) =>
+          `${baseUrl}/${type}/${handle}`,
+        noItemsFallback: '/jarjarbinks',
+      } as any);
+
+      expect(await sitemap.text()).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+          <url><loc>https://example.com/jarjarbinks</loc></url>
+        </urlset>"
+      `);
+    });
+  });
+});
+
+function mockSitemapIndexResponse(
+  data: any = {
+    products: {
+      pagesCount: {count: 5},
+    },
+    collections: {
+      pagesCount: {count: 2},
+    },
+    articles: {
+      pagesCount: {count: 2},
+    },
+    pages: {
+      pagesCount: {count: 2},
+    },
+    blogs: {
+      pagesCount: {count: 2},
+    },
+    metaObjects: {
+      pagesCount: {count: 2},
+    },
+  },
+) {
+  return {
+    query: async () => data,
+  };
+}
+
+function mockSitemapResponse(
+  type: string,
+  amount: number,
+  updatedAt: string = '2021-09-01T00:00:00Z',
+) {
+  const items = !amount
+    ? []
+    : new Array(amount).fill(0).map((_, i) => ({
+        handle: i + 1,
+        type,
+        updatedAt,
+      }));
+
+  return {
+    query: async () => ({
+      sitemap: {
+        resources: {
+          items,
+        },
+      },
+    }),
+  };
+}

--- a/packages/hydrogen/src/sitemap/sitemap.ts
+++ b/packages/hydrogen/src/sitemap/sitemap.ts
@@ -1,4 +1,4 @@
-import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
+import type {LoaderFunctionArgs} from '@remix-run/server-runtime';
 
 const SITEMAP_INDEX_PREFIX = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n`;

--- a/packages/hydrogen/src/sitemap/sitemap.ts
+++ b/packages/hydrogen/src/sitemap/sitemap.ts
@@ -103,7 +103,7 @@ interface GetSiteMapOptions {
   /** A Remix Request object */
   request: Request;
   /** A function that produces a canonical url for a resource. It is called multiple times for each locale supported by the app. */
-  getLink?: (options: {
+  getLink: (options: {
     type: string | SITEMAP_INDEX_TYPE;
     baseUrl: string;
     handle?: string;

--- a/packages/hydrogen/src/sitemap/sitemap.ts
+++ b/packages/hydrogen/src/sitemap/sitemap.ts
@@ -1,4 +1,5 @@
 import type {LoaderFunctionArgs} from '@remix-run/server-runtime';
+import type {Storefront} from '../storefront';
 
 const SITEMAP_INDEX_PREFIX = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n`;
@@ -18,7 +19,7 @@ type SITEMAP_INDEX_TYPE =
 
 interface SitemapIndexOptions {
   /** The Storefront API Client from Hydrogen */
-  storefront: LoaderFunctionArgs['context']['storefront'];
+  storefront: Storefront;
   /** A Remix Request object */
   request: Request;
   /** The types of pages to include in the sitemap index. */
@@ -99,7 +100,7 @@ interface GetSiteMapOptions {
   /** The params object from Remix */
   params: LoaderFunctionArgs['params'];
   /** The Storefront API Client from Hydrogen */
-  storefront: LoaderFunctionArgs['context']['storefront'];
+  storefront: Storefront;
   /** A Remix Request object */
   request: Request;
   /** A function that produces a canonical url for a resource. It is called multiple times for each locale supported by the app. */

--- a/packages/hydrogen/src/sitemap/sitemap.ts
+++ b/packages/hydrogen/src/sitemap/sitemap.ts
@@ -1,18 +1,12 @@
-import {LoaderFunctionArgs} from '@shopify/remix-oxygen';
-import {
-  CountryCode,
-  LanguageCode,
-} from '@shopify/hydrogen/storefront-api-types';
+import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
 
 const SITEMAP_INDEX_PREFIX = `<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
-const SITEMAP_INDEX_SUFFIX = `</sitemapindex>`;
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n`;
+const SITEMAP_INDEX_SUFFIX = `\n</sitemapindex>`;
 
 const SITEMAP_PREFIX = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">`;
 const SITEMAP_SUFFIX = `</urlset>`;
-
-type Locale = `${LanguageCode}-${CountryCode}`;
 
 type SITEMAP_INDEX_TYPE =
   | 'pages'
@@ -22,20 +16,45 @@ type SITEMAP_INDEX_TYPE =
   | 'articles'
   | 'metaObjects';
 
-/**
- * Generate a sitemap index that links to separate sitemaps for each resource type.
- */
-export async function getSitemapIndex({
-  storefront,
-  request,
-  types = ['products', 'pages', 'collections', 'metaObjects', 'articles'],
-  customUrls = [],
-}: {
+interface SitemapIndexOptions {
+  /** The Storefront API Client from Hydrogen */
   storefront: LoaderFunctionArgs['context']['storefront'];
+  /** A Remix Request object */
   request: Request;
+  /** The types of pages to include in the sitemap index. */
   types?: SITEMAP_INDEX_TYPE[];
-  customUrls?: string[];
-}) {
+  /** Add a URL to a custom child sitemap */
+  customChildSitemaps?: string[];
+}
+
+/**
+ * Generate a sitemap index that links to separate sitemaps for each resource type. Returns a standard Response object.
+ */
+export async function getSitemapIndex(
+  options: SitemapIndexOptions,
+): Promise<Response> {
+  const {
+    storefront,
+    request,
+    types = [
+      'products',
+      'pages',
+      'collections',
+      'metaObjects',
+      'articles',
+      'blogs',
+    ],
+    customChildSitemaps = [],
+  } = options;
+
+  if (!request || !request.url)
+    throw new Error('A request object is required to generate a sitemap index');
+
+  if (!storefront || !storefront.query)
+    throw new Error(
+      'A storefront client is required to generate a sitemap index',
+    );
+
   const data = await storefront.query(SITEMAP_INDEX_QUERY, {
     storefrontApiVersion: 'unstable',
   });
@@ -49,12 +68,22 @@ export async function getSitemapIndex({
   const body =
     SITEMAP_INDEX_PREFIX +
     types
-      .map((type) =>
-        getSiteMapLinks(type, data[type].pagesCount.count, baseUrl),
-      )
+      .map((type) => {
+        if (!data[type]) {
+          throw new Error(
+            `[h2:sitemap:error] No data found for type ${type}. Check types passed to \`getSitemapIndex\``,
+          );
+        }
+        return getSiteMapLinks(type, data[type].pagesCount.count, baseUrl);
+      })
       .join('\n') +
-    customUrls
-      .map((url) => '<sitemap><loc>' + url + '</loc></sitemap>')
+    customChildSitemaps
+      .map(
+        (url) =>
+          '  <sitemap><loc>' +
+          (baseUrl + (url.startsWith('/') ? url : '/' + url)) +
+          '</loc></sitemap>',
+      )
       .join('\n') +
     SITEMAP_INDEX_SUFFIX;
 
@@ -74,26 +103,54 @@ interface GetSiteMapOptions {
   /** A Remix Request object */
   request: Request;
   /** A function that produces a canonical url for a resource. It is called multiple times for each locale supported by the app. */
-  getLink: (options: {
+  getLink?: (options: {
     type: string | SITEMAP_INDEX_TYPE;
     baseUrl: string;
     handle?: string;
-    locale?: Locale;
+    locale?: string;
   }) => string;
   /** An array of locales to generate alternate tags */
-  locales: Locale[];
+  locales?: string[];
   /** Optionally customize the changefreq property for each URL */
   getChangeFreq?: (options: {
     type: string | SITEMAP_INDEX_TYPE;
     handle: string;
   }) => string;
+  /** If the sitemap has no links, fallback to rendering a link to the homepage. This prevents errors in Google's search console. Defaults to `/`.  */
+  noItemsFallback?: string;
 }
 
 /**
  * Generate a sitemap for a specific resource type.
  */
-export async function getSitemap(options: GetSiteMapOptions) {
-  const {storefront, request, params, getLink, locales = []} = options;
+export async function getSitemap(
+  options: GetSiteMapOptions,
+): Promise<Response> {
+  const {
+    storefront,
+    request,
+    params,
+    getLink,
+    locales = [],
+    getChangeFreq,
+    noItemsFallback = '/',
+  } = options;
+
+  if (!params)
+    throw new Error(
+      '[h2:sitemap:error] Remix params object is required to generate a sitemap',
+    );
+
+  if (!request || !request.url)
+    throw new Error('A request object is required to generate a sitemap');
+
+  if (!storefront || !storefront.query)
+    throw new Error('A storefront client is required to generate a index');
+
+  if (!getLink)
+    throw new Error(
+      'A `getLink` function to generate each resource is required to build a sitemap',
+    );
 
   if (!params.type || !params.page)
     throw new Response('No data found', {status: 404});
@@ -111,34 +168,38 @@ export async function getSitemap(options: GetSiteMapOptions) {
     storefrontApiVersion: 'unstable',
   });
 
-  if (!data?.sitemap?.resources?.items?.length) {
-    throw new Response('Not found', {status: 404});
-  }
-
   const baseUrl = new URL(request.url).origin;
+  let body: string = '';
 
-  const body =
-    SITEMAP_PREFIX +
-    data.sitemap.resources.items
-      .map((item: {handle: string; updatedAt: string; type?: string}) => {
-        return renderUrlTag({
-          getChangeFreq: options.getChangeFreq,
-          url: getLink({
-            type: item.type ?? type,
-            baseUrl,
+  if (!data?.sitemap?.resources?.items?.length) {
+    body =
+      SITEMAP_PREFIX +
+      `\n  <url><loc>${baseUrl + noItemsFallback}</loc></url>\n` +
+      SITEMAP_SUFFIX;
+  } else {
+    body =
+      SITEMAP_PREFIX +
+      data.sitemap.resources.items
+        .map((item: {handle: string; updatedAt: string; type?: string}) => {
+          return renderUrlTag({
+            getChangeFreq,
+            url: getLink({
+              type: item.type ?? type,
+              baseUrl,
+              handle: item.handle,
+            }),
+            type,
+            getLink,
+            updatedAt: item.updatedAt,
             handle: item.handle,
-          }),
-          type,
-          getLink,
-          updatedAt: item.updatedAt,
-          handle: item.handle,
-          metaobjectType: item.type,
-          locales,
-          baseUrl,
-        });
-      })
-      .join('\n') +
-    SITEMAP_SUFFIX;
+            metaobjectType: item.type,
+            locales,
+            baseUrl,
+          });
+        })
+        .join('\n') +
+      SITEMAP_SUFFIX;
+  }
 
   return new Response(body, {
     headers: {
@@ -152,7 +213,7 @@ function getSiteMapLinks(resource: string, count: number, baseUrl: string) {
   let links = ``;
 
   for (let i = 1; i <= count; i++) {
-    links += `<sitemap><loc>${baseUrl}/sitemap/${resource}/${i}.xml</loc></sitemap>`;
+    links += `  <sitemap><loc>${baseUrl}/sitemap/${resource}/${i}.xml</loc></sitemap>\n`;
   }
   return links;
 }
@@ -176,11 +237,11 @@ function renderUrlTag({
     type: string;
     baseUrl: string;
     handle?: string;
-    locale?: Locale;
+    locale?: string;
   }) => string;
   url: string;
   updatedAt: string;
-  locales: Locale[];
+  locales: string[];
   getChangeFreq?: (options: {type: string; handle: string}) => string;
 }) {
   return `<url>
@@ -203,7 +264,7 @@ ${locales
   `.trim();
 }
 
-function renderAlternateTag(url: string, locale: Locale) {
+function renderAlternateTag(url: string, locale: string) {
   return `  <xhtml:link rel="alternate" hreflang="${locale}" href="${url}" />`;
 }
 
@@ -221,7 +282,7 @@ const PRODUCT_SITEMAP_QUERY = `#graphql
 ` as const;
 
 const COLLECTION_SITEMAP_QUERY = `#graphql
-    query SitemapProducts($page: Int!) {
+    query SitemapCollections($page: Int!) {
       sitemap(type: COLLECTION) {
         resources(page: $page) {
           items {
@@ -234,7 +295,7 @@ const COLLECTION_SITEMAP_QUERY = `#graphql
 ` as const;
 
 const ARTICLE_SITEMAP_QUERY = `#graphql
-    query SitemapProducts($page: Int!) {
+    query SitemapArticles($page: Int!) {
       sitemap(type: ARTICLE) {
         resources(page: $page) {
           items {
@@ -247,7 +308,7 @@ const ARTICLE_SITEMAP_QUERY = `#graphql
 ` as const;
 
 const PAGE_SITEMAP_QUERY = `#graphql
-    query SitemapProducts($page: Int!) {
+    query SitemapPages($page: Int!) {
       sitemap(type: PAGE) {
         resources(page: $page) {
           items {
@@ -260,7 +321,7 @@ const PAGE_SITEMAP_QUERY = `#graphql
 ` as const;
 
 const BLOG_SITEMAP_QUERY = `#graphql
-    query SitemapProducts($page: Int!) {
+    query SitemapBlogs($page: Int!) {
       sitemap(type: BLOG) {
         resources(page: $page) {
           items {
@@ -273,7 +334,7 @@ const BLOG_SITEMAP_QUERY = `#graphql
 ` as const;
 
 const METAOBJECT_SITEMAP_QUERY = `#graphql
-    query SitemapProducts($page: Int!) {
+    query SitemapMetaobjects($page: Int!) {
       sitemap(type: METAOBJECT_PAGE) {
         resources(page: $page) {
           items {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Introduce a new abstraction for generating sitemap index and child sitemaps. The sitemap example has also been updated to use it. This is a pre-release, so the utilities are prefixed with `unstable__`. We expect to stabilize them for the the October Hydrogen release.

Docs are available at: https://shopify-dev.shopify-dev-k41k.bret-little.us.spin.dev/docs/api/hydrogen/2024-07/utilities/getSitemapIndex 

Resolves https://github.com/Shopify/hydrogen-internal/issues/125

#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [X] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
