### PR TITLE
Bump cli dependencies to 3.77.1.

### DIFF
--- a/.changeset/rich-trains-smash.md
+++ b/.changeset/rich-trains-smash.md
@@ -1,0 +1,6 @@
+---
+"skeleton": patch
+"@shopify/cli-hydrogen": patch
+---
+
+Updates the `@shopify/cli`, `@shopify/cli-kit` and `@shopify/plugin-cloudflare` dependencies to 3.77.1.

--- a/.changeset/rich-trains-smash.md
+++ b/.changeset/rich-trains-smash.md
@@ -1,6 +1,7 @@
 ---
 "skeleton": patch
 "@shopify/cli-hydrogen": patch
+"@shopify/create-hydrogen": patch
 ---
 
 Updates the `@shopify/cli`, `@shopify/cli-kit` and `@shopify/plugin-cloudflare` dependencies to 3.77.1.

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -29,7 +29,7 @@
     "@remix-run/dev": "^2.16.1",
     "@remix-run/fs-routes": "^2.16.1",
     "@remix-run/route-config": "^2.16.1",
-    "@shopify/cli": "~3.77.0",
+    "@shopify/cli": "~3.77.1",
     "@types/compression": "^1.7.2",
     "@types/express": "^4.17.17",
     "@types/morgan": "^1.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
         "@playwright/test": "^1.40.1",
-        "@shopify/cli": "~3.77.0",
+        "@shopify/cli": "~3.77.1",
         "@types/eslint": "^9.6.1",
         "@types/semver": "^7.5.8",
         "@typescript-eslint/eslint-plugin": "^8.21.0",
@@ -121,7 +121,7 @@
         "@remix-run/node": "^2.16.1",
         "@remix-run/react": "^2.16.1",
         "@remix-run/server-runtime": "^2.16.1",
-        "@shopify/hydrogen": "2025.1.2",
+        "@shopify/hydrogen": "2025.1.3",
         "compression": "^1.7.4",
         "cross-env": "^7.0.3",
         "express": "^4.19.2",
@@ -135,7 +135,7 @@
         "@remix-run/dev": "^2.16.1",
         "@remix-run/fs-routes": "^2.16.1",
         "@remix-run/route-config": "^2.16.1",
-        "@shopify/cli": "~3.77.0",
+        "@shopify/cli": "~3.77.1",
         "@types/compression": "^1.7.2",
         "@types/express": "^4.17.17",
         "@types/morgan": "^1.9.4",
