### PR TITLE
Allow `withCache` to pass in a `shouldCacheResponse` function

### DIFF
--- a/.changeset/blue-hounds-dress.md
+++ b/.changeset/blue-hounds-dress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+allow `withCache` to pass in a `shouldCacheResponse` function

--- a/packages/hydrogen/src/cache/create-with-cache.ts
+++ b/packages/hydrogen/src/cache/create-with-cache.ts
@@ -35,6 +35,7 @@ export function createWithCache<T = unknown>(
     cacheKey: CacheKey,
     strategy: CachingStrategy,
     actionFn: ({addDebugData}: CacheActionFunctionParam) => T | Promise<T>,
+    shouldCacheResult?: (value: T) => boolean,
   ) {
     return runWithCache<T>(cacheKey, actionFn, {
       strategy,
@@ -44,6 +45,7 @@ export function createWithCache<T = unknown>(
         ...getDebugHeaders(request),
         stackInfo: getCallerStackLine?.(),
       },
+      shouldCacheResult,
     });
   };
 }


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Turns out we never give the option to pass a `shouldCacheResponse` for `withCache`.

Without the `shouldCacheResponse`, by default, queries are always cached in worker, regardless of the status code of the response.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
