### PR TITLE
Cookbook: slimmer files rendering for rules

### DIFF
--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -7,16 +7,14 @@ alwaysApply: false
 # Overview
 
 This rule describes how to implement "Subscriptions" in a Hydrogen storefront. Below is a "recipe" that contains the steps to apply to a basic Hydrogen skeleton template to achieve the desired outcome.
-
 The same logic can be applied to any other Hydrogen storefront project, adapting the implementation details to the specific needs/structure/conventions of the project, but it's up to the developer to do so.
-
 If there are any prerequisites, the recipe below will explain them; if the user is trying to implement the feature described in this recipe, make sure to prominently mention the prerequisites and any other preliminary instructions, as well as followups.
-
-Please remember that specific documentation about Storefront API, which might be relevant to the user, is available at <https://shopify.dev/docs/api/storefront>.
-
 If the user is asking on how to implement the feature from scratch, please first describe the feature in a general way before jumping into the implementation details.
-
 Please note that the recipe steps below are not necessarily ordered in the way they should be executed, as it depends on the user's needs and the specific details of the project. The recipe steps descriptions should allow you to understand what is required to be done in a certain order and what is not. Remember that file names in the recipe are related to the Hydrogen skeleton template, not the user's project, so make sure to adapt the file names to the user's project.
+
+# AI model verification steps
+
+- Never edit generated files (ending with .d.ts) directly; instead, run the `npm run codegen` command to update them.
 
 # Summary
 
@@ -216,12 +214,9 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
 
-#### File: [`app/components/CartLineItem.tsx`](/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: /app/components/CartLineItem.tsx
 
 ```diff
-index bd33a2cf..a18e4b52 100644
---- a/templates/skeleton/app/components/CartLineItem.tsx
-+++ b/templates/skeleton/app/components/CartLineItem.tsx
 @@ -3,8 +3,8 @@ import type {CartLayout} from '~/components/CartMain';
  import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
  import {useVariantUrl} from '~/lib/variants';
@@ -257,7 +252,6 @@ index bd33a2cf..a18e4b52 100644
            {selectedOptions.map((option) => (
              <li key={option.name}>
                <small>
-
 ```
 
 ### Step 3: Update `ProductForm` to support subscriptions
@@ -267,14 +261,9 @@ index bd33a2cf..a18e4b52 100644
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
 
-#### File: [`app/components/ProductForm.tsx`](/templates/skeleton/app/components/ProductForm.tsx)
-
-<details>
+#### File: /app/components/ProductForm.tsx
 
 ```diff
-index e8616a61..e41b91ad 100644
---- a/templates/skeleton/app/components/ProductForm.tsx
-+++ b/templates/skeleton/app/components/ProductForm.tsx
 @@ -6,120 +6,169 @@ import type {
  } from '@shopify/hydrogen/storefront-api-types';
  import {AddToCartButton} from './AddToCartButton';
@@ -582,10 +571,7 @@ index e8616a61..e41b91ad 100644
 +    </div>
 +  );
 +}
-
 ```
-
-</details>
 
 ### Step 4: Update `ProductPrice` to display subscription pricing
 
@@ -593,14 +579,9 @@ index e8616a61..e41b91ad 100644
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
 
-#### File: [`app/components/ProductPrice.tsx`](/templates/skeleton/app/components/ProductPrice.tsx)
-
-<details>
+#### File: /app/components/ProductPrice.tsx
 
 ```diff
-index 32460ae2..59eed1d8 100644
---- a/templates/skeleton/app/components/ProductPrice.tsx
-+++ b/templates/skeleton/app/components/ProductPrice.tsx
 @@ -1,13 +1,31 @@
 +import type {CurrencyCode} from '@shopify/hydrogen/customer-account-api-types';
 +import type {
@@ -708,22 +689,16 @@ index 32460ae2..59eed1d8 100644
 +    </div>
 +  );
 +}
-
 ```
-
-</details>
 
 ### Step 5: Add selling plan data to cart queries
 
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
 
-#### File: [`app/lib/fragments.ts`](/templates/skeleton/app/lib/fragments.ts)
+#### File: /app/lib/fragments.ts
 
 ```diff
-index dc4426a9..cfe3a938 100644
---- a/templates/skeleton/app/lib/fragments.ts
-+++ b/templates/skeleton/app/lib/fragments.ts
 @@ -54,6 +54,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
          }
        }
@@ -748,7 +723,6 @@ index dc4426a9..cfe3a938 100644
    }
    fragment CartApiQuery on Cart {
      updatedAt
-
 ```
 
 ### Step 6: Add `SellingPlanSelector` to product pages
@@ -758,14 +732,9 @@ index dc4426a9..cfe3a938 100644
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
 
-#### File: [`app/routes/products.$handle.tsx`](/templates/skeleton/app/routes/products.$handle.tsx)
-
-<details>
+#### File: /app/routes/products.$handle.tsx
 
 ```diff
-index 2dc6bda2..aad7e5f1 100644
---- a/templates/skeleton/app/routes/products.$handle.tsx
-+++ b/templates/skeleton/app/routes/products.$handle.tsx
 @@ -1,3 +1,5 @@
 +import type {SellingPlanFragment} from 'storefrontapi.generated';
 +import type {LinksFunction} from '@remix-run/node';
@@ -947,10 +916,6 @@ index 2dc6bda2..aad7e5f1 100644
 +  ${SELLING_PLAN_GROUP_FRAGMENT}
    ${PRODUCT_VARIANT_FRAGMENT}
  ` as const;
- 
-
 ```
-
-</details>
 
 </recipe_implementation>

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -90,7 +90,6 @@ index bd33a2cf..a18e4b52 100644
            {selectedOptions.map((option) => (
              <li key={option.name}>
                <small>
-
 ```
 
 ### Step 4: Update `ProductForm` to support subscriptions
@@ -415,7 +414,6 @@ index e8616a61..e41b91ad 100644
 +    </div>
 +  );
 +}
-
 ```
 
 </details>
@@ -541,7 +539,6 @@ index 32460ae2..59eed1d8 100644
 +    </div>
 +  );
 +}
-
 ```
 
 </details>