@@ -8402,9 +8402,9 @@
       "license": "MIT"
     },
     "node_modules/@shopify/cli": {
-      "version": "3.77.0",
-      "resolved": "https://registry.npmjs.org/@shopify/cli/-/cli-3.77.0.tgz",
-      "integrity": "sha512-lJunyjof822uNPXRuPRdHt/yFHtUySMsotKxEwIOIEFLB5HXJw93y4xuglO+kb18H8QPNXFvDiqxyM2XSiJGSA==",
+      "version": "3.77.1",
+      "resolved": "https://registry.npmjs.org/@shopify/cli/-/cli-3.77.1.tgz",
+      "integrity": "sha512-/f5h2/9J0SF0MP+C+OYx2HHsEiiLVGwYU9FhkmkDwAfXdbCMAxbmZpz+flzJ1GO9Bum3c0SB5WENN/LGUoxWJQ==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -39792,14 +39792,14 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "9.0.8",
+      "version": "9.0.9",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
         "@oclif/core": "3.26.5",
-        "@shopify/cli-kit": "^3.77.0",
+        "@shopify/cli-kit": "^3.77.1",
         "@shopify/oxygen-cli": "4.6.10",
-        "@shopify/plugin-cloudflare": "^3.77.0",
+        "@shopify/plugin-cloudflare": "^3.77.1",
         "ansi-escapes": "^6.2.0",
         "chokidar": "3.5.3",
         "cli-truncate": "^4.0.0",
@@ -39841,8 +39841,8 @@
       "peerDependencies": {
         "@graphql-codegen/cli": "^5.0.2",
         "@remix-run/dev": "^2.16.1",
-        "@shopify/hydrogen-codegen": "^0.3.2",
-        "@shopify/mini-oxygen": "^3.1.1",
+        "@shopify/hydrogen-codegen": "^0.3.3",
+        "@shopify/mini-oxygen": "^3.1.2",
         "graphql-config": "^5.0.3",
         "vite": "^5.1.0 || ^6.2.0"
       },
@@ -40567,7 +40567,7 @@
     },
     "packages/create-hydrogen": {
       "name": "@shopify/create-hydrogen",
-      "version": "5.0.17",
+      "version": "5.0.18",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.34.1"
@@ -40774,10 +40774,10 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2025.1.2",
+      "version": "2025.1.3",
       "license": "MIT",
       "dependencies": {
-        "@shopify/hydrogen-react": "2025.1.2",
+        "@shopify/hydrogen-react": "2025.1.3",
         "content-security-policy-builder": "^2.2.0",
         "isbot": "^5.1.21",
         "source-map-support": "^0.5.21",
@@ -40815,7 +40815,7 @@
     },
     "packages/hydrogen-codegen": {
       "name": "@shopify/hydrogen-codegen",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@shopify/graphql-codegen": "^0.1.0"
@@ -41050,7 +41050,7 @@
     },
     "packages/hydrogen-react": {
       "name": "@shopify/hydrogen-react",
-      "version": "2025.1.2",
+      "version": "2025.1.3",
       "license": "MIT",
       "dependencies": {
         "@google/model-viewer": "^4.0.0",
@@ -41805,7 +41805,7 @@
     },
     "packages/mini-oxygen": {
       "name": "@shopify/mini-oxygen",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "@miniflare/cache": "^2.14.4",
@@ -42308,7 +42308,7 @@
     },
     "packages/remix-oxygen": {
       "name": "@shopify/remix-oxygen",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "MIT",
       "devDependencies": {
         "@remix-run/server-runtime": "^2.16.1",
@@ -42320,12 +42320,12 @@
       }
     },
     "templates/skeleton": {
-      "version": "2025.1.2",
+      "version": "2025.1.3",
       "dependencies": {
         "@remix-run/react": "^2.16.1",
         "@remix-run/server-runtime": "^2.16.1",
-        "@shopify/hydrogen": "2025.1.2",
-        "@shopify/remix-oxygen": "^2.0.11",
+        "@shopify/hydrogen": "2025.1.3",
+        "@shopify/remix-oxygen": "^2.0.12",
         "graphql": "^16.10.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^5.1.22",
@@ -42340,9 +42340,9 @@
         "@remix-run/dev": "^2.16.1",
         "@remix-run/fs-routes": "^2.16.1",
         "@remix-run/route-config": "^2.16.1",
-        "@shopify/cli": "~3.77.0",
-        "@shopify/hydrogen-codegen": "^0.3.2",
-        "@shopify/mini-oxygen": "^3.1.1",
+        "@shopify/cli": "~3.77.1",
+        "@shopify/hydrogen-codegen": "^0.3.3",
+        "@shopify/mini-oxygen": "^3.1.2",
         "@shopify/oxygen-workers-types": "^4.1.6",
         "@shopify/prettier-config": "^1.1.2",
         "@total-typescript/ts-reset": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
     "@playwright/test": "^1.40.1",
-    "@shopify/cli": "~3.77.0",
+    "@shopify/cli": "~3.77.1",
     "@types/eslint": "^9.6.1",
     "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^8.21.0",
@@ -120,7 +120,7 @@
   },
   "overrides": {
     "@oclif/core": "3.26.5",
-    "@shopify/cli-kit": "3.77.0"
+    "@shopify/cli-kit": "3.77.1"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.34.9"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,9 +39,9 @@
   "dependencies": {
     "@ast-grep/napi": "0.11.0",
     "@oclif/core": "3.26.5",
-    "@shopify/cli-kit": "^3.77.0",
+    "@shopify/cli-kit": "^3.77.1",
     "@shopify/oxygen-cli": "4.6.10",
-    "@shopify/plugin-cloudflare": "^3.77.0",
+    "@shopify/plugin-cloudflare": "^3.77.1",
     "ansi-escapes": "^6.2.0",
     "chokidar": "3.5.3",
     "cli-truncate": "^4.0.0",

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -32,7 +32,7 @@
     "@remix-run/dev": "^2.16.1",
     "@remix-run/fs-routes": "^2.16.1",
     "@remix-run/route-config": "^2.16.1",
-    "@shopify/cli": "~3.77.0",
+    "@shopify/cli": "~3.77.1",
     "@shopify/hydrogen-codegen": "^0.3.3",
     "@shopify/mini-oxygen": "^3.1.2",
     "@shopify/oxygen-workers-types": "^4.1.6",


### PR DESCRIPTION
### WHY are these changes introduced?

We want to the cli dependencies to be updated to 3.77.1.

### WHAT is this pull request doing?

Updates the `@shopify/cli`, `@shopify/cli-kit` and `@shopify/plugin-cloudflare` dependencies to 3.77.1.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
