### PR TITLE
Fix analytic provider breaking after a 404 page

### DIFF
--- a/.changeset/six-melons-beg.md
+++ b/.changeset/six-melons-beg.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix analytics provider breaking after hitting a 404 page

--- a/packages/hydrogen/src/analytics-manager/AnalyticsProvider.test.tsx
+++ b/packages/hydrogen/src/analytics-manager/AnalyticsProvider.test.tsx
@@ -153,8 +153,8 @@ describe('<Analytics.Provider />', () => {
       expect(analytics?.shop).toBe(SHOP_DATA);
       expect(analytics?.cart).toBe(CART_DATA);
       expect(analytics?.customData).toEqual({test: 'test'});
-      expect(analytics?.privacyBanner).toEqual(null);
-      expect(analytics?.customerPrivacy).toEqual(null);
+      expect(analytics?.privacyBanner).toBeDefined();
+      expect(analytics?.customerPrivacy).toBeDefined();
     });
 
     it('returns default canTrack true', async () => {
@@ -411,6 +411,8 @@ function LoopAnalytics({
       global.window.Shopify.customerPrivacy = {
         setTrackingConsent: () => {},
         analyticsProcessingAllowed: () => true,
+        saleOfDataAllowed: () => true,
+        marketingAllowed: () => true,
       };
     }
     if (registerCallback) {

--- a/packages/hydrogen/src/customer-privacy/ShopifyCustomerPrivacy.tsx
+++ b/packages/hydrogen/src/customer-privacy/ShopifyCustomerPrivacy.tsx
@@ -204,7 +204,7 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
     if (!withPrivacyBanner || observing.current.privacyBanner) return;
     observing.current.privacyBanner = true;
 
-    let customPrivacyBanner: PrivacyBanner | undefined = undefined;
+    let customPrivacyBanner: PrivacyBanner | undefined = window.privacyBanner || undefined;
 
     const privacyBannerWatcher = {
       configurable: true,
@@ -252,7 +252,7 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
 
     let customCustomerPrivacy: CustomerPrivacy | null = null;
     let customShopify: {customerPrivacy: CustomerPrivacy} | undefined | object =
-      undefined;
+      window.Shopify || undefined;
 
     // monitor for when window.Shopify = {} is first set
     Object.defineProperty(window, 'Shopify', {

--- a/packages/hydrogen/src/customer-privacy/ShopifyCustomerPrivacy.tsx
+++ b/packages/hydrogen/src/customer-privacy/ShopifyCustomerPrivacy.tsx
@@ -204,7 +204,8 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
     if (!withPrivacyBanner || observing.current.privacyBanner) return;
     observing.current.privacyBanner = true;
 
-    let customPrivacyBanner: PrivacyBanner | undefined = window.privacyBanner || undefined;
+    let customPrivacyBanner: PrivacyBanner | undefined =
+      window.privacyBanner || undefined;
 
     const privacyBannerWatcher = {
       configurable: true,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fixes: https://github.com/Shopify/hydrogen/issues/2576

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
