### PR TITLE
Bump minimal version of Node.js to 18.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Hydrogen legacy v1 has been moved [to a separate repo](https://github.com/Shopif
 
 **Requirements:**
 
-- Node.js version 16.14.0 or higher
+- Node.js version 18.0.0 or higher
 - `npm` (or your package manager of choice, such as `yarn` or `pnpm`)
 
 1. Install the latest version of Hydrogen:


### PR DESCRIPTION
### WHY are these changes introduced?

We will get the following error when we execute `npm run dev` under `Node.js 16.x`:

```js
ReferenceError: fetch is not defined
    at Server.warmupWorkerdCache (file:///home/johnniang/workspaces/johnniang/shopify/hydrogen-quickstart/node_modules/@shopify/mini-oxygen/dist/vite/server-middleware.js:152:7)
```

I found that https://github.com/Shopify/hydrogen/pull/1543 upgraded minimal version of Node.js engine to 18, but the  README didn't be updated.

### WHAT is this pull request doing?

This PR bumps minimal version of Node.js to 18.0.0. 

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation