### PR TITLE
chore(docs): replace "action" to "loader" in the login function comment

### DIFF
--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -59,7 +59,7 @@ export type LogoutOptions = {
 };
 
 export type CustomerAccount = {
-  /** Start the OAuth login flow. This function should be called and returned from a Remix loader or an action.
+  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.
    * It redirects the customer to a Shopify login domain. It also defined the final path the customer
    * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is
    * automatically setup unless `customAuthStatusHandler` option is in use)

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -59,7 +59,7 @@ export type LogoutOptions = {
 };
 
 export type CustomerAccount = {
-  /** Start the OAuth login flow. This function should be called and returned from a Remix action.
+  /** Start the OAuth login flow. This function should be called and returned from a Remix loader or an action.
    * It redirects the customer to a Shopify login domain. It also defined the final path the customer
    * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is
    * automatically setup unless `customAuthStatusHandler` option is in use)


### PR DESCRIPTION
### WHY are these changes introduced?

Currently the comment for our `CustomerAccount#login` function specify it should be called and returned from an `action`, though it should be done from a `loader` - and this is what we also write in our [docs](https://shopify.dev/docs/storefronts/headless/building-with-the-customer-account-api/hydrogen#create-the-login-route).

### WHAT is this pull request doing?
Fixes the wording in the comment.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
