### PR TITLE
Cookbook (scripts): YAML manifest, recipe fixes

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -21,7 +21,9 @@
     - [Update](#update)
       - [Syntax](#syntax-5)
       - [Example](#example-5)
-
+    - [Schema](#schema)
+      - [Syntax](#syntax-6)
+      - [Example](#example-6)
 
 This is the Hydrogen Cookbook, a collection of example _recipes_ to showcase specific scenarios and usecases for Hydrogen projects.
 
@@ -31,10 +33,10 @@ A _recipe_ is a reproducible sequence of steps meant to be applied to the [skele
 
 Each recipe is located in the [cookbook's recipes folder](/cookbook/recipes/) and is structured with a specific set of conventions. This is how a recipe folder is organized:
 
-- `recipe.json`: the JSON file containig the whole recipe definition, in a machine-readable format.
+- `recipe.yaml`: the JSON file containig the whole recipe definition, in a machine-readable format.
 - `ingredients/`: a folder containing _new_ files that the recipe introduces. They will be copied as-is to the skeleton template.
-- `patches/`: a folder containing patches to be applied to existing files in the skeleton template. The file ↔ patch mappings are defined in the `recipe.json` file under the `ingredients` key.
-- `README.md`: the human-readable Markdown render of the recipe, based off of the `recipe.json` file.
+- `patches/`: a folder containing patches to be applied to existing files in the skeleton template. The file ↔ patch mappings are defined in the `recipe.yaml` file under the `ingredients` key.
+- `README.md`: the human-readable Markdown render of the recipe, based off of the `recipe.yaml` file.
 
 ## Usage
 
@@ -88,7 +90,7 @@ The workflow for creating a new recipe is as follows:
 1. Make the desired changes to the skeleton template
 2. (Optional) Mark relevant portions of the code with `@description` comments describing what the changes are doing
 3. Run the `generate` command with the recipe name
-4. (Optional) Adjust the `recipe.json` output as desired, filling in potential missing information (e.g. the recipe title and description)
+4. (Optional) Adjust the `recipe.yaml` output as desired, filling in potential missing information (e.g. the recipe title and description)
 
 #### Syntax
 
@@ -103,7 +105,7 @@ Options:
   --recipe           The name of the recipe to generate
                                                  [string] [required]
   --onlyFiles        Only generate the files for the recipe, not the
-                     recipe.json file.                     [boolean]
+                     recipe.yaml file.                     [boolean]
   --referenceBranch  The reference branch to use for the recipe
                                    [string] [default: "origin/main"]
 ```
@@ -198,7 +200,7 @@ Options:
   --help             Show help                                         [boolean]
   --recipe           The name of the recipe to regenerate. If not provided, all
                      recipes will be regenerated.                       [string]
-  --onlyFiles        Only generate the files for the recipe, not the recipe.json
+  --onlyFiles        Only generate the files for the recipe, not the recipe.yaml
                      file.                                             [boolean]
   --format           The format to render the recipe in
                           [string] [required] [choices: "github", "shopify.dev"]
@@ -237,4 +239,26 @@ Options:
 
 ```sh
 npm run cookbook -- update --recipe my-recipe
+```
+
+### Schema
+
+`schema` will regenerate the JSON schema for the recipe manifest file off of the Zod schema definition.
+
+#### Syntax
+
+```plain
+cookbook.ts schema
+
+Render the recipe JSON schema out of the Recipe type.
+
+Options:
+  --version  Show version number                                       [boolean]
+  --help     Show help                                                 [boolean]
+```
+
+#### Example
+
+```sh
+npm run cookbook -- schema
 ```

--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -11,7 +11,8 @@
         "inquirer": "^12.4.2",
         "ts-node": "^10.9.2",
         "yargs": "^17.7.2",
-        "zod": "^3.24.2"
+        "zod": "^3.24.2",
+        "zod-to-json-schema": "^3.24.5"
       },
       "devDependencies": {
         "@types/node": "^22.13.4",
@@ -896,6 +897,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -9,7 +9,8 @@
     "inquirer": "^12.4.2",
     "ts-node": "^10.9.2",
     "yargs": "^17.7.2",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {
     "@types/node": "^22.13.4",

--- a/cookbook/recipe.schema.json
+++ b/cookbook/recipe.schema.json
@@ -17,10 +17,7 @@
       "description": "The notes of the recipe"
     },
     "image": {
-      "type": [
-        "string",
-        "null"
-      ],
+      "type": ["string", "null"],
       "description": "The image of the recipe"
     },
     "ingredients": {
@@ -33,16 +30,11 @@
             "description": "The path of the ingredient"
           },
           "description": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "The description of the ingredient"
           }
         },
-        "required": [
-          "path"
-        ],
+        "required": ["path"],
         "additionalProperties": false
       },
       "description": "The ingredients of the recipe"
@@ -54,11 +46,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "PATCH",
-              "INFO",
-              "COPY_INGREDIENTS"
-            ],
+            "enum": ["PATCH", "INFO", "COPY_INGREDIENTS"],
             "description": "The type of step"
           },
           "name": {
@@ -66,10 +54,7 @@
             "description": "The name of the step"
           },
           "description": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "The description of the step"
           },
           "notes": {
@@ -100,19 +85,13 @@
                   "description": "The patch file of the diff"
                 }
               },
-              "required": [
-                "file",
-                "patchFile"
-              ],
+              "required": ["file", "patchFile"],
               "additionalProperties": false
             },
             "description": "The diffs of the step"
           }
         },
-        "required": [
-          "type",
-          "name"
-        ],
+        "required": ["type", "name"],
         "additionalProperties": false
       },
       "description": "The steps of the recipe"
@@ -129,13 +108,7 @@
       "description": "The commit hash the recipe is based on"
     }
   },
-  "required": [
-    "title",
-    "description",
-    "ingredients",
-    "steps",
-    "commit"
-  ],
+  "required": ["title", "description", "ingredients", "steps", "commit"],
   "additionalProperties": false,
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/cookbook/recipe.schema.json
+++ b/cookbook/recipe.schema.json
@@ -1,0 +1,141 @@
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "The title of the recipe"
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the recipe"
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "The notes of the recipe"
+    },
+    "image": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The image of the recipe"
+    },
+    "ingredients": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The path of the ingredient"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The description of the ingredient"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false
+      },
+      "description": "The ingredients of the recipe"
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "PATCH",
+              "INFO",
+              "COPY_INGREDIENTS"
+            ],
+            "description": "The type of step"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the step"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The description of the step"
+          },
+          "notes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The notes of the step"
+          },
+          "ingredients": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The ingredients of the step"
+          },
+          "diffs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "description": "The file of the diff"
+                },
+                "patchFile": {
+                  "type": "string",
+                  "description": "The patch file of the diff"
+                }
+              },
+              "required": [
+                "file",
+                "patchFile"
+              ],
+              "additionalProperties": false
+            },
+            "description": "The diffs of the step"
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "description": "The steps of the recipe"
+    },
+    "deletedFiles": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "The deleted files of the recipe"
+    },
+    "commit": {
+      "type": "string",
+      "description": "The commit hash the recipe is based on"
+    }
+  },
+  "required": [
+    "title",
+    "description",
+    "ingredients",
+    "steps",
+    "commit"
+  ],
+  "additionalProperties": false,
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/cookbook/src/commands/generate.ts
+++ b/cookbook/src/commands/generate.ts
@@ -1,11 +1,13 @@
 import {CommandModule} from 'yargs';
 import {FILES_TO_IGNORE_FOR_GENERATE} from '../lib/constants';
 import {generateRecipe} from '../lib/generate';
+import {RecipeManifestFormat} from '../lib/util';
 
 type GenerateArgs = {
   recipe: string;
   onlyFiles: boolean;
   referenceBranch: string;
+  recipeManifestFormat: RecipeManifestFormat;
 };
 
 export const generate: CommandModule<{}, GenerateArgs> = {
@@ -20,12 +22,17 @@ export const generate: CommandModule<{}, GenerateArgs> = {
     onlyFiles: {
       type: 'boolean',
       description:
-        'Only generate the files for the recipe, not the recipe.json file.',
+        'Only generate the files for the recipe, not the recipe.yaml file.',
     },
     referenceBranch: {
       type: 'string',
       description: 'The reference branch to use for the recipe',
       default: 'origin/main',
+    },
+    recipeManifestFormat: {
+      type: 'string',
+      description: 'The format of the recipe manifest file',
+      default: 'yaml',
     },
   },
   handler,
@@ -37,6 +44,7 @@ async function handler(args: GenerateArgs) {
     filenamesToIgnore: FILES_TO_IGNORE_FOR_GENERATE,
     onlyFiles: args.onlyFiles,
     referenceBranch: args.referenceBranch,
+    recipeManifestFormat: args.recipeManifestFormat,
   });
 
   console.log();

--- a/cookbook/src/commands/index.ts
+++ b/cookbook/src/commands/index.ts
@@ -4,3 +4,4 @@ export {regenerate} from './regenerate';
 export {render} from './render';
 export {update} from './update';
 export {validate} from './validate';
+export {schema} from './schema';

--- a/cookbook/src/commands/regenerate.ts
+++ b/cookbook/src/commands/regenerate.ts
@@ -4,13 +4,13 @@ import {applyRecipe} from '../lib/apply';
 import {FILES_TO_IGNORE_FOR_GENERATE, TEMPLATE_PATH} from '../lib/constants';
 import {generateRecipe} from '../lib/generate';
 import {isRenderFormat, RENDER_FORMATS, renderRecipe} from '../lib/render';
-import {listRecipes, separator} from '../lib/util';
-
+import {listRecipes, separator, RecipeManifestFormat} from '../lib/util';
 type RegenerateArgs = {
   recipe?: string;
   onlyFiles: boolean;
   format: string;
   referenceBranch: string;
+  recipeManifestFormat: RecipeManifestFormat;
 };
 
 export const regenerate: CommandModule<{}, RegenerateArgs> = {
@@ -25,18 +25,23 @@ export const regenerate: CommandModule<{}, RegenerateArgs> = {
     onlyFiles: {
       type: 'boolean',
       description:
-        'Only generate the files for the recipe, not the recipe.json file.',
+        'Only generate the files for the recipe, not the recipe.yaml file.',
     },
     format: {
       type: 'string',
       description: 'The format to render the recipe in',
-      required: true,
       choices: RENDER_FORMATS,
+      default: 'github',
     },
     referenceBranch: {
       type: 'string',
       description: 'The reference branch to use for the recipe',
       default: 'origin/main',
+    },
+    recipeManifestFormat: {
+      type: 'string',
+      description: 'The format of the recipe manifest file',
+      default: 'yaml',
     },
   },
   handler,
@@ -69,6 +74,7 @@ async function handler(args: RegenerateArgs) {
       onlyFiles: args.onlyFiles,
       filenamesToIgnore: FILES_TO_IGNORE_FOR_GENERATE,
       referenceBranch: args.referenceBranch,
+      recipeManifestFormat: args.recipeManifestFormat,
     });
     // render the recipe
     renderRecipe({

--- a/cookbook/src/commands/render.ts
+++ b/cookbook/src/commands/render.ts
@@ -18,8 +18,8 @@ export const render: CommandModule<{}, RenderArgs> = {
     format: {
       type: 'string',
       description: 'The format to render the recipe in',
-      required: true,
       choices: RENDER_FORMATS,
+      default: 'github',
     },
   },
   handler,

--- a/cookbook/src/commands/schema.ts
+++ b/cookbook/src/commands/schema.ts
@@ -1,0 +1,25 @@
+import {CommandModule} from 'yargs';
+import {zodToJsonSchema} from 'zod-to-json-schema';
+import fs from 'fs';
+import {COOKBOOK_PATH} from '../lib/constants';
+import path from 'path';
+import {RecipeSchema} from '../lib/recipe';
+
+type SchemaArgs = {};
+
+export const schema: CommandModule<{}, SchemaArgs> = {
+  command: 'schema',
+  describe: 'Render the recipe JSON schema out of the Recipe type.',
+  builder: {},
+  handler,
+};
+
+async function handler(_: SchemaArgs) {
+  const jsonSchema = zodToJsonSchema(RecipeSchema);
+  console.log(JSON.stringify(jsonSchema, null, 2));
+
+  fs.writeFileSync(
+    path.join(COOKBOOK_PATH, 'recipe.schema.json'),
+    JSON.stringify(jsonSchema, null, 2),
+  );
+}

--- a/cookbook/src/commands/update.ts
+++ b/cookbook/src/commands/update.ts
@@ -42,7 +42,7 @@ export const update: CommandModule<{}, UpdateArgs> = {
     recipeManifestFormat: {
       type: 'string',
       description: 'The format of the recipe manifest file',
-      default: 'json',
+      default: 'yaml',
     },
   },
   handler,

--- a/cookbook/src/commands/update.ts
+++ b/cookbook/src/commands/update.ts
@@ -11,12 +11,18 @@ import {
   TEMPLATE_PATH,
 } from '../lib/constants';
 import {generateRecipe} from '../lib/generate';
-import {parseRecipeFromString} from '../lib/recipe';
 import {renderRecipe} from '../lib/render';
-import {makeRandomTempDir, parseReferenceBranch} from '../lib/util';
+import {
+  RecipeManifestFormat,
+  makeRandomTempDir,
+  parseReferenceBranch,
+} from '../lib/util';
+import {loadRecipe} from '../lib/recipe';
+
 type UpdateArgs = {
   recipe: string;
   referenceBranch: string;
+  recipeManifestFormat: RecipeManifestFormat;
 };
 
 export const update: CommandModule<{}, UpdateArgs> = {
@@ -32,6 +38,11 @@ export const update: CommandModule<{}, UpdateArgs> = {
       type: 'string',
       description: 'The branch to update the recipe from',
       default: 'origin/main',
+    },
+    recipeManifestFormat: {
+      type: 'string',
+      description: 'The format of the recipe manifest file',
+      default: 'json',
     },
   },
   handler,
@@ -51,12 +62,9 @@ async function handler(args: UpdateArgs) {
   }
 
   // load the recipe
-  const {commit} = parseRecipeFromString(
-    fs.readFileSync(
-      path.join(COOKBOOK_PATH, 'recipes', recipeName, 'recipe.json'),
-      'utf8',
-    ),
-  );
+  const {commit} = loadRecipe({
+    directory: path.join(COOKBOOK_PATH, 'recipes', recipeName),
+  });
 
   // checkout the repo at the recipe's commit hash
   execSync(`git checkout ${commit}`);
@@ -137,6 +145,7 @@ async function handler(args: UpdateArgs) {
       filenamesToIgnore: FILES_TO_IGNORE_FOR_GENERATE,
       onlyFiles: false,
       referenceBranch: args.referenceBranch,
+      recipeManifestFormat: args.recipeManifestFormat,
     });
 
     // copy the recipe to the temp folder

--- a/cookbook/src/index.ts
+++ b/cookbook/src/index.ts
@@ -10,6 +10,7 @@ const cli = yargs(process.argv.slice(2))
   .command(commands.apply)
   .command(commands.validate)
   .command(commands.regenerate)
-  .command(commands.update);
+  .command(commands.update)
+  .command(commands.schema);
 
 cli.showHelpOnFail(true).demandCommand().help().argv;

--- a/cookbook/src/lib/apply.ts
+++ b/cookbook/src/lib/apply.ts
@@ -7,7 +7,7 @@ import {
   TEMPLATE_DIRECTORY,
   TEMPLATE_PATH,
 } from './constants';
-import {parseRecipeFromString} from './recipe';
+import {loadRecipe} from './recipe';
 import {parseGitStatus} from './util';
 
 /**
@@ -22,8 +22,7 @@ export function applyRecipe(params: {
 
   // load the recipe.json file
   console.log(`- 🍱 Loading recipe '${params.recipeTitle}'…`);
-  const recipePath = path.join(recipeDir, 'recipe.json');
-  const recipe = parseRecipeFromString(fs.readFileSync(recipePath, 'utf8'));
+  const recipe = loadRecipe({directory: recipeDir});
 
   // list the ingredients in the recipe's ingredients folder as a list of flat paths (e.g. foo/bar/baz.txt)
   const ingredientsPath = path.join(recipeDir, 'ingredients');

--- a/cookbook/src/lib/generate.ts
+++ b/cookbook/src/lib/generate.ts
@@ -134,8 +134,6 @@ async function generateSteps(params: {
     return !file.endsWith('.d.ts');
   });
 
-  console.log('modifiedFiles', modifiedFiles);
-
   for await (const file of modifiedFiles) {
     const {fullPath, patchFilename} = createPatchFile({
       file,

--- a/cookbook/src/lib/markdown.ts
+++ b/cookbook/src/lib/markdown.ts
@@ -1,4 +1,5 @@
 import {assertNever} from './util';
+import fs from 'fs';
 
 export type MDNote = {
   type: 'NOTE';
@@ -212,4 +213,22 @@ export function renderMDBlock(block: MDBlock): string {
     default:
       assertNever(block);
   }
+}
+
+export function mdLinkString(url: string, text: string): string {
+  return `[${text}](${url})`;
+}
+
+export function maybeMDBlock<T>(
+  value: T | null | undefined,
+  makeBlock: (v: T) => MDBlock[],
+): MDBlock[] {
+  if (value == null) {
+    return [];
+  }
+  return makeBlock(value);
+}
+
+export function serializeMDBlocksToFile(blocks: MDBlock[], filePath: string) {
+  fs.writeFileSync(filePath, blocks.map(renderMDBlock).join('\n\n'));
 }

--- a/cookbook/src/lib/recipe.ts
+++ b/cookbook/src/lib/recipe.ts
@@ -1,4 +1,7 @@
 import {z} from 'zod';
+import path from 'path';
+import fs from 'fs';
+import YAML from 'yaml';
 
 const IngredientSchema = z.object({
   path: z.string().describe('The path of the ingredient'),
@@ -38,7 +41,7 @@ const StepSchema = z.object({
 
 export type Step = z.infer<typeof StepSchema>;
 
-const RecipeSchema = z.object({
+export const RecipeSchema = z.object({
   title: z.string().describe('The title of the recipe'),
   description: z.string().describe('The description of the recipe'),
   notes: z.array(z.string()).optional().describe('The notes of the recipe'),
@@ -61,6 +64,22 @@ export type Recipe = z.infer<typeof RecipeSchema>;
  * @param data The JSON string to parse
  * @returns The parsed Recipe object
  */
-export function parseRecipeFromString(data: string): Recipe {
-  return RecipeSchema.parse(JSON.parse(data));
+export function loadRecipe(params: {directory: string}): Recipe {
+  if (fs.existsSync(path.join(params.directory, 'recipe.yaml'))) {
+    return RecipeSchema.parse(
+      YAML.parse(
+        fs.readFileSync(path.join(params.directory, 'recipe.yaml'), 'utf8'),
+      ),
+    );
+  } else if (fs.existsSync(path.join(params.directory, 'recipe.json'))) {
+    return RecipeSchema.parse(
+      JSON.parse(
+        fs.readFileSync(path.join(params.directory, 'recipe.json'), 'utf8'),
+      ),
+    );
+  } else {
+    throw new Error(
+      `recipe.yaml or recipe.json not found in ${params.directory}`,
+    );
+  }
 }

--- a/cookbook/src/lib/util.ts
+++ b/cookbook/src/lib/util.ts
@@ -180,7 +180,7 @@ export function listRecipes(): string[] {
 
 export function isInGitHistory(params: {path: string}): boolean {
   try {
-    execSync(`git ls-files --error-unmatch ${params.path}`);
+    execSync(`git ls-files --error-unmatch ${params.path}`, {stdio: 'ignore'});
     return true;
   } catch (_) {
     return false;

--- a/cookbook/tsconfig.json
+++ b/cookbook/tsconfig.json
@@ -7,6 +7,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
+    "noFallthroughCasesInSwitch": true
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This PR introduces some improvements to the cookbook scripts derived from the work on the subscriptions recipe.

### WHAT is this pull request doing?

**Cookbook scripts**
- Use `zod` to better define and parse the recipe manifest file.
- Use YAML as a preferred format for the recipe manifest file, with a JSON schema that enforces its structure.
- Add `schema` command to regenerate the schema file if the Recipe type/schema changes.
- Improve error reporting for the `generate` script
- Improve a bit the structure of the rendered markdown, and use `github` as the default value for the `--format` flag for better ergonomics

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation
