### PR TITLE
Add upgrade codemod for updating oxygen imports

### DIFF
--- a/packages/cli/src/codemods/2025-5.ts
+++ b/packages/cli/src/codemods/2025-5.ts
@@ -1,0 +1,95 @@
+import semver from 'semver';
+import {resolvePath} from '@shopify/cli-kit/node/path';
+import {glob, readFile, writeFile} from '@shopify/cli-kit/node/fs';
+import {getViteConfig} from '../lib/vite-config.js';
+import {AbortError} from '@shopify/cli-kit/node/error';
+import {importLangAstGrep} from '../lib/ast.js';
+import {renderSelectPrompt} from '@shopify/cli-kit/node/ui';
+
+export default {
+  version: '2025.4.1',
+  async codemod(path: string) {
+    const shouldUpdateImports = await renderSelectPrompt({
+      message: `Do you want run a codemap that upates the imports from @shopify/remix-oxygen to react-router?`,
+      choices: [
+        {
+          label: 'Yes',
+          value: 'yes',
+        },
+        {
+          label: 'No',
+          value: 'no',
+        },
+      ],
+      defaultValue: 'yes',
+    });
+
+    if (shouldUpdateImports === 'yes') {
+      await updateOxygenImports(path);
+    }
+  },
+};
+
+async function updateOxygenImports(path: string) {
+  const directory = resolvePath(path);
+
+  const viteConfig = await getViteConfig(directory).catch(() => null);
+
+  if (!viteConfig) {
+    throw new AbortError(
+      'No Vite config found. This command is only supported in Vite projects.',
+    );
+  }
+
+  const {remixConfig} = viteConfig;
+
+  const files = await glob('**/*.{js,jsx,ts,tsx}', {
+    cwd: remixConfig.appDirectory,
+    absolute: true,
+  });
+
+  for (const file of files) {
+    const content = await readFile(file, {encoding: 'utf8'});
+    const fileExtension = file.split('.').pop()! as 'ts' | 'tsx' | 'js' | 'jsx';
+    const astGrep = await importLangAstGrep(fileExtension);
+    const ast = astGrep.parse(content);
+    const root = ast.root();
+
+    // Find all import statements
+    const importNodes = root.findAll({
+      rule: {
+        kind: 'import_statement',
+      },
+    });
+
+    // Filter for imports from @shopify/remix-oxygen
+    const remixOxygenImports = importNodes.filter((node) => {
+      const nodeText = node.text();
+      return nodeText.includes('@shopify/remix-oxygen');
+    });
+
+    // Skip if no imports found
+    if (remixOxygenImports.length === 0) continue;
+
+    let updatedContent = content;
+
+    for (const importNode of remixOxygenImports) {
+      const importText = importNode.text();
+
+      // Create a new import statement with the same imports but from react-router
+      const newImportText = importText.replace(
+        /@shopify\/remix-oxygen/g,
+        'react-router',
+      );
+
+      // Replace the old import with the new one
+      updatedContent = updatedContent.replace(importText, newImportText);
+    }
+
+    // Only write the file if changes were made
+    if (updatedContent !== content) {
+      await writeFile(file, updatedContent);
+      console.log(`Updated imports in ${file}`);
+    }
+  }
+}

--- a/packages/cli/src/codemods/codemod.ts
+++ b/packages/cli/src/codemods/codemod.ts
@@ -1,0 +1,26 @@
+import {getAbsoluteVersion} from '../commands/hydrogen/upgrade.js';
+import upgrade20255 from './2025-5.js';
+import semver from 'semver';
+
+const upgrades = [upgrade20255];
+
+export async function runCodemodUpgrades(
+  from: string,
+  to: string,
+  path: string,
+) {
+  const fromVersion = getAbsoluteVersion(from);
+  const toVersion = getAbsoluteVersion(to);
+
+  const upgradesToRun = upgrades.filter(({version}) => {
+    return semver.gt(version, fromVersion) && semver.lte(version, toVersion);
+  });
+
+  for (const upgrade of upgradesToRun) {
+    try {
+      await upgrade.codemod(path);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+}


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Sometimes upgrading to a new version has changes that need to be made to the code. This adds infra to run a codemod for at the end of an `upgrade` command.

This particular codemod added is for changing the imports from `@shopify/remix-oxygen` to `react-router`, which is an optional task in the React Router 7 migration.

### HOW to test your changes?

This PR sets the codemod to apply to the version `2024.4.1`, which hasn't been released yet. So to test it, modify the version in `2025-5.ts` to be a previous version like `2024.1.2`. Then setup an older version of Hydrogen `npm create@shopify/hydrogen@2023.10.1`. Then from within the mono repo run `npx shopify hydrogen upgrade --path /path/to/your/old/version/of/hydrogen`

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
