### PR TITLE
Add Hydrogen context provider for i18n overrides

### DIFF
--- a/packages/hydrogen-react/src/HydrogenProvider.doc.ts
+++ b/packages/hydrogen-react/src/HydrogenProvider.doc.ts
@@ -1,0 +1,44 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'HydrogenProvider',
+  category: 'components',
+  isVisualComponent: false,
+  related: [
+    {
+      name: 'useShop',
+      type: 'hook',
+      url: '/api/hydrogen-react/hooks/useshop',
+    },
+  ],
+  description:
+    "The `HydrogenProvider` component wraps your entire Hydrogen app and provides localization data for the app. You should place it in your app's entry point component.",
+  type: 'component',
+  defaultExample: {
+    description: 'I am the default example',
+    codeblock: {
+      tabs: [
+        {
+          title: 'JavaScript',
+          code: './HydrogenProvider.example.jsx',
+          language: 'jsx',
+        },
+        {
+          title: 'TypeScript',
+          code: './HydrogenProvider.example.tsx',
+          language: 'tsx',
+        },
+      ],
+      title: 'Example code',
+    },
+  },
+  definitions: [
+    {
+      title: 'Props',
+      type: 'HydrogenContextProps',
+      description: '',
+    },
+  ],
+};
+
+export default data;

--- a/packages/hydrogen-react/src/HydrogenProvider.example.jsx
+++ b/packages/hydrogen-react/src/HydrogenProvider.example.jsx
@@ -1,0 +1,20 @@
+import {HydrogenProvider, useShop} from '@shopify/hydrogen-react';
+
+export default function App() {
+  return (
+    <HydrogenProvider countryIsoCode="CA" languageIsoCode="EN">
+      <UsingUseShop />
+    </HydrogenProvider>
+  );
+}
+
+export function UsingUseShop() {
+  const shop = useShop();
+
+  return (
+    <>
+      <div>{shop.languageIsoCode}</div>
+      <div>{shop.countryIsoCode}</div>
+    </>
+  );
+}

--- a/packages/hydrogen-react/src/HydrogenProvider.example.tsx
+++ b/packages/hydrogen-react/src/HydrogenProvider.example.tsx
@@ -1,0 +1,20 @@
+import {HydrogenProvider, useShop} from '@shopify/hydrogen-react';
+
+export default function App() {
+  return (
+    <HydrogenProvider countryIsoCode="CA" languageIsoCode="EN">
+      <UsingUseShop />
+    </HydrogenProvider>
+  );
+}
+
+export function UsingUseShop() {
+  const shop = useShop();
+
+  return (
+    <>
+      <div>{shop.languageIsoCode}</div>
+      <div>{shop.countryIsoCode}</div>
+    </>
+  );
+}

--- a/packages/hydrogen-react/src/HydrogenProvider.test.tsx
+++ b/packages/hydrogen-react/src/HydrogenProvider.test.tsx
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'vitest';
+
+import {render, screen, renderHook} from '@testing-library/react';
+import {useShop} from './ShopifyProvider.js';
+import {HydrogenProvider} from './HydrogenProvider.js';
+
+describe('<HydrogenProvider/>', () => {
+  it('renders its children', () => {
+    render(
+      <HydrogenProvider countryIsoCode={'US'} languageIsoCode={'EN'}>
+        <div>child</div>;
+      </HydrogenProvider>,
+    );
+
+    expect(screen.getByText('child')).toBeInTheDocument();
+  });
+
+  it('returns the hydrogen context values', () => {
+    const {result} = renderHook(() => useShop(), {
+      wrapper: ({children}) => (
+        <HydrogenProvider countryIsoCode={'CA'} languageIsoCode={'FR'}>
+          {children}
+        </HydrogenProvider>
+      ),
+    });
+
+    expect(result.current.countryIsoCode).toBe('CA');
+    expect(result.current.languageIsoCode).toBe('FR');
+  });
+});

--- a/packages/hydrogen-react/src/HydrogenProvider.tsx
+++ b/packages/hydrogen-react/src/HydrogenProvider.tsx
@@ -1,12 +1,44 @@
-import {createContext} from 'react';
+import {createContext, ReactNode, useContext} from 'react';
 import {CountryCode, LanguageCode} from './storefront-api-types.js';
 
 export type HydrogenContextValue = {
-  languageIsoCode: LanguageCode | null;
+  /**
+   * The code designating a country, which generally follows ISO 3166-1 alpha-2 guidelines. If a territory doesn't have a country code value in the `CountryCode` enum, it might be considered a subdivision of another country. For example, the territories associated with Spain are represented by the country code `ES`, and the territories associated with the United States of America are represented by the country code `US`.
+   */
   countryIsoCode: CountryCode | null;
+  /**
+   * `ISO 369` language codes supported by Shopify.
+   */
+  languageIsoCode: LanguageCode | null;
 };
 
-export const HydrogenContext = createContext<HydrogenContextValue>({
+const defaultHydrogenContext: HydrogenContextValue = {
   languageIsoCode: null,
   countryIsoCode: null,
-});
+};
+
+const HydrogenContext = createContext<HydrogenContextValue>(
+  defaultHydrogenContext,
+);
+
+export interface HydrogenProviderProps extends HydrogenContextValue {
+  children: ReactNode;
+}
+
+/**
+ * The `<HydrogenProvider/>` component enables use of the `useShop()` hook. The component should wrap your Hydrogen app.
+ */
+export function HydrogenProvider({
+  children,
+  ...hydrogenConfig
+}: HydrogenProviderProps): JSX.Element {
+  return (
+    <HydrogenContext.Provider value={hydrogenConfig}>
+      {children}
+    </HydrogenContext.Provider>
+  );
+}
+
+export function useHydrogenContext(): HydrogenContextValue {
+  return useContext(HydrogenContext);
+}

--- a/packages/hydrogen-react/src/HydrogenProvider.tsx
+++ b/packages/hydrogen-react/src/HydrogenProvider.tsx
@@ -1,0 +1,12 @@
+import {createContext} from 'react';
+import {CountryCode, LanguageCode} from './storefront-api-types.js';
+
+export type HydrogenContextValue = {
+  languageIsoCode: LanguageCode | null;
+  countryIsoCode: CountryCode | null;
+};
+
+export const HydrogenContext = createContext<HydrogenContextValue>({
+  languageIsoCode: null,
+  countryIsoCode: null,
+});

--- a/packages/hydrogen-react/src/ShopifyProvider.test.tsx
+++ b/packages/hydrogen-react/src/ShopifyProvider.test.tsx
@@ -7,6 +7,7 @@ import {
   type ShopifyProviderProps,
 } from './ShopifyProvider.js';
 import type {PartialDeep} from 'type-fest';
+import {HydrogenContext, HydrogenContextValue} from './HydrogenProvider.js';
 
 const SHOPIFY_CONFIG: ShopifyProviderProps = {
   storeDomain: 'https://notashop.myshopify.com',
@@ -221,6 +222,61 @@ describe('<ShopifyProvider/>', () => {
       expect(result.current.getStorefrontApiUrl()).toBe(
         'https://notashop.myshopify.com/api/2025-01/graphql.json',
       );
+    });
+  });
+
+  describe('hydrogen context overrides', () => {
+    it('returns the hydrogen overrides if provided (partial override)', () => {
+      function runTest(hydrogenContextValue: HydrogenContextValue) {
+        const {result} = renderHook(() => useShop(), {
+          wrapper: ({children}) => (
+            <HydrogenContext.Provider value={hydrogenContextValue}>
+              <ShopifyProvider {...SHOPIFY_CONFIG}>{children}</ShopifyProvider>
+            </HydrogenContext.Provider>
+          ),
+        });
+        return result;
+      }
+
+      const result = runTest({languageIsoCode: 'FR', countryIsoCode: null});
+      expect(result.current.countryIsoCode).toBe(SHOPIFY_CONFIG.countryIsoCode);
+      expect(result.current.languageIsoCode).toBe('FR');
+    });
+
+    it('returns the hydrogen overrides if provided (full override)', () => {
+      function runTest(hydrogenContextValue: HydrogenContextValue) {
+        const {result} = renderHook(() => useShop(), {
+          wrapper: ({children}) => (
+            <HydrogenContext.Provider value={hydrogenContextValue}>
+              <ShopifyProvider {...SHOPIFY_CONFIG}>{children}</ShopifyProvider>
+            </HydrogenContext.Provider>
+          ),
+        });
+        return result;
+      }
+
+      const result = runTest({languageIsoCode: 'FR', countryIsoCode: 'FR'});
+      expect(result.current.countryIsoCode).toBe('FR');
+      expect(result.current.languageIsoCode).toBe('FR');
+    });
+
+    it('returns the hydrogen overrides if provided (full override, without ShopifyProvider)', () => {
+      // Note(FR): this ensures the current behavior – however it's arguable that not having the ShopifyProvider at all
+      // should not be possible, as docs currently say it _must_ be there.
+      function runTest(hydrogenContextValue: HydrogenContextValue) {
+        const {result} = renderHook(() => useShop(), {
+          wrapper: ({children}) => (
+            <HydrogenContext.Provider value={hydrogenContextValue}>
+              {children}
+            </HydrogenContext.Provider>
+          ),
+        });
+        return result;
+      }
+
+      const result = runTest({languageIsoCode: 'FR', countryIsoCode: 'FR'});
+      expect(result.current.countryIsoCode).toBe('FR');
+      expect(result.current.languageIsoCode).toBe('FR');
     });
   });
 });

--- a/packages/hydrogen-react/src/ShopifyProvider.test.tsx
+++ b/packages/hydrogen-react/src/ShopifyProvider.test.tsx
@@ -7,7 +7,7 @@ import {
   type ShopifyProviderProps,
 } from './ShopifyProvider.js';
 import type {PartialDeep} from 'type-fest';
-import {HydrogenContext, HydrogenContextValue} from './HydrogenProvider.js';
+import {HydrogenProvider} from './HydrogenProvider.js';
 
 const SHOPIFY_CONFIG: ShopifyProviderProps = {
   storeDomain: 'https://notashop.myshopify.com',
@@ -227,35 +227,28 @@ describe('<ShopifyProvider/>', () => {
 
   describe('hydrogen context overrides', () => {
     it('returns the hydrogen overrides if provided (partial override)', () => {
-      function runTest(hydrogenContextValue: HydrogenContextValue) {
-        const {result} = renderHook(() => useShop(), {
-          wrapper: ({children}) => (
-            <HydrogenContext.Provider value={hydrogenContextValue}>
-              <ShopifyProvider {...SHOPIFY_CONFIG}>{children}</ShopifyProvider>
-            </HydrogenContext.Provider>
-          ),
-        });
-        return result;
-      }
+      const {result} = renderHook(() => useShop(), {
+        wrapper: ({children}) => (
+          <HydrogenProvider countryIsoCode={'FR'} languageIsoCode={null}>
+            <ShopifyProvider {...SHOPIFY_CONFIG}>{children}</ShopifyProvider>
+          </HydrogenProvider>
+        ),
+      });
 
-      const result = runTest({languageIsoCode: 'FR', countryIsoCode: null});
-      expect(result.current.countryIsoCode).toBe(SHOPIFY_CONFIG.countryIsoCode);
-      expect(result.current.languageIsoCode).toBe('FR');
+      expect(result.current.countryIsoCode).toBe('FR');
+      expect(result.current.languageIsoCode).toBe(
+        SHOPIFY_CONFIG.languageIsoCode,
+      );
     });
 
     it('returns the hydrogen overrides if provided (full override)', () => {
-      function runTest(hydrogenContextValue: HydrogenContextValue) {
-        const {result} = renderHook(() => useShop(), {
-          wrapper: ({children}) => (
-            <HydrogenContext.Provider value={hydrogenContextValue}>
-              <ShopifyProvider {...SHOPIFY_CONFIG}>{children}</ShopifyProvider>
-            </HydrogenContext.Provider>
-          ),
-        });
-        return result;
-      }
-
-      const result = runTest({languageIsoCode: 'FR', countryIsoCode: 'FR'});
+      const {result} = renderHook(() => useShop(), {
+        wrapper: ({children}) => (
+          <HydrogenProvider countryIsoCode={'FR'} languageIsoCode={'FR'}>
+            <ShopifyProvider {...SHOPIFY_CONFIG}>{children}</ShopifyProvider>
+          </HydrogenProvider>
+        ),
+      });
       expect(result.current.countryIsoCode).toBe('FR');
       expect(result.current.languageIsoCode).toBe('FR');
     });
@@ -263,18 +256,14 @@ describe('<ShopifyProvider/>', () => {
     it('returns the hydrogen overrides if provided (full override, without ShopifyProvider)', () => {
       // Note(FR): this ensures the current behavior – however it's arguable that not having the ShopifyProvider at all
       // should not be possible, as docs currently say it _must_ be there.
-      function runTest(hydrogenContextValue: HydrogenContextValue) {
-        const {result} = renderHook(() => useShop(), {
-          wrapper: ({children}) => (
-            <HydrogenContext.Provider value={hydrogenContextValue}>
-              {children}
-            </HydrogenContext.Provider>
-          ),
-        });
-        return result;
-      }
+      const {result} = renderHook(() => useShop(), {
+        wrapper: ({children}) => (
+          <HydrogenProvider countryIsoCode={'FR'} languageIsoCode={'FR'}>
+            {children}
+          </HydrogenProvider>
+        ),
+      });
 
-      const result = runTest({languageIsoCode: 'FR', countryIsoCode: 'FR'});
       expect(result.current.countryIsoCode).toBe('FR');
       expect(result.current.languageIsoCode).toBe('FR');
     });

--- a/packages/hydrogen-react/src/ShopifyProvider.tsx
+++ b/packages/hydrogen-react/src/ShopifyProvider.tsx
@@ -2,6 +2,7 @@ import {createContext, useContext, useMemo, type ReactNode} from 'react';
 import type {LanguageCode, CountryCode} from './storefront-api-types.js';
 import {SFAPI_VERSION} from './storefront-api-constants.js';
 import {getPublicTokenHeadersRaw} from './storefront-client.js';
+import {HydrogenContext} from './HydrogenProvider.js';
 
 export const defaultShopifyContext: ShopifyContextValue = {
   storeDomain: 'test',
@@ -94,7 +95,16 @@ export function useShop(): ShopifyContextValue {
   if (!shopContext) {
     throw new Error(`'useShop()' must be a descendent of <ShopifyProvider/>`);
   }
-  return shopContext;
+
+  const hydrogenContext = useContext(HydrogenContext);
+
+  return {
+    ...shopContext,
+    countryIsoCode:
+      hydrogenContext.countryIsoCode ?? shopContext.countryIsoCode,
+    languageIsoCode:
+      hydrogenContext.languageIsoCode ?? shopContext.languageIsoCode,
+  };
 }
 
 export interface ShopifyProviderBase {

--- a/packages/hydrogen-react/src/ShopifyProvider.tsx
+++ b/packages/hydrogen-react/src/ShopifyProvider.tsx
@@ -2,7 +2,7 @@ import {createContext, useContext, useMemo, type ReactNode} from 'react';
 import type {LanguageCode, CountryCode} from './storefront-api-types.js';
 import {SFAPI_VERSION} from './storefront-api-constants.js';
 import {getPublicTokenHeadersRaw} from './storefront-client.js';
-import {HydrogenContext} from './HydrogenProvider.js';
+import {useHydrogenContext} from './HydrogenProvider.js';
 
 export const defaultShopifyContext: ShopifyContextValue = {
   storeDomain: 'test',
@@ -96,7 +96,7 @@ export function useShop(): ShopifyContextValue {
     throw new Error(`'useShop()' must be a descendent of <ShopifyProvider/>`);
   }
 
-  const hydrogenContext = useContext(HydrogenContext);
+  const hydrogenContext = useHydrogenContext();
 
   return {
     ...shopContext,

--- a/packages/hydrogen-react/src/index.ts
+++ b/packages/hydrogen-react/src/index.ts
@@ -51,6 +51,7 @@ export {
   type MappedProductOptions,
   mapSelectedProductOptionToObject,
 } from './getProductOptions.js';
+export {HydrogenProvider} from './HydrogenProvider.js';
 export {Image, IMAGE_FRAGMENT} from './Image.js';
 export {useLoadScript} from './load-script.js';
 export {MediaFile} from './MediaFile.js';

--- a/templates/skeleton/app/root.tsx
+++ b/templates/skeleton/app/root.tsx
@@ -1,4 +1,5 @@
 import {useNonce, getShopAnalytics, Analytics} from '@shopify/hydrogen';
+import {HydrogenProvider} from '@shopify/hydrogen-react';
 import {defer, type LoaderFunctionArgs} from '@shopify/remix-oxygen';
 import {
   Links,
@@ -16,7 +17,6 @@ import resetStyles from '~/styles/reset.css?url';
 import appStyles from '~/styles/app.css?url';
 import {PageLayout} from '~/components/PageLayout';
 import {FOOTER_QUERY, HEADER_QUERY} from '~/lib/fragments';
-import {HydrogenContext} from '@shopify/hydrogen-react/HydrogenProvider';
 
 export type RootLoader = typeof loader;
 
@@ -155,11 +155,9 @@ export function Layout({children}: {children?: React.ReactNode}) {
         <Links />
       </head>
       <body>
-        <HydrogenContext.Provider
-          value={{
-            countryIsoCode: data?.i18n.country ?? null,
-            languageIsoCode: data?.i18n.language ?? null,
-          }}
+        <HydrogenProvider
+          countryIsoCode={data?.i18n.country ?? null}
+          languageIsoCode={data?.i18n.language ?? null}
         >
           {data ? (
             <Analytics.Provider
@@ -172,7 +170,7 @@ export function Layout({children}: {children?: React.ReactNode}) {
           ) : (
             children
           )}
-        </HydrogenContext.Provider>
+        </HydrogenProvider>
         <ScrollRestoration nonce={nonce} />
         <Scripts nonce={nonce} />
       </body>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2507 

`useMoney` and `Money` inside Hydrogen don't respect i18n localization params passed to the storefront context as those components take the localization data from a wrapping `ShopifyProvider`.

There are multiple possible ways of tackling this, with the spectrum going from introducing breaking changes, to adding renamed counterparts that receive explicit i18n data, to introducing a Hydrogen specific context that overrides the localization data. This PR implements the approach of the H2 context.

### WHAT is this pull request doing?

- Introduce a new `HydrogenContext` that contains the i18n data (country and language codes).
- Update the `useShop` hook (used by `useMoney`) to override the context data coming from `ShopifyProvider` with the values coming from `HydrogenContext` (if present).
- Update the skeleton template's `Layout` function so that it wraps everything with `HydrogenContext.Provider`.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation
