### PR TITLE
Fix: Revise version-related text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Hydrogen is organized as a [monorepo](https://monorepo.tools/), which includes m
 
 Hydrogen and hydrogen-react are tied to specific versions of the [Shopify Storefront API](https://shopify.dev/api/storefront), which follows [calver](https://calver.org/).
 
-For example, if you're using Storefront API version `2023-01`, then Hydrogen and hydrogen-react versions `2022.1.x` are fully compatible.
+For example, if you're using Storefront API version `2025-01`, then Hydrogen and hydrogen-react versions `2025.1.x` are fully compatible.
 
 If the Storefront API version update includes breaking changes, then Hydrogen and hydrogen-react may also include breaking changes. Because the API version is updated every three months, breaking changes could occur every three months.
 


### PR DESCRIPTION
### WHY are these changes introduced?

This PR is a very small, non-functional change targeting the README.

The understanding is that hydrogen-react, compatible with the `2023-01` SFAPI, aligns with the `2023.1.x` version (matching the year), not `2022.1.x`. This PR corrects that accordingly.

Additionally, considering that `2023` might not have a specific significance anymore, this PR also updates the year to `2025`.

### WHAT is this pull request doing?

Updates the version-related text in the README.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation