### PR TITLE
Update MiniOxygen to latest workerd version

### DIFF
--- a/.changeset/spicy-rats-press.md
+++ b/.changeset/spicy-rats-press.md
@@ -1,0 +1,5 @@
+---
+'@shopify/mini-oxygen': patch
+---
+
+Update internal version of the worker runtime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2679,9 +2679,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20240304.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240304.0.tgz",
-      "integrity": "sha512-rfHlvsWzkqEEQNvm14AOE/BYHYzB9wxQHCaZZEgwOuTl5KpDcs9La0N0LaDTR78ESumIWOcifVmko2VTrZb7TQ==",
+      "version": "1.20240925.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240925.0.tgz",
+      "integrity": "sha512-KdLnSXuzB65CbqZPm+qYzk+zkQ1tUNPaaRGYVd/jPYAxwwtfTUQdQ+ahDPwVVs2tmQELKy7ZjQjf2apqSWUfjw==",
       "cpu": [
         "x64"
       ],
@@ -2694,9 +2694,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20240304.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240304.0.tgz",
-      "integrity": "sha512-IXGOxHsPdRYfAzcY6IroI1PDvx3hhXf18qFCloHp8Iw5bzLgq/PTjcp10Z/2xedZ2hVlfpHy1eEptsTmi9YeNw==",
+      "version": "1.20240925.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240925.0.tgz",
+      "integrity": "sha512-MiQ6uUmCXjsXgWNV+Ock2tp2/tYqNJGzjuaH6jFioeRF+//mz7Tv7J7EczOL4zq+TH8QFOh0/PUsLyazIWVGng==",
       "cpu": [
         "arm64"
       ],
@@ -2709,9 +2709,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20240304.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240304.0.tgz",
-      "integrity": "sha512-G1BEzbw9TFIeMvc425F145IetC7fuH4KOkGhseLq9y/mt5PfDWkghwmXSK+q0BiMwm0XAobtzVlHcEr2u4WlRQ==",
+      "version": "1.20240925.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240925.0.tgz",
+      "integrity": "sha512-Rjix8jsJMfsInmq3Hm3fmiRQ+rwzuWRPV1pg/OWhMSfNP7Qp2RCU+RGkhgeR9Z5eNAje0Sn2BMrFq4RvF9/yRA==",
       "cpu": [
         "x64"
       ],
@@ -2724,9 +2724,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20240304.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240304.0.tgz",
-      "integrity": "sha512-LLk/d/y77TRu6QOG3CJUI2cD3Ff2lSg0ts6G83bsm9ZK+WKObWFFSPBy9l81m3EnlKFh7RZCzxN4J10kuDaO8w==",
+      "version": "1.20240925.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240925.0.tgz",
+      "integrity": "sha512-VYIPeMHQRtbwQoIjUwS/zULlywPxyDvo46XkTpIW5MScEChfqHvAYviQ7TzYGx6Q+gmZmN+DUB2KOMx+MEpCxA==",
       "cpu": [
         "arm64"
       ],
@@ -2739,9 +2739,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20240304.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240304.0.tgz",
-      "integrity": "sha512-I/j6nVpM+WDPg+bYUAiKLkwQsjrXFjpOGHvwYmcM44hnDjgODzk7AbVssEIXnhEO3oupBeuKvffr0lvX0Ngmpw==",
+      "version": "1.20240925.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240925.0.tgz",
+      "integrity": "sha512-C8peGvaU5R51bIySi1VbyfRgwNSSRknqoFSnSbSBI3uTN3THTB3UnmRKy7GXJDmyjgXuT9Pcs1IgaWNubLtNtw==",
       "cpu": [
         "x64"
       ],
@@ -11257,8 +11257,7 @@
     "node_modules/capnp-ts/node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -21771,9 +21770,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20240304.2",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240304.2.tgz",
-      "integrity": "sha512-yQ5TBKv7TlvF8khFvvH+1WWk8cBnaLgNzcbJ5DLQOdecxdDxUCVlN38HThd6Nhcz6EY+ckDkww8FkugUbSSpIQ==",
+      "version": "3.20240925.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240925.0.tgz",
+      "integrity": "sha512-2LmQbKHf0n6ertUKhT+Iltixi53giqDH7P71+wCir3OnGyXIODqYwOECx1mSDNhYThpxM2dav8UdPn6SQiMoXw==",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "acorn": "^8.8.0",
@@ -21782,11 +21781,11 @@
         "exit-hook": "^2.2.1",
         "glob-to-regexp": "^0.4.1",
         "stoppable": "^1.1.0",
-        "undici": "^5.28.2",
-        "workerd": "1.20240304.0",
-        "ws": "^8.11.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20240925.0",
+        "ws": "^8.17.1",
         "youch": "^3.2.2",
