### PR TITLE
Fix prettier on changeset PR

### DIFF
--- a/.changeset/blue-timers-juggle.md
+++ b/.changeset/blue-timers-juggle.md
@@ -1,0 +1,18 @@
+---
+"@shopify/cli-hydrogen": patch
+---
+
+Test
+
+  1. Create a `routes.ts` file.
+
+     ```ts
+     import {flatRoutes} from '@remix-run/fs-routes';
+     import {layout, type RouteConfi } from '@remix-run/route-config';
+     import {hydrogenRoutes} from '@shopify/hydrogen';
+
+     export default hydrogenRoutes([
+       // Your entire app reading from routes folder using Layout from layout.tsx
+       layout('./layout.tsx', await flatRoutes()),
+     ]) satisfies RouteConfig;
+     ```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typecheck:examples": "turbo typecheck --parallel --filter=./examples/*",
     "test": "turbo run test --parallel",
     "test:watch": "turbo run test:watch",
-    "version": "changeset version && npm run version:post",
+    "version": "changeset version && npm run version:post && npm run format",
     "version:post": "npm run version:hydrogen && npm run version:cli",
     "version:hydrogen": "node -p \"'export const LIB_VERSION = \\'' + require('./packages/hydrogen/package.json').version + '\\';'\" > packages/hydrogen/src/version.ts",
     "version:cli": "cd packages/cli && npm run generate:manifest",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -51,13 +51,13 @@
   1. Create a `routes.ts` file.
 
      ```ts
-     import { flatRoutes } from "@remix-run/fs-routes";
-     import { layout, type RouteConfig } from "@remix-run/route-config";
-     import { hydrogenRoutes } from "@shopify/hydrogen";
+     import {flatRoutes} from '@remix-run/fs-routes';
+     import {layout, type RouteConfig} from '@remix-run/route-config';
+     import {hydrogenRoutes} from '@shopify/hydrogen';
 
      export default hydrogenRoutes([
        // Your entire app reading from routes folder using Layout from layout.tsx
-       layout("./layout.tsx", await flatRoutes()),
+       layout('./layout.tsx', await flatRoutes()),
      ]) satisfies RouteConfig;
      ```
 
@@ -440,10 +440,10 @@
 - This is an important fix to a bug with 404 routes and path-based i18n projects where some unknown routes would not properly render a 404. This fixes all new projects, but to fix existing projects, add a `($locale).tsx` route with the following contents: ([#1732](https://github.com/Shopify/hydrogen/pull/1732)) by [@blittle](https://github.com/blittle)
 
   ```ts
-  import { type LoaderFunctionArgs } from "@remix-run/server-runtime";
+  import {type LoaderFunctionArgs} from '@remix-run/server-runtime';
 
-  export async function loader({ params, context }: LoaderFunctionArgs) {
-    const { language, country } = context.storefront.i18n;
+  export async function loader({params, context}: LoaderFunctionArgs) {
+    const {language, country} = context.storefront.i18n;
 
     if (
       params.locale &&
@@ -451,7 +451,7 @@
     ) {
       // If the locale URL param is defined, yet we still are still at the default locale
       // then the the locale param must be invalid, send to the 404 page
-      throw new Response(null, { status: 404 });
+      throw new Response(null, {status: 404});
     }
 
     return null;
@@ -1050,17 +1050,17 @@ Shopify CLI now gives you [more options](https://shopify.dev/docs/custom-storefr
   **Optional**: you can tune the codegen configuration by providing a `<root>/codegen.ts` file (or specify a different path with the `--codegen-config-path` flag) with the following content:
 
   ```ts
-  import type { CodegenConfig } from "@graphql-codegen/cli";
-  import { preset, pluckConfig, schema } from "@shopify/hydrogen-codegen";
+  import type {CodegenConfig} from '@graphql-codegen/cli';
+  import {preset, pluckConfig, schema} from '@shopify/hydrogen-codegen';
 
   export default <CodegenConfig>{
     overwrite: true,
     pluckConfig,
     generates: {
-      ["storefrontapi.generated.d.ts"]: {
+      ['storefrontapi.generated.d.ts']: {
         preset,
         schema,
-        documents: ["*.{ts,tsx}", "app/**/*.{ts,tsx}"],
+        documents: ['*.{ts,tsx}', 'app/**/*.{ts,tsx}'],
       },
     },
   };


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Changeset seems to be on a whole different prettier config when updating CHANGELOG.md. Causing changeset PR failing prettier CI test.

### WHAT is this pull request doing?

Make sure monorepo's prettier is run after `npm run version`

### HOW to test your changes?

1. We have to merge this PR with the test changeset snippet
2. See what gets generated in the Changeset PR

#### Post-merge steps

Remove the test changeset snippet if everything looks good

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
