### PR TITLE
Fix `getProductOption` from crashing when one of the optionValues doesn't return a `firstSelectableVariant`

### DIFF
--- a/.changeset/nasty-rules-hammer.md
+++ b/.changeset/nasty-rules-hammer.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen-react': patch
+'@shopify/hydrogen': patch
+---
+
+Fix `getProductOptions` crashing when one of variants returns a null `firstSelectableVariant`.

--- a/packages/hydrogen-react/src/getProductOptions.test.ts
+++ b/packages/hydrogen-react/src/getProductOptions.test.ts
@@ -263,7 +263,7 @@ describe('getProductOptions', () => {
             },
             {
               "available": false,
-              "exists": false,
+              "exists": true,
               "firstSelectableVariant": null,
               "handle": "mail-it-in-freestyle-snowboard",
               "isDifferentProduct": false,

--- a/packages/hydrogen-react/src/getProductOptions.test.ts
+++ b/packages/hydrogen-react/src/getProductOptions.test.ts
@@ -208,6 +208,166 @@ describe('getProductOptions', () => {
       ]
     `);
   });
+
+  it('returns the options array with variant information even if one of the optionValue returns a null firstSelectableVariant', () => {
+    const options = getProductOptions(
+      PRODUCT_2 as unknown as RecursivePartial<Product>,
+    );
+    expect(options).toMatchInlineSnapshot(`
+      [
+        {
+          "name": "Size",
+          "optionValues": [
+            {
+              "available": true,
+              "exists": true,
+              "firstSelectableVariant": {
+                "availableForSale": true,
+                "id": "gid://shopify/ProductVariant/41007290613816",
+                "product": {
+                  "handle": "mail-it-in-freestyle-snowboard",
+                },
+                "selectedOptions": [
+                  {
+                    "name": "Size",
+                    "value": "154cm",
+                  },
+                  {
+                    "name": "Color",
+                    "value": "Sea Green / Desert",
+                  },
+                ],
+              },
+              "handle": "mail-it-in-freestyle-snowboard",
+              "isDifferentProduct": false,
+              "name": "154cm",
+              "selected": true,
+              "variant": {
+                "availableForSale": true,
+                "id": "gid://shopify/ProductVariant/41007290613816",
+                "product": {
+                  "handle": "mail-it-in-freestyle-snowboard",
+                },
+                "selectedOptions": [
+                  {
+                    "name": "Size",
+                    "value": "154cm",
+                  },
+                  {
+                    "name": "Color",
+                    "value": "Sea Green / Desert",
+                  },
+                ],
+              },
+              "variantUriQuery": "Size=154cm&Color=Sea+Green+%2F+Desert",
+            },
+            {
+              "available": false,
+              "exists": false,
+              "firstSelectableVariant": null,
+              "handle": "mail-it-in-freestyle-snowboard",
+              "isDifferentProduct": false,
+              "name": "158cm",
+              "selected": false,
+              "variant": null,
+              "variantUriQuery": "",
+            },
+            {
+              "available": true,
+              "exists": true,
+              "firstSelectableVariant": {
+                "availableForSale": true,
+                "id": "gid://shopify/ProductVariant/41007290679352",
+                "product": {
+                  "handle": "mail-it-in-freestyle-snowboard",
+                },
+                "selectedOptions": [
+                  {
+                    "name": "Size",
+                    "value": "160cm",
+                  },
+                  {
+                    "name": "Color",
+                    "value": "Sea Green / Desert",
+                  },
+                ],
+              },
+              "handle": "mail-it-in-freestyle-snowboard",
+              "isDifferentProduct": false,
+              "name": "160cm",
+              "selected": false,
+              "variant": {
+                "availableForSale": true,
+                "id": "gid://shopify/ProductVariant/41007290679352",
+                "product": {
+                  "handle": "mail-it-in-freestyle-snowboard",
+                },
+                "selectedOptions": [
+                  {
+                    "name": "Size",
+                    "value": "160cm",
+                  },
+                  {
+                    "name": "Color",
+                    "value": "Sea Green / Desert",
+                  },
+                ],
+              },
+              "variantUriQuery": "Size=160cm&Color=Sea+Green+%2F+Desert",
+            },
+          ],
+        },
+        {
+          "name": "Color",
+          "optionValues": [
+            {
+              "available": true,
+              "exists": true,
+              "firstSelectableVariant": {
+                "availableForSale": true,
+                "id": "gid://shopify/ProductVariant/41007290613816",
+                "product": {
+                  "handle": "mail-it-in-freestyle-snowboard",
+                },
+                "selectedOptions": [
+                  {
+                    "name": "Size",
+                    "value": "154cm",
+                  },
+                  {
+                    "name": "Color",
+                    "value": "Sea Green / Desert",
+                  },
+                ],
+              },
+              "handle": "mail-it-in-freestyle-snowboard",
+              "isDifferentProduct": false,
+              "name": "Sea Green / Desert",
+              "selected": true,
+              "variant": {
+                "availableForSale": true,
+                "id": "gid://shopify/ProductVariant/41007290613816",
+                "product": {
+                  "handle": "mail-it-in-freestyle-snowboard",
+                },
+                "selectedOptions": [
+                  {
+                    "name": "Size",
+                    "value": "154cm",
+                  },
+                  {
+                    "name": "Color",
+                    "value": "Sea Green / Desert",
+                  },
+                ],
+              },
+              "variantUriQuery": "Size=154cm&Color=Sea+Green+%2F+Desert",
+            },
+          ],
+        },
+      ]
+    `);
+  })
 });
 
 describe('getAdjacentAndFirstAvailableVariants', () => {
@@ -469,39 +629,6 @@ describe('checkProductParam', () => {
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
       `${ERROR_MSG_START}options.optionValues.name${ERROR_MSG_END}`,
-    );
-  });
-
-  it('logs warnings when provided an invalid options input - missing optionValues.firstSelectableVariant', () => {
-    checkProductParam(
-      {
-        id: 'snowboard',
-        handle: 'snowboard',
-        options: [
-          {
-            name: 'Color',
-            optionValues: [
-              {
-                name: 'Turquoise',
-                swatch: {
-                  color: '#6cbfc0',
-                  image: null,
-                },
-              },
-            ],
-          },
-        ],
-        encodedVariantExistence: '',
-        encodedVariantAvailability: '',
-        selectedOrFirstAvailableVariant: null,
-        adjacentVariants: [],
-      } as unknown as RecursivePartial<Product>,
-      true,
-    );
-
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledWith(
-      `${ERROR_MSG_START}options.optionValues.firstSelectableVariant${ERROR_MSG_END}`,
     );
   });
 
@@ -1063,6 +1190,47 @@ describe('checkProductParam', () => {
       `${ERROR_MSG_START}adjacentVariants.selectedOptions.value${ERROR_MSG_END}`,
     );
   });
+
+  it('does not log warnings when provided options has one of the optionValue that is returning a null firstSelectableVariant', () => {
+    checkProductParam(
+      {
+        id: 'snowboard',
+        handle: 'snowboard',
+        options: [
+          {
+            name: 'Color',
+            optionValues: [
+              {
+                name: 'Turquoise',
+                firstSelectableVariant: null,
+              },
+              {
+                name: 'Ember',
+                firstSelectableVariant: {
+                  product: {
+                    handle: 'snowboard',
+                  },
+                  selectedOptions: [
+                    {
+                      name: 'Color',
+                      value: 'Ember',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        encodedVariantExistence: '',
+        encodedVariantAvailability: '',
+        selectedOrFirstAvailableVariant: null,
+        adjacentVariants: [],
+      } as unknown as RecursivePartial<Product>,
+      true,
+    );
+
+    expect(console.error).toHaveBeenCalledTimes(0);
+  });
 });
 
 const PRODUCT = {
@@ -1201,6 +1369,126 @@ const PRODUCT = {
         },
       ],
     },
+    {
+      availableForSale: true,
+      id: 'gid://shopify/ProductVariant/41007290679352',
+      product: {
+        handle: 'mail-it-in-freestyle-snowboard',
+      },
+      selectedOptions: [
+        {
+          name: 'Size',
+          value: '160cm',
+        },
+        {
+          name: 'Color',
+          value: 'Sea Green / Desert',
+        },
+      ],
+    },
+  ],
+};
+
+
+const PRODUCT_2 = {
+  id: 'gid://shopify/Product/6730949034040',
+  handle: 'mail-it-in-freestyle-snowboard',
+  encodedVariantExistence: 'v1_0:0,1:0,2:0,',
+  encodedVariantAvailability: 'v1_0:0,2:0,',
+  options: [
+    {
+      name: 'Size',
+      optionValues: [
+        {
+          name: '154cm',
+          firstSelectableVariant: {
+            availableForSale: true,
+            id: 'gid://shopify/ProductVariant/41007290613816',
+            product: {
+              handle: 'mail-it-in-freestyle-snowboard',
+            },
+            selectedOptions: [
+              {
+                name: 'Size',
+                value: '154cm',
+              },
+              {
+                name: 'Color',
+                value: 'Sea Green / Desert',
+              },
+            ],
+          },
+        },
+        {
+          name: '158cm',
+          firstSelectableVariant: null,
+        },
+        {
+          name: '160cm',
+          firstSelectableVariant: {
+            availableForSale: true,
+            id: 'gid://shopify/ProductVariant/41007290679352',
+            product: {
+              handle: 'mail-it-in-freestyle-snowboard',
+            },
+            selectedOptions: [
+              {
+                name: 'Size',
+                value: '160cm',
+              },
+              {
+                name: 'Color',
+                value: 'Sea Green / Desert',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      name: 'Color',
+      optionValues: [
+        {
+          name: 'Sea Green / Desert',
+          firstSelectableVariant: {
+            availableForSale: true,
+            id: 'gid://shopify/ProductVariant/41007290613816',
+            product: {
+              handle: 'mail-it-in-freestyle-snowboard',
+            },
+            selectedOptions: [
+              {
+                name: 'Size',
+                value: '154cm',
+              },
+              {
+                name: 'Color',
+                value: 'Sea Green / Desert',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  selectedOrFirstAvailableVariant: {
+    availableForSale: true,
+    id: 'gid://shopify/ProductVariant/41007290613816',
+    product: {
+      handle: 'mail-it-in-freestyle-snowboard',
+    },
+    selectedOptions: [
+      {
+        name: 'Size',
+        value: '154cm',
+      },
+      {
+        name: 'Color',
+        value: 'Sea Green / Desert',
+      },
+    ],
+  },
+  adjacentVariants: [
     {
       availableForSale: true,
       id: 'gid://shopify/ProductVariant/41007290679352',

--- a/packages/hydrogen-react/src/getProductOptions.test.ts
+++ b/packages/hydrogen-react/src/getProductOptions.test.ts
@@ -367,7 +367,7 @@ describe('getProductOptions', () => {
         },
       ]
     `);
-  })
+  });
 });
 
 describe('getAdjacentAndFirstAvailableVariants', () => {
@@ -1388,7 +1388,6 @@ const PRODUCT = {
     },
   ],
 };
-
 
 const PRODUCT_2 = {
   id: 'gid://shopify/Product/6730949034040',

--- a/packages/hydrogen-react/src/getProductOptions.ts
+++ b/packages/hydrogen-react/src/getProductOptions.ts
@@ -432,7 +432,7 @@ export function getProductOptions(
           handle,
           variantUriQuery: searchParams.toString(),
           selected: selectedOptions[option.name] === value.name,
-          exists: exists ? !!variant : exists,
+          exists,
           available,
           isDifferentProduct: handle !== productHandle,
         };

--- a/packages/hydrogen-react/src/getProductOptions.ts
+++ b/packages/hydrogen-react/src/getProductOptions.ts
@@ -420,7 +420,7 @@ export function getProductOptions(
 
         // Build the query params for this option value
         let variantOptionParam = {};
-        if (!!variant) {
+        if (variant) {
           variantOptionParam = mapSelectedProductOptionToObject(
             variant.selectedOptions || [],
           );

--- a/packages/hydrogen-react/src/getProductOptions.ts
+++ b/packages/hydrogen-react/src/getProductOptions.ts
@@ -241,7 +241,9 @@ export function checkProductParam(
       }
 
       // It is possible for firstSelectableVariant to be null
-      firstOptionValues = product.options[0].optionValues.filter((value) => !!value?.firstSelectableVariant)[0];
+      firstOptionValues = product.options[0].optionValues.filter(
+        (value) => !!value?.firstSelectableVariant,
+      )[0];
 
       // Check for options.optionValues.firstSelectableVariant
       if (firstOptionValues?.firstSelectableVariant) {

--- a/packages/hydrogen-react/src/getProductOptions.ts
+++ b/packages/hydrogen-react/src/getProductOptions.ts
@@ -233,12 +233,15 @@ export function checkProductParam(
 
     // Check for options.optionValues
     if (product?.options[0]?.optionValues) {
-      const firstOptionValues = product.options[0].optionValues[0];
+      let firstOptionValues = product.options[0].optionValues[0];
 
       // Check for options.optionValues.name
       if (checkAll && !firstOptionValues?.name) {
         validParam = logErrorAndReturnFalse('options.optionValues.name');
       }
+
+      // It is possible for firstSelectableVariant to be null
+      firstOptionValues = product.options[0].optionValues.filter((value) => !!value?.firstSelectableVariant)[0];
 
       // Check for options.optionValues.firstSelectableVariant
       if (firstOptionValues?.firstSelectableVariant) {
@@ -248,10 +251,6 @@ export function checkProductParam(
           'options.optionValues.firstSelectableVariant',
           validParam,
           checkAll,
-        );
-      } else {
-        validParam = logErrorAndReturnFalse(
-          'options.optionValues.firstSelectableVariant',
         );
       }
     } else {
@@ -418,11 +417,14 @@ export function getProductOptions(
           variants[targetKey] || value.firstSelectableVariant;
 
         // Build the query params for this option value
-        const variantOptionParam = mapSelectedProductOptionToObject(
-          variant.selectedOptions || [],
-        );
+        let variantOptionParam = {};
+        if (!!variant) {
+          variantOptionParam = mapSelectedProductOptionToObject(
+            variant.selectedOptions || [],
+          );
+        }
         const searchParams = new URLSearchParams(variantOptionParam);
-        const handle = variant?.product?.handle;
+        const handle = variant?.product?.handle || productHandle;
 
         return {
           ...value,
@@ -430,7 +432,7 @@ export function getProductOptions(
           handle,
           variantUriQuery: searchParams.toString(),
           selected: selectedOptions[option.name] === value.name,
-          exists,
+          exists: exists ? !!variant : exists,
           available,
           isDifferentProduct: handle !== productHandle,
         };


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/hydrogen/issues/2698

On a very rare occasion, `optionValues.firstSelectableVariant` may return `null`. 

### WHAT is this pull request doing?

Make sure `getProductOption` handles well if encountered a null `firstSelectableVariant`.

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
