### PR TITLE
Cookbook: remove markers from headings

### DIFF
--- a/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -135,7 +135,7 @@ export const combinedListingsSettings = {
 ```
 
 
-### Step 3: Update the `ProductForm` component
+### Step 3: Update the ProductForm component
 
 - Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings and for variants' selected state.
 - Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
@@ -237,7 +237,7 @@ export const combinedListingsSettings = {
  }
 ```
 
-### Step 4: Extend the `ProductImage` component
+### Step 4: Extend the ProductImage component
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
@@ -263,7 +263,7 @@ Update the `ProductImage` component to support images from both product variants
      return <div className="product-image" />;
 ```
 
-### Step 5: Show a range of prices for combined listings in `ProductItem`
+### Step 5: Show a range of prices for combined listings in ProductItem
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 

--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -546,7 +546,7 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
                <small>
 ```
 
-### Step 3: Update `ProductForm` to support subscriptions
+### Step 3: Update ProductForm to support subscriptions
 
 1. Add conditional rendering to display either subscription options or standard variant selectors.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
@@ -865,7 +865,7 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 +}
 ```
 
-### Step 4: Update `ProductPrice` to display subscription pricing
+### Step 4: Update ProductPrice to display subscription pricing
 
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
@@ -1017,7 +1017,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
      updatedAt
 ```
 
-### Step 6: Add `SellingPlanSelector` to product pages
+### Step 6: Add SellingPlanSelector to product pages
 
 1. Add the `SellingPlanSelector` component to display subscription options on product pages.
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
@@ -1210,7 +1210,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
  ` as const;
 ```
 
-### Step 7: Add a link to the **Subscriptions** page
+### Step 7: Add a link to the Subscriptions page
 
 Add a `Subscriptions` link to the account menu.
 

--- a/cookbook/recipes/combined-listings/README.md
+++ b/cookbook/recipes/combined-listings/README.md
@@ -25,7 +25,7 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
+| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
 
 ## Steps
 
@@ -57,15 +57,15 @@ export const combinedListingsSettings = {
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+- [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
-### Step 4: Update the `ProductForm` component
+### Step 4: Update the ProductForm component
 
 - Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings and for variants' selected state.
 - Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
 
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -168,12 +168,12 @@ index e8616a61..b6567c21 100644
 
 </details>
 
-### Step 5: Extend the `ProductImage` component
+### Step 5: Extend the ProductImage component
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..f1c9f2cd 100644
@@ -197,12 +197,12 @@ index 5f3ac1cc..f1c9f2cd 100644
      return <div className="product-image" />;
 ```
 
-### Step 6: Show a range of prices for combined listings in `ProductItem`
+### Step 6: Show a range of prices for combined listings in ProductItem
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 62c64b50..034b5660 100644
@@ -244,7 +244,7 @@ index 62c64b50..034b5660 100644
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
 
-#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/lib/redirect.ts)
+#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/lib/redirect.ts)
 
 ```diff
 index ce1feb5a..29fe2ecc 100644
@@ -289,7 +289,7 @@ index ce1feb5a..29fe2ecc 100644
 - (Optional) Add the filtering query to the product query to exclude combined listings.
 
 
-#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/_index.tsx)
+#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/_index.tsx)
 
 <details>
 
@@ -375,7 +375,7 @@ index 34747528..6e485083 100644
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/collections.$handle.tsx)
 
 <details>
 
@@ -448,7 +448,7 @@ index f1d7fa3e..17edfb7d 100644
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
 
-#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/collections.all.tsx)
+#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/collections.all.tsx)
 
 ```diff
 index 3a31b2f7..c756c9e1 100644
@@ -508,7 +508,7 @@ index 3a31b2f7..c756c9e1 100644
 - (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -649,7 +649,7 @@ index 2dc6bda2..8baafac9 100644
 Add a class to the product item to show a range of prices for combined listings.
 
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..c8fa5109 100644

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -82,7 +82,7 @@ steps:
       - templates/skeleton/app/lib/combined-listings.ts
   - type: PATCH
     index: 4
-    name: Update the `ProductForm` component
+    name: Update the ProductForm component
     description: >
       - Update the `ProductForm` component to hide the `Add to cart` button for
       the parent products of combined listings and for variants' selected state.
@@ -94,7 +94,7 @@ steps:
         patchFile: ProductForm.tsx.8e409a.patch
   - type: PATCH
     index: 5
-    name: Extend the `ProductImage` component
+    name: Extend the ProductImage component
     description: >
       Update the `ProductImage` component to support images from both product
       variants and the product itself.
@@ -103,7 +103,7 @@ steps:
         patchFile: ProductImage.tsx.4e6c4c.patch
   - type: PATCH
     index: 6
-    name: Show a range of prices for combined listings in `ProductItem`
+    name: Show a range of prices for combined listings in ProductItem
     description: >
       Update `ProductItem.tsx` to show a range of prices for the combined
       listing parent product instead of the variant price.
@@ -191,4 +191,4 @@ llms:
       solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
-commit: 01b89bb30d1cf985e5b61961cffc6cffa002d3a0
+commit: 2ff53492d0c9152bd59063ae6ea34576ea9a4608

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -24,12 +24,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
-| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
-| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
-| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
-| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
-| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
+| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
+| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
+| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
+| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
+| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
+| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
 
 ## Steps
 
@@ -45,12 +45,12 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
-- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
-- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
-- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
-- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
-- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 ### Step 3: Render the selling plan in the cart
 
@@ -58,7 +58,7 @@ Copy all the files found in the `ingredients/` directory into your project.
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
 
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..a18e4b52 100644
@@ -101,14 +101,14 @@ index bd33a2cf..a18e4b52 100644
                <small>
 ```
 
-### Step 4: Update `ProductForm` to support subscriptions
+### Step 4: Update ProductForm to support subscriptions
 
 1. Add conditional rendering to display either subscription options or standard variant selectors.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -427,13 +427,13 @@ index e8616a61..e41b91ad 100644
 
 </details>
 
-### Step 5: Update `ProductPrice` to display subscription pricing
+### Step 5: Update ProductPrice to display subscription pricing
 
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
 
-#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/components/ProductPrice.tsx)
+#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductPrice.tsx)
 
 <details>
 
@@ -557,7 +557,7 @@ index 32460ae2..59eed1d8 100644
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
 
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/lib/fragments.ts)
 
 ```diff
 index dc4426a9..cfe3a938 100644
@@ -589,14 +589,14 @@ index dc4426a9..cfe3a938 100644
      updatedAt
 ```
 
-### Step 7: Add `SellingPlanSelector` to product pages
+### Step 7: Add SellingPlanSelector to product pages
 
 1. Add the `SellingPlanSelector` component to display subscription options on product pages.
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -789,12 +789,12 @@ index 2dc6bda2..aad7e5f1 100644
 
 </details>
 
-### Step 8: Add a link to the **Subscriptions** page
+### Step 8: Add a link to the Subscriptions page
 
 Add a `Subscriptions` link to the account menu.
 
 
-#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/01b89bb30d1cf985e5b61961cffc6cffa002d3a0/templates/skeleton/app/routes/account.tsx)
+#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/account.tsx)
 
 ```diff
 index 0941d4e0..976ae9df 100644

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -76,7 +76,7 @@ steps:
         patchFile: CartLineItem.tsx.8e657b.patch
   - type: PATCH
     index: 4
-    name: Update `ProductForm` to support subscriptions
+    name: Update ProductForm to support subscriptions
     description: >
       1. Add conditional rendering to display either subscription options or
       standard variant selectors.
@@ -91,7 +91,7 @@ steps:
         patchFile: ProductForm.tsx.8e409a.patch
   - type: PATCH
     index: 5
-    name: Update `ProductPrice` to display subscription pricing
+    name: Update ProductPrice to display subscription pricing
     description: >
       1. Add a `SellingPlanPrice` function to calculate adjusted prices based on
       subscription plan type (fixed amount, fixed price, or percentage).
@@ -113,7 +113,7 @@ steps:
         patchFile: fragments.ts.e8eb04.patch
   - type: PATCH
     index: 7
-    name: Add `SellingPlanSelector` to product pages
+    name: Add SellingPlanSelector to product pages
     description: >
       1. Add the `SellingPlanSelector` component to display subscription options
       on product pages.
@@ -127,7 +127,7 @@ steps:
         patchFile: products.$handle.tsx.3e0b7e.patch
   - type: PATCH
     index: 8
-    name: Add a link to the **Subscriptions** page
+    name: Add a link to the Subscriptions page
     description: |
       Add a `Subscriptions` link to the account menu.
     diffs:
@@ -148,4 +148,4 @@ llms:
     - issue: I'm not seeing the subscription details on my cart line items.
       solution: Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
-commit: 01b89bb30d1cf985e5b61961cffc6cffa002d3a0
+commit: 2ff53492d0c9152bd59063ae6ea34576ea9a4608

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -135,7 +135,7 @@ export const combinedListingsSettings = {
 ```
 
 
-### Step 3: Update the `ProductForm` component
+### Step 3: Update the ProductForm component
 
 - Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings and for variants' selected state.
 - Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
@@ -237,7 +237,7 @@ export const combinedListingsSettings = {
  }
 ```
 
-### Step 4: Extend the `ProductImage` component
+### Step 4: Extend the ProductImage component
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
@@ -263,7 +263,7 @@ Update the `ProductImage` component to support images from both product variants
      return <div className="product-image" />;
 ```
 
-### Step 5: Show a range of prices for combined listings in `ProductItem`
+### Step 5: Show a range of prices for combined listings in ProductItem
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -546,7 +546,7 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
                <small>
 ```
 
-### Step 3: Update `ProductForm` to support subscriptions
+### Step 3: Update ProductForm to support subscriptions
 
 1. Add conditional rendering to display either subscription options or standard variant selectors.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
@@ -865,7 +865,7 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 +}
 ```
 
-### Step 4: Update `ProductPrice` to display subscription pricing
+### Step 4: Update ProductPrice to display subscription pricing
 
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
@@ -1017,7 +1017,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
      updatedAt
 ```
 
-### Step 6: Add `SellingPlanSelector` to product pages
+### Step 6: Add SellingPlanSelector to product pages
 
 1. Add the `SellingPlanSelector` component to display subscription options on product pages.
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
@@ -1210,7 +1210,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
  ` as const;
 ```
 
-### Step 7: Add a link to the **Subscriptions** page
+### Step 7: Add a link to the Subscriptions page
 
 Add a `Subscriptions` link to the account menu.
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Remove markdown markers (e.g. backticks) from step names which are rendered into headings.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
