### PR TITLE
Cookbook recipes: better copy for Copy Ingredients

### DIFF
--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -32,11 +32,11 @@ Add subscription-based products to your Hydrogen storefront.
 
 <troubleshooting>
 - **Issue**: I'm getting an error when I try to add a subscription to my storefront.
-  **Solution**: Make sure you have the Shopify Subscriptions app installed and configured correctly.
+  **Solution**: Make sure you've installed the Shopify Subscriptions app and set up selling plans for subscription products in your Shopify admin.
 - **Issue**: I'm not seeing the subscription options on my product pages.
-  **Solution**: Make sure you have the Shopify Subscriptions app installed and configured correctly.
+  **Solution**: Make sure you've installed the Shopify Subscriptions app and set up selling plans for subscription products in your Shopify admin.
 - **Issue**: I'm not seeing the subscription details on my cart line items.
-  **Solution**: Make sure you have the Shopify Subscriptions app installed and configured correctly.
+  **Solution**: Make sure you've installed the Shopify Subscriptions app and set up selling plans for subscription products in your Shopify admin.
 </troubleshooting>
 
 # Recipe Implementation
@@ -57,7 +57,7 @@ In this recipe you'll make the following changes:
 2. Modify product detail pages to display subscription options with accurate pricing using the `SellingPlanSelector` component.
 3. Enhance GraphQL fragments to fetch all necessary selling plan data.
 4. Display subscription details on applicable line items in the cart.
-5. Add a `Subscriptions` page to manage customer subscriptions, with the ability to list them and cancel the active ones.
+5. Add a **Subscriptions** page where customers can manage their subscriptions, which includes the option to cancel active subscriptions.
 
 
 ## Requirements
@@ -69,7 +69,7 @@ To implement subscriptions in your own store, you need to install a subscription
 
 ### templates/skeleton/app/components/SellingPlanSelector.tsx
 
-The `SellingPlanSelector` component is used to display the available subscription options on product pages.
+Displays the available subscription options on product pages.
 
 ```tsx
 import type {
@@ -451,7 +451,7 @@ Subscriptions management page styles.
 
 ### templates/skeleton/app/styles/selling-plan.css
 
-The `selling-plan.css` file is used to style the `SellingPlanSelector` component.
+Styles the `SellingPlanSelector` component.
 
 ```css
 .selling-plan-group {
@@ -1210,7 +1210,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
  ` as const;
 ```
 
-### Step 7: Add a `Subscriptions` link to the account menu
+### Step 7: Add a link to the **Subscriptions** page
 
 Add a `Subscriptions` link to the account menu.
 

--- a/cookbook/recipes/combined-listings/README.md
+++ b/cookbook/recipes/combined-listings/README.md
@@ -25,7 +25,7 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [`app/lib/combined-listings.ts`](ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
+| [app/lib/combined-listings.ts](ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
 
 ## Steps
 
@@ -55,9 +55,9 @@ export const combinedListingsSettings = {
 
 ### Step 3: Add ingredients to your project
 
-Copy all the files found in the `ingredients/` directory to the current directory.
+Copy all the files found in the `ingredients/` directory into your project.
 
-- [`app/lib/combined-listings.ts`](ingredients/templates/skeleton/app/lib/combined-listings.ts)
+- [app/lib/combined-listings.ts](/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
 ### Step 4: Update the `ProductForm` component
 
@@ -65,7 +65,7 @@ Copy all the files found in the `ingredients/` directory to the current director
 - Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
 
 
-#### File: [`app/components/ProductForm.tsx`](/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -173,7 +173,7 @@ index e8616a61..b6567c21 100644
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
 
-#### File: [`app/components/ProductImage.tsx`](/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..f1c9f2cd 100644
@@ -202,7 +202,7 @@ index 5f3ac1cc..f1c9f2cd 100644
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
 
-#### File: [`app/components/ProductItem.tsx`](/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 62c64b50..034b5660 100644
@@ -244,7 +244,7 @@ index 62c64b50..034b5660 100644
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
 
-#### File: [`app/lib/redirect.ts`](/templates/skeleton/app/lib/redirect.ts)
+#### File: [app/lib/redirect.ts](/templates/skeleton/app/lib/redirect.ts)
 
 ```diff
 index ce1feb5a..29fe2ecc 100644
@@ -289,7 +289,7 @@ index ce1feb5a..29fe2ecc 100644
 - (Optional) Add the filtering query to the product query to exclude combined listings.
 
 
-#### File: [`app/routes/_index.tsx`](/templates/skeleton/app/routes/_index.tsx)
+#### File: [app/routes/_index.tsx](/templates/skeleton/app/routes/_index.tsx)
 
 <details>
 
@@ -375,7 +375,7 @@ index 34747528..6e485083 100644
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
 
-#### File: [`app/routes/collections.$handle.tsx`](/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](/templates/skeleton/app/routes/collections.$handle.tsx)
 
 <details>
 
@@ -448,7 +448,7 @@ index f1d7fa3e..17edfb7d 100644
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
 
-#### File: [`app/routes/collections.all.tsx`](/templates/skeleton/app/routes/collections.all.tsx)
+#### File: [app/routes/collections.all.tsx](/templates/skeleton/app/routes/collections.all.tsx)
 
 ```diff
 index 3a31b2f7..c756c9e1 100644
@@ -508,7 +508,7 @@ index 3a31b2f7..c756c9e1 100644
 - (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
 
-#### File: [`app/routes/products.$handle.tsx`](/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -649,7 +649,7 @@ index 2dc6bda2..8baafac9 100644
 Add a class to the product item to show a range of prices for combined listings.
 
 
-#### File: [`app/styles/app.css`](/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..c8fa5109 100644

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -77,8 +77,7 @@ steps:
   - type: COPY_INGREDIENTS
     index: 3
     name: Add ingredients to your project
-    description: Copy all the files found in the `ingredients/` directory to the
-      current directory.
+    description: Copy all the files found in the `ingredients/` directory into your project.
     ingredients:
       - templates/skeleton/app/lib/combined-listings.ts
   - type: PATCH
@@ -192,4 +191,4 @@ llms:
       solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
-commit: e1d77d5714e2472fa87fcc56473078f9fd263f72
+commit: c34d66c5781af2c56725f35fd978b1af09fd4bbd

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -24,12 +24,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [`app/components/SellingPlanSelector.tsx`](ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
-| [`app/graphql/customer-account/CustomerSubscriptionsMutations.ts`](ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
-| [`app/graphql/customer-account/CustomerSubscriptionsQuery.ts`](ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
-| [`app/routes/account.subscriptions.tsx`](ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
-| [`app/styles/account-subscriptions.css`](ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
-| [`app/styles/selling-plan.css`](ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
+| [app/components/SellingPlanSelector.tsx](ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
+| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
+| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
+| [app/routes/account.subscriptions.tsx](ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
+| [app/styles/account-subscriptions.css](ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
+| [app/styles/selling-plan.css](ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
 
 ## Steps
 
@@ -43,14 +43,14 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 
 ### Step 2: Add ingredients to your project
 
-Copy all the files found in the `ingredients/` directory to the current directory.
+Copy all the files found in the `ingredients/` directory into your project.
 
-- [`app/components/SellingPlanSelector.tsx`](ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
-- [`app/graphql/customer-account/CustomerSubscriptionsMutations.ts`](ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
-- [`app/graphql/customer-account/CustomerSubscriptionsQuery.ts`](ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
-- [`app/routes/account.subscriptions.tsx`](ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
-- [`app/styles/account-subscriptions.css`](ingredients/templates/skeleton/app/styles/account-subscriptions.css)
-- [`app/styles/selling-plan.css`](ingredients/templates/skeleton/app/styles/selling-plan.css)
+- [app/components/SellingPlanSelector.tsx](/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+- [app/routes/account.subscriptions.tsx](/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+- [app/styles/account-subscriptions.css](/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+- [app/styles/selling-plan.css](/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 ### Step 3: Render the selling plan in the cart
 
@@ -58,7 +58,7 @@ Copy all the files found in the `ingredients/` directory to the current director
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
 
-#### File: [`app/components/CartLineItem.tsx`](/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..a18e4b52 100644
@@ -108,7 +108,7 @@ index bd33a2cf..a18e4b52 100644
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
 
-#### File: [`app/components/ProductForm.tsx`](/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -433,7 +433,7 @@ index e8616a61..e41b91ad 100644
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
 
-#### File: [`app/components/ProductPrice.tsx`](/templates/skeleton/app/components/ProductPrice.tsx)
+#### File: [app/components/ProductPrice.tsx](/templates/skeleton/app/components/ProductPrice.tsx)
 
 <details>
 
@@ -557,7 +557,7 @@ index 32460ae2..59eed1d8 100644
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
 
-#### File: [`app/lib/fragments.ts`](/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](/templates/skeleton/app/lib/fragments.ts)
 
 ```diff
 index dc4426a9..cfe3a938 100644
@@ -596,7 +596,7 @@ index dc4426a9..cfe3a938 100644
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
 
-#### File: [`app/routes/products.$handle.tsx`](/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -789,12 +789,12 @@ index 2dc6bda2..aad7e5f1 100644
 
 </details>
 
-### Step 8: Add a link to the **Subscriptions** page in the account menu
+### Step 8: Add a link to the **Subscriptions** page
 
 Add a `Subscriptions` link to the account menu.
 
 
-#### File: [`app/routes/account.tsx`](/templates/skeleton/app/routes/account.tsx)
+#### File: [app/routes/account.tsx](/templates/skeleton/app/routes/account.tsx)
 
 ```diff
 index 0941d4e0..976ae9df 100644

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -21,8 +21,7 @@ requirements: >
   [Shopify Subscriptions app](https://apps.shopify.com/shopify-subscriptions).
 ingredients:
   - path: templates/skeleton/app/components/SellingPlanSelector.tsx
-    description: Displays the
-      available subscription options on product pages.
+    description: Displays the available subscription options on product pages.
   - path: templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts
     description: Mutations for managing customer subscriptions.
   - path: templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts
@@ -32,8 +31,7 @@ ingredients:
   - path: templates/skeleton/app/styles/account-subscriptions.css
     description: Subscriptions management page styles.
   - path: templates/skeleton/app/styles/selling-plan.css
-    description: Styles the
-      `SellingPlanSelector` component.
+    description: Styles the `SellingPlanSelector` component.
 deletedFiles: []
 steps:
   - type: INFO
@@ -56,8 +54,7 @@ steps:
   - type: COPY_INGREDIENTS
     index: 2
     name: Add ingredients to your project
-    description: Copy all the files found in the `ingredients/` directory to the
-      current directory.
+    description: Copy all the files found in the `ingredients/` directory into your project.
     ingredients:
       - templates/skeleton/app/components/SellingPlanSelector.tsx
       - templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts
@@ -130,7 +127,7 @@ steps:
         patchFile: products.$handle.tsx.3e0b7e.patch
   - type: PATCH
     index: 8
-    name: Add a link to the **Subscriptions** page 
+    name: Add a link to the **Subscriptions** page
     description: |
       Add a `Subscriptions` link to the account menu.
     diffs:
@@ -143,9 +140,12 @@ llms:
     - How do I display subscription details on applicable line items in the cart?
   troubleshooting:
     - issue: I'm getting an error when I try to add a subscription to my storefront.
-      solution: Make sure you've installed the Shopify Subscriptions app and set up selling plans for subscription products in your Shopify admin.
+      solution: Make sure you've installed the Shopify Subscriptions app and set up
+        selling plans for subscription products in your Shopify admin.
     - issue: I'm not seeing the subscription options on my product pages.
-      solution: Make sure you've installed the Shopify Subscriptions app and set up selling plans for subscription products in your Shopify admin.
+      solution: Make sure you've installed the Shopify Subscriptions app and set up
+        selling plans for subscription products in your Shopify admin.
     - issue: I'm not seeing the subscription details on my cart line items.
-      solution: Make sure you've installed the Shopify Subscriptions app and set up selling plans for subscription products in your Shopify admin.
-commit: bb04693ef039b7f68b782011f79f91773819c3e4
+      solution: Make sure you've installed the Shopify Subscriptions app and set up
+        selling plans for subscription products in your Shopify admin.
+commit: c34d66c5781af2c56725f35fd978b1af09fd4bbd

--- a/cookbook/src/lib/generate.ts
+++ b/cookbook/src/lib/generate.ts
@@ -208,7 +208,7 @@ function copyIngredientsStep(ingredients: Ingredient[]): Step {
     index: 0,
     name: 'Add ingredients to your project',
     description:
-      'Copy all the files found in the `ingredients/` directory to the current directory.',
+      'Copy all the files found in the `ingredients/` directory into your project.',
     ingredients: ingredients.map((ingredient) => ingredient.path),
   };
 }

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -32,11 +32,11 @@ Add subscription-based products to your Hydrogen storefront.
 
 <troubleshooting>
 - **Issue**: I'm getting an error when I try to add a subscription to my storefront.
-  **Solution**: Make sure you have the Shopify Subscriptions app installed and configured correctly.
+  **Solution**: Make sure you've installed the Shopify Subscriptions app and set up selling plans for subscription products in your Shopify admin.
 - **Issue**: I'm not seeing the subscription options on my product pages.
-  **Solution**: Make sure you have the Shopify Subscriptions app installed and configured correctly.
+  **Solution**: Make sure you've installed the Shopify Subscriptions app and set up selling plans for subscription products in your Shopify admin.
 - **Issue**: I'm not seeing the subscription details on my cart line items.
-  **Solution**: Make sure you have the Shopify Subscriptions app installed and configured correctly.
+  **Solution**: Make sure you've installed the Shopify Subscriptions app and set up selling plans for subscription products in your Shopify admin.
 </troubleshooting>
 
 # Recipe Implementation
@@ -57,7 +57,7 @@ In this recipe you'll make the following changes:
 2. Modify product detail pages to display subscription options with accurate pricing using the `SellingPlanSelector` component.
 3. Enhance GraphQL fragments to fetch all necessary selling plan data.
 4. Display subscription details on applicable line items in the cart.
-5. Add a `Subscriptions` page to manage customer subscriptions, with the ability to list them and cancel the active ones.
+5. Add a **Subscriptions** page where customers can manage their subscriptions, which includes the option to cancel active subscriptions.
 
 
 ## Requirements
@@ -69,7 +69,7 @@ To implement subscriptions in your own store, you need to install a subscription
 
 ### templates/skeleton/app/components/SellingPlanSelector.tsx
 
-The `SellingPlanSelector` component is used to display the available subscription options on product pages.
+Displays the available subscription options on product pages.
 
 ```tsx
 import type {
@@ -451,7 +451,7 @@ Subscriptions management page styles.
 
 ### templates/skeleton/app/styles/selling-plan.css
 
-The `selling-plan.css` file is used to style the `SellingPlanSelector` component.
+Styles the `SellingPlanSelector` component.
 
 ```css
 .selling-plan-group {
@@ -1210,7 +1210,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
  ` as const;
 ```
 
-### Step 7: Add a `Subscriptions` link to the account menu
+### Step 7: Add a link to the **Subscriptions** page
 
 Add a `Subscriptions` link to the account menu.
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Fix the copy for the `Copy Ingredients` recipe steps, so they mention "your project" rather than "the current directory".

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
