### PR TITLE
fix(hydrogen-react): uninstall specific prettier version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32449,7 +32449,6 @@
         "cpy-cli": "^4.2.0",
         "happy-dom": "^17.0.0",
         "npm-run-all": "^4.1.5",
-        "prettier": "^3.4.2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "rimraf": "^4.1.2",
@@ -34089,22 +34088,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/hydrogen-react/node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "packages/hydrogen-react/node_modules/prism-react-renderer": {

--- a/packages/hydrogen-react/package.json
+++ b/packages/hydrogen-react/package.json
@@ -148,7 +148,6 @@
     "cpy-cli": "^4.2.0",
     "happy-dom": "^17.0.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^3.4.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "rimraf": "^4.1.2",


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

In `hydrogen-react` we had a different version of prettier than the rest of the repo, which caused subtle difference in formatting vie the IDE (that used this version), and the format check from the root of the monorepo (that used the older version)

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

Removing the specific prettier version in `hydrogen-react`, so that all prettier checks (IDE and CLI) will use the same version from the monorepo root.

This affects only `devDependencies` so only affects the development _of_ `hydrogen-react` (no user facing changes)

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
