### PR TITLE
Fix `totalValue` test measurement

### DIFF
--- a/packages/hydrogen-react/src/analytics-utils.ts
+++ b/packages/hydrogen-react/src/analytics-utils.ts
@@ -2,7 +2,9 @@ import type {
   ShopifyMonorailPayload,
   ShopifyMonorailEvent,
   ShopifyGid,
+  ShopifyAnalyticsProduct,
 } from './analytics-types.js';
+import {faker} from '@faker-js/faker';
 
 /**
  * Builds a Shopify Monorail event from a Shopify Monorail payload and a schema ID.
@@ -105,4 +107,35 @@ export function errorIfServer(fnName: string): boolean {
     return true;
   }
   return false;
+}
+
+/**
+ * Get a random number [1,1000]
+ * @returns A random number
+ */
+export function randomNatural() {
+  return faker.number.int({min: 1, max: 1000});
+}
+
+/**
+ * Calculate product price * quantity
+ * @param product - The product
+ * @returns A number
+ */
+export const getProductValue = (product: ShopifyAnalyticsProduct): number =>
+  parseFloat(product.price) * (product.quantity || 0);
+
+/**
+ * Reduce all products and get their total value
+ * @param products - The products
+ * @returns A number
+ */
+export function getProductsValue(
+  products?: ShopifyAnalyticsProduct[],
+): number | undefined {
+  return products?.reduce(
+    (previousValue, currentProduct) =>
+      previousValue + getProductValue(currentProduct),
+    0,
+  );
 }


### PR DESCRIPTION
Fix `totalValue` test measurement

### WHY are these changes introduced?

In my limited experience, I notice many Shopify stores are sending an incorrect
`totalValue`(in analytics lib)/`total_value`(in network request) measurement in
their analytics. Most Shopify storefronts default to sending just the
`product.value`.

I am pretty sure this is incorrect:
https://github.com/Shopify/hydrogen/blob/e7db0a546cc432c365f04296895cdd5b71e123d0/packages/hydrogen-react/src/analytics-types.ts#L116-L117

I went to verify this, but the tests do not rigourously test the `totalValue`. It
just sends placeholder value, not based on the products at all. Currently, it
is not clear what expected `totalValue` is for different product payloads.

### WHAT is this pull request doing?

Enhances the tests to ensure the totalValue is more accurate. Establishes
that `totalValue` is indeed the total value of the products in the event.

1. adds helpers
2. tests the helpers
3. enhances the tests to have accurate `totalValue` measurement, making it
   clear `totalValue` is based on `products` total value.

### HOW to test your changes?

`npm run test`

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
