### PR TITLE
Add a GraphQL Proxy

### DIFF
--- a/.changeset/grumpy-ducks-travel.md
+++ b/.changeset/grumpy-ducks-travel.md
@@ -1,0 +1,23 @@
+---
+'skeleton': patch
+'@shopify/hydrogen': patch
+---
+
+Add a new route available on all hydrogen sites that proxies GraphQL requests to Shopify.
+For example, `https://hydrogen.shop/api/2024-07/graphql` proxies to `https://hydrogen-preview.myshopify.com/api/2024-07/graphql`.
+This allows the browser to make SFAPI requests on the same domain.
+
+Note, your `server.ts` needs to be updated to return a caught response:
+
+```diff
+try {
+ ...
+} catch (error) {
+  if (!(error instanceof Response)) {
+    console.error(error);
+  }
+-  return new Response('An unexpected error occurred', {status: 500});
++  return error instanceof Response ? error : new Response('An unexpected error occurred', {status: 500});
+}
+
+```

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -224,7 +224,7 @@ export function createHydrogenContext<
     customerAccount,
   });
 
-  proxyGraphQL(storefront, request as Request, waitUntil);
+  maybeProxyGraphQL(storefront, request as Request, waitUntil);
 
   return {
     storefront,
@@ -306,7 +306,7 @@ export type HydrogenContextOptionsForDocs<
   };
 };
 
-function proxyGraphQL<TI18n extends I18nBase>(
+function maybeProxyGraphQL<TI18n extends I18nBase>(
   storefront: StorefrontClient<TI18n>['storefront'],
   request?: Request,
   waitUntil?: WaitUntil,

--- a/templates/skeleton/.env
+++ b/templates/skeleton/.env
@@ -1,0 +1,3 @@
+# These variables are only available locally in MiniOxygen
+
+SESSION_SECRET="foobar"

--- a/templates/skeleton/.env
+++ b/templates/skeleton/.env
@@ -1,3 +1,0 @@
-# These variables are only available locally in MiniOxygen
-
-SESSION_SECRET="foobar"

--- a/templates/skeleton/server.ts
+++ b/templates/skeleton/server.ts
@@ -55,9 +55,12 @@ export default {
 
       return response;
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-      return new Response('An unexpected error occurred', {status: 500});
+      if (!(error instanceof Response)) {
+        console.error(error);
+      }
+      return error instanceof Response
+        ? error
+        : new Response('An unexpected error occurred', {status: 500});
     }
   },
 };


### PR DESCRIPTION
Add a new route available on all hydrogen sites that proxies GraphQL requests to Shopify.
For example, `https://hydrogen.shop/api/2024-07/graphql` proxies to `https://hydrogen-preview.myshopify.com/api/2024-07/graphql`.
This allows the browser to make SFAPI requests on the same domain.

Note, your `server.ts` needs to be updated to return a caught response:

```diff
try {
 ...
} catch (error) {
  if (!(error instanceof Response)) {
    console.error(error);
  }
-  return new Response('An unexpected error occurred', {status: 500});
+  return error instanceof Response ? error : new Response('An unexpected error occurred', {status: 500});
}

```
