### PR TITLE
Add a route to the skeleton template that proxies the tokenless api

### DIFF
--- a/.changeset/flat-apples-chew.md
+++ b/.changeset/flat-apples-chew.md
@@ -1,0 +1,5 @@
+---
+"skeleton": patch
+---
+
+Add a new tokenless Storefront API route to the starter template.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -866,7 +866,7 @@
       "aliases": [],
       "args": {
         "routeName": {
-          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.",
+          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.",
           "name": "routeName",
           "options": [
             "home",
@@ -880,6 +880,7 @@
             "search",
             "robots",
             "sitemap",
+            "tokenlessApi",
             "all"
           ],
           "required": true

--- a/packages/cli/src/lib/setups/routes/generate.ts
+++ b/packages/cli/src/lib/setups/routes/generate.ts
@@ -48,6 +48,7 @@ const ROUTE_MAP = {
   search: ['search', 'api.predictive-search'],
   robots: '[robots.txt]',
   sitemap: ['[sitemap.xml]', 'sitemap.$type.$page[.xml]'],
+  tokenlessApi: 'api.$version.[graphql.json]',
 };
 
 type RouteKey = keyof typeof ROUTE_MAP;

--- a/packages/create-hydrogen/integration.test.ts
+++ b/packages/create-hydrogen/integration.test.ts
@@ -59,6 +59,7 @@ describe('create-hydrogen', () => {
         │      • Search (/search)                                                      │
         │      • Robots (/robots.txt)                                                  │
         │      • Sitemap (/sitemap.xml & /sitemap/:type/:page.xml)                     │
+        │      • TokenlessApi (/api/:version/graphql.json)                             │
         │                                                                              │
         │  Next steps                                                                  │
         │                                                                              │

--- a/templates/skeleton/app/routes/api.$version.[graphql.json].tsx
+++ b/templates/skeleton/app/routes/api.$version.[graphql.json].tsx
@@ -1,0 +1,14 @@
+import {LoaderFunctionArgs} from '@remix-run/server-runtime';
+
+export async function action({params, context, request}: LoaderFunctionArgs) {
+  const response = await fetch(
+    `https://${context.env.PUBLIC_CHECKOUT_DOMAIN}/api/${params.version}/graphql.json?&fast_storefront_renderer=staging-east-2`,
+    {
+      method: 'POST',
+      body: request.body,
+      headers: request.headers,
+    },
+  );
+
+  return new Response(response.body, {headers: new Headers(response.headers)});
+}

--- a/templates/skeleton/app/routes/api.$version.[graphql.json].tsx
+++ b/templates/skeleton/app/routes/api.$version.[graphql.json].tsx
@@ -1,8 +1,8 @@
-import {LoaderFunctionArgs} from '@remix-run/server-runtime';
+import {LoaderFunctionArgs} from 'react-router';
 
 export async function action({params, context, request}: LoaderFunctionArgs) {
   const response = await fetch(
-    `https://${context.env.PUBLIC_CHECKOUT_DOMAIN}/api/${params.version}/graphql.json?&fast_storefront_renderer=staging-east-2`,
+    `https://${context.env.PUBLIC_CHECKOUT_DOMAIN}/api/${params.version}/graphql.json`,
     {
       method: 'POST',
       body: request.body,


### PR DESCRIPTION
# WHY are these changes introduced?
Add a route to the skeleton template that proxies the tokenless API. The merchant can opt into this functionality simply by adding the route. Should the logic of the route be packaged into Hydrogen though? Essentially two options:

As is, all the logic directly in the template:
```TypeScript
import {LoaderFunctionArgs} from '@remix-run/server-runtime';

export async function action({params, context, request}: LoaderFunctionArgs) {
  const response = await fetch(
    `https://${context.env.PUBLIC_CHECKOUT_DOMAIN}/api/${params.version}/graphql.json`,
    {
      method: 'POST',
      body: request.body,
      headers: request.headers,
    },
  );

  return new Response(response.body, {headers: new Headers(response.headers)});
}
```
Package into Hydrogen

```TypeScript
import {proxyStorefrontAPI} from '@shopify/hydrogen';

export const action = proxyStorefrontAPI();

// or

export async function action(...args) {
  return proxyStorefrontAPI(...args);
}
```