### PR TITLE
[skeleton] Add blog posts to sitemap

### DIFF
--- a/templates/skeleton/storefrontapi.generated.d.ts
+++ b/templates/skeleton/storefrontapi.generated.d.ts
@@ -323,6 +323,20 @@ export type SitemapQuery = {
       Pick<StorefrontAPI.Page, 'updatedAt' | 'handle' | 'onlineStoreUrl'>
     >;
   };
+  blogs: {
+    nodes: Array<
+      Pick<StorefrontAPI.Blog, 'handle'> & {
+        articles: {
+          nodes: Array<
+            Pick<
+              StorefrontAPI.Article,
+              'publishedAt' | 'handle' | 'onlineStoreUrl'
+            >
+          >;
+        };
+      }
+    >;
+  };
 };
 
 export type FeaturedCollectionFragment = Pick<
@@ -1212,7 +1226,7 @@ interface GeneratedQueryTypes {
     return: StoreRobotsQuery;
     variables: StoreRobotsQueryVariables;
   };
-  '#graphql\n  query Sitemap($urlLimits: Int, $language: LanguageCode)\n  @inContext(language: $language) {\n    products(\n      first: $urlLimits\n      query: "published_status:\'online_store:visible\'"\n    ) {\n      nodes {\n        updatedAt\n        handle\n        onlineStoreUrl\n        title\n        featuredImage {\n          url\n          altText\n        }\n      }\n    }\n    collections(\n      first: $urlLimits\n      query: "published_status:\'online_store:visible\'"\n    ) {\n      nodes {\n        updatedAt\n        handle\n        onlineStoreUrl\n      }\n    }\n    pages(first: $urlLimits, query: "published_status:\'published\'") {\n      nodes {\n        updatedAt\n        handle\n        onlineStoreUrl\n      }\n    }\n  }\n': {
+  '#graphql\n  query Sitemap($urlLimits: Int, $language: LanguageCode)\n  @inContext(language: $language) {\n    products(\n      first: $urlLimits\n      query: "published_status:\'online_store:visible\'"\n    ) {\n      nodes {\n        updatedAt\n        handle\n        onlineStoreUrl\n        title\n        featuredImage {\n          url\n          altText\n        }\n      }\n    }\n    collections(\n      first: $urlLimits\n      query: "published_status:\'online_store:visible\'"\n    ) {\n      nodes {\n        updatedAt\n        handle\n        onlineStoreUrl\n      }\n    }\n    pages(first: $urlLimits, query: "published_status:\'published\'") {\n      nodes {\n        updatedAt\n        handle\n        onlineStoreUrl\n      }\n    }\n    blogs(first: $urlLimits, query: "published_status:\'published\'") {\n      nodes {\n        handle\n        articles (first: $urlLimits, query: "published_status:\'published\'") {\n          nodes {\n            publishedAt\n            handle\n            onlineStoreUrl\n          }\n        }\n      }\n    }\n  }\n': {
     return: SitemapQuery;
     variables: SitemapQueryVariables;
   };


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

It would be nice to include blog posts in the sitemap

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

Adds the blog posts to the sitemap

### HOW to test your changes?

Check `/sitemap.xml`, scroll all the way to the bottom

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