-        "zod": "^3.20.6"
+        "zod": "^3.22.3"
       },
       "bin": {
         "miniflare": "bootstrap.js"
@@ -29524,9 +29523,9 @@
       "license": "MIT"
     },
     "node_modules/workerd": {
-      "version": "1.20240304.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240304.0.tgz",
-      "integrity": "sha512-/tYxdypPh9NKQje9r7bgBB73vAQfCQZbEPjNlxE/ml7jNKMHnRZv/D+By4xO0IPAifa37D0sJFokvYOahz1Lqw==",
+      "version": "1.20240925.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240925.0.tgz",
+      "integrity": "sha512-/Jj6+yLwfieZGEt3Kx4+5MoufuC3g/8iFaIh4MPBNGJOGYmdSKXvgCqz09m2+tVCYnysRfbq2zcbVxJRBfOCqQ==",
       "hasInstallScript": true,
       "bin": {
         "workerd": "bin/workerd"
@@ -29535,11 +29534,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20240304.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20240304.0",
-        "@cloudflare/workerd-linux-64": "1.20240304.0",
-        "@cloudflare/workerd-linux-arm64": "1.20240304.0",
-        "@cloudflare/workerd-windows-64": "1.20240304.0"
+        "@cloudflare/workerd-darwin-64": "1.20240925.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20240925.0",
+        "@cloudflare/workerd-linux-64": "1.20240925.0",
+        "@cloudflare/workerd-linux-arm64": "1.20240925.0",
+        "@cloudflare/workerd-windows-64": "1.20240925.0"
       }
     },
     "node_modules/worktop": {
@@ -32482,7 +32481,7 @@
         "body-parser": "1.20.2",
         "connect": "^3.7.0",
         "get-port": "^7.0.0",
-        "miniflare": "3.20240304.2",
+        "miniflare": "^3.20240925.0",
         "mrmime": "1.0.1",
         "source-map": "^0.7.4",
         "source-map-support": "^0.5.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "@remix-run/node": "^2.10.1",
         "@remix-run/react": "^2.10.1",
         "@remix-run/server-runtime": "^2.10.1",
-        "@shopify/hydrogen": "2024.7.7",
+        "@shopify/hydrogen": "2024.7.8",
         "compression": "^1.7.4",
         "cross-env": "^7.0.3",
         "express": "^4.19.2",
@@ -30160,10 +30160,10 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2024.7.7",
+      "version": "2024.7.8",
       "license": "MIT",
       "dependencies": {
-        "@shopify/hydrogen-react": "2024.7.4",
+        "@shopify/hydrogen-react": "2024.7.5",
         "content-security-policy-builder": "^2.2.0",
         "source-map-support": "^0.5.21",
         "type-fest": "^4.5.0",
@@ -30227,7 +30227,7 @@
     },
     "packages/hydrogen-react": {
       "name": "@shopify/hydrogen-react",
-      "version": "2024.7.4",
+      "version": "2024.7.5",
       "license": "MIT",
       "dependencies": {
         "@google/model-viewer": "^1.12.1",
@@ -32566,7 +32566,7 @@
     },
     "packages/remix-oxygen": {
       "name": "@shopify/remix-oxygen",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "devDependencies": {
         "@remix-run/server-runtime": "^2.10.1",
@@ -32578,12 +32578,12 @@
       }
     },
     "templates/skeleton": {
-      "version": "2024.7.8",
+      "version": "2024.7.9",
       "dependencies": {
         "@remix-run/react": "^2.10.1",
         "@remix-run/server-runtime": "^2.10.1",
-        "@shopify/hydrogen": "2024.7.7",
-        "@shopify/remix-oxygen": "^2.0.7",
+        "@shopify/hydrogen": "2024.7.8",
+        "@shopify/remix-oxygen": "^2.0.8",
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^3.8.0",

--- a/packages/mini-oxygen/package.json
+++ b/packages/mini-oxygen/package.json
@@ -52,7 +52,7 @@
     "body-parser": "1.20.2",
     "connect": "^3.7.0",
     "get-port": "^7.0.0",
-    "miniflare": "3.20240304.2",
+    "miniflare": "^3.20240925.0",
     "mrmime": "1.0.1",
     "source-map": "^0.7.4",
     "source-map-support": "^0.5.21",

--- a/packages/mini-oxygen/src/worker/e2e.test.ts
+++ b/packages/mini-oxygen/src/worker/e2e.test.ts
@@ -143,7 +143,9 @@ describe('MiniOxygen Worker Runtime', () => {
         const response = await fetch('/');
 
         expect(response.status).toEqual(500);
-        await expect(response.text()).resolves.toEqual('Error: test');
+        await expect(response.text()).resolves.toSatisfy((result) =>
+          (result as string).startsWith('Error: test'),
+        );
 
         // console.error from workerd is asynchronous
         await vi.waitFor(


### PR DESCRIPTION
This will be needed for #2380 

The last time I tried to make this update it was breaking sourcemaps. However, it seems that this version doesn't have that issue. The only thing that changed is that the error stack now contain one extra line, hence the update to the tests.

We should merge this asap to use it for a while in the monorepo before release.