### PR TITLE
Cookbook: steps indexes

### DIFF
--- a/cookbook/recipe.schema.json
+++ b/cookbook/recipe.schema.json
@@ -76,6 +76,10 @@
             ],
             "description": "The type of step"
           },
+          "index": {
+            "type": "number",
+            "description": "The index of the step"
+          },
           "name": {
             "type": "string",
             "description": "The name of the step"
@@ -126,6 +130,7 @@
         },
         "required": [
           "type",
+          "index",
           "name"
         ],
         "additionalProperties": false

--- a/cookbook/src/lib/generate.ts
+++ b/cookbook/src/lib/generate.ts
@@ -143,7 +143,9 @@ async function generateSteps(params: {
     return !file.endsWith('.d.ts');
   });
 
+  let i = 0;
   for await (const file of modifiedFiles) {
+    i++;
     const {fullPath, patchFilename} = createPatchFile({
       file,
       patchesDirPath: params.patchesDirPath,
@@ -161,6 +163,7 @@ async function generateSteps(params: {
 
     const step: Step = {
       type: 'PATCH',
+      index: existingStep?.index ?? i,
       name: existingStep?.name ?? file.replace(TEMPLATE_DIRECTORY, ''),
       description: existingDescription ?? null,
       diffs: [
@@ -179,7 +182,16 @@ async function generateSteps(params: {
       ? [copyIngredientsStep(params.ingredients)]
       : [];
 
-  return [...existingInfoSteps, ...maybeCopyIngredientsStep, ...patchSteps];
+  const steps = [
+    ...existingInfoSteps,
+    ...maybeCopyIngredientsStep,
+    ...patchSteps.sort((a, b) => a.index - b.index),
+  ];
+
+  return steps.map((step, index) => ({
+    ...step,
+    index: index + 1, // normalize the indexes
+  }));
 }
 
 function maybeLoadExistingRecipe(recipePath: string): Recipe | null {
@@ -193,6 +205,7 @@ function maybeLoadExistingRecipe(recipePath: string): Recipe | null {
 function copyIngredientsStep(ingredients: Ingredient[]): Step {
   return {
     type: 'COPY_INGREDIENTS',
+    index: 0,
     name: 'Add ingredients to your project',
     description:
       'Copy all the files found in the `ingredients/` directory to the current directory.',

--- a/cookbook/src/lib/recipe.ts
+++ b/cookbook/src/lib/recipe.ts
@@ -25,6 +25,7 @@ const StepSchema = z.object({
   type: z
     .enum(['PATCH', 'INFO', 'COPY_INGREDIENTS'])
     .describe('The type of step'),
+  index: z.number().describe('The index of the step'),
   name: z.string().describe('The name of the step'),
   description: z
     .string()


### PR DESCRIPTION
### WHY are these changes introduced?

When regenerating a recipe we might want to force certain steps in specific positions of the array and have them stay there upon changes.

### WHAT is this pull request doing?

This PR adds a `index` prop to the step schema, and uses those values to sort the generated recipe manifest, normalizing them to be start from 1 for clarity.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation