### PR TITLE
Prevent scroll reset on variant change

### DIFF
--- a/.changeset/loud-bags-cross.md
+++ b/.changeset/loud-bags-cross.md
@@ -1,4 +1,5 @@
 ---
+'@shopify/create-hydrogen': patch
 'skeleton': patch
 ---
 

--- a/.changeset/loud-bags-cross.md
+++ b/.changeset/loud-bags-cross.md
@@ -1,0 +1,5 @@
+---
+'skeleton': patch
+---
+
+Prevent scroll reset on variant change

--- a/templates/skeleton/app/components/ProductForm.tsx
+++ b/templates/skeleton/app/components/ProductForm.tsx
@@ -86,6 +86,7 @@ export function ProductForm({
                         if (!selected) {
                           navigate(`?${variantUriQuery}`, {
                             replace: true,
+                            preventScrollReset: true,
                           });
                         }
                       }}
@@ -98,7 +99,7 @@ export function ProductForm({
             </div>
             <br />
           </div>
-        )
+        );
       })}
       <AddToCartButton
         disabled={!selectedVariant || !selectedVariant.availableForSale}


### PR DESCRIPTION
### WHY are these changes introduced?

In the the product form updates we switched from links to buttons. We also need to port over `preventScrollReset`.

https://github.com/user-attachments/assets/ab67afde-9e97-4618-ab91-5e71ae79df18

### WHAT is this pull request doing?

`navigate` takes a [`preventScrollReset`](https://remix.run/docs/zh/main/hooks/use-navigate#options) option.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation