### PR TITLE
Cookbook: Cursor rules

### DIFF
--- a/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -1,0 +1,836 @@
+---
+description: Recipe for implementing "Subscriptions (subscriptions)" in a Hydrogen storefront. Add subscription-based products to your Hydrogen storefront.
+globs: templates/**/*
+alwaysApply: "false"
+---
+
+# Overview
+
+This rule describes how to implement "Subscriptions" in a Hydrogen storefront. Below is a "recipe" that contains the steps to apply to a basic Hydrogen skeleton template to achieve the desired outcome.
+
+The same logic can be applied to any other Hydrogen storefront project, adapting the implementation details to the specific needs/structure/conventions of the project, but it's up to the developer to do so.
+
+If there are any prerequisites, the recipe below will explain them; if the user is trying to implement the feature described in this recipe, make sure to prominently mention the prerequisites and any other preliminary instructions, as well as followups.
+
+Please remember that specific documentation about Storefront API, which might be relevant to the user, is available at <https://shopify.dev/docs/api/storefront>.
+
+If the user is asking on how to implement the feature from scratch, please first describe the feature in a general way before jumping into the implementation details.
+
+Please note that the recipe steps below are not necessarily ordered in the way they should be executed, as it depends on the user's needs and the specific details of the project. The recipe steps descriptions should allow you to understand what is required to be done in a certain order and what is not. Remember that file names in the recipe are related to the Hydrogen skeleton template, not the user's project, so make sure to adapt the file names to the user's project.
+
+# Summary
+
+Add subscription-based products to your Hydrogen storefront.
+
+# User Intent Recognition
+
+<user_queries>
+- How do I add subscriptions to my Hydrogen storefront?
+- How do I add selling plans to my Hydrogen storefront?
+- How do I display subscription details on applicable line items in the cart?
+</user_queries>
+
+# Troubleshooting
+
+<troubleshooting>
+- **Issue**: I'm getting an error when I try to add a subscription to my storefront.
+  **Solution**: Make sure you have the Shopify Subscriptions app installed and configured correctly.
+- **Issue**: I'm not seeing the subscription options on my product pages.
+  **Solution**: Make sure you have the Shopify Subscriptions app installed and configured correctly.
+- **Issue**: I'm not seeing the subscription details on my cart line items.
+  **Solution**: Make sure you have the Shopify Subscriptions app installed and configured correctly.
+</troubleshooting>
+
+# Recipe Implementation
+
+Here's the subscriptions recipe for the base Hydrogen skeleton template:
+
+<recipe_implementation>
+
+## Description
+
+This recipe lets you sell subscription-based products on your Hydrogen storefront by implementing [selling plan groups](https://shopify.dev/docs/api/storefront/latest/objects/SellingPlanGroup). Your customers will be able to choose between one-time purchases or recurring subscriptions for any products with available selling plans.
+
+
+In this recipe you'll make the following changes:
+
+
+1. Set up a subscriptions app in your Shopify admin and add selling plans to any products that will be sold as subscriptions.
+2. Modify product detail pages to display subscription options with accurate pricing using the `SellingPlanSelector` component.
+3. Enhance GraphQL fragments to fetch all necessary selling plan data.
+4. Display subscription details on applicable line items in the cart.
+
+
+## Requirements
+
+To implement subscriptions in your own store, you need to install a subscriptions app in your Shopify admin. In this recipe, we'll use the [Shopify Subscriptions app](https://apps.shopify.com/shopify-subscriptions).
+
+
+## Ingredients
+
+_New files added to the template by this recipe._
+
+- `templates/skeleton/app/components/SellingPlanSelector.tsx` : The `SellingPlanSelector` component is used to display the available subscription options on product pages.
+- `templates/skeleton/app/styles/selling-plan.css` : The `selling-plan.css` file is used to style the `SellingPlanSelector` component.
+
+## Steps
+
+### Step 1: Set up the Shopify Subscriptions app
+
+1. Install the [Shopify Subscriptions app](https://apps.shopify.com/shopify-subscriptions).
+2. In your Shopify admin, [use the Subscriptions app](https://admin.shopify.com/apps/subscriptions-remix/app) to create one or more subscription plans.
+3. On the [Products](https://admin.shopify.com/products) page, open any products that will be sold as subscriptions and add the relevant subscription plans in the **Purchase options** section.
+The Hydrogen demo storefront comes pre-configured with an example subscription product with the handle `shopify-wax`.
+
+
+### Step 2: Add ingredients to your project
+
+Copy all the files found in the `ingredients/` directory to the current directory.
+
+- [`app/components/SellingPlanSelector.tsx`](ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+- [`app/styles/selling-plan.css`](ingredients/templates/skeleton/app/styles/selling-plan.css)
+
+### Step 3: Render the selling plan in the cart
+
+1. Update `CartLineItem` to show subscription details when they're available.
+2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
+
+
+#### File: [`app/components/CartLineItem.tsx`](/templates/skeleton/app/components/CartLineItem.tsx)
+
+```diff
+index 26102b61..4ec8324b 100644
+--- a/templates/skeleton/app/components/CartLineItem.tsx
++++ b/templates/skeleton/app/components/CartLineItem.tsx
+@@ -3,8 +3,8 @@ import type {CartLayout} from '~/components/CartMain';
+ import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
+ import {useVariantUrl} from '~/lib/variants';
+ import {Link} from '@remix-run/react';
+-import {ProductPrice} from './ProductPrice';
+-import {useAside} from './Aside';
++import {ProductPrice} from '~/components/ProductPrice';
++import {useAside} from '~/components/Aside';
+ import type {CartApiQueryFragment} from 'storefrontapi.generated';
+ 
+ type CartLine = OptimisticCartLine<CartApiQueryFragment>;
+@@ -20,7 +20,9 @@ export function CartLineItem({
+   layout: CartLayout;
+   line: CartLine;
+ }) {
+-  const {id, merchandise} = line;
++  // Get the selling plan allocation
++  const {id, merchandise, sellingPlanAllocation} = line;
++
+   const {product, title, image, selectedOptions} = merchandise;
+   const lineItemUrl = useVariantUrl(product.handle, selectedOptions);
+   const {close} = useAside();
+@@ -54,6 +56,12 @@ export function CartLineItem({
+         </Link>
+         <ProductPrice price={line?.cost?.totalAmount} />
+         <ul>
++          {/* Optionally render the selling plan name if available */}
++          {sellingPlanAllocation && (
++            <li key={sellingPlanAllocation.sellingPlan.name}>
++              <small>{sellingPlanAllocation.sellingPlan.name}</small>
++            </li>
++          )}
+           {selectedOptions.map((option) => (
+             <li key={option.name}>
+               <small>
+
+```
+
+### Step 4: Update `ProductForm` to support subscriptions
+
+1. Add conditional rendering to display either subscription options or standard variant selectors.
+2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
+3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
+
+
+#### File: [`app/components/ProductForm.tsx`](/templates/skeleton/app/components/ProductForm.tsx)
+
+<details>
+
+```diff
+index e8616a61..e41b91ad 100644
+--- a/templates/skeleton/app/components/ProductForm.tsx
++++ b/templates/skeleton/app/components/ProductForm.tsx
+@@ -6,120 +6,169 @@ import type {
+ } from '@shopify/hydrogen/storefront-api-types';
+ import {AddToCartButton} from './AddToCartButton';
+ import {useAside} from './Aside';
+-import type {ProductFragment} from 'storefrontapi.generated';
++import type {
++  ProductFragment,
++  SellingPlanFragment,
++} from 'storefrontapi.generated';
++import {
++  SellingPlanSelector,
++  type SellingPlanGroup,
++} from '~/components/SellingPlanSelector';
+ 
+ export function ProductForm({
+   productOptions,
+   selectedVariant,
++  sellingPlanGroups,
++  selectedSellingPlan,
+ }: {
+   productOptions: MappedProductOptions[];
+   selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
++  selectedSellingPlan: SellingPlanFragment | null;
++  sellingPlanGroups: ProductFragment['sellingPlanGroups'];
+ }) {
+   const navigate = useNavigate();
+   const {open} = useAside();
+   return (
+     <div className="product-form">
+-      {productOptions.map((option) => {
+-        // If there is only a single value in the option values, don't display the option
+-        if (option.optionValues.length === 1) return null;
++      {sellingPlanGroups.nodes.length > 0 ? (
++        <>
++          <SellingPlanSelector
++            sellingPlanGroups={sellingPlanGroups}
++            selectedSellingPlan={selectedSellingPlan}
++          >
++            {({sellingPlanGroup}) => (
++              <SellingPlanGroup
++                key={sellingPlanGroup.name}
++                sellingPlanGroup={sellingPlanGroup}
++              />
++            )}
++          </SellingPlanSelector>
++          <br />
++          <AddToCartButton
++            disabled={!selectedSellingPlan}
++            onClick={() => {
++              open('cart');
++            }}
++            lines={
++              selectedSellingPlan && selectedVariant
++                ? [
++                    {
++                      quantity: 1,
++                      selectedVariant,
++                      sellingPlanId: selectedSellingPlan.id,
++                      merchandiseId: selectedVariant.id,
++                    },
++                  ]
++                : []
++            }
++          >
++            {selectedSellingPlan ? 'Subscribe' : 'Select Subscription'}
++          </AddToCartButton>
++        </>
++      ) : (
++        productOptions.map((option) => {
++          // If there is only a single value in the option values, don't display the option
++          if (option.optionValues.length === 1) return null;
+ 
+-        return (
+-          <div className="product-options" key={option.name}>
+-            <h5>{option.name}</h5>
+-            <div className="product-options-grid">
+-              {option.optionValues.map((value) => {
+-                const {
+-                  name,
+-                  handle,
+-                  variantUriQuery,
+-                  selected,
+-                  available,
+-                  exists,
+-                  isDifferentProduct,
+-                  swatch,
+-                } = value;
++          return (
++            <div className="product-options" key={option.name}>
++              <h5>{option.name}</h5>
++              <div className="product-options-grid">
++                {option.optionValues.map((value) => {
++                  const {
++                    name,
++                    handle,
++                    variantUriQuery,
++                    selected,
++                    available,
++                    exists,
++                    isDifferentProduct,
++                    swatch,
++                  } = value;
+ 
+-                if (isDifferentProduct) {
+-                  // SEO
+-                  // When the variant is a combined listing child product
+-                  // that leads to a different url, we need to render it
+-                  // as an anchor tag
+-                  return (
+-                    <Link
+-                      className="product-options-item"
+-                      key={option.name + name}
+-                      prefetch="intent"
+-                      preventScrollReset
+-                      replace
+-                      to={`/products/${handle}?${variantUriQuery}`}
+-                      style={{
+-                        border: selected
+-                          ? '1px solid black'
+-                          : '1px solid transparent',
+-                        opacity: available ? 1 : 0.3,
+-                      }}
+-                    >
+-                      <ProductOptionSwatch swatch={swatch} name={name} />
+-                    </Link>
+-                  );
+-                } else {
+-                  // SEO
+-                  // When the variant is an update to the search param,
+-                  // render it as a button with javascript navigating to
+-                  // the variant so that SEO bots do not index these as
+-                  // duplicated links
+-                  return (
+-                    <button
+-                      type="button"
+-                      className={`product-options-item${
+-                        exists && !selected ? ' link' : ''
+-                      }`}
+-                      key={option.name + name}
+-                      style={{
+-                        border: selected
+-                          ? '1px solid black'
+-                          : '1px solid transparent',
+-                        opacity: available ? 1 : 0.3,
+-                      }}
+-                      disabled={!exists}
+-                      onClick={() => {
+-                        if (!selected) {
+-                          navigate(`?${variantUriQuery}`, {
+-                            replace: true,
+-                            preventScrollReset: true,
+-                          });
+-                        }
+-                      }}
+-                    >
+-                      <ProductOptionSwatch swatch={swatch} name={name} />
+-                    </button>
+-                  );
++                  if (isDifferentProduct) {
++                    // SEO
++                    // When the variant is a combined listing child product
++                    // that leads to a different url, we need to render it
++                    // as an anchor tag
++                    return (
++                      <Link
++                        className="product-options-item"
++                        key={option.name + name}
++                        prefetch="intent"
++                        preventScrollReset
++                        replace
++                        to={`/products/${handle}?${variantUriQuery}`}
++                        style={{
++                          border: selected
++                            ? '1px solid black'
++                            : '1px solid transparent',
++                          opacity: available ? 1 : 0.3,
++                        }}
++                      >
++                        <ProductOptionSwatch swatch={swatch} name={name} />
++                      </Link>
++                    );
++                  } else {
++                    // SEO
++                    // When the variant is an update to the search param,
++                    // render it as a button with javascript navigating to
++                    // the variant so that SEO bots do not index these as
++                    // duplicated links
++                    return (
++                      <button
++                        type="button"
++                        className={`product-options-item${
++                          exists && !selected ? ' link' : ''
++                        }`}
++                        key={option.name + name}
++                        style={{
++                          border: selected
++                            ? '1px solid black'
++                            : '1px solid transparent',
++                          opacity: available ? 1 : 0.3,
++                        }}
++                        disabled={!exists}
++                        onClick={() => {
++                          if (!selected) {
++                            navigate(`?${variantUriQuery}`, {
++                              replace: true,
++                              preventScrollReset: true,
++                            });
++                          }
++                        }}
++                      >
++                        <ProductOptionSwatch swatch={swatch} name={name} />
++                      </button>
++                    );
++                  }
++                })}
++              </div>
++              <AddToCartButton
++                disabled={!selectedVariant || !selectedVariant.availableForSale}
++                onClick={() => {
++                  open('cart');
++                }}
++                lines={
++                  selectedVariant
++                    ? [
++                        {
++                          merchandiseId: selectedVariant.id,
++                          quantity: 1,
++                          selectedVariant,
++                        },
++                      ]
++                    : []
+                 }
+-              })}
++              >
++                {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
++              </AddToCartButton>
++
++              <br />
+             </div>
+-            <br />
+-          </div>
+-        );
+-      })}
+-      <AddToCartButton
+-        disabled={!selectedVariant || !selectedVariant.availableForSale}
+-        onClick={() => {
+-          open('cart');
+-        }}
+-        lines={
+-          selectedVariant
+-            ? [
+-                {
+-                  merchandiseId: selectedVariant.id,
+-                  quantity: 1,
+-                  selectedVariant,
+-                },
+-              ]
+-            : []
+-        }
+-      >
+-        {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
+-      </AddToCartButton>
++          );
++        })
++      )}
+     </div>
+   );
+ }
+@@ -148,3 +197,38 @@ function ProductOptionSwatch({
+     </div>
+   );
+ }
++
++// Update as you see fit to match your design and requirements
++function SellingPlanGroup({
++  sellingPlanGroup,
++}: {
++  sellingPlanGroup: SellingPlanGroup;
++}) {
++  return (
++    <div className="selling-plan-group" key={sellingPlanGroup.name}>
++      <p className="selling-plan-group-title">
++        <strong>{sellingPlanGroup.name}:</strong>
++      </p>
++      {sellingPlanGroup.sellingPlans.nodes.map((sellingPlan) => {
++        return (
++          <Link
++            key={sellingPlan.id}
++            prefetch="intent"
++            to={sellingPlan.url}
++            className={`selling-plan ${
++              sellingPlan.isSelected ? 'selected' : 'unselected'
++            }`}
++            preventScrollReset
++            replace
++          >
++            <p>
++              {sellingPlan.options.map(
++                (option) => `${option.name} ${option.value}`,
++              )}
++            </p>
++          </Link>
++        );
++      })}
++    </div>
++  );
++}
+
+```
+
+</details>
+
+### Step 5: Update `ProductPrice` to display subscription pricing
+
+1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
+2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
+
+
+#### File: [`app/components/ProductPrice.tsx`](/templates/skeleton/app/components/ProductPrice.tsx)
+
+<details>
+
+```diff
+index 32460ae2..59eed1d8 100644
+--- a/templates/skeleton/app/components/ProductPrice.tsx
++++ b/templates/skeleton/app/components/ProductPrice.tsx
+@@ -1,13 +1,31 @@
++import type {CurrencyCode} from '@shopify/hydrogen/customer-account-api-types';
++import type {
++  ProductFragment,
++  SellingPlanFragment,
++} from 'storefrontapi.generated';
+ import {Money} from '@shopify/hydrogen';
+ import type {MoneyV2} from '@shopify/hydrogen/storefront-api-types';
+ 
+ export function ProductPrice({
+   price,
+   compareAtPrice,
++  selectedSellingPlan,
++  selectedVariant,
+ }: {
+   price?: MoneyV2;
+   compareAtPrice?: MoneyV2 | null;
++  selectedVariant?: ProductFragment['selectedOrFirstAvailableVariant'];
++  selectedSellingPlan?: SellingPlanFragment | null;
+ }) {
++  if (selectedSellingPlan) {
++    return (
++      <SellingPlanPrice
++        selectedSellingPlan={selectedSellingPlan}
++        selectedVariant={selectedVariant}
++      />
++    );
++  }
++
+   return (
+     <div className="product-price">
+       {compareAtPrice ? (
+@@ -25,3 +43,74 @@ export function ProductPrice({
+     </div>
+   );
+ }
++
++type SellingPlanPrice = {
++  amount: number;
++  currencyCode: CurrencyCode;
++};
++
++/*
++  Render the selected selling plan price is available
++*/
++function SellingPlanPrice({
++  selectedSellingPlan,
++  selectedVariant,
++}: {
++  selectedSellingPlan: SellingPlanFragment;
++  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
++}) {
++  if (!selectedVariant) {
++    return null;
++  }
++
++  const sellingPlanPriceAdjustments = selectedSellingPlan?.priceAdjustments;
++
++  if (!sellingPlanPriceAdjustments?.length) {
++    return selectedVariant ? <Money data={selectedVariant.price} /> : null;
++  }
++
++  const selectedVariantPrice: SellingPlanPrice = {
++    amount: parseFloat(selectedVariant.price.amount),
++    currencyCode: selectedVariant.price.currencyCode,
++  };
++
++  const sellingPlanPrice: SellingPlanPrice = sellingPlanPriceAdjustments.reduce(
++    (acc, adjustment) => {
++      switch (adjustment.adjustmentValue.__typename) {
++        case 'SellingPlanFixedAmountPriceAdjustment':
++          return {
++            amount:
++              acc.amount +
++              parseFloat(adjustment.adjustmentValue.adjustmentAmount.amount),
++            currencyCode: acc.currencyCode,
++          };
++        case 'SellingPlanFixedPriceAdjustment':
++          return {
++            amount: parseFloat(adjustment.adjustmentValue.price.amount),
++            currencyCode: acc.currencyCode,
++          };
++        case 'SellingPlanPercentagePriceAdjustment':
++          return {
++            amount:
++              acc.amount *
++              (1 - adjustment.adjustmentValue.adjustmentPercentage / 100),
++            currencyCode: acc.currencyCode,
++          };
++        default:
++          return acc;
++      }
++    },
++    selectedVariantPrice,
++  );
++
++  return (
++    <div className="selling-plan-price">
++      <Money
++        data={{
++          amount: `${sellingPlanPrice.amount}`,
++          currencyCode: sellingPlanPrice.currencyCode,
++        }}
++      />
++    </div>
++  );
++}
+
+```
+
+</details>
+
+### Step 6: Add selling plan data to cart queries
+
+Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
+
+
+#### File: [`app/lib/fragments.ts`](/templates/skeleton/app/lib/fragments.ts)
+
+```diff
+index dc4426a9..cfe3a938 100644
+--- a/templates/skeleton/app/lib/fragments.ts
++++ b/templates/skeleton/app/lib/fragments.ts
+@@ -54,6 +54,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
+         }
+       }
+     }
++    sellingPlanAllocation {
++      sellingPlan {
++         name
++      }
++    }
+   }
+   fragment CartLineComponent on ComponentizableCartLine {
+     id
+@@ -104,6 +109,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
+         }
+       }
+     }
++    sellingPlanAllocation {
++      sellingPlan {
++         name
++      }
++    }
+   }
+   fragment CartApiQuery on Cart {
+     updatedAt
+
+```
+
+### Step 7: Add `SellingPlanSelector` to product pages
+
+1. Add the `SellingPlanSelector` component to display subscription options on product pages.
+2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
+3. Fetch subscription data through the updated cart GraphQL fragments.
+
+
+#### File: [`app/routes/products.$handle.tsx`](/templates/skeleton/app/routes/products.$handle.tsx)
+
+<details>
+
+```diff
+index 2dc6bda2..aad7e5f1 100644
+--- a/templates/skeleton/app/routes/products.$handle.tsx
++++ b/templates/skeleton/app/routes/products.$handle.tsx
+@@ -1,3 +1,5 @@
++import type {SellingPlanFragment} from 'storefrontapi.generated';
++import type {LinksFunction} from '@remix-run/node';
+ import {redirect, type LoaderFunctionArgs} from '@shopify/remix-oxygen';
+ import {useLoaderData, type MetaFunction} from '@remix-run/react';
+ import {
+@@ -13,6 +15,12 @@ import {ProductImage} from '~/components/ProductImage';
+ import {ProductForm} from '~/components/ProductForm';
+ import {redirectIfHandleIsLocalized} from '~/lib/redirect';
+ 
++import sellingPanStyle from '~/styles/selling-plan.css?url';
++
++export const links: LinksFunction = () => [
++  {rel: 'stylesheet', href: sellingPanStyle},
++];
++
+ export const meta: MetaFunction<typeof loader> = ({data}) => {
+   return [
+     {title: `Hydrogen | ${data?.product.title ?? ''}`},
+@@ -63,8 +71,34 @@ async function loadCriticalData({
+   // The API handle might be localized, so redirect to the localized handle
+   redirectIfHandleIsLocalized(request, {handle, data: product});
+ 
++  // Initialize the selectedSellingPlan to null
++  let selectedSellingPlan = null;
++
++  // Get the selected selling plan id from the request url
++  const selectedSellingPlanId =
++    new URL(request.url).searchParams.get('selling_plan') ?? null;
++
++  // Get the selected selling plan bsed on the selectedSellingPlanId
++  if (selectedSellingPlanId) {
++    const selectedSellingPlanGroup =
++      product.sellingPlanGroups.nodes?.find((sellingPlanGroup) => {
++        return sellingPlanGroup.sellingPlans.nodes?.find(
++          (sellingPlan: SellingPlanFragment) =>
++            sellingPlan.id === selectedSellingPlanId,
++        );
++      }) ?? null;
++
++    if (selectedSellingPlanGroup) {
++      selectedSellingPlan =
++        selectedSellingPlanGroup.sellingPlans.nodes.find((sellingPlan) => {
++          return sellingPlan.id === selectedSellingPlanId;
++        }) ?? null;
++    }
++  }
++
+   return {
+     product,
++    selectedSellingPlan,
+   };
+ }
+ 
+@@ -81,7 +115,7 @@ function loadDeferredData({context, params}: LoaderFunctionArgs) {
+ }
+ 
+ export default function Product() {
+-  const {product} = useLoaderData<typeof loader>();
++  const {product, selectedSellingPlan} = useLoaderData<typeof loader>();
+ 
+   // Optimistically selects a variant with given available variant information
+   const selectedVariant = useOptimisticVariant(
+@@ -99,7 +133,7 @@ export default function Product() {
+     selectedOrFirstAvailableVariant: selectedVariant,
+   });
+ 
+-  const {title, descriptionHtml} = product;
++  const {title, descriptionHtml, sellingPlanGroups} = product;
+ 
+   return (
+     <div className="product">
+@@ -109,11 +143,15 @@ export default function Product() {
+         <ProductPrice
+           price={selectedVariant?.price}
+           compareAtPrice={selectedVariant?.compareAtPrice}
++          selectedSellingPlan={selectedSellingPlan}
++          selectedVariant={selectedVariant}
+         />
+         <br />
+         <ProductForm
+           productOptions={productOptions}
+           selectedVariant={selectedVariant}
++          selectedSellingPlan={selectedSellingPlan}
++          sellingPlanGroups={sellingPlanGroups}
+         />
+         <br />
+         <br />
+@@ -180,6 +218,73 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
+   }
+ ` as const;
+ 
++const SELLING_PLAN_FRAGMENT = `#graphql
++  fragment SellingPlanMoney on MoneyV2 {
++    amount
++    currencyCode
++  }
++  fragment SellingPlan on SellingPlan {
++    id
++    options {
++      name
++      value
++    }
++    priceAdjustments {
++      adjustmentValue {
++        ... on SellingPlanFixedAmountPriceAdjustment {
++          __typename
++          adjustmentAmount {
++            ... on MoneyV2 {
++               ...SellingPlanMoney
++            }
++          }
++        }
++        ... on SellingPlanFixedPriceAdjustment {
++          __typename
++          price {
++            ... on MoneyV2 {
++              ...SellingPlanMoney
++            }
++          }
++        }
++        ... on SellingPlanPercentagePriceAdjustment {
++          __typename
++          adjustmentPercentage
++        }
++      }
++      orderCount
++    }
++    recurringDeliveries
++    checkoutCharge {
++      type
++      value {
++        ... on MoneyV2 {
++          ...SellingPlanMoney
++        }
++        ... on SellingPlanCheckoutChargePercentageValue {
++          percentage
++        }
++      }
++    }
++ }
++` as const;
++
++const SELLING_PLAN_GROUP_FRAGMENT = `#graphql
++  fragment SellingPlanGroup on SellingPlanGroup {
++    name
++    options {
++      name
++      values
++    }
++    sellingPlans(first:10) {
++      nodes {
++        ...SellingPlan
++      }
++    }
++  }
++  ${SELLING_PLAN_FRAGMENT}
++` as const;
++
+ const PRODUCT_FRAGMENT = `#graphql
+   fragment Product on Product {
+     id
+@@ -207,6 +312,11 @@ const PRODUCT_FRAGMENT = `#graphql
+         }
+       }
+     }
++    sellingPlanGroups(first:10) {
++      nodes {
++        ...SellingPlanGroup
++      }
++    }
+     selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
+       ...ProductVariant
+     }
+@@ -218,6 +328,7 @@ const PRODUCT_FRAGMENT = `#graphql
+       title
+     }
+   }
++  ${SELLING_PLAN_GROUP_FRAGMENT}
+   ${PRODUCT_VARIANT_FRAGMENT}
+ ` as const;
+ 
+
+```
+
+</details>
+
+</recipe_implementation>

--- a/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -1,7 +1,7 @@
 ---
 description: Recipe for implementing "Subscriptions (subscriptions)" in a Hydrogen storefront. Add subscription-based products to your Hydrogen storefront.
 globs: templates/**/*
-alwaysApply: "false"
+alwaysApply: false
 ---
 
 # Overview

--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -1,6 +1,6 @@
 ---
 description: Recipe for implementing "Subscriptions (subscriptions)" in a Hydrogen storefront. Add subscription-based products to your Hydrogen storefront.
-globs: "*"
+globs: *
 alwaysApply: false
 ---
 

--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -1,6 +1,6 @@
 ---
 description: Recipe for implementing "Subscriptions (subscriptions)" in a Hydrogen storefront. Add subscription-based products to your Hydrogen storefront.
-globs: templates/**/*
+globs: "*"
 alwaysApply: false
 ---
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -85,6 +85,8 @@ npm run cookbook -- apply --recipe my-recipe
 
 `generate` will build a recipe folder based on the current changes made to the skeleton template, effectively snapshotting its state into a reproducible recipe.
 
+Additionally, it will also generate the Cursor rule (and related LLM-friendly files) for the recipe.
+
 The workflow for creating a new recipe is as follows:
 
 1. Make the desired changes to the skeleton template

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -2,6 +2,7 @@
 
 - [🧑‍🍳 Hydrogen Cookbook](#-hydrogen-cookbook)
   - [Recipes](#recipes)
+  - [Cursor rules](#cursor-rules)
   - [Usage](#usage)
     - [Apply](#apply)
       - [Syntax](#syntax)
@@ -37,6 +38,10 @@ Each recipe is located in the [cookbook's recipes folder](/cookbook/recipes/) an
 - `ingredients/`: a folder containing _new_ files that the recipe introduces. They will be copied as-is to the skeleton template.
 - `patches/`: a folder containing patches to be applied to existing files in the skeleton template. The file ↔ patch mappings are defined in the `recipe.yaml` file under the `ingredients` key.
 - `README.md`: the human-readable Markdown render of the recipe, based off of the `recipe.yaml` file.
+
+## Cursor rules
+
+Recipes come paired with [Cursor](https://www.cursor.com/) rules that can be included in a Hydrogen project to improve the AI-assisted coding experience. The rules are available in [the .cursor folder](/cookbook/.cursor) and can be copied verbatim into the `.cursor` folder at the root of a Hydrogen project repository.
 
 ## Usage
 

--- a/cookbook/recipe.schema.json
+++ b/cookbook/recipe.schema.json
@@ -142,6 +142,44 @@
     "commit": {
       "type": "string",
       "description": "The commit hash the recipe is based on"
+    },
+    "llms": {
+      "type": "object",
+      "properties": {
+        "userQueries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The user queries of the recipe",
+          "default": []
+        },
+        "troubleshooting": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "issue": {
+                "type": "string",
+                "description": "The issue of the troubleshooting"
+              },
+              "solution": {
+                "type": "string",
+                "description": "The solution of the troubleshooting"
+              }
+            },
+            "required": [
+              "issue",
+              "solution"
+            ],
+            "additionalProperties": false
+          },
+          "description": "The troubleshooting of the recipe",
+          "default": []
+        }
+      },
+      "additionalProperties": false,
+      "default": {}
     }
   },
   "required": [

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -108,4 +108,19 @@ steps:
     diffs:
       - file: app/routes/products.$handle.tsx
         patchFile: products.$handle.tsx.3e0b7e.patch
-commit: 366119f5d492f9d3e04df39392b35f343573bbd9
+llms:
+  userQueries:
+    - How do I add subscriptions to my Hydrogen storefront?
+    - How do I add selling plans to my Hydrogen storefront?
+    - How do I display subscription details on applicable line items in the cart?
+  troubleshooting:
+    - issue: I'm getting an error when I try to add a subscription to my storefront.
+      solution: Make sure you have the Shopify Subscriptions app installed and
+        configured correctly.
+    - issue: I'm not seeing the subscription options on my product pages.
+      solution: Make sure you have the Shopify Subscriptions app installed and
+        configured correctly.
+    - issue: I'm not seeing the subscription details on my cart line items.
+      solution: Make sure you have the Shopify Subscriptions app installed and
+        configured correctly.
+commit: bc6be29eb460426161de0ec2dd2601b74329d826

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -123,4 +123,4 @@ llms:
     - issue: I'm not seeing the subscription details on my cart line items.
       solution: Make sure you have the Shopify Subscriptions app installed and
         configured correctly.
-commit: bc6be29eb460426161de0ec2dd2601b74329d826
+commit: 61ddf92487524b3c04632ae2cfdaa2869a3ae02c

--- a/cookbook/src/lib/generate.ts
+++ b/cookbook/src/lib/generate.ts
@@ -19,6 +19,7 @@ import {
   RecipeManifestFormat,
   recreateDirectory,
 } from './util';
+import {generateLLMsFiles} from './llms';
 
 /**
  * Generate a recipe.
@@ -90,6 +91,9 @@ export async function generateRecipe(params: {
     ingredients,
   });
 
+  const userQueries = existingRecipe?.llms.userQueries ?? [];
+  const troubleshooting = existingRecipe?.llms.troubleshooting ?? [];
+
   const recipe: Recipe = {
     title: existingRecipe?.title ?? recipeName,
     summary: existingRecipe?.summary ?? '',
@@ -99,6 +103,7 @@ export async function generateRecipe(params: {
     ingredients,
     deletedFiles,
     steps,
+    llms: {userQueries, troubleshooting},
     commit: getMainCommitHash(parseReferenceBranch(referenceBranch)),
   };
 
@@ -115,6 +120,9 @@ export async function generateRecipe(params: {
         YAML.stringify(recipe);
 
   fs.writeFileSync(recipeManifestPath, data);
+
+  console.log('- 📖 Generating LLMs files…');
+  generateLLMsFiles(recipeName);
 
   return recipeManifestPath;
 }

--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -24,7 +24,7 @@ function renderRecipeRuleBlocks(
     mdFrontMatter({
       description: `Recipe for implementing "${recipe.title} (${recipeName})" in a Hydrogen storefront. ${recipe.summary}`,
       globs,
-      alwaysApply: 'false',
+      alwaysApply: false,
     }),
 
     // preamble

--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import {COOKBOOK_PATH, REPO_ROOT} from './constants';
+import {COOKBOOK_PATH} from './constants';
 import {createDirectoryIfNotExists, getPatchesDir} from './util';
 import {
   maybeMDBlock,
@@ -118,7 +118,10 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
 }
 
 export function generateLLMsFiles(recipeName: string) {
-  createDirectoryIfNotExists(path.join(REPO_ROOT, '.cursor', 'rules'));
+  const rulesDir = path.join(COOKBOOK_PATH, '.cursor', 'rules');
+  createDirectoryIfNotExists(rulesDir);
+
+  const rulePath = path.join(rulesDir, `cookbook-recipe-${recipeName}.mdc`);
 
   console.log('Generating recipe Cursor rule…');
   console.log(`- ${recipeName}`);
@@ -126,16 +129,7 @@ export function generateLLMsFiles(recipeName: string) {
     directory: path.join(COOKBOOK_PATH, 'recipes', recipeName),
   });
 
-  const blocks = renderRecipeRuleBlocks(recipeName, recipe, 'templates/**/*');
+  const blocks = renderRecipeRuleBlocks(recipeName, recipe, '*');
 
-  serializeMDBlocksToFile(blocks, getRecipeRulePath(recipeName), 'github');
-}
-
-function getRecipeRulePath(recipeName: string) {
-  return path.join(
-    REPO_ROOT,
-    '.cursor',
-    'rules',
-    `cookbook-recipe-${recipeName}.mdc`,
-  );
+  serializeMDBlocksToFile(blocks, rulePath, 'github');
 }

--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -1,0 +1,141 @@
+import path from 'path';
+import {COOKBOOK_PATH, REPO_ROOT} from './constants';
+import {createDirectoryIfNotExists, getPatchesDir} from './util';
+import {
+  maybeMDBlock,
+  MDBlock,
+  mdFrontMatter,
+  mdHeading,
+  mdList,
+  mdNote,
+  mdParagraph,
+  serializeMDBlocksToFile,
+} from './markdown';
+import {renderStep} from './render';
+import {loadRecipe, Recipe} from './recipe';
+
+function renderRecipeRuleBlocks(
+  recipeName: string,
+  recipe: Recipe,
+  globs: 'templates/**/*' | '*',
+): MDBlock[] {
+  return [
+    // cursor rule frontmatter
+    mdFrontMatter({
+      description: `Recipe for implementing "${recipe.title} (${recipeName})" in a Hydrogen storefront. ${recipe.summary}`,
+      globs,
+      alwaysApply: 'false',
+    }),
+
+    // preamble
+    mdParagraph(
+      `
+# Overview
+
+This rule describes how to implement "${recipe.title}" in a Hydrogen storefront. Below is a "recipe" that contains the steps to apply to a basic Hydrogen skeleton template to achieve the desired outcome.
+
+The same logic can be applied to any other Hydrogen storefront project, adapting the implementation details to the specific needs/structure/conventions of the project, but it's up to the developer to do so.
+
+If there are any prerequisites, the recipe below will explain them; if the user is trying to implement the feature described in this recipe, make sure to prominently mention the prerequisites and any other preliminary instructions, as well as followups.
+
+Please remember that specific documentation about Storefront API, which might be relevant to the user, is available at <https://shopify.dev/docs/api/storefront>.
+
+If the user is asking on how to implement the feature from scratch, please first describe the feature in a general way before jumping into the implementation details.
+
+Please note that the recipe steps below are not necessarily ordered in the way they should be executed, as it depends on the user's needs and the specific details of the project. The recipe steps descriptions should allow you to understand what is required to be done in a certain order and what is not. Remember that file names in the recipe are related to the Hydrogen skeleton template, not the user's project, so make sure to adapt the file names to the user's project.
+
+# Summary
+
+${recipe.summary}
+
+# User Intent Recognition
+
+<user_queries>
+${recipe.llms.userQueries.map((query) => `- ${query}`).join('\n')}
+</user_queries>
+
+# Troubleshooting
+
+<troubleshooting>
+${recipe.llms.troubleshooting
+  .map((troubleshooting) =>
+    `
+- **Issue**: ${troubleshooting.issue}
+  **Solution**: ${troubleshooting.solution}\
+`.trim(),
+  )
+  .join('\n')}
+</troubleshooting>
+
+# Recipe Implementation
+
+Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
+`.trim(),
+    ),
+
+    // recipe data
+    mdParagraph(`<recipe_implementation>`),
+    ...[
+      mdHeading(2, 'Description'),
+      mdParagraph(recipe.description),
+
+      // notes
+      ...(recipe.notes != null && recipe.notes.length > 0
+        ? [
+            mdHeading(2, 'Notes'),
+            ...maybeMDBlock(recipe.notes, (notes) => notes.map(mdNote)),
+          ]
+        : []),
+
+      // requirements
+      ...(recipe.requirements != null && recipe.requirements.length > 0
+        ? [mdHeading(2, 'Requirements'), mdParagraph(recipe.requirements)]
+        : []),
+
+      // ingredients
+      mdHeading(2, 'Ingredients'),
+      mdParagraph('_New files added to the template by this recipe._'),
+      mdList(
+        recipe.ingredients.map(
+          (ingredient) => `\`${ingredient.path}\` : ${ingredient.description}`,
+        ),
+      ),
+
+      mdHeading(2, 'Steps'),
+      ...recipe.steps.flatMap((step, index): MDBlock[] =>
+        renderStep(step, index, recipe.ingredients, getPatchesDir(recipeName)),
+      ),
+
+      ...(recipe.deletedFiles != null && recipe.deletedFiles.length > 0
+        ? [
+            mdHeading(2, 'Deleted Files'),
+            mdList(recipe.deletedFiles.map((file) => `[\`${file}\`](${file})`)),
+          ]
+        : []),
+    ],
+    mdParagraph(`</recipe_implementation>`),
+  ];
+}
+
+export function generateLLMsFiles(recipeName: string) {
+  createDirectoryIfNotExists(path.join(REPO_ROOT, '.cursor', 'rules'));
+
+  console.log('Generating recipe Cursor rule…');
+  console.log(`- ${recipeName}`);
+  const recipe = loadRecipe({
+    directory: path.join(COOKBOOK_PATH, 'recipes', recipeName),
+  });
+
+  const blocks = renderRecipeRuleBlocks(recipeName, recipe, 'templates/**/*');
+
+  serializeMDBlocksToFile(blocks, getRecipeRulePath(recipeName), 'github');
+}
+
+function getRecipeRulePath(recipeName: string) {
+  return path.join(
+    REPO_ROOT,
+    '.cursor',
+    'rules',
+    `cookbook-recipe-${recipeName}.mdc`,
+  );
+}

--- a/cookbook/src/lib/markdown.ts
+++ b/cookbook/src/lib/markdown.ts
@@ -211,11 +211,21 @@ export function renderMDBlock(block: MDBlock, format: RenderFormat): string {
     case 'QUOTE':
       return `> ${block.text}`;
     case 'FRONTMATTER':
-      return [
-        '---',
-        YAML.stringify(block.data, {lineWidth: 0}).trim(),
-        '---',
-      ].join('\n');
+      const stringified = YAML.stringify(block.data, {
+        lineWidth: 0,
+        defaultStringType: 'PLAIN',
+        defaultKeyType: 'PLAIN',
+      })
+        .trim()
+        // Remove any quotes wrapping the stringified values manually,
+        // as some of them may have been added by the YAML stringifier while Cursor doesn't like them.
+        .split('\n')
+        .map((line) => {
+          return line.replace(/^([^'"]+): ['"](.+)['"]/, '$1: $2');
+        })
+        .join('\n');
+
+      return ['---', stringified, '---'].join('\n');
     case 'NOTE':
       return [
         '> [!NOTE]',

--- a/cookbook/src/lib/markdown.ts
+++ b/cookbook/src/lib/markdown.ts
@@ -16,10 +16,10 @@ export function mdNote(text: string): MDNote {
 
 export type MDFrontMatter = {
   type: 'FRONTMATTER';
-  data: Record<string, string>;
+  data: Record<string, unknown>;
 };
 
-export function mdFrontMatter(data: Record<string, string>): MDFrontMatter {
+export function mdFrontMatter(data: Record<string, unknown>): MDFrontMatter {
   return {
     type: 'FRONTMATTER',
     data,

--- a/cookbook/src/lib/markdown.ts
+++ b/cookbook/src/lib/markdown.ts
@@ -211,7 +211,11 @@ export function renderMDBlock(block: MDBlock, format: RenderFormat): string {
     case 'QUOTE':
       return `> ${block.text}`;
     case 'FRONTMATTER':
-      return ['---', YAML.stringify(block.data), '---'].join('\n');
+      return [
+        '---',
+        YAML.stringify(block.data, {lineWidth: 0}).trim(),
+        '---',
+      ].join('\n');
     case 'NOTE':
       return [
         '> [!NOTE]',

--- a/cookbook/src/lib/recipe.ts
+++ b/cookbook/src/lib/recipe.ts
@@ -41,6 +41,13 @@ const StepSchema = z.object({
 
 export type Step = z.infer<typeof StepSchema>;
 
+export const TroubleshootingSchema = z.object({
+  issue: z.string().describe('The issue of the troubleshooting'),
+  solution: z.string().describe('The solution of the troubleshooting'),
+});
+
+export type Troubleshooting = z.infer<typeof TroubleshootingSchema>;
+
 export const RecipeSchema = z.object({
   title: z.string().describe('The title of the recipe'),
   summary: z.string().describe('The summary of what the recipe does'),
@@ -60,6 +67,21 @@ export const RecipeSchema = z.object({
     .optional()
     .describe('The deleted files of the recipe'),
   commit: z.string().describe('The commit hash the recipe is based on'),
+  llms: z
+    .object({
+      userQueries: z
+        .array(z.string())
+        .optional()
+        .describe('The user queries of the recipe')
+        .default([]),
+      troubleshooting: z
+        .array(TroubleshootingSchema)
+        .optional()
+        .describe('The troubleshooting of the recipe')
+        .default([]),
+    })
+    .optional()
+    .default({}),
 });
 
 export type Recipe = z.infer<typeof RecipeSchema>;


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds Cursor rules generation for Cookbook recipes.

### WHAT is this pull request doing?

1. Add logic to generate Cursor rules off of Cookbook recipe manifests
2. Output the update rule as part of the `generate` script
3. Generate the rule for the `subscriptions` recipe and store them in the `cookbook/.cursor` folder, which can be copied as-is into a Hydrogen project
4. Updat the Cookbook `README` accordingly

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation