### PR TITLE
Removed unnecessary call to exchangeAccessToken.

### DIFF
--- a/packages/hydrogen/src/customer/auth.helpers.test.ts
+++ b/packages/hydrogen/src/customer/auth.helpers.test.ts
@@ -83,7 +83,7 @@ describe('auth.helpers', () => {
       await expect(run).rejects.toThrowError('Unauthorized');
     });
 
-    it('Throws when there is no valid authorization code in the session', async () => {
+    it('Throws when an invalid access token is received', async () => {
       (session.get as any).mockReturnValueOnce({
         refreshToken: 'refreshToken',
       });
@@ -109,7 +109,7 @@ describe('auth.helpers', () => {
       }
 
       await expect(run).rejects.toThrowError(
-        'Unauthorized oAuth access token was not provided during token exchange.',
+        'Unauthorized Invalid access token received.',
       );
     });
 

--- a/packages/hydrogen/src/customer/auth.helpers.ts
+++ b/packages/hydrogen/src/customer/auth.helpers.ts
@@ -134,6 +134,10 @@ export async function refreshToken({
     refresh_token,
   }: Omit<AccessTokenResponse, 'id_token'> = await response.json();
 
+  if (!access_token || access_token.length === 0) {
+    throw new BadRequest('Unauthorized', 'Invalid access token received.');
+  }
+
   session.set(CUSTOMER_ACCOUNT_SESSION_KEY, {
     accessToken: access_token,
     // Store the date in future the token expires, separated by two minutes

--- a/packages/hydrogen/src/customer/auth.helpers.ts
+++ b/packages/hydrogen/src/customer/auth.helpers.ts
@@ -134,16 +134,8 @@ export async function refreshToken({
     refresh_token,
   }: Omit<AccessTokenResponse, 'id_token'> = await response.json();
 
-  const accessToken = await exchangeAccessToken(
-    access_token,
-    customerAccountId,
-    customerAccountTokenExchangeUrl,
-    httpsOrigin,
-    debugInfo,
-  );
-
   session.set(CUSTOMER_ACCOUNT_SESSION_KEY, {
-    accessToken,
+    accessToken: access_token,
     // Store the date in future the token expires, separated by two minutes
     expiresAt:
       new Date(new Date().getTime() + (expires_in - 120) * 1000).getTime() + '',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/hydrogen/discussions/2783

Corrects an issue where when the access token expires, the user becomes temporarily logged out until a subsequent request causes them to be logged in again.

### WHAT is this pull request doing?

Removes the call to `exchangeAccessToken` which is currently made in `refreshToken`, as it is unnecessary and causes an exception to be thrown causing the user to be logged out.

### HOW to test your changes?

Ordinarily this will trigger once an hour as the access token expires, it's possible to modify the expiry date in the code to make it expire more often. One way to trigger this is to have a loader call `isLoggedIn` and monitor the result as they should stay logged in with the fix in this PR.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
