### PR TITLE
Fix JavaScript project creation to change the skeleton project filename of the layout file.

### DIFF
--- a/.changeset/forty-tools-search.md
+++ b/.changeset/forty-tools-search.md
@@ -1,0 +1,7 @@
+---
+"@shopify/cli-hydrogen": patch
+"@shopify/create-hydrogen": patch
+"skeleton": patch
+---
+
+Fixed an issue with the creation of JavaScript projects.

--- a/packages/cli/src/lib/transpile/project.ts
+++ b/packages/cli/src/lib/transpile/project.ts
@@ -60,6 +60,16 @@ function convertConfigToJS(
 }
 
 export async function transpileProject(projectDir: string, keepTypes = true) {
+  // Change the `routes.ts` file first as that points to a file with a
+  // TypeScript extension.
+  const routesPath = joinPath(projectDir, 'app/routes.ts');
+  const routesFileContent = await readFile(routesPath);
+  const replacedRoutesFileContent = routesFileContent.replace(
+    './layout.tsx',
+    './layout.jsx',
+  );
+  await writeFile(routesPath, replacedRoutesFileContent);
+
   const entries = await glob('**/*.+(ts|tsx)', {
     absolute: true,
     cwd: projectDir,


### PR DESCRIPTION
### WHY are these changes introduced?

When creating a project with JavaScript source, the routes file was looking for `layout.tsx` when it should be looking for `layout.jsx`.

### WHAT is this pull request doing?

It adds a step to `transpileProject` that rewrites the `routes.ts` file appropriately.

### HOW to test your changes?

Create a new project and choose JavaScript as the source type.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
