### PR TITLE
Update hydrogen vite plugin optimizeDeps include list for react-router

### DIFF
--- a/.changeset/fuzzy-peas-fix.md
+++ b/.changeset/fuzzy-peas-fix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add react-router to default optimizeDeps include list

--- a/packages/hydrogen/src/vite/plugin.ts
+++ b/packages/hydrogen/src/vite/plugin.ts
@@ -71,6 +71,7 @@ export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
                 'react-dom',
                 'react-dom/server',
                 '@remix-run/server-runtime',
+                'react-router',
               ],
             },
           },

--- a/packages/hydrogen/src/vite/plugin.ts
+++ b/packages/hydrogen/src/vite/plugin.ts
@@ -70,7 +70,6 @@ export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
                 'react/jsx-dev-runtime',
                 'react-dom',
                 'react-dom/server',
-                '@remix-run/server-runtime',
                 'react-router',
               ],
             },
@@ -207,7 +206,7 @@ hydrogen.v3preset = () =>
         buildDirectory: 'dist',
       };
     },
-  }) satisfies RemixPreset;
+  } satisfies RemixPreset);
 
 hydrogen.preset = () =>
   ({
@@ -259,4 +258,4 @@ hydrogen.preset = () =>
         },
       };
     },
-  }) satisfies RemixPreset;
+  } satisfies RemixPreset);


### PR DESCRIPTION
- Added `react-router`
- Removed `@remix-run/server-runtime`

TODO:
- `content-security-policy-builder` ?
- `worktop/cookie` ?

---

react-router WIP Log

Failed to resolve dependency: content-security-policy-builder, present in client 'optimizeDeps.include'
Failed to resolve dependency: worktop/cookie, present in client 'optimizeDeps.include'
Failed to resolve dependency: @remix-run/server-runtime, present in ssr 'optimizeDeps.include'
  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help

Warning: MiniOxygen couldn't load your app's entry point.
Try adding "react-router" to the "ssr.optimizeDeps.include" array in your Vite config.

Warning: MiniOxygen couldn't load your app's entry point.
Try adding "react-router" to the "ssr.optimizeDeps.include" array in your Vite config.

Warning: MiniOxygen couldn't load your app's entry point.
Try adding "react-router" to the "ssr.optimizeDeps.include" array in your Vite config.

Warning: MiniOxygen couldn't load your app's entry point.
Try adding "react-router" to the "ssr.optimizeDeps.include" array in your Vite config.

Warning: MiniOxygen couldn't load your app's entry point.
Try adding "react-router" to the "ssr.optimizeDeps.include" array in your Vite config