### PR TITLE
Copyedits for combined listings recipe

### DIFF
--- a/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -1,5 +1,5 @@
 ---
-description: Recipe for implementing "Combined Listings (combined-listings)" in a Hydrogen storefront. Handle Shopify combined listings in product pages and search results.
+description: Recipe for implementing "Combined Listings (combined-listings)" in a Hydrogen storefront. Handle combined listings on product pages and in search results.
 globs: *
 alwaysApply: false
 ---
@@ -18,12 +18,12 @@ Please note that the recipe steps below are not necessarily ordered in the way t
 
 # Summary
 
-Handle Shopify combined listings in product pages and search results.
+Handle combined listings on product pages and in search results.
 
 # User Intent Recognition
 
 <user_queries>
-- How can I show combined listings in product pages and search results using Hydrogen?
+- How can I show combined listings on product pages and search results using Hydrogen?
 - How can I display the featured image of the combined listing parent product instead of the variant image?
 - How can I redirect to the first variant of a combined listing when the handle is requested?
 - How can I filter out combined listings from the product list when using Shopify headless?
@@ -34,7 +34,7 @@ Handle Shopify combined listings in product pages and search results.
 
 <troubleshooting>
 - **Issue**: Combined listings are being displayed in the product list.
-  **Solution**: Make sure to tag combined listing parent products in the Shopify Admin and use that tag to filter out combined listings from the product list in the GraphQL query.
+  **Solution**: Make sure to tag combined listing parent products in the Shopify admin and use that tag to filter out combined listings from the product list in the GraphQL query.
 </troubleshooting>
 
 # Recipe Implementation
@@ -46,29 +46,32 @@ Here's the combined-listings recipe for the base Hydrogen skeleton template:
 ## Description
 
 
-This recipe handles Shopify [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) in product pages and search results.
+This recipe lets you display [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) on product pages and in search results for your Hydrogen storefront. A combined listing groups separate products together into a single product listing using a shared option like color or size.
+Each product appears as a variant but can have its own title, description, URL, and images.
 
+In this recipe, you'll make the following changes:
 
-## Notes
+1. Set up the Combined Listings app in your Shopify admin and group relevant products together as combined listings.
+2. Configure how combined listings will be handled on your storefront.
+3. Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings.
+4. Update the `ProductImage` component to support images from product variants and the product itself.
+5. Show a range of prices for combined listings in `ProductItem`.
 
-> [!NOTE]
-> Combined listings are available only to stores on a [Shopify Plus](https://www.shopify.com/plus) or enterprise plan.
 
 ## Requirements
 
-- Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) in your store.
-- [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing).
-- Add a tag to any combined listing parent products to indicate they're a combined listing, for example `combined`.
+- Your store must be on either a [Shopify Plus](https://www.shopify.com/plus) or enterprise plan.
+- Your store must have the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) installed.
 
 
 ## New files added to the template by this recipe
 
 ### templates/skeleton/app/lib/combined-listings.ts
 
-Utilities and settings for handling combined listings.
+The `combined-listings.ts` file contains utilities and settings for handling combined listings.
 
 ```ts
-// Edit these values to customize the combined listings behaviors
+// Edit these values to customize combined listings' behavior
 export const combinedListingsSettings = {
   // If true, loading the product page will redirect to the first variant
   redirectToFirstVariant: false,
@@ -108,9 +111,14 @@ export function isCombinedListing(product: unknown) {
 
 ## Steps
 
-### Step 1: Configure combined listings behavior
+### Step 1: Set up the Combined Listings app
 
-Combined listings work out of the box, but you can customize specific behaviors when retrieving and displaying combined listing parent products.
+1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings). 2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing). 3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
+
+
+### Step 2: Configure combined listings behavior
+
+You can customize how the parent products of combined listings are retrieved and displayed.
 
 To make this process easier, we included a configuration object in the `combined-listings.ts` file that you can edit to customize according to your preferences.
 
@@ -127,9 +135,9 @@ export const combinedListingsSettings = {
 ```
 
 
-### Step 2: Update the `ProductForm` component
+### Step 3: Update the `ProductForm` component
 
-Update the `ProductForm` component to hide the `Add to cart` button for combined listings parent products, as well as the selected state for variants.
+Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings and for variants' selected state.
 
 
 #### File: /app/components/ProductForm.tsx
@@ -224,7 +232,7 @@ Update the `ProductForm` component to hide the `Add to cart` button for combined
  }
 ```
 
-### Step 3: Extend the `ProductImage` component
+### Step 4: Extend the `ProductImage` component
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
@@ -250,10 +258,9 @@ Update the `ProductImage` component to support images from both product variants
      return <div className="product-image" />;
 ```
 
-### Step 4: Show a range of prices for combined listings in `ProductItem`
+### Step 5: Show a range of prices for combined listings in `ProductItem`
 
-If the product is a combined listing, show a range of prices for the
-combined listing parent product instead of the variant price.
+Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
 
 #### File: /app/components/ProductItem.tsx
@@ -290,9 +297,9 @@ combined listing parent product instead of the variant price.
  }
 ```
 
-### Step 5: (optional) Add combined listings redirect utility
+### Step 6: (Optional) Add redirect utility to first variant of a combined listing
 
-If you wish to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a utility to redirect to the first variant of a combined listing when the handle of the parent is requested, add a utility to redirect to the first variant of a combined listing.
+If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
 
 #### File: /app/lib/redirect.ts
@@ -331,10 +338,10 @@ If you wish to redirect automatically to the first variant of a combined listing
 +}
 ```
 
-### Step 6: Update queries for combined listings
+### Step 7: Update queries for combined listings
 
-- Add the `tags` property to the ones returned by the product query.
-- (optional) Add the filtering query to the product query to exclude combined listings.
+- Add the `tags` property to the items returned by the product query.
+- (Optional) Add the filtering query to the product query to exclude combined listings.
 
 
 #### File: /app/routes/_index.tsx
@@ -411,9 +418,9 @@ If you wish to redirect automatically to the first variant of a combined listing
        }
 ```
 
-### Step 7: (optional) Filter out combined listings from individual collections pages
+### Step 8: (Optional) Filter out combined listings from collections pages
 
-Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they are retrieved, based on their tags.
+Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
 
 #### File: /app/routes/collections.$handle.tsx
@@ -477,7 +484,7 @@ Since it's not possible to directly apply query filters when retrieving collecti
            ...ProductItem
 ```
 
-### Step 8: (optional) Filter out combined listings from collections index page
+### Step 9: (Optional) Filter out combined listings from the collections index page
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
@@ -532,11 +539,11 @@ Update the `collections.all` route to filter out combined listings from the sear
        }
 ```
 
-### Step 9: Update the product page
+### Step 10: Update the product page
 
 - Display a range of prices for combined listings instead of the variant price.
 - Show the featured image of the combined listing parent product instead of the variant image.
-- (optional) Redirect to the first variant of a combined listing when the handle is requested
+- (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
 
 #### File: /app/routes/products.$handle.tsx
@@ -668,7 +675,7 @@ Update the `collections.all` route to filter out combined listings from the sear
        optionValues {
 ```
 
-### Step 10: Update stylesheet
+### Step 11: Update stylesheet
 
 Add a class to the product item to show a range of prices for combined listings.
 

--- a/cookbook/recipes/combined-listings/README.md
+++ b/cookbook/recipes/combined-listings/README.md
@@ -1,17 +1,22 @@
 # Combined Listings
 
 
-This recipe handles Shopify [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) in product pages and search results.
+This recipe lets you display [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) on product pages and in search results for your Hydrogen storefront. A combined listing groups separate products together into a single product listing using a shared option like color or size.
+Each product appears as a variant but can have its own title, description, URL, and images.
 
+In this recipe, you'll make the following changes:
 
-> [!NOTE]
-> Combined listings are available only to stores on a [Shopify Plus](https://www.shopify.com/plus) or enterprise plan.
+1. Set up the Combined Listings app in your Shopify admin and group relevant products together as combined listings.
+2. Configure how combined listings will be handled on your storefront.
+3. Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings.
+4. Update the `ProductImage` component to support images from product variants and the product itself.
+5. Show a range of prices for combined listings in `ProductItem`.
+
 
 ## Requirements
 
-- Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) in your store.
-- [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing).
-- Add a tag to any combined listing parent products to indicate they're a combined listing, for example `combined`.
+- Your store must be on either a [Shopify Plus](https://www.shopify.com/plus) or enterprise plan.
+- Your store must have the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) installed.
 
 
 ## Ingredients
@@ -20,13 +25,18 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [`app/lib/combined-listings.ts`](ingredients/templates/skeleton/app/lib/combined-listings.ts) | Utilities and settings for handling combined listings. |
+| [`app/lib/combined-listings.ts`](ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
 
 ## Steps
 
-### Step 1: Configure combined listings behavior
+### Step 1: Set up the Combined Listings app
 
-Combined listings work out of the box, but you can customize specific behaviors when retrieving and displaying combined listing parent products.
+1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings). 2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing). 3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
+
+
+### Step 2: Configure combined listings behavior
+
+You can customize how the parent products of combined listings are retrieved and displayed.
 
 To make this process easier, we included a configuration object in the `combined-listings.ts` file that you can edit to customize according to your preferences.
 
@@ -43,15 +53,15 @@ export const combinedListingsSettings = {
 ```
 
 
-### Step 2: Add ingredients to your project
+### Step 3: Add ingredients to your project
 
 Copy all the files found in the `ingredients/` directory to the current directory.
 
 - [`app/lib/combined-listings.ts`](ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
-### Step 3: Update the `ProductForm` component
+### Step 4: Update the `ProductForm` component
 
-Update the `ProductForm` component to hide the `Add to cart` button for combined listings parent products, as well as the selected state for variants.
+Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings and for variants' selected state.
 
 
 #### File: [`app/components/ProductForm.tsx`](/templates/skeleton/app/components/ProductForm.tsx)
@@ -153,7 +163,7 @@ index e8616a61..838a903a 100644
 
 </details>
 
-### Step 4: Extend the `ProductImage` component
+### Step 5: Extend the `ProductImage` component
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
@@ -182,10 +192,9 @@ index 5f3ac1cc..f1c9f2cd 100644
      return <div className="product-image" />;
 ```
 
-### Step 5: Show a range of prices for combined listings in `ProductItem`
+### Step 6: Show a range of prices for combined listings in `ProductItem`
 
-If the product is a combined listing, show a range of prices for the
-combined listing parent product instead of the variant price.
+Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
 
 #### File: [`app/components/ProductItem.tsx`](/templates/skeleton/app/components/ProductItem.tsx)
@@ -225,9 +234,9 @@ index 62c64b50..034b5660 100644
  }
 ```
 
-### Step 6: (optional) Add combined listings redirect utility
+### Step 7: (Optional) Add redirect utility to first variant of a combined listing
 
-If you wish to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a utility to redirect to the first variant of a combined listing when the handle of the parent is requested, add a utility to redirect to the first variant of a combined listing.
+If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
 
 #### File: [`app/lib/redirect.ts`](/templates/skeleton/app/lib/redirect.ts)
@@ -269,10 +278,10 @@ index ce1feb5a..29fe2ecc 100644
 +}
 ```
 
-### Step 7: Update queries for combined listings
+### Step 8: Update queries for combined listings
 
-- Add the `tags` property to the ones returned by the product query.
-- (optional) Add the filtering query to the product query to exclude combined listings.
+- Add the `tags` property to the items returned by the product query.
+- (Optional) Add the filtering query to the product query to exclude combined listings.
 
 
 #### File: [`app/routes/_index.tsx`](/templates/skeleton/app/routes/_index.tsx)
@@ -356,9 +365,9 @@ index 34747528..6e485083 100644
 
 </details>
 
-### Step 8: (optional) Filter out combined listings from individual collections pages
+### Step 9: (Optional) Filter out combined listings from collections pages
 
-Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they are retrieved, based on their tags.
+Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
 
 #### File: [`app/routes/collections.$handle.tsx`](/templates/skeleton/app/routes/collections.$handle.tsx)
@@ -429,7 +438,7 @@ index f1d7fa3e..17edfb7d 100644
 
 </details>
 
