### PR TITLE
Bl route warnings

### DIFF
--- a/.changeset/quick-carrots-perform.md
+++ b/.changeset/quick-carrots-perform.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add warnings to the Shopify CLI when reserved routes are defined

--- a/.changeset/quick-carrots-perform.md
+++ b/.changeset/quick-carrots-perform.md
@@ -2,4 +2,4 @@
 '@shopify/cli-hydrogen': patch
 ---
 
-Add warnings to the Shopify CLI when reserved routes are defined
+Add warnings to the Shopify CLI when your app uses reserved routes. These routes are reserved by Oxygen, and any local routes that conflict with them will not be used.

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -14,7 +14,11 @@ import {commonFlags, flagsToCamelObject} from '../../lib/flags.js';
 import {prepareDiffDirectory} from '../../lib/template-diff.js';
 import {getViteConfig, isViteProject} from '../../lib/vite-config.js';
 import {checkLockfileStatus} from '../../lib/check-lockfile.js';
-import {findMissingRoutes} from '../../lib/missing-routes.js';
+import {
+  findMissingRoutes,
+  findReservedRoutes,
+  warnReservedRoutes,
+} from '../../lib/route-validator.js';
 import {runClassicCompilerBuild} from '../../lib/classic-compiler/build.js';
 import {hydrogenBundleAnalyzer} from '../../lib/bundle/vite-plugin.js';
 import {
@@ -339,6 +343,10 @@ export async function runBuild({
           }. For more details, run \`${exec} shopify hydrogen check routes\`.\n`,
       );
     }
+  }
+
+  if (!watch && !disableRouteWarning) {
+    warnReservedRoutes(findReservedRoutes(remixConfig));
   }
 
   return {

--- a/packages/cli/src/commands/hydrogen/check.ts
+++ b/packages/cli/src/commands/hydrogen/check.ts
@@ -2,7 +2,12 @@ import Command from '@shopify/cli-kit/node/base-command';
 import {resolvePath} from '@shopify/cli-kit/node/path';
 import {commonFlags} from '../../lib/flags.js';
 import {getRemixConfig} from '../../lib/remix-config.js';
-import {findMissingRoutes, logMissingRoutes} from '../../lib/missing-routes.js';
+import {
+  findMissingRoutes,
+  findReservedRoutes,
+  logMissingRoutes,
+  warnReservedRoutes,
+} from '../../lib/route-validator.js';
 
 import {Args} from '@oclif/core';
 
@@ -40,4 +45,5 @@ export default class GenerateRoute extends Command {
 export async function runCheckRoutes({directory}: {directory: string}) {
   const remixConfig = await getRemixConfig(directory);
   logMissingRoutes(findMissingRoutes(remixConfig));
+  warnReservedRoutes(findReservedRoutes(remixConfig));
 }

--- a/packages/cli/src/lib/classic-compiler/build.ts
+++ b/packages/cli/src/lib/classic-compiler/build.ts
@@ -25,7 +25,7 @@ import {
   type ServerMode,
 } from '../remix-config.js';
 import {checkLockfileStatus} from '../check-lockfile.js';
-import {findMissingRoutes} from '../missing-routes.js';
+import {findMissingRoutes} from '../route-validator.js';
 import {createRemixLogger, muteRemixLogs} from '../log.js';
 import {codegen} from '../codegen.js';
 import {

--- a/packages/cli/src/lib/route-validator.test.ts
+++ b/packages/cli/src/lib/route-validator.test.ts
@@ -57,34 +57,34 @@ describe('reserved-routes', () => {
   });
 
   it("doesn't find routes that don't match the reserved routes", async () => {
-    expect(
-      findReservedRoutes(createRoute('/collections/:handle')),
-    ).toHaveLength(0);
+    expect(findReservedRoutes(createRoute('collections/:handle'))).toHaveLength(
+      0,
+    );
   });
 
   it('returns an array of reserved routes', async () => {
     expect(
-      findReservedRoutes(createRoute('/api/2024-10/graphql.json')),
+      findReservedRoutes(createRoute('api/2024-10/graphql.json')),
     ).toHaveLength(1);
 
     expect(
-      findReservedRoutes(createRoute('/api/:param/graphql.json')),
+      findReservedRoutes(createRoute('api/:param/graphql.json')),
     ).toHaveLength(1);
   });
 
   it('finds reserved routes /cdn/', async () => {
-    expect(findReservedRoutes(createRoute('/cdn/'))).toHaveLength(1);
+    expect(findReservedRoutes(createRoute('cdn/'))).toHaveLength(1);
 
     expect(
-      findReservedRoutes(createRoute('/cdn/something/for/you.jpg')),
+      findReservedRoutes(createRoute('cdn/something/for/you.jpg')),
     ).toHaveLength(1);
   });
 
   it('finds reserved routes /_t/', async () => {
-    expect(findReservedRoutes(createRoute('/_t/'))).toHaveLength(1);
+    expect(findReservedRoutes(createRoute('_t/'))).toHaveLength(1);
 
     expect(
-      findReservedRoutes(createRoute('/_t/something/for/you.jpg')),
+      findReservedRoutes(createRoute('_t/something/for/you.jpg')),
     ).toHaveLength(1);
   });
 });

--- a/packages/cli/src/lib/route-validator.test.ts
+++ b/packages/cli/src/lib/route-validator.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest';
-import {findMissingRoutes} from './missing-routes.js';
+import {findMissingRoutes, findReservedRoutes} from './route-validator.js';
 
 const createRoute = (path: string) => ({
   routes: {
@@ -48,5 +48,37 @@ describe('missing-routes', () => {
         findMissingRoutes(createRoute(validRoute), requiredRoutes),
       ).toHaveLength(0);
     }
+  });
+});
+
+describe.only('reserved-routes', () => {
+  it('returns an empty array when no routes are present', async () => {
+    expect(findReservedRoutes({routes: {}})).toHaveLength(0);
+  });
+
+  it('returns an array of reserved routes', async () => {
+    expect(
+      findReservedRoutes(createRoute('/api/2024-10/graphql.json')),
+    ).toHaveLength(1);
+
+    expect(
+      findReservedRoutes(createRoute('/api/:param/graphql.json')),
+    ).toHaveLength(1);
+  });
+
+  it('finds reserved routes /cdn/', async () => {
+    expect(findReservedRoutes(createRoute('/cdn/'))).toHaveLength(1);
+
+    expect(
+      findReservedRoutes(createRoute('/cdn/something/for/you.jpg')),
+    ).toHaveLength(1);
+  });
+
+  it('finds reserved routes /_t/', async () => {
+    expect(findReservedRoutes(createRoute('/_t/'))).toHaveLength(1);
+
+    expect(
+      findReservedRoutes(createRoute('/_t/something/for/you.jpg')),
+    ).toHaveLength(1);
   });
 });

--- a/packages/cli/src/lib/route-validator.test.ts
+++ b/packages/cli/src/lib/route-validator.test.ts
@@ -51,7 +51,7 @@ describe('missing-routes', () => {
   });
 });
 
-describe.only('reserved-routes', () => {
+describe('reserved-routes', () => {
   it('returns an empty array when no routes are present', async () => {
     expect(findReservedRoutes({routes: {}})).toHaveLength(0);
   });

--- a/packages/cli/src/lib/route-validator.test.ts
+++ b/packages/cli/src/lib/route-validator.test.ts
@@ -56,6 +56,12 @@ describe('reserved-routes', () => {
     expect(findReservedRoutes({routes: {}})).toHaveLength(0);
   });
 
+  it("doesn't find routes that don't match the reserved routes", async () => {
+    expect(
+      findReservedRoutes(createRoute('/collections/:handle')),
+    ).toHaveLength(0);
+  });
+
   it('returns an array of reserved routes', async () => {
     expect(
       findReservedRoutes(createRoute('/api/2024-10/graphql.json')),


### PR DESCRIPTION
### WHY are these changes introduced?

Add warnings to the Shopify CLI when your app uses reserved routes. These routes are reserved by Oxygen, and any local routes that conflict with them will not be used.
