### PR TITLE
Deprecating VariantSelector

### DIFF
--- a/.changeset/polite-bears-rhyme.md
+++ b/.changeset/polite-bears-rhyme.md
@@ -2,7 +2,7 @@
 '@shopify/hydrogen': patch
 ---
 
-# Deprecation Notice: VariantSelector
+Deprecation Notice: VariantSelector
 
 `VariantSelector` is deprecated because it does not supports 2k variants or combined listing products. Use `getProductOptions` for a streamlined migration to a modern scalable product form.
 

--- a/.changeset/polite-bears-rhyme.md
+++ b/.changeset/polite-bears-rhyme.md
@@ -1,0 +1,714 @@
+---
+'@shopify/hydrogen': patch
+---
+
+# Deprecation Notice: VariantSelector
+
+`VariantSelector` is deprecated because it does not supports 2k variants or combined listing products. Use `getProductOptions` for a streamlined migration to a modern scalable product form.
+
+1. Update the SFAPI product query to request the new required fields `encodedVariantExistence` and `encodedVariantAvailability`. This will allow the product form to determine which variants are available for selection.
+
+```diff
+const PRODUCT_FRAGMENT = `#graphql
+  fragment Product on Product {
+    id
+    title
+    vendor
+    handle
+    descriptionHtml
+    description
++    encodedVariantExistence
++    encodedVariantAvailability
+    options {
+      name
+      optionValues {
+        name
++        firstSelectableVariant {
++          ...ProductVariant
++        }
++        swatch {
++          color
++          image {
++            previewImage {
++              url
++            }
++          }
++        }
+      }
+    }
+-    selectedVariant: selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
++    selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
++      ...ProductVariant
++    }
++    adjacentVariants (selectedOptions: $selectedOptions) {
++      ...ProductVariant
++    }
+-    variants(first: 1) {
+-      nodes {
+-        ...ProductVariant
+-      }
+-    }
+    seo {
+      description
+      title
+    }
+  }
+  ${PRODUCT_VARIANT_FRAGMENT}
+` as const;
+```
+
+2. Remove the `VARIANTS_QUERY` and related logic from `loadDeferredData`, as querying all variants is no longer necessary. Simplifies the function to return an empty object.
+
+```diff
+function loadDeferredData({context, params}: LoaderFunctionArgs) {
++  // Put any API calls that is not critical to be available on first page render
++  // For example: product reviews, product recommendations, social feeds.
+-  // In order to show which variants are available in the UI, we need to query
+-  // all of them. But there might be a *lot*, so instead separate the variants
+-  // into it's own separate query that is deferred. So there's a brief moment
+-  // where variant options might show as available when they're not, but after
+-  // this deferred query resolves, the UI will update.
+-  const variants = context.storefront
+-    .query(VARIANTS_QUERY, {
+-      variables: {handle: params.handle!},
+-    })
+-    .catch((error) => {
+-      // Log query errors, but don't throw them so the page can still render
+-      console.error(error);
+-      return null;
+-    });
+
++  return {}
+-  return {
+-    variants,
+-  };
+}
+```
+
+3. Update the `Product` component to use `getAdjacentAndFirstAvailableVariants` for determining the selected variant, improving handling of adjacent and available variants.
+
+```diff
+import {
+  getSelectedProductOptions,
+  Analytics,
+  useOptimisticVariant,
++  getAdjacentAndFirstAvailableVariants,
+} from '@shopify/hydrogen';
+
+export default function Product() {
++  const {product} = useLoaderData<typeof loader>();
+-  const {product, variants} = useLoaderData<typeof loader>();
+
++  // Optimistically selects a variant with given available variant information
++  const selectedVariant = useOptimisticVariant(
++    product.selectedOrFirstAvailableVariant,
++    getAdjacentAndFirstAvailableVariants(product),
++  );
+-  const selectedVariant = useOptimisticVariant(
+-    product.selectedVariant,
+-    variants,
+-  );
+```
+
+4. Automatically update the URL with search parameters based on the selected product variant's options when no search parameters are present, ensuring the URL reflects the current selection without triggering navigation.
+
+```diff
+import {
+  getSelectedProductOptions,
+  Analytics,
+  useOptimisticVariant,
+  getAdjacentAndFirstAvailableVariants,
++  mapSelectedProductOptionToObject,
+} from '@shopify/hydrogen';
+
+export default function Product() {
+  const {product} = useLoaderData<typeof loader>();
+
+  // Optimistically selects a variant with given available variant information
+  const selectedVariant = useOptimisticVariant(
+    product.selectedOrFirstAvailableVariant,
+    getAdjacentAndFirstAvailableVariants(product),
+  );
+
++  // Sets the search param to the selected variant without navigation
++  // only when no search params are set in the url
++  useEffect(() => {
++    const searchParams = new URLSearchParams(
++      mapSelectedProductOptionToObject(
++        selectedVariant.selectedOptions || [],
++      ),
++    );
+
++    if (window.location.search === '' && searchParams.toString() !== '') {
++      window.history.replaceState(
++        {},
++        '',
++        `${location.pathname}?${searchParams.toString()}`,
++      );
++    }
++  }, [
++    JSON.stringify(selectedVariant.selectedOptions),
++  ]);
+```
+
+5. Retrieve the product options array using `getProductOptions`, enabling efficient handling of product variants and their associated options.
+
+```diff
+import {
+  getSelectedProductOptions,
+  Analytics,
+  useOptimisticVariant,
++  getProductOptions,
+  getAdjacentAndFirstAvailableVariants,
+  mapSelectedProductOptionToObject,
+} from '@shopify/hydrogen';
+
+export default function Product() {
+  const {product} = useLoaderData<typeof loader>();
+
+  // Optimistically selects a variant with given available variant information
+  const selectedVariant = useOptimisticVariant(
+    product.selectedOrFirstAvailableVariant,
+    getAdjacentAndFirstAvailableVariants(product),
+  );
+
+  // Sets the search param to the selected variant without navigation
+  // only when no search params are set in the url
+  useEffect(() => {
+    // ...
+  }, [
+    JSON.stringify(selectedVariant.selectedOptions),
+  ]);
+
++  // Get the product options array
++  const productOptions = getProductOptions({
++    ...product,
++    selectedOrFirstAvailableVariant: selectedVariant,
++  });
+```
+
+6. Remove `Await` and `Suspense` from `ProductForm` as there are no longer any asynchronous queries to wait for, simplifying the component structure.
+
+```diff
+export default function Product() {
+
+  ...
+
+  return (
+    ...
++        <ProductForm
++          productOptions={productOptions}
++          selectedVariant={selectedVariant}
++        />
+-        <Suspense
+-          fallback={
+-            <ProductForm
+-              product={product}
+-              selectedVariant={selectedVariant}
+-              variants={[]}
+-            />
+-          }
+-        >
+-          <Await
+-            errorElement="There was a problem loading product variants"
+-            resolve={variants}
+-          >
+-            {(data) => (
+-              <ProductForm
+-                product={product}
+-                selectedVariant={selectedVariant}
+-                variants={data?.product?.variants.nodes || []}
+-              />
+-            )}
+-          </Await>
+-        </Suspense>
+```
+
+7. Refactor `ProductForm` to handle combined listing products and variants efficiently. It uses links for different product URLs and buttons for variant updates, improving SEO and user experience.
+
+```tsx
+import {Link, useNavigate} from '@remix-run/react';
+import {type MappedProductOptions} from '@shopify/hydrogen';
+import type {
+  Maybe,
+  ProductOptionValueSwatch,
+} from '@shopify/hydrogen/storefront-api-types';
+import {AddToCartButton} from './AddToCartButton';
+import {useAside} from './Aside';
+import type {ProductFragment} from 'storefrontapi.generated';
+
+export function ProductForm({
+  productOptions,
+  selectedVariant,
+}: {
+  productOptions: MappedProductOptions[];
+  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
+}) {
+  const navigate = useNavigate();
+  const {open} = useAside();
+  return (
+    <div className="product-form">
+      {productOptions.map((option) => (
+        <div className="product-options" key={option.name}>
+          <h5>{option.name}</h5>
+          <div className="product-options-grid">
+            {option.optionValues.map((value) => {
+              const {
+                name,
+                handle,
+                variantUriQuery,
+                selected,
+                available,
+                exists,
+                isDifferentProduct,
+                swatch,
+              } = value;
+
+              if (isDifferentProduct) {
+                // SEO
+                // When the variant is a combined listing child product
+                // that leads to a different URL, we need to render it
+                // as an anchor tag
+                return (
+                  <Link
+                    className="product-options-item"
+                    key={option.name + name}
+                    prefetch="intent"
+                    preventScrollReset
+                    replace
+                    to={`/products/${handle}?${variantUriQuery}`}
+                    style={{
+                      border: selected
+                        ? '1px solid black'
+                        : '1px solid transparent',
+                      opacity: available ? 1 : 0.3,
+                    }}
+                  >
+                    <ProductOptionSwatch swatch={swatch} name={name} />
+                  </Link>
+                );
+              } else {
+                // SEO
+                // When the variant is an update to the search param,
+                // render it as a button with JavaScript navigating to
+                // the variant so that SEO bots do not index these as
+                // duplicated links
+                return (
+                  <button
+                    type="button"
+                    className={`product-options-item${
+                      exists && !selected ? ' link' : ''
+                    }`}
+                    key={option.name + name}
+                    style={{
+                      border: selected
+                        ? '1px solid black'
+                        : '1px solid transparent',
+                      opacity: available ? 1 : 0.3,
+                    }}
+                    disabled={!exists}
+                    onClick={() => {
+                      if (!selected) {
+                        navigate(`?${variantUriQuery}`, {
+                          replace: true,
+                        });
+                      }
+                    }}
+                  >
+                    <ProductOptionSwatch swatch={swatch} name={name} />
+                  </button>
+                );
+              }
+            })}
+          </div>
+          <br />
+        </div>
+      ))}
+      <AddToCartButton
+        disabled={!selectedVariant || !selectedVariant.availableForSale}
+        onClick={() => {
+          open('cart');
+        }}
+        lines={
+          selectedVariant
+            ? [
+                {
+                  merchandiseId: selectedVariant.id,
+                  quantity: 1,
+                  selectedVariant,
+                },
+              ]
+            : []
+        }
+      >
+        {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
+      </AddToCartButton>
+    </div>
+  );
+}
+
+function ProductOptionSwatch({
+  swatch,
+  name,
+}: {
+  swatch?: Maybe<ProductOptionValueSwatch> | undefined;
+  name: string;
+}) {
+  const image = swatch?.image?.previewImage?.url;
+  const color = swatch?.color;
+
+  if (!image && !color) return name;
+
+  return (
+    <div
+      aria-label={name}
+      className="product-option-label-swatch"
+      style={{
+        backgroundColor: color || 'transparent',
+      }}
+    >
+      {!!image && <img src={image} alt={name} />}
+    </div>
+  );
+}
+```
+
+8. Make `useVariantUrl` and `getVariantUrl` functions more flexible by allowing `selectedOptions` to be optional. This ensures compatibility with cases where no options are provided.
+
+```diff
+export function useVariantUrl(
+  handle: string,
+-  selectedOptions: SelectedOption[],
++  selectedOptions?: SelectedOption[],
+) {
+  const {pathname} = useLocation();
+
+  return useMemo(() => {
+    return getVariantUrl({
+      handle,
+      pathname,
+      searchParams: new URLSearchParams(),
+      selectedOptions,
+    });
+  }, [handle, selectedOptions, pathname]);
+}
+export function getVariantUrl({
+  handle,
+  pathname,
+  searchParams,
+  selectedOptions,
+}: {
+  handle: string;
+  pathname: string;
+  searchParams: URLSearchParams;
+-  selectedOptions: SelectedOption[];
++  selectedOptions?: SelectedOption[],
+}) {
+  const match = /(\/[a-zA-Z]{2}-[a-zA-Z]{2}\/)/g.exec(pathname);
+  const isLocalePathname = match && match.length > 0;
+  const path = isLocalePathname
+    ? `${match![0]}products/${handle}`
+    : `/products/${handle}`;
+
+-  selectedOptions.forEach((option) => {
++  selectedOptions?.forEach((option) => {
+    searchParams.set(option.name, option.value);
+  });
+```
+
+9. Remove unnecessary variant queries and references in `routes/collections.$handle.tsx`, simplifying the code by relying on the product route to fetch the first available variant.
+
+```diff
+const PRODUCT_ITEM_FRAGMENT = `#graphql
+  fragment MoneyProductItem on MoneyV2 {
+    amount
+    currencyCode
+  }
+  fragment ProductItem on Product {
+    id
+    handle
+    title
+    featuredImage {
+      id
+      altText
+      url
+      width
+      height
+    }
+    priceRange {
+      minVariantPrice {
+        ...MoneyProductItem
+      }
+      maxVariantPrice {
+        ...MoneyProductItem
+      }
+    }
+-    variants(first: 1) {
+-      nodes {
+-        selectedOptions {
+-          name
+-          value
+-        }
+-      }
+-    }
+  }
+` as const;
+```
+
+and remove the variant reference
+
+```diff
+function ProductItem({
+  product,
+  loading,
+}: {
+  product: ProductItemFragment;
+  loading?: 'eager' | 'lazy';
+}) {
+-  const variant = product.variants.nodes[0];
+-  const variantUrl = useVariantUrl(product.handle, variant.selectedOptions);
++  const variantUrl = useVariantUrl(product.handle);
+  return (
+```
+
+10. Simplify the `ProductItem` component by removing variant-specific queries and logic. The `useVariantUrl` function now generates URLs without relying on variant options, reducing complexity.
+
+```diff
+const PRODUCT_ITEM_FRAGMENT = `#graphql
+  fragment MoneyProductItem on MoneyV2 {
+    amount
+    currencyCode
+  }
+  fragment ProductItem on Product {
+    id
+    handle
+    title
+    featuredImage {
+      id
+      altText
+      url
+      width
+      height
+    }
+    priceRange {
+      minVariantPrice {
+        ...MoneyProductItem
+      }
+      maxVariantPrice {
+        ...MoneyProductItem
+      }
+    }
+-    variants(first: 1) {
+-      nodes {
+-        selectedOptions {
+-          name
+-          value
+-        }
+-      }
+-    }
+  }
+` as const;
+```
+
+and remove the variant reference
+
+```diff
+function ProductItem({
+  product,
+  loading,
+}: {
+  product: ProductItemFragment;
+  loading?: 'eager' | 'lazy';
+}) {
+-  const variant = product.variants.nodes[0];
+-  const variantUrl = useVariantUrl(product.handle, variant.selectedOptions);
++  const variantUrl = useVariantUrl(product.handle);
+  return (
+```
+
+11. Replace `variants(first: 1)` with `selectedOrFirstAvailableVariant` in GraphQL fragments to directly fetch the most relevant variant, improving query efficiency and clarity.
+
+```diff
+const SEARCH_PRODUCT_FRAGMENT = `#graphql
+  fragment SearchProduct on Product {
+    __typename
+    handle
+    id
+    publishedAt
+    title
+    trackingParameters
+    vendor
+-    variants(first: 1) {
+-      nodes {
++    selectedOrFirstAvailableVariant(
++      selectedOptions: []
++      ignoreUnknownOptions: true
++      caseInsensitiveMatch: true
++    ) {
+        id
+        image {
+          url
+          altText
+          width
+          height
+        }
+        price {
+          amount
+          currencyCode
+        }
+        compareAtPrice {
+          amount
+          currencyCode
+        }
+        selectedOptions {
+          name
+          value
+        }
+        product {
+          handle
+          title
+        }
+     }
+-    }
+  }
+` as const;
+```
+
+```diff
+const PREDICTIVE_SEARCH_PRODUCT_FRAGMENT = `#graphql
+  fragment PredictiveProduct on Product {
+    __typename
+    id
+    title
+    handle
+    trackingParameters
+-    variants(first: 1) {
+-      nodes {
++    selectedOrFirstAvailableVariant(
++      selectedOptions: []
++      ignoreUnknownOptions: true
++      caseInsensitiveMatch: true
++    ) {
+        id
+        image {
+          url
+          altText
+          width
+          height
+        }
+        price {
+          amount
+          currencyCode
+        }
+     }
+-    }
+  }
+```
+
+12. Refactor `SearchResultsProducts` to use `selectedOrFirstAvailableVariant` for fetching product price and image, simplifying the logic and improving performance.
+
+```diff
+function SearchResultsProducts({
+  term,
+  products,
+}: PartialSearchResult<'products'>) {
+  if (!products?.nodes.length) {
+    return null;
+  }
+
+  return (
+    <div className="search-result">
+      <h2>Products</h2>
+      <Pagination connection={products}>
+        {({nodes, isLoading, NextLink, PreviousLink}) => {
+          const ItemsMarkup = nodes.map((product) => {
+            const productUrl = urlWithTrackingParams({
+              baseUrl: `/products/${product.handle}`,
+              trackingParams: product.trackingParameters,
+              term,
+            });
+
++            const price = product?.selectedOrFirstAvailableVariant?.price;
++            const image = product?.selectedOrFirstAvailableVariant?.image;
+
+            return (
+              <div className="search-results-item" key={product.id}>
+                <Link prefetch="intent" to={productUrl}>
+-                  {product.variants.nodes[0].image && (
++                  {image && (
+                    <Image
+-                      data={product.variants.nodes[0].image}
++                      data={image}
+                      alt={product.title}
+                      width={50}
+                    />
+                  )}
+                  <div>
+                    <p>{product.title}</p>
+                    <small>
+-                      <Money data={product.variants.nodes[0].price} />
++                      {price &&
++                        <Money data={price} />
++                      }
+                    </small>
+                  </div>
+                </Link>
+              </div>
+            );
+          });
+```
+
+13. Update `SearchResultsPredictive` to use `selectedOrFirstAvailableVariant` for fetching product price and image, ensuring accurate and efficient data retrieval.
+
+```diff
+function SearchResultsPredictiveProducts({
+  term,
+  products,
+  closeSearch,
+}: PartialPredictiveSearchResult<'products'>) {
+  if (!products.length) return null;
+
+  return (
+    <div className="predictive-search-result" key="products">
+      <h5>Products</h5>
+      <ul>
+        {products.map((product) => {
+          const productUrl = urlWithTrackingParams({
+            baseUrl: `/products/${product.handle}`,
+            trackingParams: product.trackingParameters,
+            term: term.current,
+          });
+
++          const price = product?.selectedOrFirstAvailableVariant?.price;
+-          const image = product?.variants?.nodes?.[0].image;
++          const image = product?.selectedOrFirstAvailableVariant?.image;
+          return (
+            <li className="predictive-search-result-item" key={product.id}>
+              <Link to={productUrl} onClick={closeSearch}>
+                {image && (
+                  <Image
+                    alt={image.altText ?? ''}
+                    src={image.url}
+                    width={50}
+                    height={50}
+                  />
+                )}
+                <div>
+                  <p>{product.title}</p>
+                  <small>
+-                    {product?.variants?.nodes?.[0].price && (
++                    {price && (
+-                      <Money data={product.variants.nodes[0].price} />
++                      <Money data={price} />
+                    )}
+                  </small>
+                </div>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+```

--- a/docs/preview/package.json
+++ b/docs/preview/package.json
@@ -26,7 +26,7 @@
     "@types/react-dom": "^18.2.7",
     "@types/react-syntax-highlighter": "^15.5.7",
     "typescript": "^5.2.2",
-    "vite": "^6.2.0",
+    "vite": "^6.2.4",
     "vite-tsconfig-paths": "^4.3.1"
   },
   "engines": {

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -39,7 +39,7 @@
     "nodemon": "^2.0.22",
     "npm-run-all": "^4.1.5",
     "typescript": "^5.2.2",
-    "vite": "^6.2.0",
+    "vite": "^6.2.4",
     "vite-tsconfig-paths": "^4.3.1"
   },
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "@types/react-dom": "^18.2.7",
         "@types/react-syntax-highlighter": "^15.5.7",
         "typescript": "^5.2.2",
-        "vite": "^6.2.0",
+        "vite": "^6.2.4",
         "vite-tsconfig-paths": "^4.3.1"
       },
       "engines": {
@@ -145,7 +145,7 @@
         "nodemon": "^2.0.22",
         "npm-run-all": "^4.1.5",
         "typescript": "^5.2.2",
-        "vite": "^6.2.0",
+        "vite": "^6.2.4",
         "vite-tsconfig-paths": "^4.3.1"
       },
       "engines": {
@@ -37549,9 +37549,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -39792,7 +39792,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "9.0.9",
+      "version": "9.0.11",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -39832,7 +39832,7 @@
         "flame-chart-js": "2.3.2",
         "get-port": "^7.0.0",
         "type-fest": "^4.33.0",
-        "vite": "^6.2.0",
+        "vite": "^6.2.4",
         "vitest": "^1.0.4"
       },
       "engines": {
@@ -40567,7 +40567,7 @@
     },
     "packages/create-hydrogen": {
       "name": "@shopify/create-hydrogen",
-      "version": "5.0.18",
+      "version": "5.0.20",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.34.1"
@@ -41096,7 +41096,7 @@
         "rimraf": "^6.0.1",
         "ts-expect": "^1.3.0",
         "typescript": "^5.7.3",
-        "vite": "^6.2.1",
+        "vite": "^6.2.4",
         "vitest": "^1.0.4"
       },
       "engines": {
@@ -42320,7 +42320,7 @@
       }
     },
     "templates/skeleton": {
-      "version": "2025.1.3",
+      "version": "2025.1.5",
       "dependencies": {
         "@remix-run/react": "^2.16.1",
         "@remix-run/server-runtime": "^2.16.1",
@@ -42363,7 +42363,7 @@
         "globals": "^15.14.0",
         "prettier": "^3.4.2",
         "typescript": "^5.2.2",
-        "vite": "^6.2.0",
+        "vite": "^6.2.4",
         "vite-tsconfig-paths": "^4.3.1"
       },
       "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
     "flame-chart-js": "2.3.2",
     "get-port": "^7.0.0",
     "type-fest": "^4.33.0",
-    "vite": "^6.2.0",
+    "vite": "^6.2.4",
     "vitest": "^1.0.4"
   },
   "dependencies": {

--- a/packages/hydrogen-react/package.json
+++ b/packages/hydrogen-react/package.json
@@ -165,7 +165,7 @@
     "rimraf": "^6.0.1",
     "ts-expect": "^1.3.0",
     "typescript": "^5.7.3",
-    "vite": "^6.2.1",
+    "vite": "^6.2.4",
     "vitest": "^1.0.4"
   },
   "peerDependencies": {

--- a/packages/hydrogen/src/product/VariantSelector.ts
+++ b/packages/hydrogen/src/product/VariantSelector.ts
@@ -10,7 +10,6 @@ import type {
 } from '@shopify/hydrogen-react/storefront-api-types';
 import {type ReactNode, useMemo, createElement, Fragment} from 'react';
 import type {PartialDeep} from 'type-fest';
-import {warnOnce} from '../utils/warning';
 
 export type VariantOption = {
   name: string;
@@ -53,6 +52,10 @@ type VariantSelectorProps = {
   children: ({option}: {option: VariantOption}) => ReactNode;
 };
 
+/**
+ * @deprecated This component will be deprecated and removed in the next major version 2025-07
+ * Please use the [getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getselectedproductoptions) util instead.
+ */
 export function VariantSelector({
   handle,
   options: _options = [],
@@ -62,22 +65,7 @@ export function VariantSelector({
   selectedVariant,
   children,
 }: VariantSelectorProps) {
-  // Deprecation notice for product.options.values
-  // TODO: Remove this after product.options.values is removed from the Storefront API
   let options = _options;
-  if (options[0]?.values) {
-    warnOnce(
-      '[h2:warn:VariantSelector] product.options.values is deprecated. Use product.options.optionValues instead.',
-    );
-
-    if (!!options[0] && !options[0].optionValues) {
-      // Convert the old values format to the new optionValues format
-      options = _options.map((option) => ({
-        ...option,
-        optionValues: option.values?.map((value) => ({name: value})) || [],
-      }));
-    }
-  }
 
   const variants =
     _variants instanceof Array ? _variants : flattenConnection(_variants);

--- a/packages/hydrogen/src/product/VariantSelector.ts
+++ b/packages/hydrogen/src/product/VariantSelector.ts
@@ -34,6 +34,10 @@ export type VariantOptionValue = {
   optionValue: PartialProductOptionValues;
 };
 
+/**
+ * @deprecated This component will be deprecated and removed in the next major version 2025-07
+ * Please use the [getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getselectedproductoptions) util instead.
+ */
 type VariantSelectorProps = {
   /** The product handle for all of the variants */
   handle: string;
@@ -54,7 +58,9 @@ type VariantSelectorProps = {
 
 /**
  * @deprecated This component will be deprecated and removed in the next major version 2025-07
- * Please use the [getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getselectedproductoptions) util instead.
+ * Please use the [getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getselectedproductoptions)
+ * and [getAdjacentAndFirstAvailableVariants](https://shopify.dev/docs/api/hydrogen/latest/utilities/getadjacentandfirstavailablevariants) utils instead.
+ * See the Skeleton template routes/product.$handle.tsx file for an example of how to use them.
  */
 export function VariantSelector({
   handle,

--- a/packages/hydrogen/src/product/VariantSelector.ts
+++ b/packages/hydrogen/src/product/VariantSelector.ts
@@ -10,6 +10,7 @@ import type {
 } from '@shopify/hydrogen-react/storefront-api-types';
 import {type ReactNode, useMemo, createElement, Fragment} from 'react';
 import type {PartialDeep} from 'type-fest';
+import {warnOnce} from '../utils/warning';
 
 export type VariantOption = {
   name: string;
@@ -77,7 +78,22 @@ export function VariantSelector({
   selectedVariant,
   children,
 }: VariantSelectorProps) {
+  // Deprecation notice for product.options.values
+  // TODO: Remove this after product.options.values is removed from the Storefront API
   let options = _options;
+  if (options[0]?.values) {
+    warnOnce(
+      '[h2:warn:VariantSelector] product.options.values is deprecated. Use product.options.optionValues instead.',
+    );
+
+    if (!!options[0] && !options[0].optionValues) {
+      // Convert the old values format to the new optionValues format
+      options = _options.map((option) => ({
+        ...option,
+        optionValues: option.values?.map((value) => ({name: value})) || [],
+      }));
+    }
+  }
 
   const variants =
     _variants instanceof Array ? _variants : flattenConnection(_variants);

--- a/packages/hydrogen/src/product/VariantSelector.ts
+++ b/packages/hydrogen/src/product/VariantSelector.ts
@@ -35,8 +35,12 @@ export type VariantOptionValue = {
 };
 
 /**
- * @deprecated This component will be deprecated and removed in the next major version 2025-07
- * Please use the [getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getselectedproductoptions) util instead.
+ * @deprecated VariantSelector will be deprecated and removed in the next major version 2025-07
+ * Please use [getProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getproductoptions),
+ * [getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getselectedproductoptions),
+ * [getAdjacentAndFirstAvailableVariants](https://shopify.dev/docs/api/hydrogen/latest/utilities/getadjacentandfirstavailablevariants) utils instead.
+ * and [useSelectedOptionInUrlParam](https://shopify.dev/docs/api/hydrogen/latest/utilities/useselectedoptioninurlparam)
+ * For a full implementation see the Skeleton template [routes/product.$handle.tsx](https://github.com/Shopify/hydrogen/blob/main/templates/skeleton/app/routes/products.%24handle.tsx).
  */
 type VariantSelectorProps = {
   /** The product handle for all of the variants */
@@ -57,10 +61,12 @@ type VariantSelectorProps = {
 };
 
 /**
- * @deprecated This component will be deprecated and removed in the next major version 2025-07
- * Please use the [getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getselectedproductoptions)
- * and [getAdjacentAndFirstAvailableVariants](https://shopify.dev/docs/api/hydrogen/latest/utilities/getadjacentandfirstavailablevariants) utils instead.
- * See the Skeleton template routes/product.$handle.tsx file for an example of how to use them.
+ * @deprecated VariantSelector will be deprecated and removed in the next major version 2025-07
+ * Please use [getProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getproductoptions),
+ * [getSelectedProductOptions](https://shopify.dev/docs/api/hydrogen/latest/utilities/getselectedproductoptions),
+ * [getAdjacentAndFirstAvailableVariants](https://shopify.dev/docs/api/hydrogen/latest/utilities/getadjacentandfirstavailablevariants) utils instead.
+ * and [useSelectedOptionInUrlParam](https://shopify.dev/docs/api/hydrogen/latest/utilities/useselectedoptioninurlparam)
+ * For a full implementation see the Skeleton template [routes/product.$handle.tsx](https://github.com/Shopify/hydrogen/blob/main/templates/skeleton/app/routes/products.%24handle.tsx).
  */
 export function VariantSelector({
   handle,

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "globals": "^15.14.0",
     "typescript": "^5.2.2",
-    "vite": "^6.2.0",
+    "vite": "^6.2.4",
     "vite-tsconfig-paths": "^4.3.1"
   },
   "engines": {


### PR DESCRIPTION
# Deprecating VariantSelector: A New Path Forward for Product Forms

## The Problem

The current VariantSelector component has reached its limits. It cannot handle complex scenarios like products with 2,000 variants or combined listing products. Updating it would require breaking changes that would disrupt merchant storefronts.

## The Solution

We recommend using the `getProductOptions` utility instead. This approach:

- Fully supports products with up to 2,000 variants
- Works seamlessly with combined listing products
- Provides a future-proof foundation for product pages
- Aligns with our skeleton template, which has already made this transition

## Next Steps

Our skeleton template has already implemented this recommended approach. To set merchants up for success, we should deprecate the VariantSelector component and guide them toward using the `getProductOptions` utility for their product pages.

This change will help merchants build more robust product forms without running into the current limitations of VariantSelector.

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
