### PR TITLE
Update getProductOptions to handle divergent options

### DIFF
--- a/.changeset/afraid-onions-change.md
+++ b/.changeset/afraid-onions-change.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen-react': patch
+'@shopify/hydrogen': patch
+---
+
+Update `getProductOptions` to handle divergent product options.

--- a/packages/hydrogen-react/src/getProductOptions.test.ts
+++ b/packages/hydrogen-react/src/getProductOptions.test.ts
@@ -368,6 +368,54 @@ describe('getProductOptions', () => {
       ]
     `);
   });
+
+  it('only returns options presented in the selected variant\'s selectedOptions', () => {
+    const options = getProductOptions(
+      {
+        ...PRODUCT,
+        selectedOrFirstAvailableVariant: {
+          availableForSale: true,
+          id: 'gid://shopify/ProductVariant/41007290613816',
+          product: {
+            handle: 'mail-it-in-freestyle-snowboard',
+          },
+          selectedOptions: [
+            {
+              name: 'Size',
+              value: '154cm',
+            },
+          ],
+        },
+      } as unknown as RecursivePartial<Product>,
+    );
+    expect(options.length).toBe(1);
+  });
+
+  it('does not error if product option doesn\'t have an entry for one of the selected option', () => {
+    const options = getProductOptions(
+      {
+        ...PRODUCT,
+        selectedOrFirstAvailableVariant: {
+          availableForSale: true,
+          id: 'gid://shopify/ProductVariant/41007290613816',
+          product: {
+            handle: 'mail-it-in-freestyle-snowboard',
+          },
+          selectedOptions: [
+            {
+              name: 'Size',
+              value: '154cm',
+            },
+            {
+              name: 'Weight',
+              value: '5lbs',
+            },
+          ],
+        },
+      } as unknown as RecursivePartial<Product>,
+    );
+    expect(options.length).toBe(1);
+  });
 });
 
 describe('getAdjacentAndFirstAvailableVariants', () => {

--- a/packages/hydrogen-react/src/getProductOptions.test.ts
+++ b/packages/hydrogen-react/src/getProductOptions.test.ts
@@ -369,51 +369,47 @@ describe('getProductOptions', () => {
     `);
   });
 
-  it('only returns options presented in the selected variant\'s selectedOptions', () => {
-    const options = getProductOptions(
-      {
-        ...PRODUCT,
-        selectedOrFirstAvailableVariant: {
-          availableForSale: true,
-          id: 'gid://shopify/ProductVariant/41007290613816',
-          product: {
-            handle: 'mail-it-in-freestyle-snowboard',
-          },
-          selectedOptions: [
-            {
-              name: 'Size',
-              value: '154cm',
-            },
-          ],
+  it("only returns options presented in the selected variant's selectedOptions", () => {
+    const options = getProductOptions({
+      ...PRODUCT,
+      selectedOrFirstAvailableVariant: {
+        availableForSale: true,
+        id: 'gid://shopify/ProductVariant/41007290613816',
+        product: {
+          handle: 'mail-it-in-freestyle-snowboard',
         },
-      } as unknown as RecursivePartial<Product>,
-    );
+        selectedOptions: [
+          {
+            name: 'Size',
+            value: '154cm',
+          },
+        ],
+      },
+    } as unknown as RecursivePartial<Product>);
     expect(options.length).toBe(1);
   });
 
-  it('does not error if product option doesn\'t have an entry for one of the selected option', () => {
-    const options = getProductOptions(
-      {
-        ...PRODUCT,
-        selectedOrFirstAvailableVariant: {
-          availableForSale: true,
-          id: 'gid://shopify/ProductVariant/41007290613816',
-          product: {
-            handle: 'mail-it-in-freestyle-snowboard',
-          },
-          selectedOptions: [
-            {
-              name: 'Size',
-              value: '154cm',
-            },
-            {
-              name: 'Weight',
-              value: '5lbs',
-            },
-          ],
+  it("does not error if product option doesn't have an entry for one of the selected option", () => {
+    const options = getProductOptions({
+      ...PRODUCT,
+      selectedOrFirstAvailableVariant: {
+        availableForSale: true,
+        id: 'gid://shopify/ProductVariant/41007290613816',
+        product: {
+          handle: 'mail-it-in-freestyle-snowboard',
         },
-      } as unknown as RecursivePartial<Product>,
-    );
+        selectedOptions: [
+          {
+            name: 'Size',
+            value: '154cm',
+          },
+          {
+            name: 'Weight',
+            value: '5lbs',
+          },
+        ],
+      },
+    } as unknown as RecursivePartial<Product>);
     expect(options.length).toBe(1);
   });
 });

--- a/packages/hydrogen-react/src/getProductOptions.ts
+++ b/packages/hydrogen-react/src/getProductOptions.ts
@@ -42,18 +42,21 @@ type MappedProductOptionValue = ProductOptionValue & ProductOptionValueState;
  *  }
  */
 function mapProductOptions(options: ProductOption[]): ProductOptionsMapping {
-  return Object.assign({}, ...options.map((option: ProductOption) => {
-    return {
-      [option.name]: Object.assign(
-        {},
-        ...(option?.optionValues
-          ? option.optionValues.map((value, index) => {
-              return {[value.name]: index};
-            })
-          : []),
-      )
-    } as Record<string, number>;
-  }));
+  return Object.assign(
+    {},
+    ...options.map((option: ProductOption) => {
+      return {
+        [option.name]: Object.assign(
+          {},
+          ...(option?.optionValues
+            ? option.optionValues.map((value, index) => {
+                return {[value.name]: index};
+              })
+            : []),
+        ),
+      } as Record<string, number>;
+    }),
+  );
 }
 
 /**
@@ -120,7 +123,10 @@ function encodeSelectedProductOptionAsKey(
     | Record<string, string>,
 ): string {
   if (Array.isArray(selectedOption)) {
-    return Object.assign({}, ...selectedOption.map((option) => ({[option.name]: option.value})))
+    return Object.assign(
+      {},
+      ...selectedOption.map((option) => ({[option.name]: option.value})),
+    );
   } else {
     return JSON.stringify(selectedOption);
   }
@@ -166,7 +172,9 @@ function buildEncodingArrayFromSelectedOptions(
   productOptionMappings: ProductOptionsMapping,
 ): Array<number> {
   const encoding = Object.keys(selectedOption).map((key) => {
-    return productOptionMappings[key] ? productOptionMappings[key][selectedOption[key]] : null;
+    return productOptionMappings[key]
+      ? productOptionMappings[key][selectedOption[key]]
+      : null;
   });
   return encoding.filter((code) => code !== null);
 }
@@ -401,10 +409,12 @@ export function getProductOptions(
 
   // The available product options is dictated by the selected options of the current variant:
   // Filter out un-used options (Happens on parent combined listing product)
-  const selectedOptionKeys = selectedVariant?.selectedOptions.map((option) => option.name);
+  const selectedOptionKeys = selectedVariant?.selectedOptions.map(
+    (option) => option.name,
+  );
   const filteredOptions = options.filter((option) => {
-    return selectedOptionKeys && selectedOptionKeys.indexOf(option.name) >= 0
-  })
+    return selectedOptionKeys && selectedOptionKeys.indexOf(option.name) >= 0;
+  });
 
   // Get a mapping of product option names to their index for matching encoded values
   const productOptionMappings = mapProductOptions(options);
@@ -438,10 +448,7 @@ export function getProductOptions(
         );
 
         // Top-down option check for existence and availability
-        const topDownKey = encodingKey.slice(
-          0,
-          optionIndex + 1,
-        );
+        const topDownKey = encodingKey.slice(0, optionIndex + 1);
         const exists = isOptionValueCombinationInEncodedVariant(
           topDownKey,
           encodedVariantExistence || '',

--- a/packages/hydrogen-react/src/getProductOptions.ts
+++ b/packages/hydrogen-react/src/getProductOptions.ts
@@ -123,10 +123,12 @@ function encodeSelectedProductOptionAsKey(
     | Record<string, string>,
 ): string {
   if (Array.isArray(selectedOption)) {
-    return JSON.stringify(Object.assign(
-      {},
-      ...selectedOption.map((option) => ({[option.name]: option.value})),
-    ));
+    return JSON.stringify(
+      Object.assign(
+        {},
+        ...selectedOption.map((option) => ({[option.name]: option.value})),
+      ),
+    );
   } else {
     return JSON.stringify(selectedOption);
   }

--- a/packages/hydrogen-react/src/getProductOptions.ts
+++ b/packages/hydrogen-react/src/getProductOptions.ts
@@ -123,10 +123,10 @@ function encodeSelectedProductOptionAsKey(
     | Record<string, string>,
 ): string {
   if (Array.isArray(selectedOption)) {
-    return Object.assign(
+    return JSON.stringify(Object.assign(
       {},
       ...selectedOption.map((option) => ({[option.name]: option.value})),
-    );
+    ));
   } else {
     return JSON.stringify(selectedOption);
   }

--- a/packages/hydrogen-react/src/getProductOptions.ts
+++ b/packages/hydrogen-react/src/getProductOptions.ts
@@ -10,7 +10,7 @@ import type {
 export type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
-type ProductOptionsMapping = Record<string, number>;
+type ProductOptionsMapping = Record<string, Record<string, number>>;
 type ProductOptionValueState = {
   variant: ProductVariant;
   handle: string;
@@ -36,22 +36,24 @@ type MappedProductOptionValue = ProductOptionValue & ProductOptionValueState;
  *    \}
  *  ]
  * Would return
- *  [
- *    \{Red: 0, Blue: 1\},
- *    \{Small: 0, Medium: 1, Large: 2\}
- *  ]
+ *  {
+ *    'Color': \{Red: 0, Blue: 1\},
+ *    'Size': \{Small: 0, Medium: 1, Large: 2\}
+ *  }
  */
-function mapProductOptions(options: ProductOption[]): ProductOptionsMapping[] {
-  return options.map((option: ProductOption) => {
-    return Object.assign(
-      {},
-      ...(option?.optionValues
-        ? option.optionValues.map((value, index) => {
-            return {[value.name]: index};
-          })
-        : []),
-    ) as ProductOptionsMapping;
-  });
+function mapProductOptions(options: ProductOption[]): ProductOptionsMapping {
+  return Object.assign({}, ...options.map((option: ProductOption) => {
+    return {
+      [option.name]: Object.assign(
+        {},
+        ...(option?.optionValues
+          ? option.optionValues.map((value, index) => {
+              return {[value.name]: index};
+            })
+          : []),
+      )
+    } as Record<string, number>;
+  }));
 }
 
 /**
@@ -107,39 +109,66 @@ function mapSelectedProductOptionToObjectAsString(
  *    \}
  *  ]
  * Would return
- *  [0,1]
- *
- * Also works with the result of mapSelectedProductOption. For example:
- *  \{
+ *  JSON.stringify({
  *    Color: 'Red',
  *    Size: 'Medium',
- *  \}
- * Would return
- *  [0,1]
- *
- * @param selectedOption - The selected product option
- * @param productOptionMappings - The result of product option mapping from mapProductOptions
- * @returns
+ *  })
  */
 function encodeSelectedProductOptionAsKey(
   selectedOption:
     | Pick<SelectedOption, 'name' | 'value'>[]
     | Record<string, string>,
-  productOptionMappings: ProductOptionsMapping[],
 ): string {
   if (Array.isArray(selectedOption)) {
-    return JSON.stringify(
-      selectedOption.map((key, index) => {
-        return productOptionMappings[index][key.value];
-      }),
-    );
+    return Object.assign({}, ...selectedOption.map((option) => ({[option.name]: option.value})))
   } else {
-    return JSON.stringify(
-      Object.keys(selectedOption).map((key, index) => {
-        return productOptionMappings[index][selectedOption[key]];
-      }),
-    );
+    return JSON.stringify(selectedOption);
   }
+}
+
+/**
+ * Build the encoding array for the given selected options. For example, if we have
+ * the following productOptionMappings:
+ *
+ *  {
+ *    'Color': \{Red: 0, Blue: 1\},
+ *    'Size': \{Small: 0, Medium: 1, Large: 2\}
+ *  }
+ *
+ * A selectedOption of
+ *
+ * {
+ *    Color: 'Red',
+ *    Size: 'Medium',
+ * }
+ *
+ * `buildEncodingArrayFromSelectedOptions` will produce
+ *
+ * [0,1]
+ *
+ * If in the case where a selected option doesn't exists in the mapping array, for example:
+ *
+ * {
+ *    Color: 'Red',
+ *    Fabric: 'Cotton',
+ *    Size: 'Medium',
+ * }
+ *
+ * `buildEncodingArrayFromSelectedOptions` will still produce
+ *
+ *  [0,1]
+ *
+ * This can be caused by when we do not have all the product
+ * option information for the loading optimistic variant
+ */
+function buildEncodingArrayFromSelectedOptions(
+  selectedOption: Record<string, string>,
+  productOptionMappings: ProductOptionsMapping,
+): Array<number> {
+  const encoding = Object.keys(selectedOption).map((key) => {
+    return productOptionMappings[key] ? productOptionMappings[key][selectedOption[key]] : null;
+  });
+  return encoding.filter((code) => code !== null);
 }
 
 /**
@@ -169,14 +198,12 @@ function encodeSelectedProductOptionAsKey(
  */
 function mapVariants(
   variants: ProductVariant[],
-  productOptionMappings: ProductOptionsMapping[],
 ): Record<string, ProductVariant> {
   return Object.assign(
     {},
     ...variants.map((variant) => {
       const variantKey = encodeSelectedProductOptionAsKey(
         variant.selectedOptions || [],
-        productOptionMappings,
       );
       return {[variantKey]: variant};
     }),
@@ -371,13 +398,20 @@ export function getProductOptions(
     encodedVariantAvailability,
     handle: productHandle,
   } = checkedProduct;
+
+  // The available product options is dictated by the selected options of the current variant:
+  // Filter out un-used options (Happens on parent combined listing product)
+  const selectedOptionKeys = selectedVariant?.selectedOptions.map((option) => option.name);
+  const filteredOptions = options.filter((option) => {
+    return selectedOptionKeys && selectedOptionKeys.indexOf(option.name) >= 0
+  })
+
   // Get a mapping of product option names to their index for matching encoded values
   const productOptionMappings = mapProductOptions(options);
 
   // Get the adjacent variants mapped to the encoded selected option values
   const variants = mapVariants(
     selectedVariant ? [selectedVariant, ...adjacentVariants] : adjacentVariants,
-    productOptionMappings,
   );
 
   // Get the key:value version of selected options for building url query params
@@ -385,7 +419,7 @@ export function getProductOptions(
     selectedVariant ? selectedVariant.selectedOptions : [],
   );
 
-  const productOptions = options.map((option, optionIndex) => {
+  const productOptions = filteredOptions.map((option, optionIndex) => {
     return {
       ...option,
       optionValues: option.optionValues.map((value) => {
@@ -397,11 +431,14 @@ export function getProductOptions(
         // Encode the new selected option values as a key for mapping to the product variants
         const targetKey = encodeSelectedProductOptionAsKey(
           targetOptionParams || [],
+        );
+        const encodingKey = buildEncodingArrayFromSelectedOptions(
+          targetOptionParams || [],
           productOptionMappings,
         );
 
         // Top-down option check for existence and availability
-        const topDownKey = (JSON.parse(targetKey) as number[]).slice(
+        const topDownKey = encodingKey.slice(
           0,
           optionIndex + 1,
         );

--- a/packages/hydrogen-react/src/getProductOptions.ts
+++ b/packages/hydrogen-react/src/getProductOptions.ts
@@ -36,10 +36,10 @@ type MappedProductOptionValue = ProductOptionValue & ProductOptionValueState;
  *    \}
  *  ]
  * Would return
- *  {
+ *  \{
  *    'Color': \{Red: 0, Blue: 1\},
  *    'Size': \{Small: 0, Medium: 1, Large: 2\}
- *  }
+ *  \}
  */
 function mapProductOptions(options: ProductOption[]): ProductOptionsMapping {
   return Object.assign(
@@ -112,10 +112,10 @@ function mapSelectedProductOptionToObjectAsString(
  *    \}
  *  ]
  * Would return
- *  JSON.stringify({
+ *  JSON.stringify(\{
  *    Color: 'Red',
  *    Size: 'Medium',
- *  })
+ *  \})
  */
 function encodeSelectedProductOptionAsKey(
   selectedOption:
@@ -136,17 +136,17 @@ function encodeSelectedProductOptionAsKey(
  * Build the encoding array for the given selected options. For example, if we have
  * the following productOptionMappings:
  *
- *  {
+ *  \{
  *    'Color': \{Red: 0, Blue: 1\},
  *    'Size': \{Small: 0, Medium: 1, Large: 2\}
- *  }
+ *  \}
  *
  * A selectedOption of
  *
- * {
+ * \{
  *    Color: 'Red',
  *    Size: 'Medium',
- * }
+ * \}
  *
  * `buildEncodingArrayFromSelectedOptions` will produce
  *
@@ -154,11 +154,11 @@ function encodeSelectedProductOptionAsKey(
  *
  * If in the case where a selected option doesn't exists in the mapping array, for example:
  *
- * {
+ * \{
  *    Color: 'Red',
  *    Fabric: 'Cotton',
  *    Size: 'Medium',
- * }
+ * \}
  *
  * `buildEncodingArrayFromSelectedOptions` will still produce
  *


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

`getProductOptions` will fail on combined listing products with divergent options. For example, we have a parent product TV and the only common option between its child products is size of the TV.

`getProductOptions` fails at finding a matching encoding and mapping with the selected option.

### WHAT is this pull request doing?

* Update the variant mapping so that we are not reliant on the encoding
* Update the encoding matching so that it doesn't fail on optimistic variant selection on non-existing option value

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