@@ -581,7 +578,6 @@ index dc4426a9..cfe3a938 100644
    }
    fragment CartApiQuery on Cart {
      updatedAt
-
 ```
 
 ### Step 7: Add `SellingPlanSelector` to product pages
@@ -780,8 +776,6 @@ index 2dc6bda2..aad7e5f1 100644
 +  ${SELLING_PLAN_GROUP_FRAGMENT}
    ${PRODUCT_VARIANT_FRAGMENT}
  ` as const;
- 
-
 ```
 
 </details>

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -28,6 +28,7 @@ ingredients:
 deletedFiles: []
 steps:
   - type: INFO
+    index: 1
     name: Set up the Shopify Subscriptions app
     description: >
       1. Install the [Shopify Subscriptions
@@ -44,6 +45,7 @@ steps:
       The Hydrogen demo storefront comes pre-configured with an example
       subscription product with the handle `shopify-wax`.
   - type: COPY_INGREDIENTS
+    index: 2
     name: Add ingredients to your project
     description: Copy all the files found in the `ingredients/` directory to the
       current directory.
@@ -51,6 +53,7 @@ steps:
       - templates/skeleton/app/components/SellingPlanSelector.tsx
       - templates/skeleton/app/styles/selling-plan.css
   - type: PATCH
+    index: 3
     name: Render the selling plan in the cart
     description: >
       1. Update `CartLineItem` to show subscription details when they're
@@ -62,6 +65,7 @@ steps:
       - file: app/components/CartLineItem.tsx
         patchFile: CartLineItem.tsx.8e657b.patch
   - type: PATCH
+    index: 4
     name: Update `ProductForm` to support subscriptions
     description: >
       1. Add conditional rendering to display either subscription options or
@@ -76,6 +80,7 @@ steps:
       - file: app/components/ProductForm.tsx
         patchFile: ProductForm.tsx.8e409a.patch
   - type: PATCH
+    index: 5
     name: Update `ProductPrice` to display subscription pricing
     description: >
       1. Add a `SellingPlanPrice` function to calculate adjusted prices based on
@@ -87,6 +92,7 @@ steps:
       - file: app/components/ProductPrice.tsx
         patchFile: ProductPrice.tsx.a5e47f.patch
   - type: PATCH
+    index: 6
     name: Add selling plan data to cart queries
     description: >
       Add a `sellingPlanAllocation` field with the plan name to the standard and
@@ -96,6 +102,7 @@ steps:
       - file: app/lib/fragments.ts
         patchFile: fragments.ts.e8eb04.patch
   - type: PATCH
+    index: 7
     name: Add `SellingPlanSelector` to product pages
     description: >
       1. Add the `SellingPlanSelector` component to display subscription options
@@ -123,4 +130,4 @@ llms:
     - issue: I'm not seeing the subscription details on my cart line items.
       solution: Make sure you have the Shopify Subscriptions app installed and
         configured correctly.
-commit: 62dc2f367bc73d4f402b96213de9e2f933d0441c
+commit: e72580831c4dd0aec3e977351366d199b4857980

--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -128,7 +128,6 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
             getPatchesDir(recipeName),
             {
               diffsRelativeToTemplate: true,
-              dontCollapseDiffs: true,
               trimDiffHeaders: true,
             },
           ),

--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -39,16 +39,14 @@ function renderRecipeRuleBlocks(
 # Overview
 
 This rule describes how to implement "${recipe.title}" in a Hydrogen storefront. Below is a "recipe" that contains the steps to apply to a basic Hydrogen skeleton template to achieve the desired outcome.
-
 The same logic can be applied to any other Hydrogen storefront project, adapting the implementation details to the specific needs/structure/conventions of the project, but it's up to the developer to do so.
-
 If there are any prerequisites, the recipe below will explain them; if the user is trying to implement the feature described in this recipe, make sure to prominently mention the prerequisites and any other preliminary instructions, as well as followups.
-
-Please remember that specific documentation about Storefront API, which might be relevant to the user, is available at <https://shopify.dev/docs/api/storefront>.
-
 If the user is asking on how to implement the feature from scratch, please first describe the feature in a general way before jumping into the implementation details.
-
 Please note that the recipe steps below are not necessarily ordered in the way they should be executed, as it depends on the user's needs and the specific details of the project. The recipe steps descriptions should allow you to understand what is required to be done in a certain order and what is not. Remember that file names in the recipe are related to the Hydrogen skeleton template, not the user's project, so make sure to adapt the file names to the user's project.
+
+# AI model verification steps
+
+- Never edit generated files (ending with .d.ts) directly; instead, run the \`npm run codegen\` command to update them.
 
 # Summary
 
@@ -80,7 +78,7 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
     ),
 
     // recipe data
-    mdParagraph(`<recipe_implementation>`),
+    mdParagraph('<recipe_implementation>'),
     ...[
       mdHeading(2, 'Description'),
       mdParagraph(recipe.description),
@@ -128,6 +126,11 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
             index,
             recipe.ingredients,
             getPatchesDir(recipeName),
+            {
+              diffsRelativeToTemplate: true,
+              dontCollapseDiffs: true,
+              trimDiffHeaders: true,
+            },
           ),
         ),
 
@@ -138,7 +141,7 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
           ]
         : []),
     ],
-    mdParagraph(`</recipe_implementation>`),
+    mdParagraph('</recipe_implementation>'),
   ];
 }
 

--- a/cookbook/src/lib/render.ts
+++ b/cookbook/src/lib/render.ts
@@ -150,7 +150,9 @@ function makeSteps(
   return [
     markdownStepsHeader,
     ...steps.flatMap((step, index) =>
-      renderStep(step, index, ingredients, patchesDir),
+      renderStep(step, index, ingredients, patchesDir, {
+        collapseDiffs: true,
+      }),
     ),
   ];
 }
@@ -161,8 +163,8 @@ export function renderStep(
   ingredients: Ingredient[],
   patchesDir: string,
   options: {
+    collapseDiffs?: boolean;
     diffsRelativeToTemplate?: boolean;
-    dontCollapseDiffs?: boolean;
     trimDiffHeaders?: boolean;
   } = {},
 ): MDBlock[] {
@@ -180,7 +182,7 @@ export function renderStep(
         : rawPatch;
 
       const collapsed =
-        !options.dontCollapseDiffs &&
+        options.collapseDiffs === true &&
         patch.split('\n').length > COLLAPSE_DIFF_LINES;
 
       return [

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -7,16 +7,14 @@ alwaysApply: false
 # Overview
 
 This rule describes how to implement "Subscriptions" in a Hydrogen storefront. Below is a "recipe" that contains the steps to apply to a basic Hydrogen skeleton template to achieve the desired outcome.
-
 The same logic can be applied to any other Hydrogen storefront project, adapting the implementation details to the specific needs/structure/conventions of the project, but it's up to the developer to do so.
-
 If there are any prerequisites, the recipe below will explain them; if the user is trying to implement the feature described in this recipe, make sure to prominently mention the prerequisites and any other preliminary instructions, as well as followups.
-
-Please remember that specific documentation about Storefront API, which might be relevant to the user, is available at <https://shopify.dev/docs/api/storefront>.
-
 If the user is asking on how to implement the feature from scratch, please first describe the feature in a general way before jumping into the implementation details.
-
 Please note that the recipe steps below are not necessarily ordered in the way they should be executed, as it depends on the user's needs and the specific details of the project. The recipe steps descriptions should allow you to understand what is required to be done in a certain order and what is not. Remember that file names in the recipe are related to the Hydrogen skeleton template, not the user's project, so make sure to adapt the file names to the user's project.
+
+# AI model verification steps
+
+- Never edit generated files (ending with .d.ts) directly; instead, run the `npm run codegen` command to update them.
 
 # Summary
 
@@ -216,12 +214,9 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
 
-#### File: [`app/components/CartLineItem.tsx`](/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: /app/components/CartLineItem.tsx
 
 ```diff
-index bd33a2cf..a18e4b52 100644
---- a/templates/skeleton/app/components/CartLineItem.tsx
-+++ b/templates/skeleton/app/components/CartLineItem.tsx
 @@ -3,8 +3,8 @@ import type {CartLayout} from '~/components/CartMain';
  import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
  import {useVariantUrl} from '~/lib/variants';
@@ -257,7 +252,6 @@ index bd33a2cf..a18e4b52 100644
            {selectedOptions.map((option) => (
              <li key={option.name}>
                <small>
-
 ```
 
 ### Step 3: Update `ProductForm` to support subscriptions
@@ -267,14 +261,9 @@ index bd33a2cf..a18e4b52 100644
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
 
-#### File: [`app/components/ProductForm.tsx`](/templates/skeleton/app/components/ProductForm.tsx)
-
-<details>
+#### File: /app/components/ProductForm.tsx
 
 ```diff
-index e8616a61..e41b91ad 100644
---- a/templates/skeleton/app/components/ProductForm.tsx
-+++ b/templates/skeleton/app/components/ProductForm.tsx
 @@ -6,120 +6,169 @@ import type {
  } from '@shopify/hydrogen/storefront-api-types';
  import {AddToCartButton} from './AddToCartButton';
@@ -582,10 +571,7 @@ index e8616a61..e41b91ad 100644
 +    </div>
 +  );
 +}
-
 ```
-
-</details>
 
 ### Step 4: Update `ProductPrice` to display subscription pricing
 
@@ -593,14 +579,9 @@ index e8616a61..e41b91ad 100644
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
 
-#### File: [`app/components/ProductPrice.tsx`](/templates/skeleton/app/components/ProductPrice.tsx)
-
-<details>
+#### File: /app/components/ProductPrice.tsx
 
 ```diff
-index 32460ae2..59eed1d8 100644
---- a/templates/skeleton/app/components/ProductPrice.tsx
-+++ b/templates/skeleton/app/components/ProductPrice.tsx
 @@ -1,13 +1,31 @@
 +import type {CurrencyCode} from '@shopify/hydrogen/customer-account-api-types';
 +import type {
@@ -708,22 +689,16 @@ index 32460ae2..59eed1d8 100644
 +    </div>
 +  );
 +}
-
 ```
-
-</details>
 
 ### Step 5: Add selling plan data to cart queries
 
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
 
-#### File: [`app/lib/fragments.ts`](/templates/skeleton/app/lib/fragments.ts)
+#### File: /app/lib/fragments.ts
 
 ```diff
-index dc4426a9..cfe3a938 100644
---- a/templates/skeleton/app/lib/fragments.ts
-+++ b/templates/skeleton/app/lib/fragments.ts
 @@ -54,6 +54,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
          }
        }
@@ -748,7 +723,6 @@ index dc4426a9..cfe3a938 100644
    }
    fragment CartApiQuery on Cart {
      updatedAt
-
 ```
 
 ### Step 6: Add `SellingPlanSelector` to product pages
@@ -758,14 +732,9 @@ index dc4426a9..cfe3a938 100644
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
 
-#### File: [`app/routes/products.$handle.tsx`](/templates/skeleton/app/routes/products.$handle.tsx)
-
-<details>
+#### File: /app/routes/products.$handle.tsx
 
 ```diff
-index 2dc6bda2..aad7e5f1 100644
---- a/templates/skeleton/app/routes/products.$handle.tsx
-+++ b/templates/skeleton/app/routes/products.$handle.tsx
 @@ -1,3 +1,5 @@
 +import type {SellingPlanFragment} from 'storefrontapi.generated';
 +import type {LinksFunction} from '@remix-run/node';
@@ -947,10 +916,6 @@ index 2dc6bda2..aad7e5f1 100644
 +  ${SELLING_PLAN_GROUP_FRAGMENT}
    ${PRODUCT_VARIANT_FRAGMENT}
  ` as const;
- 
-
 ```
-
-</details>
 
 </recipe_implementation>


### PR DESCRIPTION
### WHY are these changes introduced?

Cursor rules for recipes can benefit from a slimmer files representation.

### WHAT is this pull request doing?

This PR updates the rules generation:
- Adds explicit instructions to NOT edit `.d.ts` files directly but instead use `codegen` to generate them
- Don't show the collapsed blocks limiters on long file diffs (needed in the human readable format, but just noise in the rule)
- Use relative file paths to the current directory instead of referencing the template folder, which would not applicable
- Omit the diff headers, since they just add noise in the context of the rule

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
