### PR TITLE
Add optional headers param for logout redirect

### DIFF
--- a/.changeset/eight-poems-explode.md
+++ b/.changeset/eight-poems-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add optional headers param for logout redirect

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -329,6 +329,33 @@ describe('customer', () => {
           );
         });
 
+        it('Redirects to the customer account api logout url with optional headers from params included', async () => {
+          const origin = 'https://shop123.com';
+          const postLogoutRedirectUri = '/post-logout-landing-page';
+          const headers = {'Set-Cookie': 'cookie=test;'};
+
+          const customer = createCustomerAccountClient({
+            session,
+            customerAccountId: 'customerAccountId',
+            shopId: '1',
+            request: new Request(origin),
+            waitUntil: vi.fn(),
+          });
+
+          const response = await customer.logout({headers});
+
+          const url = new URL(response.headers.get('location')!);
+          expect(url.origin).toBe('https://shopify.com');
+          expect(url.pathname).toBe('/authentication/1/logout');
+
+          expect(response.headers.get('Set-Cookie')).toBe('cookie=test;');
+
+          // Session is cleared
+          expect(session.unset).toHaveBeenCalledWith(
+            CUSTOMER_ACCOUNT_SESSION_KEY,
+          );
+        });
+
         it('Redirects to app origin when customer is not login by default', async () => {
           const origin = 'https://shop123.com';
           const mockSession: HydrogenSession = {

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -430,7 +430,7 @@ export function createCustomerAccountClient({
 
       clearSession(session);
 
-      return redirect(logoutUrl);
+      return redirect(logoutUrl, {headers: options?.headers || {}});
     },
     isLoggedIn,
     handleAuthStatus,

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -55,6 +55,7 @@ export type LoginOptions = {
 
 export type LogoutOptions = {
   postLogoutRedirectUri?: string;
+  headers?: HeadersInit;
 };
 
 export type CustomerAccount = {

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -82,6 +82,7 @@ export type CustomerAccount = {
   /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.
    *
    * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.
+   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.
    * */
   logout: (options?: LogoutOptions) => Promise<Response>;
   /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */


### PR DESCRIPTION
### WHY are these changes introduced?

This allows for passing Set-Cookie headers to the logout redirect, allowing users the possibility of clearing certain cookies (like the cart) on logout. 

This is being used in our app to allow multiple users to share a login device without persisting carts across users.

### WHAT is this pull request doing?

Passing through an optional headers param to the logout redirect call.

### HOW to test your changes?

Added a new test to customer.test.ts to test this functionality.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation
