### PR TITLE
Cookbook: use actual Github links for files in shopify.dev output

### DIFF
--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -125,7 +125,9 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
             step,
             index,
             recipe.ingredients,
+            recipeName,
             getPatchesDir(recipeName),
+            'github',
             {
               diffsRelativeToTemplate: true,
               trimDiffHeaders: true,

--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -124,7 +124,7 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
           renderStep(
             step,
             index,
-            recipe.ingredients,
+            recipe,
             recipeName,
             getPatchesDir(recipeName),
             'github',


### PR DESCRIPTION
### WHAT is this pull request doing?

Cookbook recipes rendered with the `shopify-dev` format should use links to the Hydrogen Github repo for mentioned files.

This PR updates the `render` command so file links will be rendered targeting `https://github.com/Shopify/hydrogen/blob/<recipe-hash>/<file-path>` in their markdown links.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation