### PR TITLE
Turn on `v3_lazyRouteDiscovery` flag

### DIFF
--- a/.changeset/stupid-socks-suffer.md
+++ b/.changeset/stupid-socks-suffer.md
@@ -4,3 +4,25 @@
 ---
 
 Turn on future flag `v3_lazyRouteDiscovery`
+
+In your vite.config.ts, add the following line:
+
+```diff
+export default defineConfig({
+  plugins: [
+    hydrogen(),
+    oxygen(),
+    remix({
+      presets: [hydrogen.preset()],
+      future: {
+        v3_fetcherPersist: true,
+        v3_relativeSplatPath: true,
+        v3_throwAbortReason: true,
++        v3_lazyRouteDiscovery: true,
+      },
+    }),
+    tsconfigPaths(),
+  ],
+```
+
+Test your app by running `npm run dev` and nothing should break

--- a/.changeset/stupid-socks-suffer.md
+++ b/.changeset/stupid-socks-suffer.md
@@ -1,0 +1,6 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+---
+
+Turn on future flag `v3_lazyRouteDiscovery`

--- a/examples/classic-remix/remix.config.js
+++ b/examples/classic-remix/remix.config.js
@@ -20,5 +20,6 @@ module.exports = {
     v3_fetcherPersist: true,
     v3_relativeSplatpath: true,
     v3_throwAbortReason: true,
+    v3_lazyRouteDiscovery: true,
   },
 };

--- a/examples/express/vite.config.ts
+++ b/examples/express/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
         v3_fetcherPersist: true,
         v3_relativeSplatPath: true,
         v3_throwAbortReason: true,
+        v3_lazyRouteDiscovery: true,
       },
     }),
     tsconfigPaths(),

--- a/examples/multipass/vite.config.ts
+++ b/examples/multipass/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         v3_fetcherPersist: true,
         v3_relativeSplatPath: true,
         v3_throwAbortReason: true,
+        v3_lazyRouteDiscovery: true,
       },
     }),
     tsconfigPaths(),

--- a/packages/cli/assets/vite/vite.config.js
+++ b/packages/cli/assets/vite/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
         v3_fetcherPersist: true,
         v3_relativeSplatPath: true,
         v3_throwAbortReason: true,
+        v3_lazyRouteDiscovery: true,
       },
     }),
     tsconfigPaths(),

--- a/templates/skeleton/app/routes/collections._index.tsx
+++ b/templates/skeleton/app/routes/collections._index.tsx
@@ -84,6 +84,7 @@ function CollectionItem({
           aspectRatio="1/1"
           data={collection.image}
           loading={index < 3 ? 'eager' : undefined}
+          sizes="(min-width: 45em) 400px, 100vw"
         />
       )}
       <h5>{collection.title}</h5>

--- a/templates/skeleton/app/routes/collections._index.tsx
+++ b/templates/skeleton/app/routes/collections._index.tsx
@@ -84,7 +84,6 @@ function CollectionItem({
           aspectRatio="1/1"
           data={collection.image}
           loading={index < 3 ? 'eager' : undefined}
-          sizes="(min-width: 45em) 400px, 100vw"
         />
       )}
       <h5>{collection.title}</h5>

--- a/templates/skeleton/vite.config.ts
+++ b/templates/skeleton/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         v3_fetcherPersist: true,
         v3_relativeSplatPath: true,
         v3_throwAbortReason: true,
+        v3_lazyRouteDiscovery: true,
       },
     }),
     tsconfigPaths(),


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Turn on `v3_lazyRouteDiscovery` future flag

Remix guide: https://remix.run/docs/en/main/start/future-flags#v3_lazyroutediscovery

### Steps:

In your `vite.config.ts`, add the following line:

```diff
export default defineConfig({
  plugins: [
    hydrogen(),
    oxygen(),
    remix({
      presets: [hydrogen.preset()],
      future: {
        v3_fetcherPersist: true,
        v3_relativeSplatPath: true,
        v3_throwAbortReason: true,
+        v3_lazyRouteDiscovery: true,
      },
    }),
    tsconfigPaths(),
  ],
```

### HOW to test your changes?

`npm run dev` your app and nothing should break

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
