### PR TITLE
Snapit: adding @shopify/remix-oxygen to the forced changeset

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Force snapshot changeset
         run: |
-          printf -- "---\n'@shopify/hydrogen': patch\n'@shopify/cli-hydrogen': patch\n'@shopify/create-hydrogen': patch\n---\n\nForce snapshot build.\n" > .changeset/force-snapshot-build.md
+          printf -- "---\n'@shopify/hydrogen': patch\n'@shopify/remix-oxygen': patch\n'@shopify/cli-hydrogen': patch\n'@shopify/create-hydrogen': patch\n---\n\nForce snapshot build.\n" > .changeset/force-snapshot-build.md
 
       - name: Create snapshot version
         uses: Shopify/snapit@0c0d2dd62c9b0c94b7d03e1f54e72f18548e7752 # pin to a specific commit


### PR DESCRIPTION
### WHY are these changes introduced?

Snapit does not publish a snapshot version of `@shopify/remix-oxygen`, it only publishes `@shopify/hydrogen`, `@shopify/cli-hydrogen` and `@shopify/create-hydrogen`. But for testing React Router 7, we need a new version of `@shopify/remix-oxygen` too.

### WHAT is this pull request doing?

Adding `@shopify/remix-oxygen` to the forced changeset list.