### PR TITLE
Remove eslint-plugin-hydrogen from skeleton package.json.

### DIFF
--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -36,7 +36,6 @@
     "@shopify/oxygen-workers-types": "^4.1.6",
     "@shopify/prettier-config": "^1.1.2",
     "@total-typescript/ts-reset": "^0.6.1",
-    "eslint-plugin-hydrogen": "0.12.3",
     "prettier": "^3.4.2",
     "@types/eslint": "^9.6.1",
     "@types/react": "^18.2.22",


### PR DESCRIPTION
### WHY are these changes introduced?

We want to deprecate this plugin and it was re-added by accident.

### WHAT is this pull request doing?

Removing the `eslint-plugin-hydrogen` dependency from the skeleton project.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

