### PR TITLE
Cookbook scripts: single file mode for generate command

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -10,6 +10,7 @@
     - [Generate](#generate)
       - [Syntax](#syntax-1)
       - [Example](#example-1)
+      - [Single-file flag (`filePath`)](#single-file-flag-filepath)
     - [Validate](#validate)
       - [Syntax](#syntax-2)
       - [Example](#example-2)
@@ -107,14 +108,17 @@ cookbook.ts generate
 Generate a recipe from the skeleton's changes
 
 Options:
-  --version          Show version number                   [boolean]
-  --help             Show help                             [boolean]
-  --recipe           The name of the recipe to generate
-                                                 [string] [required]
-  --onlyFiles        Only generate the files for the recipe, not the
-                     recipe.yaml file.                     [boolean]
-  --referenceBranch  The reference branch to use for the recipe
-                                   [string] [default: "origin/main"]
+  --version               Show version number                          [boolean]
+  --help                  Show help                                    [boolean]
+  --recipe                The name of the recipe to generate [string] [required]
+  --onlyFiles             Only generate the files for the recipe, not the
+                          recipe.yaml file.                            [boolean]
+  --referenceBranch       The reference branch to use for the recipe
+                                               [string] [default: "origin/main"]
+  --recipeManifestFormat  The format of the recipe manifest file
+                                                      [string] [default: "yaml"]
+  --filePath              If specified, only generate the diffs for this file
+                          (and update any references in the recipe.     [string]
 ```
 
 #### Example
@@ -122,6 +126,13 @@ Options:
 ```sh
 npm run cookbook -- generate --recipe my-recipe
 ```
+
+
+#### Single-file flag (`filePath`)
+
+If `filePath` is provided, and it points to a file in the skeleton template folder, the command will generate the diff patch **only** for that file, without updating the manifest.
+
+The recipe must exist, as well as a step for that file.
 
 ### Validate
 

--- a/cookbook/src/commands/generate.ts
+++ b/cookbook/src/commands/generate.ts
@@ -11,6 +11,7 @@ type GenerateArgs = {
   onlyFiles: boolean;
   referenceBranch: string;
   recipeManifestFormat: RecipeManifestFormat;
+  filePath?: string;
 };
 
 export const generate: CommandModule<{}, GenerateArgs> = {
@@ -37,6 +38,11 @@ export const generate: CommandModule<{}, GenerateArgs> = {
       description: 'The format of the recipe manifest file',
       default: 'yaml',
     },
+    filePath: {
+      type: 'string',
+      description:
+        'If specified, only generate the diffs for this file (and update any references in the recipe.',
+    },
   },
   handler,
 };
@@ -51,6 +57,7 @@ async function handler(args: GenerateArgs) {
     onlyFiles: args.onlyFiles,
     referenceBranch: args.referenceBranch,
     recipeManifestFormat: args.recipeManifestFormat,
+    filePath: args.filePath,
   });
 
   copyCursorRulesToSkeleton();


### PR DESCRIPTION
### WHY are these changes introduced?

It would be good to have a single-file mode for the `generate` command, which helps with incrementally updating or fixing PRs.

### WHAT is this pull request doing?

Add a `filePath` flag to the `generate` command. When specified, it will only generate the patch for that file, if it already exists as a step in the recipe.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
