### PR TITLE
Update starter template with latest Hydrogen version

### DIFF
--- a/.changeset/slimy-drinks-fly.md
+++ b/.changeset/slimy-drinks-fly.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Update starter template with latest Hydrogen version.


### PR DESCRIPTION
`npx create-hydrogen@latest` isn't using the latest version of Hydrogen.

This PR bumps `cli-hydrogen` and `create-hydrogen` to resolve.

<img width="928" alt="image" src="https://github.com/user-attachments/assets/322aba6f-9054-4a8f-add9-161e665fc6ac">