### PR TITLE
Fix vite 6 resolve conditions

### DIFF
--- a/.changeset/blue-horses-arrive.md
+++ b/.changeset/blue-horses-arrive.md
@@ -1,0 +1,5 @@
+---
+"@shopify/mini-oxygen": patch
+---
+
+Update resolve conditions for vite 6

--- a/package-lock.json
+++ b/package-lock.json
@@ -39792,7 +39792,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "9.0.11",
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -39842,7 +39842,7 @@
         "@graphql-codegen/cli": "^5.0.2",
         "@remix-run/dev": "^2.16.1",
         "@shopify/hydrogen-codegen": "^0.3.3",
-        "@shopify/mini-oxygen": "^3.1.2",
+        "@shopify/mini-oxygen": "^3.2.0",
         "graphql-config": "^5.0.3",
         "vite": "^5.1.0 || ^6.2.0"
       },
@@ -41805,7 +41805,7 @@
     },
     "packages/mini-oxygen": {
       "name": "@shopify/mini-oxygen",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@miniflare/cache": "^2.14.4",
@@ -42320,7 +42320,7 @@
       }
     },
     "templates/skeleton": {
-      "version": "2025.1.5",
+      "version": "2025.1.6",
       "dependencies": {
         "@remix-run/react": "^2.16.1",
         "@remix-run/server-runtime": "^2.16.1",
@@ -42342,7 +42342,7 @@
         "@remix-run/route-config": "^2.16.1",
         "@shopify/cli": "~3.77.1",
         "@shopify/hydrogen-codegen": "^0.3.3",
-        "@shopify/mini-oxygen": "^3.1.2",
+        "@shopify/mini-oxygen": "^3.2.0",
         "@shopify/oxygen-workers-types": "^4.1.6",
         "@shopify/prettier-config": "^1.1.2",
         "@total-typescript/ts-reset": "^0.6.1",

--- a/packages/mini-oxygen/src/vite/plugin.ts
+++ b/packages/mini-oxygen/src/vite/plugin.ts
@@ -1,3 +1,4 @@
+import {defaultClientConditions} from 'vite';
 import path from 'node:path';
 import type {Plugin, ResolvedConfig} from 'vite';
 import {
@@ -45,11 +46,14 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
         return {
           appType: 'custom',
           resolve: {
-            conditions: ['worker', 'workerd'],
+            conditions: ['worker', 'workerd', ...defaultClientConditions],
           },
           ssr: {
             noExternal: true,
             target: 'webworker',
+            resolve: {
+              conditions: ['worker', 'workerd', ...defaultClientConditions],
+            },
           },
           // When building, the CLI will set the `ssr` option to `true`
           // if no --entry flag is passed for the default SSR entry file.


### PR DESCRIPTION
Replaces https://github.com/Shopify/hydrogen/pull/2840
closes https://github.com/Shopify/hydrogen/issues/2858 ✅ 

---

Context: 
https://shopifypartners.slack.com/archives/C02F94JC3QC/p1743413107901139
https://github.com/sanity-io/hydrogen-sanity/issues/116
https://github.com/sanity-io/visual-editing/issues/1085

Vite 6 (2025.1.3+) seems to have a different more strict NPM module resolution logic for worker exports. This PR aims to fix this by adding an additional resolve conditions for workers in the SSR option. 

