### PR TITLE
Cookbook scripts: summary, requirements, copy adjustments

### DIFF
--- a/cookbook/recipe.schema.json
+++ b/cookbook/recipe.schema.json
@@ -5,6 +5,10 @@
       "type": "string",
       "description": "The title of the recipe"
     },
+    "summary": {
+      "type": "string",
+      "description": "The summary of what the recipe does"
+    },
     "description": {
       "type": "string",
       "description": "The description of the recipe"
@@ -16,9 +20,23 @@
       },
       "description": "The notes of the recipe"
     },
-    "image": {
-      "type": ["string", "null"],
-      "description": "The image of the recipe"
+    "requirements": {
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "not": {}
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The requirements of the recipe"
     },
     "ingredients": {
       "type": "array",
@@ -30,11 +48,16 @@
             "description": "The path of the ingredient"
           },
           "description": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "The description of the ingredient"
           }
         },
-        "required": ["path"],
+        "required": [
+          "path"
+        ],
         "additionalProperties": false
       },
       "description": "The ingredients of the recipe"
@@ -46,7 +69,11 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["PATCH", "INFO", "COPY_INGREDIENTS"],
+            "enum": [
+              "PATCH",
+              "INFO",
+              "COPY_INGREDIENTS"
+            ],
             "description": "The type of step"
           },
           "name": {
@@ -54,7 +81,10 @@
             "description": "The name of the step"
           },
           "description": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "The description of the step"
           },
           "notes": {
@@ -85,13 +115,19 @@
                   "description": "The patch file of the diff"
                 }
               },
-              "required": ["file", "patchFile"],
+              "required": [
+                "file",
+                "patchFile"
+              ],
               "additionalProperties": false
             },
             "description": "The diffs of the step"
           }
         },
-        "required": ["type", "name"],
+        "required": [
+          "type",
+          "name"
+        ],
         "additionalProperties": false
       },
       "description": "The steps of the recipe"
@@ -108,7 +144,14 @@
       "description": "The commit hash the recipe is based on"
     }
   },
-  "required": ["title", "description", "ingredients", "steps", "commit"],
+  "required": [
+    "title",
+    "summary",
+    "description",
+    "ingredients",
+    "steps",
+    "commit"
+  ],
   "additionalProperties": false,
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/cookbook/src/lib/generate.ts
+++ b/cookbook/src/lib/generate.ts
@@ -92,11 +92,12 @@ export async function generateRecipe(params: {
 
   const recipe: Recipe = {
     title: existingRecipe?.title ?? recipeName,
-    image: existingRecipe?.image ?? null,
+    summary: existingRecipe?.summary ?? '',
     description: existingRecipe?.description ?? '',
     notes: existingRecipe?.notes ?? [],
-    deletedFiles,
+    requirements: existingRecipe?.requirements ?? null,
     ingredients,
+    deletedFiles,
     steps,
     commit: getMainCommitHash(parseReferenceBranch(referenceBranch)),
   };
@@ -184,9 +185,9 @@ function maybeLoadExistingRecipe(recipePath: string): Recipe | null {
 function copyIngredientsStep(ingredients: Ingredient[]): Step {
   return {
     type: 'COPY_INGREDIENTS',
-    name: 'Copy ingredients',
+    name: 'Add ingredients to your project',
     description:
-      'Copy the ingredients from the template directory to the current directory.',
+      'Copy all the files found in the `ingredients/` directory to the current directory.',
     ingredients: ingredients.map((ingredient) => ingredient.path),
   };
 }

--- a/cookbook/src/lib/recipe.ts
+++ b/cookbook/src/lib/recipe.ts
@@ -43,9 +43,14 @@ export type Step = z.infer<typeof StepSchema>;
 
 export const RecipeSchema = z.object({
   title: z.string().describe('The title of the recipe'),
+  summary: z.string().describe('The summary of what the recipe does'),
   description: z.string().describe('The description of the recipe'),
   notes: z.array(z.string()).optional().describe('The notes of the recipe'),
-  image: z.string().nullable().optional().describe('The image of the recipe'),
+  requirements: z
+    .string()
+    .optional()
+    .nullable()
+    .describe('The requirements of the recipe'),
   ingredients: z
     .array(IngredientSchema)
     .describe('The ingredients of the recipe'),


### PR DESCRIPTION
### WHY are these changes introduced?

The work on https://github.com/Shopify/hydrogen/pull/2815 led to some improvements to copy and structure for the cookbook scripts (generation + rendering).

### WHAT is this pull request doing?

This PR shards off of https://github.com/Shopify/hydrogen/pull/2815 for the logic pieces that are not recipe-specific.

In detail:

- It adds a `summary` field and a dedicated `requirement` field to the recipe schema
- It adjusts the order of the rendered blocks
- If adjusts the copy of some of the generated text, including removing header emojis and adding number indices to rendered steps
- It adjusts the shopify.dev rendering variant, fixing the front matter serialization, the fenced code blocks rendering and adding support for collapsible sections in that variant too, and escaping double curly braces which would otherwise break the Liquid parsing

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation