### PR TITLE
Cookbook: bundles recipe bump

### DIFF
--- a/.changeset/great-monkeys-admire.md
+++ b/.changeset/great-monkeys-admire.md
@@ -1,0 +1,5 @@
+---
+"skeleton": patch
+---
+
+Added bundles recipe

--- a/cookbook/recipes/bundles/README.md
+++ b/cookbook/recipes/bundles/README.md
@@ -27,8 +27,8 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
-| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
+| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
+| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
 
 ## Steps
 
@@ -45,8 +45,8 @@ _New files added to the template by this recipe._
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
-- [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+- [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+- [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
 
 ### Step 3: Update the product fragment to query for bundles and display BundledVariants
 
@@ -54,7 +54,7 @@ Copy all the files found in the `ingredients/` directory into your project.
 - Pass the `isBundle` flag to the `ProductImage` component.
 
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -178,7 +178,7 @@ index 2dc6bda2..0339d128 100644
 Like the previous step, use the `requiresComponents` field to detect if the product item is a bundle.
 
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/routes/collections.$handle.tsx)
 
 ```diff
 index f1d7fa3e..ae341f8a 100644
@@ -232,7 +232,7 @@ index f1d7fa3e..ae341f8a 100644
 Use the `requiresComponents` field to determine if a cart line item is a bundle.
 
 
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/lib/fragments.ts)
 
 <details>
 
@@ -298,7 +298,7 @@ index dc4426a9..13cc34e5 100644
 If a product is a bundle, show the `BundleBadge` component in the cart line item.
 
 
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..0790a6f2 100644
@@ -350,7 +350,7 @@ index bd33a2cf..0790a6f2 100644
 If a product is a bundle, update the text of the product button.
 
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/components/ProductForm.tsx)
 
 ```diff
 index e8616a61..07a984dc 100644
@@ -388,7 +388,7 @@ index e8616a61..07a984dc 100644
 If a product is a bundle, show the `BundleBadge` component in the `ProductImage` component.
 
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..c16b947b 100644
@@ -423,7 +423,7 @@ index 5f3ac1cc..c16b947b 100644
 If a product is a bundle, show the `BundleBadge` component in the `ProductItem` component.
 
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/components/ProductItem.tsx)
 
 <details>
 
@@ -506,7 +506,7 @@ index 62c64b50..970916bd 100644
 Make sure the bundle badge is positioned relative to the product image.
 
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..de48b6c6 100644

--- a/cookbook/recipes/bundles/recipe.yaml
+++ b/cookbook/recipes/bundles/recipe.yaml
@@ -135,4 +135,4 @@ steps:
 llms:
   userQueries: []
   troubleshooting: []
-commit: 6fc6b23a2b7df56af5bdb769b4a2cec62ce198c3
+commit: 55039b91aaac891f75b426a723e71dd07bb37716


### PR DESCRIPTION
### WHAT is this pull request doing?

Regen + bump the skeleton for the bundles recipe in https://github.com/Shopify/hydrogen/pull/2873.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
