### PR TITLE
Cookbook: shopify.dev level 2 headings

### DIFF
--- a/cookbook/src/lib/render.ts
+++ b/cookbook/src/lib/render.ts
@@ -166,7 +166,7 @@ function makeSteps(
 ): MDBlock[] {
   const markdownStepsHeader = mdHeading(2, 'Steps');
   return [
-    markdownStepsHeader,
+    ...(format === 'github' ? [markdownStepsHeader] : []),
     ...steps.flatMap((step, index) =>
       renderStep(step, index, recipe, recipeName, patchesDir, format, {
         collapseDiffs: true,
@@ -242,7 +242,7 @@ export function renderStep(
   }
 
   const markdownStep: MDBlock[] = [
-    mdHeading(3, `Step ${index + 1}: ${step.name}`),
+    mdHeading(format === 'github' ? 3 : 2, `Step ${index + 1}: ${step.name}`),
     ...(step.notes?.map(mdNote) ?? []),
     mdParagraph(step.description ?? ''),
     ...(step.ingredients != null


### PR DESCRIPTION
### WHAT is this pull request doing?

For `shopify.dev` renders, omit the `Steps` header, and instead bump the individual steps to level 2 headings.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
