### PR TITLE
Add cache busting token to `createStorefrontClient` and `createWithCache`

### DIFF
--- a/.changeset/selfish-falcons-add.md
+++ b/.changeset/selfish-falcons-add.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add cache busting token to `createStorefrontClient` and `createWithCache`.

--- a/packages/hydrogen/src/cache/create-with-cache.ts
+++ b/packages/hydrogen/src/cache/create-with-cache.ts
@@ -13,6 +13,8 @@ import type {WaitUntil} from '../types';
 type CreateWithCacheOptions = {
   /** An instance that implements the [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) */
   cache: Cache;
+  /** Token to be appended as a suffix of cache keys. Change it when you want to invalidate the cache. */
+  cacheBustingToken?: string;
   /** The `waitUntil` function is used to keep the current request/response lifecycle alive even after a response has been sent. It should be provided by your platform. */
   waitUntil: WaitUntil;
   /** The `request` object is used to access certain headers for debugging */
@@ -27,7 +29,7 @@ type CreateWithCacheOptions = {
 export function createWithCache<T = unknown>(
   cacheOptions: CreateWithCacheOptions,
 ) {
-  const {cache, waitUntil, request} = cacheOptions;
+  const {cache, cacheBustingToken, waitUntil, request} = cacheOptions;
 
   return {
     /**
@@ -54,7 +56,7 @@ export function createWithCache<T = unknown>(
         | InferredActionReturn
         | Promise<InferredActionReturn>,
     ) {
-      return runWithCache(cacheKey, actionFn, {
+      return runWithCache([cacheKey, cacheBustingToken], actionFn, {
         strategy,
         cacheInstance: cache,
         waitUntil,
@@ -84,7 +86,7 @@ export function createWithCache<T = unknown>(
     ): Promise<{data: Body | null; response: Response}> {
       return fetchWithServerCache<Body | null>(url, requestInit ?? {}, {
         waitUntil,
-        cacheKey: [url, requestInit],
+        cacheKey: [url, requestInit, cacheBustingToken],
         cacheInstance: cache,
         debugInfo: {
           url,

--- a/packages/hydrogen/src/storefront.ts
+++ b/packages/hydrogen/src/storefront.ts
@@ -166,6 +166,8 @@ type HydrogenClientProps<TI18n> = {
   storefrontHeaders?: StorefrontHeaders;
   /** An instance that implements the [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache) */
   cache?: Cache;
+  /** Token to be appended as a suffix of cache keys. Change it when you want to invalidate the cache. */
+  cacheBustingToken?: string;
   /** The globally unique identifier for the Shop */
   storefrontId?: string;
   /** The `waitUntil` function is used to keep the current request/response lifecycle alive even after a response has been sent. It should be provided by your platform. */
@@ -204,6 +206,7 @@ export function createStorefrontClient<TI18n extends I18nBase>(
   const {
     storefrontHeaders,
     cache,
+    cacheBustingToken,
     waitUntil,
     i18n,
     storefrontId,
@@ -310,6 +313,7 @@ export function createStorefrontClient<TI18n extends I18nBase>(
       requestInit.method,
       cacheKeyHeader,
       requestInit.body,
+      cacheBustingToken,
     ];
 
     const [body, response] = await fetchWithServerCache(url, requestInit, {


### PR DESCRIPTION
### WHY are these changes introduced?

In scenarios like campaign launches or other time-sensitive updates, content must be immediately visible to users. Thus, when employing a long server cache strategy (e.g., [Hydrogen's cacheLong](https://shopify.dev/docs/api/hydrogen/2023-04/utilities/cachelong))—which is often beneficial for performance—it's crucial to have a method to manually purge or bust the cache when necessary.

While some hosting providers, like [Cloudflare](https://developers.cloudflare.com/cache/how-to/purge-cache/), offer built-in support for cache purging, this functionality is currently unavailable for Hydrogen deployments on Oxygen.

### WHAT is this pull request doing?

This PR introduces a `cacheBustingToken` property to the `createStorefrontClient` and `createWithCache` functions. By updating the value of this token, developers can bust the cache, ensuring fresh content is served when required.

To make the token easily configurable, we suggest storing its value in a `CACHE_BUSTING_TOKEN` environment variable. Once set as an environment variable, users updating its value within the Shopify admin will be prompted to rebuild their current deployments and bust the cache as a result.

In the future, it could be beneficial for this environment variable to be automatically created when a new Hydrogen store is created.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation