### PR TITLE
Fix routeConfig broken on windows

### DIFF
--- a/packages/hydrogen/src/vite/get-virtual-routes.ts
+++ b/packages/hydrogen/src/vite/get-virtual-routes.ts
@@ -20,7 +20,9 @@ function getVirtualRoutesPath(
   const virtualRoutesPath = pathParts.reduce((working, dirPart) => {
     return new URL(`${dirPart}/`, working);
   }, basePath);
-  return new URL(forFile, virtualRoutesPath).pathname;
+
+  // Getting rid of the drive path (ie. '/C:/') in windows
+  return new URL(forFile, virtualRoutesPath).pathname.replace(/^\/[a-zA-Z]:\//, '/');
 }
 
 export async function getVirtualRoutesV3() {

--- a/packages/hydrogen/src/vite/get-virtual-routes.ts
+++ b/packages/hydrogen/src/vite/get-virtual-routes.ts
@@ -22,7 +22,10 @@ function getVirtualRoutesPath(
   }, basePath);
 
   // Getting rid of the drive path (ie. '/C:/') in windows
-  return new URL(forFile, virtualRoutesPath).pathname.replace(/^\/[a-zA-Z]:\//, '/');
+  return new URL(forFile, virtualRoutesPath).pathname.replace(
+    /^\/[a-zA-Z]:\//,
+    '/',
+  );
 }
 
 export async function getVirtualRoutesV3() {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Testing on `next` on windows machine. Breaking on on not finding virtual routes

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