-### Step 9: (optional) Filter out combined listings from collections index page
+### Step 10: (Optional) Filter out combined listings from the collections index page
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
@@ -487,11 +496,11 @@ index 3a31b2f7..c756c9e1 100644
        }
 ```
 
-### Step 10: Update the product page
+### Step 11: Update the product page
 
 - Display a range of prices for combined listings instead of the variant price.
 - Show the featured image of the combined listing parent product instead of the variant image.
-- (optional) Redirect to the first variant of a combined listing when the handle is requested
+- (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
 
 #### File: [`app/routes/products.$handle.tsx`](/templates/skeleton/app/routes/products.$handle.tsx)
@@ -630,7 +639,7 @@ index 2dc6bda2..8baafac9 100644
 
 </details>
 
-### Step 11: Update stylesheet
+### Step 12: Update stylesheet
 
 Add a class to the product item to show a range of prices for combined listings.
 

--- a/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts
+++ b/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts
@@ -1,4 +1,4 @@
-// Edit these values to customize the combined listings behaviors
+// Edit these values to customize combined listings' behavior
 export const combinedListingsSettings = {
   // If true, loading the product page will redirect to the first variant
   redirectToFirstVariant: false,

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -4,48 +4,55 @@ title: Combined Listings
 summary: Handle combined listings on product pages and in search results.
 description: >
   
-  This recipe lets you display [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) on product pages and in search results for your Hydrogen storefront. A combined listing groups separate products together into a single product listing using a shared option like color or size. Each product appears as a variant but can have its own title, description, URL, and images. 
+  This recipe lets you display [combined
+  listings](https://help.shopify.com/en/manual/products/combined-listings-app)
+  on product pages and in search results for your Hydrogen storefront. A
+  combined listing groups separate products together into a single product
+  listing using a shared option like color or size.
+
+  Each product appears as a variant but can have its own title, description,
+  URL, and images.
 
 
   In this recipe, you'll make the following changes:
 
 
-  1. Set up the Combined Listings app in your Shopify admin and group relevant products together as combined listings.
-  2. Configure how combined listings will be handled on your storefront.
-  3. Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings.
-  4. Update the `ProductImage` component to support images from product variants and the product itself.
-  5. Show a range of prices for combined listings in `ProductItem`.
+  1. Set up the Combined Listings app in your Shopify admin and group relevant
+  products together as combined listings.
 
+  2. Configure how combined listings will be handled on your storefront.
+
+  3. Update the `ProductForm` component to hide the `Add to cart` button for the
+  parent products of combined listings.
+
+  4. Update the `ProductImage` component to support images from product variants
+  and the product itself.
+
+  5. Show a range of prices for combined listings in `ProductItem`.
 notes: []
-  
-requirements: |
-  - Your store must be on either a [Shopify Plus](https://www.shopify.com/plus) or enterprise plan.
-  - Your store must have the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) installed.
+requirements: >
+  - Your store must be on either a [Shopify Plus](https://www.shopify.com/plus)
+  or enterprise plan.
+
+  - Your store must have the [Combined Listings
+  app](https://admin.shopify.com/apps/combined-listings) installed.
 ingredients:
   - path: templates/skeleton/app/lib/combined-listings.ts
-    description: The `combined-listings.ts` file contains utilities and settings for handling combined listings.
+    description: The `combined-listings.ts` file contains utilities and settings for
+      handling combined listings.
 deletedFiles: []
 steps:
   - type: INFO
     index: 1
     name: Set up the Combined Listings app
-    description: >
-      1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings).
-      2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing).
-      3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
-
-  - type: COPY_INGREDIENTS
-    index: 2
-    name: Add ingredients to your project
-    description: Copy all the files found in the `ingredients/` directory to your project.
-    ingredients:
-      - templates/skeleton/app/lib/combined-listings.ts
-
+    description: |
+      1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings). 2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing). 3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
   - type: INFO
-    index: 3  
+    index: 2
     name: Configure combined listings behavior
     description: >
-      You can customize how the parent products of combined listings are retrieved and displayed.
+      You can customize how the parent products of combined listings are
+      retrieved and displayed.
 
 
       To make this process easier, we included a configuration object in the
@@ -67,13 +74,21 @@ steps:
       };
 
       ```
+  - type: COPY_INGREDIENTS
+    index: 3
+    name: Add ingredients to your project
+    description: Copy all the files found in the `ingredients/` directory to the
+      current directory.
+    ingredients:
+      - templates/skeleton/app/lib/combined-listings.ts
   - type: PATCH
     index: 4
     name: Update the `ProductForm` component
     description: >
-      Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings and for variants' selected state.
-      - file: app/components/ProductForm.tsx
+      Update the `ProductForm` component to hide the `Add to cart` button for
+      the parent products of combined listings and for variants' selected state.
     diffs:
+      - file: app/components/ProductForm.tsx
         patchFile: ProductForm.tsx.8e409a.patch
   - type: PATCH
     index: 5
@@ -87,8 +102,9 @@ steps:
   - type: PATCH
     index: 6
     name: Show a range of prices for combined listings in `ProductItem`
-    description: |
-      Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
+    description: >
+      Update `ProductItem.tsx` to show a range of prices for the combined
+      listing parent product instead of the variant price.
     diffs:
       - file: app/components/ProductItem.tsx
         patchFile: ProductItem.tsx.8ddc67.patch
@@ -96,7 +112,9 @@ steps:
     index: 7
     name: (Optional) Add redirect utility to first variant of a combined listing
     description: >
-      If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
+      If you want to redirect automatically to the first variant of a combined
+      listing when the parent handle is selected, add a redirect utility that's
+      called whenever the parent handle is requested.
     diffs:
       - file: app/lib/redirect.ts
         patchFile: redirect.ts.1e6242.patch
@@ -171,4 +189,4 @@ llms:
       solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
-commit: 2529b8c128ea0b203efdd08d642d4ad07e93be49
+commit: e1d77d5714e2472fa87fcc56473078f9fd263f72

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -1,30 +1,51 @@
 # yaml-language-server: $schema=../../recipe.schema.json
 
 title: Combined Listings
-summary: Handle Shopify combined listings in product pages and search results.
+summary: Handle combined listings on product pages and in search results.
 description: >
   
-  This recipe handles Shopify [combined
-  listings](https://help.shopify.com/en/manual/products/combined-listings-app)
-  in product pages and search results.
-notes:
-  - Combined listings are available only to stores on a [Shopify
-    Plus](https://www.shopify.com/plus) or enterprise plan.
+  This recipe lets you display [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) on product pages and in search results for your Hydrogen storefront. A combined listing groups separate products together into a single product listing using a shared option like color or size. Each product appears as a variant but can have its own title, description, URL, and images. 
+
+
+  In this recipe, you'll make the following changes:
+
+
+  1. Set up the Combined Listings app in your Shopify admin and group relevant products together as combined listings.
+  2. Configure how combined listings will be handled on your storefront.
+  3. Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings.
+  4. Update the `ProductImage` component to support images from product variants and the product itself.
+  5. Show a range of prices for combined listings in `ProductItem`.
+
+notes: []
+  
 requirements: |
-  - Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) in your store.
-  - [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing).
-  - Add a tag to any combined listing parent products to indicate they're a combined listing, for example `combined`.
+  - Your store must be on either a [Shopify Plus](https://www.shopify.com/plus) or enterprise plan.
+  - Your store must have the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) installed.
 ingredients:
   - path: templates/skeleton/app/lib/combined-listings.ts
-    description: Utilities and settings for handling combined listings.
+    description: The `combined-listings.ts` file contains utilities and settings for handling combined listings.
 deletedFiles: []
 steps:
   - type: INFO
     index: 1
+    name: Set up the Combined Listings app
+    description: >
+      1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings).
+      2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing).
+      3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
+
+  - type: COPY_INGREDIENTS
+    index: 2
+    name: Add ingredients to your project
+    description: Copy all the files found in the `ingredients/` directory to your project.
+    ingredients:
+      - templates/skeleton/app/lib/combined-listings.ts
+
+  - type: INFO
+    index: 3  
     name: Configure combined listings behavior
     description: >
-      Combined listings work out of the box, but you can customize specific
-      behaviors when retrieving and displaying combined listing parent products.
+      You can customize how the parent products of combined listings are retrieved and displayed.
 
 
       To make this process easier, we included a configuration object in the
@@ -46,25 +67,16 @@ steps:
       };
 
       ```
-  - type: COPY_INGREDIENTS
-    index: 2
-    name: Add ingredients to your project
-    description: Copy all the files found in the `ingredients/` directory to the
-      current directory.
-    ingredients:
-      - templates/skeleton/app/lib/combined-listings.ts
-  - type: PATCH
-    index: 3
-    name: Update the `ProductForm` component
-    description: >
-      Update the `ProductForm` component to hide the `Add to cart` button for
-      combined listings parent products, as well as the selected state for
-      variants.
-    diffs:
-      - file: app/components/ProductForm.tsx
-        patchFile: ProductForm.tsx.8e409a.patch
   - type: PATCH
     index: 4
+    name: Update the `ProductForm` component
+    description: >
+      Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings and for variants' selected state.
+      - file: app/components/ProductForm.tsx
+    diffs:
+        patchFile: ProductForm.tsx.8e409a.patch
+  - type: PATCH
+    index: 5
     name: Extend the `ProductImage` component
     description: >
       Update the `ProductImage` component to support images from both product
@@ -73,50 +85,45 @@ steps:
       - file: app/components/ProductImage.tsx
         patchFile: ProductImage.tsx.4e6c4c.patch
   - type: PATCH
-    index: 5
+    index: 6
     name: Show a range of prices for combined listings in `ProductItem`
     description: |
-      If the product is a combined listing, show a range of prices for the
-      combined listing parent product instead of the variant price.
+      Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
     diffs:
       - file: app/components/ProductItem.tsx
         patchFile: ProductItem.tsx.8ddc67.patch
   - type: PATCH
-    index: 6
-    name: (optional) Add combined listings redirect utility
+    index: 7
+    name: (Optional) Add redirect utility to first variant of a combined listing
     description: >
-      If you wish to redirect automatically to the first variant of a combined
-      listing when the parent handle is selected, add a utility to redirect to
-      the first variant of a combined listing when the handle of the parent is
-      requested, add a utility to redirect to the first variant of a combined
-      listing.
+      If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
     diffs:
       - file: app/lib/redirect.ts
         patchFile: redirect.ts.1e6242.patch
   - type: PATCH
-    index: 7
+    index: 8
     name: Update queries for combined listings
     description: >
-      - Add the `tags` property to the ones returned by the product query.
+      - Add the `tags` property to the items returned by the product query.
 
-      - (optional) Add the filtering query to the product query to exclude
+      - (Optional) Add the filtering query to the product query to exclude
       combined listings.
     diffs:
       - file: app/routes/_index.tsx
         patchFile: _index.tsx.8041d5.patch
   - type: PATCH
-    index: 8
-    name: (optional) Filter out combined listings from individual collections pages
+    index: 9
+    name: (Optional) Filter out combined listings from collections pages
     description: >
       Since it's not possible to directly apply query filters when retrieving
       collection products, you can manually filter out combined listings after
-      they are retrieved, based on their tags.
+      they're retrieved based on their tags.
     diffs:
       - file: app/routes/collections.$handle.tsx
         patchFile: collections.$handle.tsx.951367.patch
   - type: PATCH
-    index: 9
-    name: (optional) Filter out combined listings from collections index page
+    index: 10
+    name: (Optional) Filter out combined listings from the collections index page
     description: >
       Update the `collections.all` route to filter out combined listings from
       the search results, and include the price range for combined listings.
@@ -124,7 +131,7 @@ steps:
       - file: app/routes/collections.all.tsx
         patchFile: collections.all.tsx.75880b.patch
   - type: PATCH
-    index: 10
+    index: 11
     name: Update the product page
     description: >
       - Display a range of prices for combined listings instead of the variant
@@ -133,13 +140,13 @@ steps:
       - Show the featured image of the combined listing parent product instead
       of the variant image.
 
-      - (optional) Redirect to the first variant of a combined listing when the
-      handle is requested
+      - (Optional) Redirect to the first variant of a combined listing when the
+      handle is requested.
     diffs:
       - file: app/routes/products.$handle.tsx
         patchFile: products.$handle.tsx.3e0b7e.patch
   - type: PATCH
-    index: 11
+    index: 12
     name: Update stylesheet
     description: >
       Add a class to the product item to show a range of prices for combined
@@ -149,7 +156,7 @@ steps:
         patchFile: app.css.e88d35.patch
 llms:
   userQueries:
-    - How can I show combined listings in product pages and search results using
+    - How can I show combined listings on product pages and search results using
       Hydrogen?
     - How can I display the featured image of the combined listing parent
       product instead of the variant image?
@@ -161,7 +168,7 @@ llms:
       variant price?
   troubleshooting:
     - issue: Combined listings are being displayed in the product list.
-      solution: Make sure to tag combined listing parent products in the Shopify Admin
+      solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
 commit: 2529b8c128ea0b203efdd08d642d4ad07e93be49

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -1,5 +1,5 @@
 ---
-description: Recipe for implementing "Combined Listings (combined-listings)" in a Hydrogen storefront. Handle Shopify combined listings in product pages and search results.
+description: Recipe for implementing "Combined Listings (combined-listings)" in a Hydrogen storefront. Handle combined listings on product pages and in search results.
 globs: *
 alwaysApply: false
 ---
@@ -18,12 +18,12 @@ Please note that the recipe steps below are not necessarily ordered in the way t
 
 # Summary
 
-Handle Shopify combined listings in product pages and search results.
+Handle combined listings on product pages and in search results.
 
 # User Intent Recognition
 
 <user_queries>
-- How can I show combined listings in product pages and search results using Hydrogen?
+- How can I show combined listings on product pages and search results using Hydrogen?
 - How can I display the featured image of the combined listing parent product instead of the variant image?
 - How can I redirect to the first variant of a combined listing when the handle is requested?
 - How can I filter out combined listings from the product list when using Shopify headless?
@@ -34,7 +34,7 @@ Handle Shopify combined listings in product pages and search results.
 
 <troubleshooting>
 - **Issue**: Combined listings are being displayed in the product list.
-  **Solution**: Make sure to tag combined listing parent products in the Shopify Admin and use that tag to filter out combined listings from the product list in the GraphQL query.
+  **Solution**: Make sure to tag combined listing parent products in the Shopify admin and use that tag to filter out combined listings from the product list in the GraphQL query.
 </troubleshooting>
 
 # Recipe Implementation
@@ -46,29 +46,32 @@ Here's the combined-listings recipe for the base Hydrogen skeleton template:
 ## Description
 
 
-This recipe handles Shopify [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) in product pages and search results.
+This recipe lets you display [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) on product pages and in search results for your Hydrogen storefront. A combined listing groups separate products together into a single product listing using a shared option like color or size.
+Each product appears as a variant but can have its own title, description, URL, and images.
 
+In this recipe, you'll make the following changes:
 
-## Notes
+1. Set up the Combined Listings app in your Shopify admin and group relevant products together as combined listings.
+2. Configure how combined listings will be handled on your storefront.
+3. Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings.
+4. Update the `ProductImage` component to support images from product variants and the product itself.
+5. Show a range of prices for combined listings in `ProductItem`.
 
-> [!NOTE]
-> Combined listings are available only to stores on a [Shopify Plus](https://www.shopify.com/plus) or enterprise plan.
 
 ## Requirements
 
-- Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) in your store.
-- [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing).
-- Add a tag to any combined listing parent products to indicate they're a combined listing, for example `combined`.
+- Your store must be on either a [Shopify Plus](https://www.shopify.com/plus) or enterprise plan.
+- Your store must have the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) installed.
 
 
 ## New files added to the template by this recipe
 
 ### templates/skeleton/app/lib/combined-listings.ts
 
-Utilities and settings for handling combined listings.
+The `combined-listings.ts` file contains utilities and settings for handling combined listings.
 
 ```ts
-// Edit these values to customize the combined listings behaviors
+// Edit these values to customize combined listings' behavior
 export const combinedListingsSettings = {
   // If true, loading the product page will redirect to the first variant
   redirectToFirstVariant: false,
@@ -108,9 +111,14 @@ export function isCombinedListing(product: unknown) {
 
 ## Steps
 
-### Step 1: Configure combined listings behavior
+### Step 1: Set up the Combined Listings app
 
-Combined listings work out of the box, but you can customize specific behaviors when retrieving and displaying combined listing parent products.
+1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings). 2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing). 3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
+
+
+### Step 2: Configure combined listings behavior
+
+You can customize how the parent products of combined listings are retrieved and displayed.
 
 To make this process easier, we included a configuration object in the `combined-listings.ts` file that you can edit to customize according to your preferences.
 
@@ -127,9 +135,9 @@ export const combinedListingsSettings = {
 ```
 
 
-### Step 2: Update the `ProductForm` component
+### Step 3: Update the `ProductForm` component
 
-Update the `ProductForm` component to hide the `Add to cart` button for combined listings parent products, as well as the selected state for variants.
+Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings and for variants' selected state.
 
 
 #### File: /app/components/ProductForm.tsx
@@ -224,7 +232,7 @@ Update the `ProductForm` component to hide the `Add to cart` button for combined
  }
 ```
 
-### Step 3: Extend the `ProductImage` component
+### Step 4: Extend the `ProductImage` component
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
@@ -250,10 +258,9 @@ Update the `ProductImage` component to support images from both product variants
      return <div className="product-image" />;
 ```
 
-### Step 4: Show a range of prices for combined listings in `ProductItem`
+### Step 5: Show a range of prices for combined listings in `ProductItem`
 
-If the product is a combined listing, show a range of prices for the
-combined listing parent product instead of the variant price.
+Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
 
 #### File: /app/components/ProductItem.tsx
@@ -290,9 +297,9 @@ combined listing parent product instead of the variant price.
  }
 ```
 
-### Step 5: (optional) Add combined listings redirect utility
+### Step 6: (Optional) Add redirect utility to first variant of a combined listing
 
-If you wish to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a utility to redirect to the first variant of a combined listing when the handle of the parent is requested, add a utility to redirect to the first variant of a combined listing.
+If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
 
 #### File: /app/lib/redirect.ts
@@ -331,10 +338,10 @@ If you wish to redirect automatically to the first variant of a combined listing
 +}
 ```
 
-### Step 6: Update queries for combined listings
+### Step 7: Update queries for combined listings
 
-- Add the `tags` property to the ones returned by the product query.
-- (optional) Add the filtering query to the product query to exclude combined listings.
+- Add the `tags` property to the items returned by the product query.
+- (Optional) Add the filtering query to the product query to exclude combined listings.
 
 
 #### File: /app/routes/_index.tsx
@@ -411,9 +418,9 @@ If you wish to redirect automatically to the first variant of a combined listing
        }
 ```
 
-### Step 7: (optional) Filter out combined listings from individual collections pages
+### Step 8: (Optional) Filter out combined listings from collections pages
 
-Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they are retrieved, based on their tags.
+Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
 
 #### File: /app/routes/collections.$handle.tsx
@@ -477,7 +484,7 @@ Since it's not possible to directly apply query filters when retrieving collecti
            ...ProductItem
 ```
 
-### Step 8: (optional) Filter out combined listings from collections index page
+### Step 9: (Optional) Filter out combined listings from the collections index page
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
@@ -532,11 +539,11 @@ Update the `collections.all` route to filter out combined listings from the sear
        }
 ```
 
-### Step 9: Update the product page
+### Step 10: Update the product page
 
 - Display a range of prices for combined listings instead of the variant price.
 - Show the featured image of the combined listing parent product instead of the variant image.
-- (optional) Redirect to the first variant of a combined listing when the handle is requested
+- (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
 
 #### File: /app/routes/products.$handle.tsx
@@ -668,7 +675,7 @@ Update the `collections.all` route to filter out combined listings from the sear
        optionValues {
 ```
 
-### Step 10: Update stylesheet
+### Step 11: Update stylesheet
 
 Add a class to the product item to show a range of prices for combined listings.
 


### PR DESCRIPTION
This adds copyedits to the combined insights recipe (and a bonus grammar nit in the `combined-listings.ts` file too)

cc @ruggishop -- this is a branch off of your work at https://github.com/Shopify/hydrogen/pull/2876