### PR TITLE
Update changelog title for 2024.10.1

### DIFF
--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -3,7 +3,7 @@
   "version": "1",
   "releases": [
     {
-      "title": "Remove unstable exports from remix-oxygen and update customer account buyer authentication exchange",
+      "title": "Support for 2,000 variants and combined listings",
       "version": "2024.10.1",
       "hash": "c915b67d81ff01e25eeefce8cf0510805d620d64",
       "pr": "https://github.com/Shopify/hydrogen/pull/2657",


### PR DESCRIPTION
### WHY are these changes introduced?

CLI upgrade message isn't accurate, we need to adjust the `2024.10.1` `changelog.json` title.

![image](https://github.com/user-attachments/assets/28caf1ef-222a-4550-8373-1f923e5e42e2)

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation