### PR TITLE
Use context i18n data automatically with customer account api login

### DIFF
--- a/.changeset/cyan-paws-punch.md
+++ b/.changeset/cyan-paws-punch.md
@@ -6,19 +6,12 @@ Added the ability to provide `language` data to `createCustomerAccountClient`, a
 The provided `language` will be used to set the `uilocales` property in the Customer Account API request.
 
 Calls to `login()` will use the provided `language` without having to pass it explicitly via `uiLocales`; however, if the `login()` method is
-already using its `uilocales` property, the `language` parameter coming from the context/constructor will be ignored.
+already using its `uilocales` property, the `language` parameter coming from the context/constructor will be ignored. If nothing is explicitly passed, `login()` will default to `context.i18n.language`.
 
 ```ts
 const customerAccount = createCustomerAccountClient({
   // ...
-  language: 'EN',
-});
-```
-
-```ts
-const hydrogenContext =  createHydrogenContext({
-  // ...
-  language: 'EN', // will be passed to the `customerAccount` instance
+  i18n,
 });
 ```
 

--- a/.changeset/cyan-paws-punch.md
+++ b/.changeset/cyan-paws-punch.md
@@ -1,0 +1,31 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Added the ability to provide `language` data to `createCustomerAccountClient`, and automatically pass it down to it from `createHydrogenContext`.
+The provided `language` will be used to set the `uilocales` property in the Customer Account API request.
+
+Calls to `login()` will use the provided `language` without having to pass it explicitly via `uiLocales`; however, if the `login()` method is
+already using its `uilocales` property, the `language` parameter coming from the context/constructor will be ignored.
+
+```ts
+const customerAccount = createCustomerAccountClient({
+  // ...
+  language: 'EN',
+});
+```
+
+```ts
+const hydrogenContext =  createHydrogenContext({
+  // ...
+  language: 'EN', // will be passed to the `customerAccount` instance
+});
+```
+
+```ts
+export async function loader({request, context}: LoaderFunctionArgs) {
+  return context.customerAccount.login({
+    uiLocales: 'FR', // will be used instead of the one coming from the context
+  });
+}
+```

--- a/.changeset/cyan-paws-punch.md
+++ b/.changeset/cyan-paws-punch.md
@@ -11,7 +11,7 @@ already using its `uilocales` property, the `language` parameter coming from the
 ```ts
 const customerAccount = createCustomerAccountClient({
   // ...
-  i18n,
+  language,
 });
 ```
 

--- a/.changeset/cyan-paws-punch.md
+++ b/.changeset/cyan-paws-punch.md
@@ -2,18 +2,19 @@
 '@shopify/hydrogen': patch
 ---
 
-Added the ability to provide `language` data to `createCustomerAccountClient`, and automatically pass it down to it from `createHydrogenContext`.
-The provided `language` will be used to set the `uilocales` property in the Customer Account API request.
-
-Calls to `login()` will use the provided `language` without having to pass it explicitly via `uiLocales`; however, if the `login()` method is
-already using its `uilocales` property, the `language` parameter coming from the context/constructor will be ignored. If nothing is explicitly passed, `login()` will default to `context.i18n.language`.
+Added the ability to optionally provide `language` data to `createCustomerAccountClient`, and automatically pass it down to it from `createHydrogenContext`.
+If present, the provided `language` will be used to set the `uilocales` property in the Customer Account API request.
 
 ```ts
+// Optional: provide language data to the constructor
 const customerAccount = createCustomerAccountClient({
   // ...
   language,
 });
 ```
+
+Calls to `login()` will use the provided `language` without having to pass it explicitly via `uiLocales`; however, if the `login()` method is
+already using its `uilocales` property, the `language` parameter coming from the context/constructor will be ignored. If nothing is explicitly passed, `login()` will default to `context.i18n.language`.
 
 ```ts
 export async function loader({request, context}: LoaderFunctionArgs) {

--- a/packages/hydrogen/src/createHydrogenContext.test.ts
+++ b/packages/hydrogen/src/createHydrogenContext.test.ts
@@ -9,6 +9,7 @@ import {
 } from './cart/createCartHandler';
 import {cartGetIdDefault} from './cart/cartGetIdDefault';
 import {cartSetIdDefault} from './cart/cartSetIdDefault';
+import type {CustomerAccount} from './customer/types';
 import type {HydrogenSession} from './types';
 
 vi.mock('./storefront', async () => ({

--- a/packages/hydrogen/src/createHydrogenContext.test.ts
+++ b/packages/hydrogen/src/createHydrogenContext.test.ts
@@ -1,6 +1,6 @@
 import {vi, describe, it, expect, afterEach, expectTypeOf} from 'vitest';
 import {createHydrogenContext} from './createHydrogenContext';
-import {createStorefrontClient, I18nBase} from './storefront';
+import {createStorefrontClient} from './storefront';
 import {createCustomerAccountClient} from './customer/customer';
 import {
   createCartHandler,
@@ -9,7 +9,6 @@ import {
 } from './cart/createCartHandler';
 import {cartGetIdDefault} from './cart/cartGetIdDefault';
 import {cartSetIdDefault} from './cart/cartSetIdDefault';
-import type {CustomerAccount} from './customer/types';
 import type {HydrogenSession} from './types';
 
 vi.mock('./storefront', async () => ({
@@ -168,21 +167,6 @@ describe('createHydrogenContext', () => {
       expect(vi.mocked(createStorefrontClient)).toHaveBeenCalledWith(
         expect.objectContaining({
           storefrontApiVersion: mockApiVersion,
-        }),
-      );
-    });
-
-    it('passes the i18n object to the storefront client', async () => {
-      const mockI18n: I18nBase = {language: 'EN', country: 'CA'};
-
-      createHydrogenContext({
-        ...defaultOptions,
-        i18n: mockI18n,
-      });
-
-      expect(vi.mocked(createStorefrontClient)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          i18n: mockI18n,
         }),
       );
     });

--- a/packages/hydrogen/src/createHydrogenContext.test.ts
+++ b/packages/hydrogen/src/createHydrogenContext.test.ts
@@ -1,6 +1,6 @@
 import {vi, describe, it, expect, afterEach, expectTypeOf} from 'vitest';
 import {createHydrogenContext} from './createHydrogenContext';
-import {createStorefrontClient} from './storefront';
+import {createStorefrontClient, I18nBase} from './storefront';
 import {createCustomerAccountClient} from './customer/customer';
 import {
   createCartHandler,
@@ -168,6 +168,21 @@ describe('createHydrogenContext', () => {
       expect(vi.mocked(createStorefrontClient)).toHaveBeenCalledWith(
         expect.objectContaining({
           storefrontApiVersion: mockApiVersion,
+        }),
+      );
+    });
+
+    it('passes the i18n object to the storefront client', async () => {
+      const mockI18n: I18nBase = {language: 'EN', country: 'CA'};
+
+      createHydrogenContext({
+        ...defaultOptions,
+        i18n: mockI18n,
+      });
+
+      expect(vi.mocked(createStorefrontClient)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          i18n: mockI18n,
         }),
       );
     });

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -205,6 +205,9 @@ export function createHydrogenContext<
     authUrl: customerAccountOptions?.authUrl,
     customAuthStatusHandler: customerAccountOptions?.customAuthStatusHandler,
 
+    // locale
+    i18n,
+
     // defaults
     customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID,
     shopId: env.SHOP_ID,

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -206,7 +206,7 @@ export function createHydrogenContext<
     customAuthStatusHandler: customerAccountOptions?.customAuthStatusHandler,
 
     // locale
-    language: i18n?.language,
+    i18n,
 
     // defaults
     customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID,

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -206,7 +206,7 @@ export function createHydrogenContext<
     customAuthStatusHandler: customerAccountOptions?.customAuthStatusHandler,
 
     // locale
-    i18n,
+    language: i18n?.language,
 
     // defaults
     customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID,

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -173,7 +173,6 @@ describe('customer', () => {
       describe('locales', () => {
         it('Redirects to the customer account api login url with uiLocales as param (i18n in the constructor)', async () => {
           const origin = 'https://something-good.com';
-          const authUrl = 'https://something-bad.com/customer-account/auth';
 
           const customer = createCustomerAccountClient({
             session,
@@ -181,7 +180,6 @@ describe('customer', () => {
             shopId: '1',
             request: new Request(origin),
             waitUntil: vi.fn(),
-            authUrl,
             i18n: {language: 'FR', country: 'CA'},
           });
 
@@ -193,7 +191,6 @@ describe('customer', () => {
 
         it('Redirects to the customer account api login url with uiLocales as param (uiLocales in the param)', async () => {
           const origin = 'https://something-good.com';
-          const authUrl = 'https://something-bad.com/customer-account/auth';
 
           const customer = createCustomerAccountClient({
             session,
@@ -201,7 +198,6 @@ describe('customer', () => {
             shopId: '1',
             request: new Request(origin),
             waitUntil: vi.fn(),
-            authUrl,
           });
 
           const response = await customer.login({
@@ -214,7 +210,6 @@ describe('customer', () => {
 
         it('Redirects to the customer account api login url with uiLocales as param (override)', async () => {
           const origin = 'https://something-good.com';
-          const authUrl = 'https://something-bad.com/customer-account/auth';
 
           const customer = createCustomerAccountClient({
             session,
@@ -222,7 +217,6 @@ describe('customer', () => {
             shopId: '1',
             request: new Request(origin),
             waitUntil: vi.fn(),
-            authUrl,
             i18n: {language: 'IT', country: 'IT'},
           });
 

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -3,7 +3,6 @@ import type {HydrogenSession, HydrogenSessionData} from '../types';
 import {createCustomerAccountClient, getMaybeUILocales} from './customer';
 import {BUYER_SESSION_KEY, CUSTOMER_ACCOUNT_SESSION_KEY} from './constants';
 import crypto from 'node:crypto';
-import {LanguageCode} from '@shopify/hydrogen-react/storefront-api-types';
 
 if (!globalThis.crypto) {
   globalThis.crypto = crypto as any;
@@ -180,7 +179,7 @@ describe('customer', () => {
             shopId: '1',
             request: new Request(origin),
             waitUntil: vi.fn(),
-            language: 'FR',
+            i18n: {language: 'FR', country: 'FR'},
           });
 
           const response = await customer.login();
@@ -217,7 +216,7 @@ describe('customer', () => {
             shopId: '1',
             request: new Request(origin),
             waitUntil: vi.fn(),
-            language: 'IT',
+            i18n: {language: 'IT', country: 'IT'},
           });
 
           const response = await customer.login({

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -180,13 +180,13 @@ describe('customer', () => {
             shopId: '1',
             request: new Request(origin),
             waitUntil: vi.fn(),
-            i18n: {language: 'FR', country: 'CA'},
+            language: 'FR',
           });
 
           const response = await customer.login();
           const url = new URL(response.headers.get('location')!);
 
-          expect(url.searchParams.get('ui_locales')).toBe('fr-CA');
+          expect(url.searchParams.get('ui_locales')).toBe('fr');
         });
 
         it('Redirects to the customer account api login url with uiLocales as param (uiLocales in the param)', async () => {
@@ -217,7 +217,7 @@ describe('customer', () => {
             shopId: '1',
             request: new Request(origin),
             waitUntil: vi.fn(),
-            i18n: {language: 'IT', country: 'IT'},
+            language: 'IT',
           });
 
           const response = await customer.login({
@@ -1142,40 +1142,65 @@ describe('customer', () => {
 describe('getMaybeUILocales', () => {
   it('returns null if no i18n is provided', () => {
     const uiLocales = getMaybeUILocales({
-      i18n: null,
+      contextLanguage: null,
       uiLocalesOverride: null,
     });
     expect(uiLocales).toBeNull();
   });
 
-  it('returns the i18n locale (formatted) if no options override is provided', () => {
+  it('returns the context locale (formatted) if no options override is provided', () => {
     const uiLocales = getMaybeUILocales({
-      i18n: {language: 'EN', country: 'CA'},
+      contextLanguage: 'EN',
       uiLocalesOverride: null,
     });
-    expect(uiLocales).toBe('en-CA');
+    expect(uiLocales).toBe('en');
+
+    const uiLocalesWithRegion = getMaybeUILocales({
+      contextLanguage: 'PT_PT',
+      uiLocalesOverride: null,
+    });
+    expect(uiLocalesWithRegion).toBe('pt-PT');
   });
 
   it('returns the uiLocales data (formatted) if the i18n locale is not provided', () => {
     const uiLocales = getMaybeUILocales({
-      i18n: null,
+      contextLanguage: null,
       uiLocalesOverride: 'FR',
     });
     expect(uiLocales).toBe('fr');
 
-    // NOTE(ruggi): this is testing the current behavior even if `uiLocale` is not a LanguageCode.
-    const uiLocalesWithCountry = getMaybeUILocales({
-      i18n: null,
-      uiLocalesOverride: 'FR-CA' as unknown as LanguageCode,
+    const uiLocalesWithRegion = getMaybeUILocales({
+      contextLanguage: null,
+      uiLocalesOverride: 'PT_PT',
     });
-    expect(uiLocalesWithCountry).toBe('fr-CA');
+    expect(uiLocalesWithRegion).toBe('pt-PT');
   });
 
   it('overrides the i18n locale if both the it and the uiLocales override are provided', () => {
     const uiLocales = getMaybeUILocales({
-      i18n: {language: 'EN', country: 'CA'},
+      contextLanguage: 'EN',
       uiLocalesOverride: 'FR',
     });
     expect(uiLocales).toBe('fr');
+  });
+
+  it('enforces a regional variant if the language is a regional language', () => {
+    const portuguese = getMaybeUILocales({
+      contextLanguage: 'PT',
+      uiLocalesOverride: null,
+    });
+    expect(portuguese).toBe('pt-PT');
+
+    const mandarin = getMaybeUILocales({
+      contextLanguage: 'ZH',
+      uiLocalesOverride: null,
+    });
+    expect(mandarin).toBe('zh-CN');
+
+    const dutch = getMaybeUILocales({
+      contextLanguage: 'NL',
+      uiLocalesOverride: null,
+    });
+    expect(dutch).toBe('nl');
   });
 });

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -179,7 +179,7 @@ describe('customer', () => {
             shopId: '1',
             request: new Request(origin),
             waitUntil: vi.fn(),
-            i18n: {language: 'FR', country: 'FR'},
+            language: 'FR',
           });
 
           const response = await customer.login();
@@ -216,7 +216,7 @@ describe('customer', () => {
             shopId: '1',
             request: new Request(origin),
             waitUntil: vi.fn(),
-            i18n: {language: 'IT', country: 'IT'},
+            language: 'IT',
           });
 
           const response = await customer.login({

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -50,7 +50,6 @@ import type {
 } from './types';
 import {createCustomerAccountHelper, URL_TYPE} from './customer-account-helper';
 import {warnOnce} from '../utils/warning';
-import {I18nBase} from '../storefront';
 import {LanguageCode} from '@shopify/hydrogen-react/storefront-api-types';
 
 function defaultAuthStatusHandler(
@@ -96,7 +95,7 @@ export function createCustomerAccountClient({
   loginPath = '/account/login',
   authorizePath = '/account/authorize',
   defaultRedirectPath = '/account',
-  language,
+  i18n,
 }: CustomerAccountOptions): CustomerAccount {
   if (customerApiVersion !== DEFAULT_CUSTOMER_API_VERSION) {
     console.warn(
@@ -358,7 +357,7 @@ export function createCustomerAccountClient({
       loginUrl.searchParams.append('nonce', nonce);
 
       const uiLocales = getMaybeUILocales({
-        contextLanguage: language ?? null,
+        contextLanguage: i18n?.language ?? null,
         uiLocalesOverride: options?.uiLocales ?? null,
       });
       if (uiLocales != null) {

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -95,7 +95,7 @@ export function createCustomerAccountClient({
   loginPath = '/account/login',
   authorizePath = '/account/authorize',
   defaultRedirectPath = '/account',
-  i18n,
+  language,
 }: CustomerAccountOptions): CustomerAccount {
   if (customerApiVersion !== DEFAULT_CUSTOMER_API_VERSION) {
     console.warn(
@@ -357,7 +357,7 @@ export function createCustomerAccountClient({
       loginUrl.searchParams.append('nonce', nonce);
 
       const uiLocales = getMaybeUILocales({
-        contextLanguage: i18n?.language ?? null,
+        contextLanguage: language ?? null,
         uiLocalesOverride: options?.uiLocales ?? null,
       });
       if (uiLocales != null) {

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -591,8 +591,6 @@ function createIfInvalidCredentialThrowError(
  * This function returns a locale string in the form <language>[-<COUNTRY_CODE>], based on the provided input params.
  * If both the i18n and the uiLocalesOverride are provided, the uiLocalesOverride will be used.
  * If none of the params are provided, it returns null.
- *
- * Note: exported for testing purposes.
  */
 export function getMaybeUILocales(params: {
   contextLanguage: LanguageCode | null;

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -598,38 +598,6 @@ export function getMaybeUILocales(params: {
   i18n: I18nBase | null;
   uiLocalesOverride: LanguageCode | null; // this will override i18nContext if both are provided
 }): string | null {
-  function toMaybeLocaleString(
-    language: string | null,
-    country: string | null,
-  ): string | null {
-    if (language != null) {
-      const languageLower = language.toLowerCase();
-      if (country != null) {
-        const countryUpper = country.toUpperCase();
-        return `${languageLower}-${countryUpper}`;
-      }
-      return languageLower;
-    }
-    return null;
-  }
-
-  function uiLocalesToMaybeLocaleString(
-    uiLocales: string | null,
-  ): string | null {
-    if (uiLocales == null) {
-      return null;
-    }
-
-    // NOTE(ruggi): the locale override coming from `uiLocale` is supposed to be a LanguageCode, so it should not contain other tokens.
-    // The current implementation is kept for backwards compatibility, however we might consider adjusting it in the future.
-    const parts = uiLocales.split('-');
-    if (parts.length === 0) {
-      return null;
-    }
-
-    return toMaybeLocaleString(parts.at(0) ?? null, parts.at(1) ?? null);
-  }
-
   const contextLocale = toMaybeLocaleString(
     params.i18n?.language ?? null,
     params.i18n?.country ?? null,
@@ -639,4 +607,34 @@ export function getMaybeUILocales(params: {
   );
 
   return optionsLocale ?? contextLocale ?? null;
+}
+
+function toMaybeLocaleString(
+  language: string | null,
+  country: string | null,
+): string | null {
+  if (language != null) {
+    const languageLower = language.toLowerCase();
+    if (country != null) {
+      const countryUpper = country.toUpperCase();
+      return `${languageLower}-${countryUpper}`;
+    }
+    return languageLower;
+  }
+  return null;
+}
+
+function uiLocalesToMaybeLocaleString(uiLocales: string | null): string | null {
+  if (uiLocales == null) {
+    return null;
+  }
+
+  // NOTE(ruggi): the locale override coming from `uiLocale` is supposed to be a LanguageCode, so it should not contain other tokens.
+  // The current implementation is kept for backwards compatibility, however we might consider adjusting it in the future.
+  const parts = uiLocales.split('-');
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return toMaybeLocaleString(parts.at(0) ?? null, parts.at(1) ?? null);
 }

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -605,7 +605,8 @@ export function getMaybeUILocales(params: {
     if (language != null) {
       const languageLower = language.toLowerCase();
       if (country != null) {
-        return `${languageLower}-${country.toUpperCase()}`;
+        const countryUpper = country.toUpperCase();
+        return `${languageLower}-${countryUpper}`;
       }
       return languageLower;
     }

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -602,8 +602,15 @@ export function getMaybeUILocales(params: {
     params.i18n?.language ?? null,
     params.i18n?.country ?? null,
   );
-  const optionsLocale = uiLocalesToMaybeLocaleString(
-    params.uiLocalesOverride ?? null,
+
+  // NOTE(ruggi): the locale override coming from `uiLocale` is supposed to be a LanguageCode, so it should not contain other tokens.
+  // The current implementation is kept for backwards compatibility, however we might consider adjusting it in the future.
+  const optionsSplit = params.uiLocalesOverride?.split('-');
+  const maybeLanguageToken = optionsSplit?.at(0) ?? null;
+  const maybeCountryToken = optionsSplit?.at(1) ?? null;
+  const optionsLocale = toMaybeLocaleString(
+    maybeLanguageToken,
+    maybeCountryToken,
   );
 
   return optionsLocale ?? contextLocale ?? null;
@@ -622,19 +629,4 @@ function toMaybeLocaleString(
     return languageLower;
   }
   return null;
-}
-
-function uiLocalesToMaybeLocaleString(uiLocales: string | null): string | null {
-  if (uiLocales == null) {
-    return null;
-  }
-
-  // NOTE(ruggi): the locale override coming from `uiLocale` is supposed to be a LanguageCode, so it should not contain other tokens.
-  // The current implementation is kept for backwards compatibility, however we might consider adjusting it in the future.
-  const parts = uiLocales.split('-');
-  if (parts.length === 0) {
-    return null;
-  }
-
-  return toMaybeLocaleString(parts.at(0) ?? null, parts.at(1) ?? null);
 }

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -596,7 +596,7 @@ function createIfInvalidCredentialThrowError(
  */
 export function getMaybeUILocales(params: {
   contextLanguage: LanguageCode | null;
-  uiLocalesOverride: LanguageCode | null; // this will override i18nContext if both are provided
+  uiLocalesOverride: LanguageCode | null; // this will override contextLanguage if both are provided
 }): string | null {
   const contextLocale = toMaybeLocaleString(params.contextLanguage ?? null);
   const optionsLocale = toMaybeLocaleString(params.uiLocalesOverride);

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -587,7 +587,13 @@ function createIfInvalidCredentialThrowError(
   };
 }
 
-// Exported for testing
+/**
+ * This function returns a locale string in the form <language>[-<COUNTRY_CODE>], based on the provided input params.
+ * If both the i18n and the uiLocalesOverride are provided, the uiLocalesOverride will be used.
+ * If none of the params are provided, it returns null.
+ *
+ * Note: exported for testing purposes.
+ */
 export function getMaybeUILocales(params: {
   i18n: I18nBase | null;
   uiLocalesOverride: LanguageCode | null; // this will override i18nContext if both are provided

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -160,7 +160,7 @@ export type CustomerAccountOptions = {
   /** Deprecated. `unstableB2b` is now stable. Please remove. */
   unstableB2b?: boolean;
   /** Localization data. */
-  i18n?: I18nBase;
+  language?: LanguageCode;
 };
 
 /** Below are types meant for documentation only. Ensure it stay in sync with the type above. */

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -9,6 +9,7 @@ import type {
   LanguageCode,
   BuyerInput,
 } from '@shopify/hydrogen-react/storefront-api-types';
+import {I18nBase} from '../storefront';
 
 // Return type of unauthorizedHandler = Return type of loader/action function
 // This type is not exported https://github.com/remix-run/react-router/blob/main/packages/router/utils.ts#L167
@@ -158,6 +159,8 @@ export type CustomerAccountOptions = {
   authorizePath?: string;
   /** Deprecated. `unstableB2b` is now stable. Please remove. */
   unstableB2b?: boolean;
+  /** Localization data. */
+  i18n?: I18nBase;
 };
 
 /** Below are types meant for documentation only. Ensure it stay in sync with the type above. */

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -9,7 +9,6 @@ import type {
   LanguageCode,
   BuyerInput,
 } from '@shopify/hydrogen-react/storefront-api-types';
-import {I18nBase} from '../storefront';
 
 // Return type of unauthorizedHandler = Return type of loader/action function
 // This type is not exported https://github.com/remix-run/react-router/blob/main/packages/router/utils.ts#L167
@@ -160,7 +159,7 @@ export type CustomerAccountOptions = {
   /** Deprecated. `unstableB2b` is now stable. Please remove. */
   unstableB2b?: boolean;
   /** Localization data. */
-  i18n?: I18nBase;
+  language?: LanguageCode;
 };
 
 /** Below are types meant for documentation only. Ensure it stay in sync with the type above. */

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -160,7 +160,7 @@ export type CustomerAccountOptions = {
   /** Deprecated. `unstableB2b` is now stable. Please remove. */
   unstableB2b?: boolean;
   /** Localization data. */
-  language?: LanguageCode;
+  i18n?: I18nBase;
 };
 
 /** Below are types meant for documentation only. Ensure it stay in sync with the type above. */


### PR DESCRIPTION
### WHY are these changes introduced?

The URL generated by the `login` method of `CustomerAccount` can receive a `uiLocales` param used to localize the login page; however it should be possible to pass localization data to the constructor of the `CustomerAccount` itself, making it less easy to forget.

### WHAT is this pull request doing?

1. Pass the language hydrogen context data (from `i18n`) to `createCustomerAccountClient`
2. Refactor the `ui_locales` param building so that it uses the context locale data, overriding it with the data in `options.uiLocales` is present.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation