### PR TITLE
Fix image warnings

### DIFF
--- a/.changeset/tender-cycles-sneeze.md
+++ b/.changeset/tender-cycles-sneeze.md
@@ -1,0 +1,5 @@
+---
+'skeleton': patch
+---
+
+Fix image size warnings on collections page

--- a/templates/skeleton/app/routes/collections._index.tsx
+++ b/templates/skeleton/app/routes/collections._index.tsx
@@ -84,6 +84,7 @@ function CollectionItem({
           aspectRatio="1/1"
           data={collection.image}
           loading={index < 3 ? 'eager' : undefined}
+          sizes="(min-width: 45em) 400px, 100vw"
         />
       )}
       <h5>{collection.title}</h5>


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

We have been getting these image size warnings from the skeleton template for the longest time.

<img width="697" alt="Screenshot 2025-01-10 at 2 07 41 PM" src="https://github.com/user-attachments/assets/4fdb9eed-18c0-413e-add1-c82d7a5d4c46" />


### WHAT is this pull request doing?

Fix that warning

### HOW to test your changes?

1. locally run the project
2. navigate to `/collections`

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
