### PR TITLE
Fix skeleton template's Typescript

### DIFF
--- a/.changeset/rotten-kangaroos-peel.md
+++ b/.changeset/rotten-kangaroos-peel.md
@@ -1,0 +1,17 @@
+---
+'skeleton': patch
+'@shopify/create-hydrogen': patch
+---
+
+Fixing typescript compile
+
+In tsconfig.json:
+
+```diff
+     "types": [
+       "@shopify/oxygen-workers-types",
+-      "@remix-run/node",
++      "@remix-run/server-runtime",
+       "vite/client"
+     ],
+```

--- a/templates/skeleton/tsconfig.json
+++ b/templates/skeleton/tsconfig.json
@@ -16,7 +16,7 @@
     "baseUrl": ".",
     "types": [
       "@shopify/oxygen-workers-types",
-      "@remix-run/node",
+      "@remix-run/server-runtime",
       "vite/client"
     ],
     "paths": {


### PR DESCRIPTION
### WHY are these changes introduced?

Steps to reproduce:
1. Create a new hydrogen repository with `pnpm shopify@latest hydrogen init`
2. `pnpm install` 
3. `pnpm tsc` to run typecheck fails with the following error message:

```
error TS2688: Cannot find type definition file for '@remix-run/node'.
  The file is in the program because:
    Entry point of type library '@remix-run/node' specified in compilerOptions

  tsconfig.json:19:7
    19       "@remix-run/node",
             ~~~~~~~~~~~~~~~~~
    File is entry point of type library specified here.

[2:54:31 PM] Found 1 error. Watching for file changes.
```


### WHAT is this pull request doing?

Change the skeleton template's `tsconfig.json` to point to `"@remix-run/server-runtime"` instead of `"@remix-run/node".

### HOW to test your changes?

1. Create a new hydrogen repository with `pnpm shopify@latest hydrogen init`
2. `pnpm install` 
3. `pnpm tsc` to run typecheck succeeds!

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
