### PR TITLE
🌟 Add Taxonomy Metafields to Product Types

### DIFF
--- a/packages/hydrogen-react/src/storefront-api-types.d.ts
+++ b/packages/hydrogen-react/src/storefront-api-types.d.ts
@@ -6111,6 +6111,8 @@ export type ProductEdge = {
 export type ProductFilter = {
   /** Filter on if the product is available for sale. */
   available?: InputMaybe<Scalars['Boolean']['input']>;
+  /** A product category to filter on. */
+  category?: InputMaybe<CategoryFilter>;
   /** A range of prices to filter with-in. */
   price?: InputMaybe<PriceRangeFilter>;
   /** A product metafield to filter on. */
@@ -6121,10 +6123,32 @@ export type ProductFilter = {
   productVendor?: InputMaybe<Scalars['String']['input']>;
   /** A product tag to filter on. */
   tag?: InputMaybe<Scalars['String']['input']>;
+  /** A standard product attribute metafield to filter on. */
+  taxonomyMetafield?: InputMaybe<TaxonomyMetafieldFilter>;
   /** A variant metafield to filter on. */
   variantMetafield?: InputMaybe<MetafieldFilter>;
   /** A variant option to filter on. */
   variantOption?: InputMaybe<VariantOptionFilter>;
+};
+
+/**
+ * A filter used to view a subset of products in a collection that match a specific category.
+ */
+export type CategoryFilter = {
+  /** The category values to filter on. */
+  id: Scalars['String']['input'];
+};
+
+/**
+ * A filter used to view a subset of products in a collection that match a specific taxonomy metafield.
+ */
+export type TaxonomyMetafieldFilter = {
+  /** The key of the taxonomy metafield to filter on. */
+  key: Scalars['String']['input'];
+  /** The namespace of the taxonomy metafield to filter on. */
+  namespace: Scalars['String']['input'];
+  /** The value of the taxonomy metafield to filter on. */
+  value: Scalars['String']['input'];
 };
 
 /** The set of valid sort keys for the ProductImage query. */


### PR DESCRIPTION
### WHY are these changes introduced?

When developing a Hydrogen store, I wanted to filter Taxonomy Metafields on my Collection filters and noticed I was getting an error on the ProductTypes type definition.

![image](https://github.com/user-attachments/assets/c3ef5407-f72f-4fcc-991f-d1ea2fc865eb)

After checking, I've could confirm the taxonomyMetafield property is not defined there, making it incompatible with Shopify GraphQL documentation:

https://shopify.dev/docs/api/storefront/2025-01/input-objects/ProductFilter

This is my first PR here, so please forgive me if I forgot something.

### WHAT is this pull request doing?

This PR adds 2 missing fields to ProductType definition:
- Category, and the respective category object that accepts an ID as a string
- TaxonomyMetafield, which although is identical to the generic Metafield object, it's defined as it's own object according to the same shopify doc link above.

### HOW to test your changes?

I did by querying GraphQL:

#### Query

```graphql
query CollectionWithTaxonomyFilter(
  $handle: String!
  $filters: [ProductFilter!]
  $first: Int
) {
  collection(handle: $handle) {
    id
    title
    description
    products(
      first: $first
      filters: $filters
    ) {
      nodes {
        id
        title
        description
        priceRange {
          minVariantPrice {
            amount
            currencyCode
          }
        }
        featuredImage {
          url
          altText
        }
      }
      pageInfo {
        hasNextPage
        endCursor
      }
    }
  }
}
```

#### Variables

```js
{
  "handle": "your-collection-handle",
  "first": 12,
  "filters": [
    {
      "taxonomyMetafield": {
        "namespace": "custom",
        "key": "category",
        "value": "electronics"
      }
    }
  ]
}
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation
