### PR TITLE
Cookbook subscriptions: display subscription options alongside the one-off

### DIFF
--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -570,7 +570,7 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 
 ### Step 3: Update ProductForm to support subscriptions
 
-1. Add conditional rendering to display either subscription options or standard variant selectors.
+1. Add conditional rendering to display subscription options alongside the standard variant selectors.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 

--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -113,10 +113,12 @@ export function SellingPlanSelector({
   selectedSellingPlan,
   children,
   paramKey = 'selling_plan',
+  selectedVariant,
 }: {
   sellingPlanGroups: ProductFragment['sellingPlanGroups'];
   selectedSellingPlan: SellingPlanFragment | null;
   paramKey?: string;
+  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
   children: (params: {
     sellingPlanGroup: SellingPlanGroup;
     selectedSellingPlan: SellingPlanFragment | null;
@@ -125,21 +127,35 @@ export function SellingPlanSelector({
   const {search, pathname} = useLocation();
   const params = new URLSearchParams(search);
 
+  const planAllocationIds: string[] =
+    selectedVariant?.sellingPlanAllocations.nodes.map(
+      (node) => node.sellingPlan.id,
+    ) ?? [];
+
   return useMemo(
     () =>
-      (sellingPlanGroups.nodes as SellingPlanGroup[]).map(
-        (sellingPlanGroup) => {
-          // Augmnet each sellingPlan node with isSelected and url
+      (sellingPlanGroups.nodes as SellingPlanGroup[])
+        // Filter out groups that don't have plans usable for the selected variant
+        .filter((group) => {
+          return group.sellingPlans.nodes.some((sellingPlan) =>
+            planAllocationIds.includes(sellingPlan.id),
+          );
+        })
+        .map((sellingPlanGroup) => {
+          // Augment each sellingPlan node with isSelected and url
           const sellingPlans = sellingPlanGroup.sellingPlans.nodes
             .map((sellingPlan: SellingPlan) => {
               if (!sellingPlan?.id) {
-                //eslint-disable-next-line no-console
                 console.warn(
                   'SellingPlanSelector: sellingPlan.id is missing in the product query',
                 );
                 return null;
               }
-              if (!sellingPlan.id) return null;
+
+              if (!sellingPlan.id) {
+                return null;
+              }
+
               params.set(paramKey, sellingPlan.id);
               sellingPlan.isSelected =
                 selectedSellingPlan?.id === sellingPlan.id;
@@ -149,10 +165,16 @@ export function SellingPlanSelector({
             .filter(Boolean) as SellingPlan[];
           sellingPlanGroup.sellingPlans.nodes = sellingPlans;
           return children({sellingPlanGroup, selectedSellingPlan});
-        },
-      ),
+        }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [sellingPlanGroups, children, selectedSellingPlan, paramKey, pathname],
+    [
+      sellingPlanGroups,
+      children,
+      selectedSellingPlan,
+      paramKey,
+      pathname,
+      selectedVariant,
+    ],
   );
 }
 
@@ -556,7 +578,7 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 #### File: /app/components/ProductForm.tsx
 
 ```diff
-@@ -6,120 +6,169 @@ import type {
+@@ -6,14 +6,25 @@ import type {
  } from '@shopify/hydrogen/storefront-api-types';
  import {AddToCartButton} from './AddToCartButton';
  import {useAside} from './Aside';
@@ -583,16 +605,20 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
  }) {
    const navigate = useNavigate();
    const {open} = useAside();
-   return (
-     <div className="product-form">
--      {productOptions.map((option) => {
--        // If there is only a single value in the option values, don't display the option
--        if (option.optionValues.length === 1) return null;
+@@ -120,6 +131,47 @@ export function ProductForm({
+       >
+         {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
+       </AddToCartButton>
 +      {sellingPlanGroups.nodes.length > 0 ? (
 +        <>
++          <br />
++          <hr />
++          <br />
++          <h3>Subscription Options</h3>
 +          <SellingPlanSelector
 +            sellingPlanGroups={sellingPlanGroups}
 +            selectedSellingPlan={selectedSellingPlan}
++            selectedVariant={selectedVariant}
 +          >
 +            {({sellingPlanGroup}) => (
 +              <SellingPlanGroup
@@ -623,208 +649,11 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 +            {selectedSellingPlan ? 'Subscribe' : 'Select Subscription'}
 +          </AddToCartButton>
 +        </>
-+      ) : (
-+        productOptions.map((option) => {
-+          // If there is only a single value in the option values, don't display the option
-+          if (option.optionValues.length === 1) return null;
- 
--        return (
--          <div className="product-options" key={option.name}>
--            <h5>{option.name}</h5>
--            <div className="product-options-grid">
--              {option.optionValues.map((value) => {
--                const {
--                  name,
--                  handle,
--                  variantUriQuery,
--                  selected,
--                  available,
--                  exists,
--                  isDifferentProduct,
--                  swatch,
--                } = value;
-+          return (
-+            <div className="product-options" key={option.name}>
-+              <h5>{option.name}</h5>
-+              <div className="product-options-grid">
-+                {option.optionValues.map((value) => {
-+                  const {
-+                    name,
-+                    handle,
-+                    variantUriQuery,
-+                    selected,
-+                    available,
-+                    exists,
-+                    isDifferentProduct,
-+                    swatch,
-+                  } = value;
- 
--                if (isDifferentProduct) {
--                  // SEO
--                  // When the variant is a combined listing child product
--                  // that leads to a different url, we need to render it
--                  // as an anchor tag
--                  return (
--                    <Link
--                      className="product-options-item"
--                      key={option.name + name}
--                      prefetch="intent"
--                      preventScrollReset
--                      replace
--                      to={`/products/${handle}?${variantUriQuery}`}
--                      style={{
--                        border: selected
--                          ? '1px solid black'
--                          : '1px solid transparent',
--                        opacity: available ? 1 : 0.3,
--                      }}
--                    >
--                      <ProductOptionSwatch swatch={swatch} name={name} />
--                    </Link>
--                  );
--                } else {
--                  // SEO
--                  // When the variant is an update to the search param,
--                  // render it as a button with javascript navigating to
--                  // the variant so that SEO bots do not index these as
--                  // duplicated links
--                  return (
--                    <button
--                      type="button"
--                      className={`product-options-item${
--                        exists && !selected ? ' link' : ''
--                      }`}
--                      key={option.name + name}
--                      style={{
--                        border: selected
--                          ? '1px solid black'
--                          : '1px solid transparent',
--                        opacity: available ? 1 : 0.3,
--                      }}
--                      disabled={!exists}
--                      onClick={() => {
--                        if (!selected) {
--                          navigate(`?${variantUriQuery}`, {
--                            replace: true,
--                            preventScrollReset: true,
--                          });
--                        }
--                      }}
--                    >
--                      <ProductOptionSwatch swatch={swatch} name={name} />
--                    </button>
--                  );
-+                  if (isDifferentProduct) {
-+                    // SEO
-+                    // When the variant is a combined listing child product
-+                    // that leads to a different url, we need to render it
-+                    // as an anchor tag
-+                    return (
-+                      <Link
-+                        className="product-options-item"
-+                        key={option.name + name}
-+                        prefetch="intent"
-+                        preventScrollReset
-+                        replace
-+                        to={`/products/${handle}?${variantUriQuery}`}
-+                        style={{
-+                          border: selected
-+                            ? '1px solid black'
-+                            : '1px solid transparent',
-+                          opacity: available ? 1 : 0.3,
-+                        }}
-+                      >
-+                        <ProductOptionSwatch swatch={swatch} name={name} />
-+                      </Link>
-+                    );
-+                  } else {
-+                    // SEO
-+                    // When the variant is an update to the search param,
-+                    // render it as a button with javascript navigating to
-+                    // the variant so that SEO bots do not index these as
-+                    // duplicated links
-+                    return (
-+                      <button
-+                        type="button"
-+                        className={`product-options-item${
-+                          exists && !selected ? ' link' : ''
-+                        }`}
-+                        key={option.name + name}
-+                        style={{
-+                          border: selected
-+                            ? '1px solid black'
-+                            : '1px solid transparent',
-+                          opacity: available ? 1 : 0.3,
-+                        }}
-+                        disabled={!exists}
-+                        onClick={() => {
-+                          if (!selected) {
-+                            navigate(`?${variantUriQuery}`, {
-+                              replace: true,
-+                              preventScrollReset: true,
-+                            });
-+                          }
-+                        }}
-+                      >
-+                        <ProductOptionSwatch swatch={swatch} name={name} />
-+                      </button>
-+                    );
-+                  }
-+                })}
-+              </div>
-+              <AddToCartButton
-+                disabled={!selectedVariant || !selectedVariant.availableForSale}
-+                onClick={() => {
-+                  open('cart');
-+                }}
-+                lines={
-+                  selectedVariant
-+                    ? [
-+                        {
-+                          merchandiseId: selectedVariant.id,
-+                          quantity: 1,
-+                          selectedVariant,
-+                        },
-+                      ]
-+                    : []
-                 }
--              })}
-+              >
-+                {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
-+              </AddToCartButton>
-+
-+              <br />
-             </div>
--            <br />
--          </div>
--        );
--      })}
--      <AddToCartButton
--        disabled={!selectedVariant || !selectedVariant.availableForSale}
--        onClick={() => {
--          open('cart');
--        }}
--        lines={
--          selectedVariant
--            ? [
--                {
--                  merchandiseId: selectedVariant.id,
--                  quantity: 1,
--                  selectedVariant,
--                },
--              ]
--            : []
--        }
--      >
--        {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
--      </AddToCartButton>
-+          );
-+        })
-+      )}
++      ) : null}
      </div>
    );
  }
-@@ -148,3 +197,38 @@ function ProductOptionSwatch({
+@@ -148,3 +200,38 @@ function ProductOptionSwatch({
      </div>
    );
  }
@@ -1115,7 +944,17 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
          />
          <br />
          <br />
-@@ -180,6 +218,73 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
+@@ -177,9 +215,83 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
+       amount
+       currencyCode
+     }
++    sellingPlanAllocations(first: 10) {
++      nodes {
++        sellingPlan {
++          id
++        }
++      }
++    }
    }
  ` as const;
  
@@ -1189,7 +1028,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
  const PRODUCT_FRAGMENT = `#graphql
    fragment Product on Product {
      id
-@@ -207,6 +312,11 @@ const PRODUCT_FRAGMENT = `#graphql
+@@ -207,6 +319,11 @@ const PRODUCT_FRAGMENT = `#graphql
          }
        }
      }
@@ -1201,7 +1040,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
      selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
        ...ProductVariant
      }
-@@ -218,6 +328,7 @@ const PRODUCT_FRAGMENT = `#graphql
+@@ -218,6 +335,7 @@ const PRODUCT_FRAGMENT = `#graphql
        title
      }
    }

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -103,7 +103,7 @@ index bd33a2cf..a18e4b52 100644
 
 ### Step 4: Update ProductForm to support subscriptions
 
-1. Add conditional rendering to display either subscription options or standard variant selectors.
+1. Add conditional rendering to display subscription options alongside the standard variant selectors.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -24,12 +24,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
-| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
-| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
-| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
-| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
-| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
+| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
+| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
+| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
+| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
+| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
+| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
 
 ## Steps
 
@@ -45,12 +45,12 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
-- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
-- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
-- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
-- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
-- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 ### Step 3: Render the selling plan in the cart
 
@@ -58,7 +58,7 @@ Copy all the files found in the `ingredients/` directory into your project.
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
 
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..a18e4b52 100644
@@ -108,15 +108,15 @@ index bd33a2cf..a18e4b52 100644
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
 ```diff
-index e8616a61..e41b91ad 100644
+index e8616a61..8b7fe8ca 100644
 --- a/templates/skeleton/app/components/ProductForm.tsx
 +++ b/templates/skeleton/app/components/ProductForm.tsx
-@@ -6,120 +6,169 @@ import type {
+@@ -6,14 +6,25 @@ import type {
  } from '@shopify/hydrogen/storefront-api-types';
  import {AddToCartButton} from './AddToCartButton';
  import {useAside} from './Aside';
@@ -143,16 +143,20 @@ index e8616a61..e41b91ad 100644
  }) {
    const navigate = useNavigate();
    const {open} = useAside();
-   return (
-     <div className="product-form">
--      {productOptions.map((option) => {
--        // If there is only a single value in the option values, don't display the option
--        if (option.optionValues.length === 1) return null;
+@@ -120,6 +131,47 @@ export function ProductForm({
+       >
+         {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
+       </AddToCartButton>
 +      {sellingPlanGroups.nodes.length > 0 ? (
 +        <>
++          <br />
++          <hr />
++          <br />
++          <h3>Subscription Options</h3>
 +          <SellingPlanSelector
 +            sellingPlanGroups={sellingPlanGroups}
 +            selectedSellingPlan={selectedSellingPlan}
++            selectedVariant={selectedVariant}
 +          >
 +            {({sellingPlanGroup}) => (
 +              <SellingPlanGroup
@@ -183,208 +187,11 @@ index e8616a61..e41b91ad 100644
 +            {selectedSellingPlan ? 'Subscribe' : 'Select Subscription'}
 +          </AddToCartButton>
 +        </>
-+      ) : (
-+        productOptions.map((option) => {
-+          // If there is only a single value in the option values, don't display the option
-+          if (option.optionValues.length === 1) return null;
- 
--        return (
--          <div className="product-options" key={option.name}>
--            <h5>{option.name}</h5>
--            <div className="product-options-grid">
--              {option.optionValues.map((value) => {
--                const {
--                  name,
--                  handle,
--                  variantUriQuery,
--                  selected,
--                  available,
--                  exists,
--                  isDifferentProduct,
--                  swatch,
--                } = value;
-+          return (
-+            <div className="product-options" key={option.name}>
-+              <h5>{option.name}</h5>
-+              <div className="product-options-grid">
-+                {option.optionValues.map((value) => {
-+                  const {
-+                    name,
-+                    handle,
-+                    variantUriQuery,
-+                    selected,
-+                    available,
-+                    exists,
-+                    isDifferentProduct,
-+                    swatch,
-+                  } = value;
- 
--                if (isDifferentProduct) {
--                  // SEO
--                  // When the variant is a combined listing child product
--                  // that leads to a different url, we need to render it
--                  // as an anchor tag
--                  return (
--                    <Link
--                      className="product-options-item"
--                      key={option.name + name}
--                      prefetch="intent"
--                      preventScrollReset
--                      replace
--                      to={`/products/${handle}?${variantUriQuery}`}
--                      style={{
--                        border: selected
--                          ? '1px solid black'
--                          : '1px solid transparent',
--                        opacity: available ? 1 : 0.3,
--                      }}
--                    >
--                      <ProductOptionSwatch swatch={swatch} name={name} />
--                    </Link>
--                  );
--                } else {
--                  // SEO
--                  // When the variant is an update to the search param,
--                  // render it as a button with javascript navigating to
--                  // the variant so that SEO bots do not index these as
--                  // duplicated links
--                  return (
--                    <button
--                      type="button"
--                      className={`product-options-item${
--                        exists && !selected ? ' link' : ''
--                      }`}
--                      key={option.name + name}
--                      style={{
--                        border: selected
--                          ? '1px solid black'
--                          : '1px solid transparent',
--                        opacity: available ? 1 : 0.3,
--                      }}
--                      disabled={!exists}
--                      onClick={() => {
--                        if (!selected) {
--                          navigate(`?${variantUriQuery}`, {
--                            replace: true,
--                            preventScrollReset: true,
--                          });
--                        }
--                      }}
--                    >
--                      <ProductOptionSwatch swatch={swatch} name={name} />
--                    </button>
--                  );
-+                  if (isDifferentProduct) {
-+                    // SEO
-+                    // When the variant is a combined listing child product
-+                    // that leads to a different url, we need to render it
-+                    // as an anchor tag
-+                    return (
-+                      <Link
-+                        className="product-options-item"
-+                        key={option.name + name}
-+                        prefetch="intent"
-+                        preventScrollReset
-+                        replace
-+                        to={`/products/${handle}?${variantUriQuery}`}
-+                        style={{
-+                          border: selected
-+                            ? '1px solid black'
-+                            : '1px solid transparent',
-+                          opacity: available ? 1 : 0.3,
-+                        }}
-+                      >
-+                        <ProductOptionSwatch swatch={swatch} name={name} />
-+                      </Link>
-+                    );
-+                  } else {
-+                    // SEO
-+                    // When the variant is an update to the search param,
-+                    // render it as a button with javascript navigating to
-+                    // the variant so that SEO bots do not index these as
-+                    // duplicated links
-+                    return (
-+                      <button
-+                        type="button"
-+                        className={`product-options-item${
-+                          exists && !selected ? ' link' : ''
-+                        }`}
-+                        key={option.name + name}
-+                        style={{
-+                          border: selected
-+                            ? '1px solid black'
-+                            : '1px solid transparent',
-+                          opacity: available ? 1 : 0.3,
-+                        }}
-+                        disabled={!exists}
-+                        onClick={() => {
-+                          if (!selected) {
-+                            navigate(`?${variantUriQuery}`, {
-+                              replace: true,
-+                              preventScrollReset: true,
-+                            });
-+                          }
-+                        }}
-+                      >
-+                        <ProductOptionSwatch swatch={swatch} name={name} />
-+                      </button>
-+                    );
-+                  }
-+                })}
-+              </div>
-+              <AddToCartButton
-+                disabled={!selectedVariant || !selectedVariant.availableForSale}
-+                onClick={() => {
-+                  open('cart');
-+                }}
-+                lines={
-+                  selectedVariant
-+                    ? [
-+                        {
-+                          merchandiseId: selectedVariant.id,
-+                          quantity: 1,
-+                          selectedVariant,
-+                        },
-+                      ]
-+                    : []
-                 }
--              })}
-+              >
-+                {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
-+              </AddToCartButton>
-+
-+              <br />
-             </div>
--            <br />
--          </div>
--        );
--      })}
--      <AddToCartButton
--        disabled={!selectedVariant || !selectedVariant.availableForSale}
--        onClick={() => {
--          open('cart');
--        }}
--        lines={
--          selectedVariant
--            ? [
--                {
--                  merchandiseId: selectedVariant.id,
--                  quantity: 1,
--                  selectedVariant,
--                },
--              ]
--            : []
--        }
--      >
--        {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
--      </AddToCartButton>
-+          );
-+        })
-+      )}
++      ) : null}
      </div>
    );
  }
-@@ -148,3 +197,38 @@ function ProductOptionSwatch({
+@@ -148,3 +200,38 @@ function ProductOptionSwatch({
      </div>
    );
  }
@@ -433,7 +240,7 @@ index e8616a61..e41b91ad 100644
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
 
-#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductPrice.tsx)
+#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/templates/skeleton/app/components/ProductPrice.tsx)
 
 <details>
 
@@ -557,7 +364,7 @@ index 32460ae2..59eed1d8 100644
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
 
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/templates/skeleton/app/lib/fragments.ts)
 
 ```diff
 index dc4426a9..cfe3a938 100644
@@ -596,12 +403,12 @@ index dc4426a9..cfe3a938 100644
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
 ```diff
-index 2dc6bda2..aad7e5f1 100644
+index 2dc6bda2..3507d496 100644
 --- a/templates/skeleton/app/routes/products.$handle.tsx
 +++ b/templates/skeleton/app/routes/products.$handle.tsx
 @@ -1,3 +1,5 @@
@@ -692,7 +499,17 @@ index 2dc6bda2..aad7e5f1 100644
          />
          <br />
          <br />
-@@ -180,6 +218,73 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
+@@ -177,9 +215,83 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
+       amount
+       currencyCode
+     }
++    sellingPlanAllocations(first: 10) {
++      nodes {
++        sellingPlan {
++          id
++        }
++      }
++    }
    }
  ` as const;
  
@@ -766,7 +583,7 @@ index 2dc6bda2..aad7e5f1 100644
  const PRODUCT_FRAGMENT = `#graphql
    fragment Product on Product {
      id
-@@ -207,6 +312,11 @@ const PRODUCT_FRAGMENT = `#graphql
+@@ -207,6 +319,11 @@ const PRODUCT_FRAGMENT = `#graphql
          }
        }
      }
@@ -778,7 +595,7 @@ index 2dc6bda2..aad7e5f1 100644
      selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
        ...ProductVariant
      }
-@@ -218,6 +328,7 @@ const PRODUCT_FRAGMENT = `#graphql
+@@ -218,6 +335,7 @@ const PRODUCT_FRAGMENT = `#graphql
        title
      }
    }
@@ -794,7 +611,7 @@ index 2dc6bda2..aad7e5f1 100644
 Add a `Subscriptions` link to the account menu.
 
 
-#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/account.tsx)
+#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/658f0c7ed75d10c0789d426a1dbc771e31a6c2a9/templates/skeleton/app/routes/account.tsx)
 
 ```diff
 index 0941d4e0..976ae9df 100644

--- a/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx
+++ b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx
@@ -39,10 +39,12 @@ export function SellingPlanSelector({
   selectedSellingPlan,
   children,
   paramKey = 'selling_plan',
+  selectedVariant,
 }: {
   sellingPlanGroups: ProductFragment['sellingPlanGroups'];
   selectedSellingPlan: SellingPlanFragment | null;
   paramKey?: string;
+  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
   children: (params: {
     sellingPlanGroup: SellingPlanGroup;
     selectedSellingPlan: SellingPlanFragment | null;
@@ -51,21 +53,35 @@ export function SellingPlanSelector({
   const {search, pathname} = useLocation();
   const params = new URLSearchParams(search);
 
+  const planAllocationIds: string[] =
+    selectedVariant?.sellingPlanAllocations.nodes.map(
+      (node) => node.sellingPlan.id,
+    ) ?? [];
+
   return useMemo(
     () =>
-      (sellingPlanGroups.nodes as SellingPlanGroup[]).map(
-        (sellingPlanGroup) => {
-          // Augmnet each sellingPlan node with isSelected and url
+      (sellingPlanGroups.nodes as SellingPlanGroup[])
+        // Filter out groups that don't have plans usable for the selected variant
+        .filter((group) => {
+          return group.sellingPlans.nodes.some((sellingPlan) =>
+            planAllocationIds.includes(sellingPlan.id),
+          );
+        })
+        .map((sellingPlanGroup) => {
+          // Augment each sellingPlan node with isSelected and url
           const sellingPlans = sellingPlanGroup.sellingPlans.nodes
             .map((sellingPlan: SellingPlan) => {
               if (!sellingPlan?.id) {
-                //eslint-disable-next-line no-console
                 console.warn(
                   'SellingPlanSelector: sellingPlan.id is missing in the product query',
                 );
                 return null;
               }
-              if (!sellingPlan.id) return null;
+
+              if (!sellingPlan.id) {
+                return null;
+              }
+
               params.set(paramKey, sellingPlan.id);
               sellingPlan.isSelected =
                 selectedSellingPlan?.id === sellingPlan.id;
@@ -75,9 +91,15 @@ export function SellingPlanSelector({
             .filter(Boolean) as SellingPlan[];
           sellingPlanGroup.sellingPlans.nodes = sellingPlans;
           return children({sellingPlanGroup, selectedSellingPlan});
-        },
-      ),
+        }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [sellingPlanGroups, children, selectedSellingPlan, paramKey, pathname],
+    [
+      sellingPlanGroups,
+      children,
+      selectedSellingPlan,
+      paramKey,
+      pathname,
+      selectedVariant,
+    ],
   );
 }

--- a/cookbook/recipes/subscriptions/patches/ProductForm.tsx.8e409a.patch
+++ b/cookbook/recipes/subscriptions/patches/ProductForm.tsx.8e409a.patch
@@ -1,7 +1,7 @@
-index e8616a61..e41b91ad 100644
+index e8616a61..8b7fe8ca 100644
 --- a/templates/skeleton/app/components/ProductForm.tsx
 +++ b/templates/skeleton/app/components/ProductForm.tsx
-@@ -6,120 +6,169 @@ import type {
+@@ -6,14 +6,25 @@ import type {
  } from '@shopify/hydrogen/storefront-api-types';
  import {AddToCartButton} from './AddToCartButton';
  import {useAside} from './Aside';
@@ -28,16 +28,20 @@ index e8616a61..e41b91ad 100644
  }) {
    const navigate = useNavigate();
    const {open} = useAside();
-   return (
-     <div className="product-form">
--      {productOptions.map((option) => {
--        // If there is only a single value in the option values, don't display the option
--        if (option.optionValues.length === 1) return null;
+@@ -120,6 +131,47 @@ export function ProductForm({
+       >
+         {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
+       </AddToCartButton>
 +      {sellingPlanGroups.nodes.length > 0 ? (
 +        <>
++          <br />
++          <hr />
++          <br />
++          <h3>Subscription Options</h3>
 +          <SellingPlanSelector
 +            sellingPlanGroups={sellingPlanGroups}
 +            selectedSellingPlan={selectedSellingPlan}
++            selectedVariant={selectedVariant}
 +          >
 +            {({sellingPlanGroup}) => (
 +              <SellingPlanGroup
@@ -68,208 +72,11 @@ index e8616a61..e41b91ad 100644
 +            {selectedSellingPlan ? 'Subscribe' : 'Select Subscription'}
 +          </AddToCartButton>
 +        </>
-+      ) : (
-+        productOptions.map((option) => {
-+          // If there is only a single value in the option values, don't display the option
-+          if (option.optionValues.length === 1) return null;
- 
--        return (
--          <div className="product-options" key={option.name}>
--            <h5>{option.name}</h5>
--            <div className="product-options-grid">
--              {option.optionValues.map((value) => {
--                const {
--                  name,
--                  handle,
--                  variantUriQuery,
--                  selected,
--                  available,
--                  exists,
--                  isDifferentProduct,
--                  swatch,
--                } = value;
-+          return (
-+            <div className="product-options" key={option.name}>
-+              <h5>{option.name}</h5>
-+              <div className="product-options-grid">
-+                {option.optionValues.map((value) => {
-+                  const {
-+                    name,
-+                    handle,
-+                    variantUriQuery,
-+                    selected,
-+                    available,
-+                    exists,
-+                    isDifferentProduct,
-+                    swatch,
-+                  } = value;
- 
--                if (isDifferentProduct) {
--                  // SEO
--                  // When the variant is a combined listing child product
--                  // that leads to a different url, we need to render it
--                  // as an anchor tag
--                  return (
--                    <Link
--                      className="product-options-item"
--                      key={option.name + name}
--                      prefetch="intent"
--                      preventScrollReset
--                      replace
--                      to={`/products/${handle}?${variantUriQuery}`}
--                      style={{
--                        border: selected
--                          ? '1px solid black'
--                          : '1px solid transparent',
--                        opacity: available ? 1 : 0.3,
--                      }}
--                    >
--                      <ProductOptionSwatch swatch={swatch} name={name} />
--                    </Link>
--                  );
--                } else {
--                  // SEO
--                  // When the variant is an update to the search param,
--                  // render it as a button with javascript navigating to
--                  // the variant so that SEO bots do not index these as
--                  // duplicated links
--                  return (
--                    <button
--                      type="button"
--                      className={`product-options-item${
--                        exists && !selected ? ' link' : ''
--                      }`}
--                      key={option.name + name}
--                      style={{
--                        border: selected
--                          ? '1px solid black'
--                          : '1px solid transparent',
--                        opacity: available ? 1 : 0.3,
--                      }}
--                      disabled={!exists}
--                      onClick={() => {
--                        if (!selected) {
--                          navigate(`?${variantUriQuery}`, {
--                            replace: true,
--                            preventScrollReset: true,
--                          });
--                        }
--                      }}
--                    >
--                      <ProductOptionSwatch swatch={swatch} name={name} />
--                    </button>
--                  );
-+                  if (isDifferentProduct) {
-+                    // SEO
-+                    // When the variant is a combined listing child product
-+                    // that leads to a different url, we need to render it
-+                    // as an anchor tag
-+                    return (
-+                      <Link
-+                        className="product-options-item"
-+                        key={option.name + name}
-+                        prefetch="intent"
-+                        preventScrollReset
-+                        replace
-+                        to={`/products/${handle}?${variantUriQuery}`}
-+                        style={{
-+                          border: selected
-+                            ? '1px solid black'
-+                            : '1px solid transparent',
-+                          opacity: available ? 1 : 0.3,
-+                        }}
-+                      >
-+                        <ProductOptionSwatch swatch={swatch} name={name} />
-+                      </Link>
-+                    );
-+                  } else {
-+                    // SEO
-+                    // When the variant is an update to the search param,
-+                    // render it as a button with javascript navigating to
-+                    // the variant so that SEO bots do not index these as
-+                    // duplicated links
-+                    return (
-+                      <button
-+                        type="button"
-+                        className={`product-options-item${
-+                          exists && !selected ? ' link' : ''
-+                        }`}
-+                        key={option.name + name}
-+                        style={{
-+                          border: selected
-+                            ? '1px solid black'
-+                            : '1px solid transparent',
-+                          opacity: available ? 1 : 0.3,
-+                        }}
-+                        disabled={!exists}
-+                        onClick={() => {
-+                          if (!selected) {
-+                            navigate(`?${variantUriQuery}`, {
-+                              replace: true,
-+                              preventScrollReset: true,
-+                            });
-+                          }
-+                        }}
-+                      >
-+                        <ProductOptionSwatch swatch={swatch} name={name} />
-+                      </button>
-+                    );
-+                  }
-+                })}
-+              </div>
-+              <AddToCartButton
-+                disabled={!selectedVariant || !selectedVariant.availableForSale}
-+                onClick={() => {
-+                  open('cart');
-+                }}
-+                lines={
-+                  selectedVariant
-+                    ? [
-+                        {
-+                          merchandiseId: selectedVariant.id,
-+                          quantity: 1,
-+                          selectedVariant,
-+                        },
-+                      ]
-+                    : []
-                 }
--              })}
-+              >
-+                {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
-+              </AddToCartButton>
-+
-+              <br />
-             </div>
--            <br />
--          </div>
--        );
--      })}
--      <AddToCartButton
--        disabled={!selectedVariant || !selectedVariant.availableForSale}
--        onClick={() => {
--          open('cart');
--        }}
--        lines={
--          selectedVariant
--            ? [
--                {
--                  merchandiseId: selectedVariant.id,
--                  quantity: 1,
--                  selectedVariant,
--                },
--              ]
--            : []
--        }
--      >
--        {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
--      </AddToCartButton>
-+          );
-+        })
-+      )}
++      ) : null}
      </div>
    );
  }
-@@ -148,3 +197,38 @@ function ProductOptionSwatch({
+@@ -148,3 +200,38 @@ function ProductOptionSwatch({
      </div>
    );
  }

--- a/cookbook/recipes/subscriptions/patches/products.$handle.tsx.3e0b7e.patch
+++ b/cookbook/recipes/subscriptions/patches/products.$handle.tsx.3e0b7e.patch
@@ -1,4 +1,4 @@
-index 2dc6bda2..aad7e5f1 100644
+index 2dc6bda2..3507d496 100644
 --- a/templates/skeleton/app/routes/products.$handle.tsx
 +++ b/templates/skeleton/app/routes/products.$handle.tsx
 @@ -1,3 +1,5 @@
@@ -89,7 +89,17 @@ index 2dc6bda2..aad7e5f1 100644
          />
          <br />
          <br />
-@@ -180,6 +218,73 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
+@@ -177,9 +215,83 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
+       amount
+       currencyCode
+     }
++    sellingPlanAllocations(first: 10) {
++      nodes {
++        sellingPlan {
++          id
++        }
++      }
++    }
    }
  ` as const;
  
@@ -163,7 +173,7 @@ index 2dc6bda2..aad7e5f1 100644
  const PRODUCT_FRAGMENT = `#graphql
    fragment Product on Product {
      id
-@@ -207,6 +312,11 @@ const PRODUCT_FRAGMENT = `#graphql
+@@ -207,6 +319,11 @@ const PRODUCT_FRAGMENT = `#graphql
          }
        }
      }
@@ -175,7 +185,7 @@ index 2dc6bda2..aad7e5f1 100644
      selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
        ...ProductVariant
      }
-@@ -218,6 +328,7 @@ const PRODUCT_FRAGMENT = `#graphql
+@@ -218,6 +335,7 @@ const PRODUCT_FRAGMENT = `#graphql
        title
      }
    }

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -78,7 +78,7 @@ steps:
     index: 4
     name: Update ProductForm to support subscriptions
     description: >
-      1. Add conditional rendering to display either subscription options or
+      1. Add conditional rendering to display subscription options alongside the
       standard variant selectors.
 
       2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -148,4 +148,4 @@ llms:
     - issue: I'm not seeing the subscription details on my cart line items.
       solution: Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
-commit: 2ff53492d0c9152bd59063ae6ea34576ea9a4608
+commit: 658f0c7ed75d10c0789d426a1dbc771e31a6c2a9

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -570,7 +570,7 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 
 ### Step 3: Update ProductForm to support subscriptions
 
-1. Add conditional rendering to display either subscription options or standard variant selectors.
+1. Add conditional rendering to display subscription options alongside the standard variant selectors.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -113,10 +113,12 @@ export function SellingPlanSelector({
   selectedSellingPlan,
   children,
   paramKey = 'selling_plan',
+  selectedVariant,
 }: {
   sellingPlanGroups: ProductFragment['sellingPlanGroups'];
   selectedSellingPlan: SellingPlanFragment | null;
   paramKey?: string;
+  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
   children: (params: {
     sellingPlanGroup: SellingPlanGroup;
     selectedSellingPlan: SellingPlanFragment | null;
@@ -125,21 +127,35 @@ export function SellingPlanSelector({
   const {search, pathname} = useLocation();
   const params = new URLSearchParams(search);
 
+  const planAllocationIds: string[] =
+    selectedVariant?.sellingPlanAllocations.nodes.map(
+      (node) => node.sellingPlan.id,
+    ) ?? [];
+
   return useMemo(
     () =>
-      (sellingPlanGroups.nodes as SellingPlanGroup[]).map(
-        (sellingPlanGroup) => {
-          // Augmnet each sellingPlan node with isSelected and url
+      (sellingPlanGroups.nodes as SellingPlanGroup[])
+        // Filter out groups that don't have plans usable for the selected variant
+        .filter((group) => {
+          return group.sellingPlans.nodes.some((sellingPlan) =>
+            planAllocationIds.includes(sellingPlan.id),
+          );
+        })
+        .map((sellingPlanGroup) => {
+          // Augment each sellingPlan node with isSelected and url
           const sellingPlans = sellingPlanGroup.sellingPlans.nodes
             .map((sellingPlan: SellingPlan) => {
               if (!sellingPlan?.id) {
-                //eslint-disable-next-line no-console
                 console.warn(
                   'SellingPlanSelector: sellingPlan.id is missing in the product query',
                 );
                 return null;
               }
-              if (!sellingPlan.id) return null;
+
+              if (!sellingPlan.id) {
+                return null;
+              }
+
               params.set(paramKey, sellingPlan.id);
               sellingPlan.isSelected =
                 selectedSellingPlan?.id === sellingPlan.id;
@@ -149,10 +165,16 @@ export function SellingPlanSelector({
             .filter(Boolean) as SellingPlan[];
           sellingPlanGroup.sellingPlans.nodes = sellingPlans;
           return children({sellingPlanGroup, selectedSellingPlan});
-        },
-      ),
+        }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [sellingPlanGroups, children, selectedSellingPlan, paramKey, pathname],
+    [
+      sellingPlanGroups,
+      children,
+      selectedSellingPlan,
+      paramKey,
+      pathname,
+      selectedVariant,
+    ],
   );
 }
 
@@ -556,7 +578,7 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 #### File: /app/components/ProductForm.tsx
 
 ```diff
-@@ -6,120 +6,169 @@ import type {
+@@ -6,14 +6,25 @@ import type {
  } from '@shopify/hydrogen/storefront-api-types';
  import {AddToCartButton} from './AddToCartButton';
  import {useAside} from './Aside';
@@ -583,16 +605,20 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
  }) {
    const navigate = useNavigate();
    const {open} = useAside();
-   return (
-     <div className="product-form">
--      {productOptions.map((option) => {
--        // If there is only a single value in the option values, don't display the option
--        if (option.optionValues.length === 1) return null;
+@@ -120,6 +131,47 @@ export function ProductForm({
+       >
+         {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
+       </AddToCartButton>
 +      {sellingPlanGroups.nodes.length > 0 ? (
 +        <>
++          <br />
++          <hr />
++          <br />
++          <h3>Subscription Options</h3>
 +          <SellingPlanSelector
 +            sellingPlanGroups={sellingPlanGroups}
 +            selectedSellingPlan={selectedSellingPlan}
++            selectedVariant={selectedVariant}
 +          >
 +            {({sellingPlanGroup}) => (
 +              <SellingPlanGroup
@@ -623,208 +649,11 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 +            {selectedSellingPlan ? 'Subscribe' : 'Select Subscription'}
 +          </AddToCartButton>
 +        </>
-+      ) : (
-+        productOptions.map((option) => {
-+          // If there is only a single value in the option values, don't display the option
-+          if (option.optionValues.length === 1) return null;
- 
--        return (
--          <div className="product-options" key={option.name}>
--            <h5>{option.name}</h5>
--            <div className="product-options-grid">
--              {option.optionValues.map((value) => {
--                const {
--                  name,
--                  handle,
--                  variantUriQuery,
--                  selected,
--                  available,
--                  exists,
--                  isDifferentProduct,
--                  swatch,
--                } = value;
-+          return (
-+            <div className="product-options" key={option.name}>
-+              <h5>{option.name}</h5>
-+              <div className="product-options-grid">
-+                {option.optionValues.map((value) => {
-+                  const {
-+                    name,
-+                    handle,
-+                    variantUriQuery,
-+                    selected,
-+                    available,
-+                    exists,
-+                    isDifferentProduct,
-+                    swatch,
-+                  } = value;
- 
--                if (isDifferentProduct) {
--                  // SEO
--                  // When the variant is a combined listing child product
--                  // that leads to a different url, we need to render it
--                  // as an anchor tag
--                  return (
--                    <Link
--                      className="product-options-item"
--                      key={option.name + name}
--                      prefetch="intent"
--                      preventScrollReset
--                      replace
--                      to={`/products/${handle}?${variantUriQuery}`}
--                      style={{
--                        border: selected
--                          ? '1px solid black'
--                          : '1px solid transparent',
--                        opacity: available ? 1 : 0.3,
--                      }}
--                    >
--                      <ProductOptionSwatch swatch={swatch} name={name} />
--                    </Link>
--                  );
--                } else {
--                  // SEO
--                  // When the variant is an update to the search param,
--                  // render it as a button with javascript navigating to
--                  // the variant so that SEO bots do not index these as
--                  // duplicated links
--                  return (
--                    <button
--                      type="button"
--                      className={`product-options-item${
--                        exists && !selected ? ' link' : ''
--                      }`}
--                      key={option.name + name}
--                      style={{
--                        border: selected
--                          ? '1px solid black'
--                          : '1px solid transparent',
--                        opacity: available ? 1 : 0.3,
--                      }}
--                      disabled={!exists}
--                      onClick={() => {
--                        if (!selected) {
--                          navigate(`?${variantUriQuery}`, {
--                            replace: true,
--                            preventScrollReset: true,
--                          });
--                        }
--                      }}
--                    >
--                      <ProductOptionSwatch swatch={swatch} name={name} />
--                    </button>
--                  );
-+                  if (isDifferentProduct) {
-+                    // SEO
-+                    // When the variant is a combined listing child product
-+                    // that leads to a different url, we need to render it
-+                    // as an anchor tag
-+                    return (
-+                      <Link
-+                        className="product-options-item"
-+                        key={option.name + name}
-+                        prefetch="intent"
-+                        preventScrollReset
-+                        replace
-+                        to={`/products/${handle}?${variantUriQuery}`}
-+                        style={{
-+                          border: selected
-+                            ? '1px solid black'
-+                            : '1px solid transparent',
-+                          opacity: available ? 1 : 0.3,
-+                        }}
-+                      >
-+                        <ProductOptionSwatch swatch={swatch} name={name} />
-+                      </Link>
-+                    );
-+                  } else {
-+                    // SEO
-+                    // When the variant is an update to the search param,
-+                    // render it as a button with javascript navigating to
-+                    // the variant so that SEO bots do not index these as
-+                    // duplicated links
-+                    return (
-+                      <button
-+                        type="button"
-+                        className={`product-options-item${
-+                          exists && !selected ? ' link' : ''
-+                        }`}
-+                        key={option.name + name}
-+                        style={{
-+                          border: selected
-+                            ? '1px solid black'
-+                            : '1px solid transparent',
-+                          opacity: available ? 1 : 0.3,
-+                        }}
-+                        disabled={!exists}
-+                        onClick={() => {
-+                          if (!selected) {
-+                            navigate(`?${variantUriQuery}`, {
-+                              replace: true,
-+                              preventScrollReset: true,
-+                            });
-+                          }
-+                        }}
-+                      >
-+                        <ProductOptionSwatch swatch={swatch} name={name} />
-+                      </button>
-+                    );
-+                  }
-+                })}
-+              </div>
-+              <AddToCartButton
-+                disabled={!selectedVariant || !selectedVariant.availableForSale}
-+                onClick={() => {
-+                  open('cart');
-+                }}
-+                lines={
-+                  selectedVariant
-+                    ? [
-+                        {
-+                          merchandiseId: selectedVariant.id,
-+                          quantity: 1,
-+                          selectedVariant,
-+                        },
-+                      ]
-+                    : []
-                 }
--              })}
-+              >
-+                {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
-+              </AddToCartButton>
-+
-+              <br />
-             </div>
--            <br />
--          </div>
--        );
--      })}
--      <AddToCartButton
--        disabled={!selectedVariant || !selectedVariant.availableForSale}
--        onClick={() => {
--          open('cart');
--        }}
--        lines={
--          selectedVariant
--            ? [
--                {
--                  merchandiseId: selectedVariant.id,
--                  quantity: 1,
--                  selectedVariant,
--                },
--              ]
--            : []
--        }
--      >
--        {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
--      </AddToCartButton>
-+          );
-+        })
-+      )}
++      ) : null}
      </div>
    );
  }
-@@ -148,3 +197,38 @@ function ProductOptionSwatch({
+@@ -148,3 +200,38 @@ function ProductOptionSwatch({
      </div>
    );
  }
@@ -1115,7 +944,17 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
          />
          <br />
          <br />
-@@ -180,6 +218,73 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
+@@ -177,9 +215,83 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
+       amount
+       currencyCode
+     }
++    sellingPlanAllocations(first: 10) {
++      nodes {
++        sellingPlan {
++          id
++        }
++      }
++    }
    }
  ` as const;
  
@@ -1189,7 +1028,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
  const PRODUCT_FRAGMENT = `#graphql
    fragment Product on Product {
      id
-@@ -207,6 +312,11 @@ const PRODUCT_FRAGMENT = `#graphql
+@@ -207,6 +319,11 @@ const PRODUCT_FRAGMENT = `#graphql
          }
        }
      }
@@ -1201,7 +1040,7 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
      selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {
        ...ProductVariant
      }
-@@ -218,6 +328,7 @@ const PRODUCT_FRAGMENT = `#graphql
+@@ -218,6 +335,7 @@ const PRODUCT_FRAGMENT = `#graphql
        title
      }
    }


### PR DESCRIPTION
### WHY are these changes introduced?

The subscriptions recipe should show both the variant selector and the one-off purchase buttons alongside the subscription options (if available) instead of only showing the subscription options if available.

### WHAT is this pull request doing?

1. Keep the variant selector and the one-off purchase button in place
2. Show the subscription options below that, separately
3. Only show groups that are applicable for the specific selected variant instead

| Before | After |
|-----|-------|
| <img width="1504" alt="Screenshot 2025-05-07 at 5 45 56 PM" src="https://github.com/user-attachments/assets/39c912fa-55ac-405d-ba96-68a34b8bedc4" /> | <img width="1504" alt="Screenshot 2025-05-07 at 5 45 14 PM" src="https://github.com/user-attachments/assets/9ca2577b-4d9d-449e-99a5-62cac20c7a47" /> |

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
