### PR TITLE
fix: support react compiler runtime

### DIFF
--- a/.changeset/old-trainers-study.md
+++ b/.changeset/old-trainers-study.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Support the React Compiler runtime

--- a/packages/hydrogen/src/vite/plugin.ts
+++ b/packages/hydrogen/src/vite/plugin.ts
@@ -62,6 +62,8 @@ export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
                 'react',
                 'react/jsx-runtime',
                 'react/jsx-dev-runtime',
+                'react/compiler-runtime', // react 19
+                'react-compiler-runtime', // react <= 18
                 'react-dom',
                 'react-dom/server',
                 '@remix-run/server-runtime',


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

`react-compiler-runtime` is published by the react core team, and needs to be handled the same way as `react/jsx-runtime`. Same goes for the new react 19 `react/compiler-runtime` entrypoint.
We did the same fix for Astro: https://github.com/withastro/astro/pull/12735

### WHAT is this pull request doing?

Just adds CJS to ESM optimizations to the vite pipeline for [React Compiler](https://react.dev/learn/react-compiler#using-the-compiler-on-libraries)

### HOW to test your changes?

I don't know if you have a React Compiler pipeline setup, but at Sanity we publish a range of libraries that publish code using `react-compiler-runtime` that you can test:
- `react-rx`
- `@portabletext/editor`
- `@sanity/visual-editing/remix`

#### Post-merge steps

Not really, this is part of the public API of supporting React and is just expected by consumer will work.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
