### PR TITLE
Cookbook: always use hash links for files

### DIFF
--- a/cookbook/recipes/combined-listings/README.md
+++ b/cookbook/recipes/combined-listings/README.md
@@ -25,7 +25,7 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/lib/combined-listings.ts](ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
+| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
 
 ## Steps
 
@@ -57,7 +57,7 @@ export const combinedListingsSettings = {
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/lib/combined-listings.ts](/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+- [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
 ### Step 4: Update the `ProductForm` component
 
@@ -65,7 +65,7 @@ Copy all the files found in the `ingredients/` directory into your project.
 - Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
 
 
-#### File: [app/components/ProductForm.tsx](/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -173,7 +173,7 @@ index e8616a61..b6567c21 100644
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
 
-#### File: [app/components/ProductImage.tsx](/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..f1c9f2cd 100644
@@ -202,7 +202,7 @@ index 5f3ac1cc..f1c9f2cd 100644
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
 
-#### File: [app/components/ProductItem.tsx](/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 62c64b50..034b5660 100644
@@ -244,7 +244,7 @@ index 62c64b50..034b5660 100644
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
 
-#### File: [app/lib/redirect.ts](/templates/skeleton/app/lib/redirect.ts)
+#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/lib/redirect.ts)
 
 ```diff
 index ce1feb5a..29fe2ecc 100644
@@ -289,7 +289,7 @@ index ce1feb5a..29fe2ecc 100644
 - (Optional) Add the filtering query to the product query to exclude combined listings.
 
 
-#### File: [app/routes/_index.tsx](/templates/skeleton/app/routes/_index.tsx)
+#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/_index.tsx)
 
 <details>
 
@@ -375,7 +375,7 @@ index 34747528..6e485083 100644
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
 
-#### File: [app/routes/collections.$handle.tsx](/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/collections.$handle.tsx)
 
 <details>
 
@@ -448,7 +448,7 @@ index f1d7fa3e..17edfb7d 100644
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
 
-#### File: [app/routes/collections.all.tsx](/templates/skeleton/app/routes/collections.all.tsx)
+#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/collections.all.tsx)
 
 ```diff
 index 3a31b2f7..c756c9e1 100644
@@ -508,7 +508,7 @@ index 3a31b2f7..c756c9e1 100644
 - (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
 
-#### File: [app/routes/products.$handle.tsx](/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -649,7 +649,7 @@ index 2dc6bda2..8baafac9 100644
 Add a class to the product item to show a range of prices for combined listings.
 
 
-#### File: [app/styles/app.css](/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..c8fa5109 100644

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -191,4 +191,4 @@ llms:
       solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
-commit: c34d66c5781af2c56725f35fd978b1af09fd4bbd
+commit: 01b89bb30d1cf985e5b61961cffc6cffa002d3a0

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -24,12 +24,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/SellingPlanSelector.tsx](ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
-| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
-| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
-| [app/routes/account.subscriptions.tsx](ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
-| [app/styles/account-subscriptions.css](ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
-| [app/styles/selling-plan.css](ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
+| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
+| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
+| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
+| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
+| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
+| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
 
 ## Steps
 
@@ -45,12 +45,12 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/components/SellingPlanSelector.tsx](/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
-- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
-- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
-- [app/routes/account.subscriptions.tsx](/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
-- [app/styles/account-subscriptions.css](/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
-- [app/styles/selling-plan.css](/ingredients/templates/skeleton/app/styles/selling-plan.css)
+- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 ### Step 3: Render the selling plan in the cart
 
@@ -58,7 +58,7 @@ Copy all the files found in the `ingredients/` directory into your project.
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
 
-#### File: [app/components/CartLineItem.tsx](/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..a18e4b52 100644
@@ -108,7 +108,7 @@ index bd33a2cf..a18e4b52 100644
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
 
-#### File: [app/components/ProductForm.tsx](/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -433,7 +433,7 @@ index e8616a61..e41b91ad 100644
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
 
-#### File: [app/components/ProductPrice.tsx](/templates/skeleton/app/components/ProductPrice.tsx)
+#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductPrice.tsx)
 
 <details>
 
@@ -557,7 +557,7 @@ index 32460ae2..59eed1d8 100644
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
 
-#### File: [app/lib/fragments.ts](/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/lib/fragments.ts)
 
 ```diff
 index dc4426a9..cfe3a938 100644
@@ -596,7 +596,7 @@ index dc4426a9..cfe3a938 100644
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
 
-#### File: [app/routes/products.$handle.tsx](/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -794,7 +794,7 @@ index 2dc6bda2..aad7e5f1 100644
 Add a `Subscriptions` link to the account menu.
 
 
-#### File: [app/routes/account.tsx](/templates/skeleton/app/routes/account.tsx)
+#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/account.tsx)
 
 ```diff
 index 0941d4e0..976ae9df 100644

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -148,4 +148,4 @@ llms:
     - issue: I'm not seeing the subscription details on my cart line items.
       solution: Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
-commit: c34d66c5781af2c56725f35fd978b1af09fd4bbd
+commit: 01b89bb30d1cf985e5b61961cffc6cffa002d3a0

--- a/cookbook/src/lib/render.ts
+++ b/cookbook/src/lib/render.ts
@@ -79,7 +79,7 @@ export function makeReadmeBlocks(
     notes.map(mdNote),
   );
 
-  const markdownIngredients = makeIngredients(recipe, recipeName, format);
+  const markdownIngredients = makeIngredients(recipe, recipeName);
 
   const markdownSteps = makeSteps(
     recipe.steps,
@@ -95,10 +95,10 @@ export function makeReadmeBlocks(
           mdHeading(2, 'Deleted Files'),
           mdList(
             recipe.deletedFiles.map((file) => {
-              const linkPrefix =
-                format === 'shopify.dev'
-                  ? hydrogenRepoFolderURL({path: '', hash: recipe.commit})
-                  : '';
+              const linkPrefix = hydrogenRepoFolderURL({
+                path: '',
+                hash: recipe.commit,
+              });
               return mdLinkString(
                 `${linkPrefix}/templates/skeleton/${file}`,
                 file,
@@ -126,11 +126,7 @@ export function makeReadmeBlocks(
   return blocks;
 }
 
-function makeIngredients(
-  recipe: Recipe,
-  recipeName: string,
-  format: RenderFormat,
-): MDBlock[] {
+function makeIngredients(recipe: Recipe, recipeName: string): MDBlock[] {
   if (recipe.ingredients.length === 0) {
     return [];
   }
@@ -142,12 +138,10 @@ function makeIngredients(
       ['File', 'Description'],
       recipe.ingredients.map((ingredient): string[] => {
         const link =
-          format === 'shopify.dev'
-            ? hydrogenRepoRecipeBaseURL({
-                recipeName,
-                hash: recipe.commit,
-              }) + `/ingredients/${ingredient.path}`
-            : `ingredients/${ingredient.path}`;
+          hydrogenRepoRecipeBaseURL({
+            recipeName,
+            hash: recipe.commit,
+          }) + `/ingredients/${ingredient.path}`;
         return [
           mdLinkString(link, ingredient.path.replace(TEMPLATE_DIRECTORY, '')),
           ingredient.description ?? '',
@@ -207,14 +201,14 @@ export function renderStep(
         options.collapseDiffs === true &&
         patch.split('\n').length > COLLAPSE_DIFF_LINES;
 
-      const linkPrefixRepo =
-        format === 'shopify.dev'
-          ? hydrogenRepoFolderURL({path: '', hash: recipe.commit})
-          : '';
-      const linkPrefixRecipe =
-        format === 'shopify.dev'
-          ? hydrogenRepoRecipeBaseURL({recipeName, hash: recipe.commit})
-          : '';
+      const linkPrefixRepo = hydrogenRepoFolderURL({
+        path: '',
+        hash: recipe.commit,
+      });
+      const linkPrefixRecipe = hydrogenRepoRecipeBaseURL({
+        recipeName,
+        hash: recipe.commit,
+      });
       const link = `${linkPrefixRepo}/templates/skeleton/${diff.file}`;
 
       return [
@@ -253,13 +247,10 @@ export function renderStep(
                 recipe.ingredients.some((other) => other.path === ingredient),
               )
               .map((i) => {
-                const linkPrefix =
-                  format === 'shopify.dev'
-                    ? hydrogenRepoRecipeBaseURL({
-                        recipeName,
-                        hash: recipe.commit,
-                      })
-                    : '';
+                const linkPrefix = hydrogenRepoRecipeBaseURL({
+                  recipeName,
+                  hash: recipe.commit,
+                });
                 return mdLinkString(
                   `${linkPrefix}/ingredients/${i}`,
                   i.replace(TEMPLATE_DIRECTORY, ''),


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/hydrogen/pull/2897 introduced actual Github links with hashes for files mentioned in the rendered output. They should also apply to the markdown rendering.

### WHAT is this pull request doing?

Use actual Github links for mentioned files in the markdown rendering as well as `shopify.dev`.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation