### PR TITLE
Cookbook: shopify.dev render fixes

### DIFF
--- a/cookbook/recipe.schema.json
+++ b/cookbook/recipe.schema.json
@@ -1,6 +1,11 @@
 {
   "type": "object",
   "properties": {
+    "gid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "The unique identifier of the recipe"
+    },
     "title": {
       "type": "string",
       "description": "The title of the recipe"
@@ -188,6 +193,7 @@
     }
   },
   "required": [
+    "gid",
     "title",
     "summary",
     "description",

--- a/cookbook/recipes/bundles/README.md
+++ b/cookbook/recipes/bundles/README.md
@@ -23,10 +23,10 @@ In this recipe, we'll use the [Shopify Bundles app](https://apps.shopify.com/sho
 
 _New files added to the template by this recipe._
 
-| File                                                                                                                                                                                                               | Description                                                                          |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
-| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)         | A badge displayed on bundle product listings.                                        |
-| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
+| File | Description |
+| --- | --- |
+| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
+| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
 
 ## Steps
 
@@ -42,15 +42,15 @@ _New files added to the template by this recipe._
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
-- [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+- [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+- [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
 
 ### Step 3: Update the product fragment to query for bundles and display BundledVariants
 
 - Add the `requiresComponents` field to the `Product` fragment, which is used to identify bundled products.
 - Pass the `isBundle` flag to the `ProductImage` component.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -70,13 +70,13 @@ index 2dc6bda2..0339d128 100644
  import {redirectIfHandleIsLocalized} from '~/lib/redirect';
 +import type {ProductVariantComponent} from '@shopify/hydrogen/storefront-api-types';
 +import {BundledVariants} from '~/components/BundledVariants';
-
+ 
  export const meta: MetaFunction<typeof loader> = ({data}) => {
    return [
 @@ -101,9 +103,12 @@ export default function Product() {
-
+ 
    const {title, descriptionHtml} = product;
-
+ 
 +  const isBundle = Boolean(product.isBundle?.requiresComponents);
 +  const bundledVariants = isBundle ? product.isBundle?.components.nodes : null;
 +
@@ -138,7 +138,7 @@ index 2dc6bda2..0339d128 100644
 +    }
    }
  ` as const;
-
+ 
 @@ -213,6 +249,25 @@ const PRODUCT_FRAGMENT = `#graphql
      adjacentVariants (selectedOptions: $selectedOptions) {
        ...ProductVariant
@@ -173,7 +173,7 @@ index 2dc6bda2..0339d128 100644
 
 Like the previous step, use the `requiresComponents` field to detect if the product item is a bundle.
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/templates/skeleton/app/routes/collections.$handle.tsx)
 
 ```diff
 index f1d7fa3e..ae341f8a 100644
@@ -184,7 +184,7 @@ index f1d7fa3e..ae341f8a 100644
  import {redirectIfHandleIsLocalized} from '~/lib/redirect';
  import {ProductItem} from '~/components/ProductItem';
 +import {ProductItemFragment} from 'storefrontapi.generated';
-
+ 
  export const meta: MetaFunction<typeof loader> = ({data}) => {
    return [{title: `Hydrogen | ${data?.collection.title ?? ''} Collection`}];
 @@ -79,7 +80,13 @@ export default function Collection() {
@@ -214,7 +214,7 @@ index f1d7fa3e..ae341f8a 100644
 +    }
    }
  ` as const;
-
+ 
 -// NOTE: https://shopify.dev/docs/api/storefront/2022-04/objects/collection
 +// NOTE: https://shopify.dev/docs/api/storefront/latest/objects/collection
  const COLLECTION_QUERY = `#graphql
@@ -226,7 +226,7 @@ index f1d7fa3e..ae341f8a 100644
 
 Use the `requiresComponents` field to determine if a cart line item is a bundle.
 
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/templates/skeleton/app/lib/fragments.ts)
 
 <details>
 
@@ -291,7 +291,7 @@ index dc4426a9..13cc34e5 100644
 
 If a product is a bundle, show the `BundleBadge` component in the cart line item.
 
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..0790a6f2 100644
@@ -302,21 +302,21 @@ index bd33a2cf..0790a6f2 100644
  import {useAside} from './Aside';
  import type {CartApiQueryFragment} from 'storefrontapi.generated';
 +import {BundleBadge} from '~/components/BundleBadge';
-
+ 
  type CartLine = OptimisticCartLine<CartApiQueryFragment>;
-
+ 
 @@ -24,6 +25,7 @@ export function CartLineItem({
    const {product, title, image, selectedOptions} = merchandise;
    const lineItemUrl = useVariantUrl(product.handle, selectedOptions);
    const {close} = useAside();
 +  const isBundle = Boolean(line.merchandise.requiresComponents);
-
+ 
    return (
      <li key={id} className="cart-line">
 @@ -38,8 +40,9 @@ export function CartLineItem({
          />
        )}
-
+ 
 -      <div>
 +      <div style={{display: 'flex', flexDirection: 'column', width: '100%'}}>
          <Link
@@ -342,7 +342,7 @@ index bd33a2cf..0790a6f2 100644
 
 If a product is a bundle, update the text of the product button.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/templates/skeleton/app/components/ProductForm.tsx)
 
 ```diff
 index e8616a61..07a984dc 100644
@@ -379,7 +379,7 @@ index e8616a61..07a984dc 100644
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductImage` component.
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..c16b947b 100644
@@ -389,7 +389,7 @@ index 5f3ac1cc..c16b947b 100644
  import type {ProductVariantFragment} from 'storefrontapi.generated';
  import {Image} from '@shopify/hydrogen';
 +import {BundleBadge} from './BundleBadge';
-
+ 
  export function ProductImage({
    image,
 +  isBundle = false,
@@ -413,7 +413,7 @@ index 5f3ac1cc..c16b947b 100644
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductItem` component.
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/templates/skeleton/app/components/ProductItem.tsx)
 
 <details>
 
@@ -432,7 +432,7 @@ index 62c64b50..970916bd 100644
 +import type {ProductItemFragment} from 'storefrontapi.generated';
  import {useVariantUrl} from '~/lib/variants';
 +import {BundleBadge} from '~/components/BundleBadge';
-
+ 
  export function ProductItem({
    product,
    loading,
@@ -495,7 +495,7 @@ index 62c64b50..970916bd 100644
 
 Make sure the bundle badge is positioned relative to the product image.
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/4fa2550c0cf7b07e2cf3b948b42c67cf3d552789/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..de48b6c6 100644
@@ -504,7 +504,7 @@ index b9294c59..de48b6c6 100644
 @@ -436,6 +436,10 @@ button.reset:hover:not(:has(> *)) {
    margin-top: 0;
  }
-
+ 
 +.product-image {
 +  position: relative;
 +}

--- a/cookbook/recipes/bundles/README.md
+++ b/cookbook/recipes/bundles/README.md
@@ -14,12 +14,10 @@ In this recipe you'll make the following changes:
 
 4. Update the cart line item template to display the bundle badge as needed.
 
-
 ## Requirements
 
 To use product bundles, you need to install a bundles app in your Shopify admin.
 In this recipe, we'll use the [Shopify Bundles app](https://apps.shopify.com/shopify-bundles).
-
 
 ## Ingredients
 
@@ -27,8 +25,8 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
-| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
+| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
+| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
 
 ## Steps
 
@@ -40,21 +38,19 @@ _New files added to the template by this recipe._
 
 3. From the [**Bundles**](https://admin.shopify.com/apps/shopify-bundles/app) page, [create a new bundle](https://help.shopify.com/en/manual/products/bundles/shopify-bundles).
 
-
 ### Step 2: Add ingredients to your project
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
-- [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+- [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+- [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
 
 ### Step 3: Update the product fragment to query for bundles and display BundledVariants
 
 - Add the `requiresComponents` field to the `Product` fragment, which is used to identify bundled products.
 - Pass the `isBundle` flag to the `ProductImage` component.
 
-
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -177,8 +173,7 @@ index 2dc6bda2..0339d128 100644
 
 Like the previous step, use the `requiresComponents` field to detect if the product item is a bundle.
 
-
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/collections.$handle.tsx)
 
 ```diff
 index f1d7fa3e..ae341f8a 100644
@@ -231,8 +226,7 @@ index f1d7fa3e..ae341f8a 100644
 
 Use the `requiresComponents` field to determine if a cart line item is a bundle.
 
-
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/lib/fragments.ts)
 
 <details>
 
@@ -297,8 +291,7 @@ index dc4426a9..13cc34e5 100644
 
 If a product is a bundle, show the `BundleBadge` component in the cart line item.
 
-
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..0790a6f2 100644
@@ -349,8 +342,7 @@ index bd33a2cf..0790a6f2 100644
 
 If a product is a bundle, update the text of the product button.
 
-
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductForm.tsx)
 
 ```diff
 index e8616a61..07a984dc 100644
@@ -387,8 +379,7 @@ index e8616a61..07a984dc 100644
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductImage` component.
 
-
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..c16b947b 100644
@@ -422,8 +413,7 @@ index 5f3ac1cc..c16b947b 100644
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductItem` component.
 
-
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductItem.tsx)
 
 <details>
 
@@ -505,8 +495,7 @@ index 62c64b50..970916bd 100644
 
 Make sure the bundle badge is positioned relative to the product image.
 
-
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/55039b91aaac891f75b426a723e71dd07bb37716/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..de48b6c6 100644

--- a/cookbook/recipes/bundles/recipe.yaml
+++ b/cookbook/recipes/bundles/recipe.yaml
@@ -155,4 +155,4 @@ llms:
         Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin. Then make sure you've updated the cart
         fragment to query for bundles.
-commit: b81c24730f207492216f2720691922bb3eed3b7b
+commit: 4fa2550c0cf7b07e2cf3b948b42c67cf3d552789

--- a/cookbook/recipes/bundles/recipe.yaml
+++ b/cookbook/recipes/bundles/recipe.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=../../recipe.schema.json
 
+gid: 8495ffc3-e69c-431a-ac0b-1abb16ab50a2
 title: Bundles
 summary: |
   Display product bundles on your Hydrogen storefront.
@@ -135,4 +136,4 @@ steps:
 llms:
   userQueries: []
   troubleshooting: []
-commit: 55039b91aaac891f75b426a723e71dd07bb37716
+commit: b81c24730f207492216f2720691922bb3eed3b7b

--- a/cookbook/recipes/combined-listings/README.md
+++ b/cookbook/recipes/combined-listings/README.md
@@ -21,7 +21,7 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
+| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
 
 ## Steps
 
@@ -55,14 +55,14 @@ export const combinedListingsSettings = {
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+- [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
 ### Step 4: Update the ProductForm component
 
 1. Update the `ProductForm` component to hide the **Add to cart** button for the parent products of combined listings and for variants' selected state.
 2. Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -169,7 +169,7 @@ index e8616a61..b6567c21 100644
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..f1c9f2cd 100644
@@ -197,7 +197,7 @@ index 5f3ac1cc..f1c9f2cd 100644
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 62c64b50..034b5660 100644
@@ -238,7 +238,7 @@ index 62c64b50..034b5660 100644
 
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
-#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/lib/redirect.ts)
+#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/lib/redirect.ts)
 
 ```diff
 index ce1feb5a..29fe2ecc 100644
@@ -282,7 +282,7 @@ index ce1feb5a..29fe2ecc 100644
 1. Add the `tags` property to the items returned by the product query.
 2. (Optional) Add the filtering query to the product query to exclude combined listings.
 
-#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/_index.tsx)
+#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/_index.tsx)
 
 <details>
 
@@ -367,7 +367,7 @@ index 34747528..6e485083 100644
 
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/collections.$handle.tsx)
 
 <details>
 
@@ -439,7 +439,7 @@ index f1d7fa3e..17edfb7d 100644
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
-#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/collections.all.tsx)
+#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/collections.all.tsx)
 
 ```diff
 index 3a31b2f7..c756c9e1 100644
@@ -498,7 +498,7 @@ index 3a31b2f7..c756c9e1 100644
 2. Show the featured image of the combined listing parent product instead of the variant image.
 3. (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -638,7 +638,7 @@ index 2dc6bda2..8baafac9 100644
 
 Add a class to the product item to show a range of prices for combined listings.
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..c8fa5109 100644

--- a/cookbook/recipes/combined-listings/README.md
+++ b/cookbook/recipes/combined-listings/README.md
@@ -1,23 +1,19 @@
 # Combined Listings
 
-
 This recipe lets you more precisely display and manage [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) on product pages and in search results for your Hydrogen storefront. A combined listing groups separate products together into a single product listing using a shared option like color or size.
 Each product appears as a variant but can have its own title, description, URL, and images.
-
 In this recipe, you'll make the following changes:
 
 1. Set up the Combined Listings app in your Shopify admin and group relevant products together as combined listings.
 2. Configure how combined listings will be handled on your storefront.
-3. Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings.
+3. Update the `ProductForm` component to hide the **Add to cart** button for the parent products of combined listings.
 4. Update the `ProductImage` component to support images from product variants and the product itself.
 5. Show a range of prices for combined listings in `ProductItem`.
-
 
 ## Requirements
 
 - Your store must be on either a [Shopify Plus](https://www.shopify.com/plus) or enterprise plan.
 - Your store must have the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) installed.
-
 
 ## Ingredients
 
@@ -25,14 +21,17 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
+| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
 
 ## Steps
 
 ### Step 1: Set up the Combined Listings app
 
-1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings). 2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing). 3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
+1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings).
 
+2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing).
+
+3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
 
 ### Step 2: Configure combined listings behavior
 
@@ -52,20 +51,18 @@ export const combinedListingsSettings = {
 };
 ```
 
-
 ### Step 3: Add ingredients to your project
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+- [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
 ### Step 4: Update the ProductForm component
 
-- Update the `ProductForm` component to hide the `Add to cart` button for the parent products of combined listings and for variants' selected state.
-- Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
+1. Update the `ProductForm` component to hide the **Add to cart** button for the parent products of combined listings and for variants' selected state.
+2. Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
 
-
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -172,8 +169,7 @@ index e8616a61..b6567c21 100644
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
-
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..f1c9f2cd 100644
@@ -201,8 +197,7 @@ index 5f3ac1cc..f1c9f2cd 100644
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
-
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 62c64b50..034b5660 100644
@@ -243,8 +238,7 @@ index 62c64b50..034b5660 100644
 
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
-
-#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/lib/redirect.ts)
+#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/lib/redirect.ts)
 
 ```diff
 index ce1feb5a..29fe2ecc 100644
@@ -285,11 +279,10 @@ index ce1feb5a..29fe2ecc 100644
 
 ### Step 8: Update queries for combined listings
 
-- Add the `tags` property to the items returned by the product query.
-- (Optional) Add the filtering query to the product query to exclude combined listings.
+1. Add the `tags` property to the items returned by the product query.
+2. (Optional) Add the filtering query to the product query to exclude combined listings.
 
-
-#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/_index.tsx)
+#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/_index.tsx)
 
 <details>
 
@@ -374,8 +367,7 @@ index 34747528..6e485083 100644
 
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
-
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/collections.$handle.tsx)
 
 <details>
 
@@ -447,8 +439,7 @@ index f1d7fa3e..17edfb7d 100644
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
-
-#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/collections.all.tsx)
+#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/collections.all.tsx)
 
 ```diff
 index 3a31b2f7..c756c9e1 100644
@@ -503,12 +494,11 @@ index 3a31b2f7..c756c9e1 100644
 
 ### Step 11: Update the product page
 
-- Display a range of prices for combined listings instead of the variant price.
-- Show the featured image of the combined listing parent product instead of the variant image.
-- (Optional) Redirect to the first variant of a combined listing when the handle is requested.
+1. Display a range of prices for combined listings instead of the variant price.
+2. Show the featured image of the combined listing parent product instead of the variant image.
+3. (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
-
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -648,8 +638,7 @@ index 2dc6bda2..8baafac9 100644
 
 Add a class to the product item to show a range of prices for combined listings.
 
-
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/2ff53492d0c9152bd59063ae6ea34576ea9a4608/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..c8fa5109 100644

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=../../recipe.schema.json
 
+gid: 6bfa1a39-3a16-4351-b34a-2369c495d5a2
 title: Combined Listings
 summary: Handle combined listings on product pages and in search results.
 description: >
-  
   This recipe lets you more precisely display and manage [combined
   listings](https://help.shopify.com/en/manual/products/combined-listings-app)
   on product pages and in search results for your Hydrogen storefront. A
@@ -13,7 +13,6 @@ description: >
   Each product appears as a variant but can have its own title, description,
   URL, and images.
 
-
   In this recipe, you'll make the following changes:
 
 
@@ -22,8 +21,8 @@ description: >
 
   2. Configure how combined listings will be handled on your storefront.
 
-  3. Update the `ProductForm` component to hide the `Add to cart` button for the
-  parent products of combined listings.
+  3. Update the `ProductForm` component to hide the **Add to cart** button for
+  the parent products of combined listings.
 
   4. Update the `ProductImage` component to support images from product variants
   and the product itself.
@@ -46,7 +45,11 @@ steps:
     index: 1
     name: Set up the Combined Listings app
     description: |
-      1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings). 2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing). 3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
+      1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings).
+
+      2. [Create combined listing products in your store](https://help.shopify.com/en/manual/products/combined-listings-app#creating-a-combined-listing).
+
+      3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
   - type: INFO
     index: 2
     name: Configure combined listings behavior
@@ -84,10 +87,11 @@ steps:
     index: 4
     name: Update the ProductForm component
     description: >
-      - Update the `ProductForm` component to hide the `Add to cart` button for
-      the parent products of combined listings and for variants' selected state.
+      1. Update the `ProductForm` component to hide the **Add to cart** button
+      for the parent products of combined listings and for variants' selected
+      state.
 
-      - Update the `Link` component to not replace the current URL when the
+      2. Update the `Link` component to not replace the current URL when the
       product is a combined listing parent product.
     diffs:
       - file: app/components/ProductForm.tsx
@@ -124,9 +128,9 @@ steps:
     index: 8
     name: Update queries for combined listings
     description: >
-      - Add the `tags` property to the items returned by the product query.
+      1. Add the `tags` property to the items returned by the product query.
 
-      - (Optional) Add the filtering query to the product query to exclude
+      2. (Optional) Add the filtering query to the product query to exclude
       combined listings.
     diffs:
       - file: app/routes/_index.tsx
@@ -154,13 +158,13 @@ steps:
     index: 11
     name: Update the product page
     description: >
-      - Display a range of prices for combined listings instead of the variant
+      1. Display a range of prices for combined listings instead of the variant
       price.
 
-      - Show the featured image of the combined listing parent product instead
+      2. Show the featured image of the combined listing parent product instead
       of the variant image.
 
-      - (Optional) Redirect to the first variant of a combined listing when the
+      3. (Optional) Redirect to the first variant of a combined listing when the
       handle is requested.
     diffs:
       - file: app/routes/products.$handle.tsx
@@ -191,4 +195,4 @@ llms:
       solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
-commit: 2ff53492d0c9152bd59063ae6ea34576ea9a4608
+commit: b81c24730f207492216f2720691922bb3eed3b7b

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -37,7 +37,8 @@ requirements: >
   app](https://admin.shopify.com/apps/combined-listings) installed.
 ingredients:
   - path: templates/skeleton/app/lib/combined-listings.ts
-    description: The `combined-listings.ts` file contains utilities and settings for
+    description:
+      The `combined-listings.ts` file contains utilities and settings for
       handling combined listings.
 deletedFiles: []
 steps:
@@ -192,7 +193,8 @@ llms:
       variant price?
   troubleshooting:
     - issue: Combined listings are being displayed in the product list.
-      solution: Make sure to tag combined listing parent products in the Shopify admin
+      solution:
+        Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
-commit: b81c24730f207492216f2720691922bb3eed3b7b
+commit: 2ff53492d0c9152bd59063ae6ea34576ea9a4608

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -20,12 +20,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
-| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
-| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
-| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
-| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
-| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
+| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
+| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
+| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
+| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
+| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
+| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
 
 ## Steps
 
@@ -40,19 +40,19 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
-- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
-- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
-- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
-- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
-- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 ### Step 3: Render the selling plan in the cart
 
 1. Update `CartLineItem` to show subscription details when they're available.
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..a18e4b52 100644
@@ -101,7 +101,7 @@ index bd33a2cf..a18e4b52 100644
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -232,7 +232,7 @@ index e8616a61..8b7fe8ca 100644
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
-#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductPrice.tsx)
+#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/components/ProductPrice.tsx)
 
 <details>
 
@@ -355,7 +355,7 @@ index 32460ae2..59eed1d8 100644
 
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/lib/fragments.ts)
 
 ```diff
 index dc4426a9..cfe3a938 100644
@@ -393,7 +393,7 @@ index dc4426a9..cfe3a938 100644
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -600,7 +600,7 @@ index 2dc6bda2..3507d496 100644
 
 Add a `Subscriptions` link to the account menu.
 
-#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/account.tsx)
+#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/routes/account.tsx)
 
 ```diff
 index 0941d4e0..976ae9df 100644

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -2,9 +2,7 @@
 
 This recipe lets you sell subscription-based products on your Hydrogen storefront by implementing [selling plan groups](https://shopify.dev/docs/api/storefront/latest/objects/SellingPlanGroup). Your customers will be able to choose between one-time purchases or recurring subscriptions for any products with available selling plans.
 
-
 In this recipe you'll make the following changes:
-
 
 1. Set up a subscriptions app in your Shopify admin and add selling plans to any products that will be sold as subscriptions.
 2. Modify product detail pages to display subscription options with accurate pricing using the `SellingPlanSelector` component.
@@ -12,11 +10,9 @@ In this recipe you'll make the following changes:
 4. Display subscription details on applicable line items in the cart.
 5. Add a **Subscriptions** page where customers can manage their subscriptions, which includes the option to cancel active subscriptions.
 
-
 ## Requirements
 
 To implement subscriptions in your own store, you need to install a subscriptions app in your Shopify admin. In this recipe, we'll use the [Shopify Subscriptions app](https://apps.shopify.com/shopify-subscriptions).
-
 
 ## Ingredients
 
@@ -24,12 +20,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
-| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
-| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
-| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
-| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
-| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
+| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
+| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
+| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
+| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
+| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
+| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
 
 ## Steps
 
@@ -40,25 +36,23 @@ _New files added to the template by this recipe._
 3. On the [Products](https://admin.shopify.com/products) page, open any products that will be sold as subscriptions and add the relevant subscription plans in the **Purchase options** section.
 The Hydrogen demo storefront comes pre-configured with an example subscription product with the handle `shopify-wax`.
 
-
 ### Step 2: Add ingredients to your project
 
 Copy all the files found in the `ingredients/` directory into your project.
 
-- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
-- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
-- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
-- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
-- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
-- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 ### Step 3: Render the selling plan in the cart
 
 1. Update `CartLineItem` to show subscription details when they're available.
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
-
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..a18e4b52 100644
@@ -107,8 +101,7 @@ index bd33a2cf..a18e4b52 100644
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
-
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -239,8 +232,7 @@ index e8616a61..8b7fe8ca 100644
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
-
-#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/components/ProductPrice.tsx)
+#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/components/ProductPrice.tsx)
 
 <details>
 
@@ -363,8 +355,7 @@ index 32460ae2..59eed1d8 100644
 
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
-
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/lib/fragments.ts)
 
 ```diff
 index dc4426a9..cfe3a938 100644
@@ -402,8 +393,7 @@ index dc4426a9..cfe3a938 100644
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
-
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -610,8 +600,7 @@ index 2dc6bda2..3507d496 100644
 
 Add a `Subscriptions` link to the account menu.
 
-
-#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/a78a9f59352087b69475794057d4ccf9f5c08a6e/templates/skeleton/app/routes/account.tsx)
+#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/b81c24730f207492216f2720691922bb3eed3b7b/templates/skeleton/app/routes/account.tsx)
 
 ```diff
 index 0941d4e0..976ae9df 100644

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -139,12 +139,15 @@ llms:
     - How do I display subscription details on applicable line items in the cart?
   troubleshooting:
     - issue: I'm getting an error when I try to add a subscription to my storefront.
-      solution: Make sure you've installed the Shopify Subscriptions app and set up
+      solution:
+        Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
     - issue: I'm not seeing the subscription options on my product pages.
-      solution: Make sure you've installed the Shopify Subscriptions app and set up
+      solution:
+        Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
     - issue: I'm not seeing the subscription details on my cart line items.
-      solution: Make sure you've installed the Shopify Subscriptions app and set up
+      solution:
+        Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
-commit: b81c24730f207492216f2720691922bb3eed3b7b
+commit: a78a9f59352087b69475794057d4ccf9f5c08a6e

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -1,13 +1,12 @@
 # yaml-language-server: $schema=../../recipe.schema.json
 
+gid: f2158739-840f-4091-a375-fcefce7e0bab
 title: Subscriptions
 summary: Add subscription-based products to your Hydrogen storefront.
 description: |
   This recipe lets you sell subscription-based products on your Hydrogen storefront by implementing [selling plan groups](https://shopify.dev/docs/api/storefront/latest/objects/SellingPlanGroup). Your customers will be able to choose between one-time purchases or recurring subscriptions for any products with available selling plans.
 
-
   In this recipe you'll make the following changes:
-
 
   1. Set up a subscriptions app in your Shopify admin and add selling plans to any products that will be sold as subscriptions.
   2. Modify product detail pages to display subscription options with accurate pricing using the `SellingPlanSelector` component.
@@ -148,4 +147,4 @@ llms:
     - issue: I'm not seeing the subscription details on my cart line items.
       solution: Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
-commit: a78a9f59352087b69475794057d4ccf9f5c08a6e
+commit: b81c24730f207492216f2720691922bb3eed3b7b

--- a/cookbook/src/lib/generate.ts
+++ b/cookbook/src/lib/generate.ts
@@ -1,5 +1,5 @@
 import {execSync} from 'child_process';
-import {createHash} from 'crypto';
+import {createHash, randomUUID} from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import YAML from 'yaml';
@@ -109,6 +109,7 @@ export async function generateRecipe(
   const troubleshooting = existingRecipe?.llms.troubleshooting ?? [];
 
   const recipe: Recipe = {
+    gid: existingRecipe?.gid ?? randomUUID(),
     title: existingRecipe?.title ?? recipeName,
     summary: existingRecipe?.summary ?? '',
     description: existingRecipe?.description ?? '',

--- a/cookbook/src/lib/markdown.ts
+++ b/cookbook/src/lib/markdown.ts
@@ -262,7 +262,9 @@ export function serializeMDBlocksToFile(
   filePath: string,
   format: RenderFormat,
 ) {
-  let data = blocks.map((block) => renderMDBlock(block, format)).join('\n\n');
+  let data = blocks
+    .map((block) => renderMDBlock(block, format).trim())
+    .join('\n\n');
   if (format === 'shopify.dev') {
     data = data.replace(/\{\{/g, "{{ '{{' }}");
   }

--- a/cookbook/src/lib/markdown.ts
+++ b/cookbook/src/lib/markdown.ts
@@ -17,12 +17,17 @@ export function mdNote(text: string): MDNote {
 export type MDFrontMatter = {
   type: 'FRONTMATTER';
   data: Record<string, unknown>;
+  comments?: string[];
 };
 
-export function mdFrontMatter(data: Record<string, unknown>): MDFrontMatter {
+export function mdFrontMatter(
+  data: Record<string, unknown>,
+  comments?: string[],
+): MDFrontMatter {
   return {
     type: 'FRONTMATTER',
     data,
+    comments,
   };
 }
 
@@ -225,7 +230,12 @@ export function renderMDBlock(block: MDBlock, format: RenderFormat): string {
         })
         .join('\n');
 
-      return ['---', stringified, '---'].join('\n');
+      return [
+        '---',
+        ...(block.comments ?? []).map((comment) => `# ${comment}`),
+        stringified,
+        '---',
+      ].join('\n');
     case 'NOTE':
       return [
         '> [!NOTE]',

--- a/cookbook/src/lib/recipe.ts
+++ b/cookbook/src/lib/recipe.ts
@@ -50,6 +50,7 @@ export const TroubleshootingSchema = z.object({
 export type Troubleshooting = z.infer<typeof TroubleshootingSchema>;
 
 export const RecipeSchema = z.object({
+  gid: z.string().uuid().describe('The unique identifier of the recipe'),
   title: z.string().describe('The title of the recipe'),
   summary: z.string().describe('The summary of what the recipe does'),
   description: z.string().describe('The description of the recipe'),

--- a/cookbook/src/lib/render.ts
+++ b/cookbook/src/lib/render.ts
@@ -1,4 +1,3 @@
-import {randomUUID} from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import {
@@ -71,7 +70,7 @@ export function makeReadmeBlocks(
   recipe: Recipe,
   format: RenderFormat,
 ) {
-  const markdownTitle = makeTitle(recipe, format);
+  const markdownTitle = makeTitle(recipeName, recipe, format);
 
   const markdownDescription = mdParagraph(recipe.description);
 
@@ -265,14 +264,21 @@ export function renderStep(
   return markdownStep;
 }
 
-function makeTitle(recipe: Recipe, format: RenderFormat): MDBlock {
+function makeTitle(
+  recipeName: string,
+  recipe: Recipe,
+  format: RenderFormat,
+): MDBlock {
   switch (format) {
     case 'shopify.dev':
-      return mdFrontMatter({
-        gid: randomUUID(),
-        title: recipe.title,
-        description: recipe.summary,
-      });
+      return mdFrontMatter(
+        {
+          gid: recipe.gid,
+          title: `${recipe.title} in Hydrogen`,
+          description: recipe.summary,
+        },
+        [doNotEditComment(recipeName)],
+      );
     case 'github':
       return mdHeading(1, recipe.title);
     default:
@@ -295,4 +301,8 @@ function hydrogenRepoRecipeBaseURL(params: {
 }): string {
   const {recipeName, hash} = params;
   return hydrogenRepoFolderURL({path: `/cookbook/recipes/${recipeName}`, hash});
+}
+
+function doNotEditComment(recipeName: string): string {
+  return `DO NOT EDIT. This file is generated from the shopify/hydrogen repo from this source file: \`cookbook/recipes/${recipeName}/recipe.yaml\``;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The shopify.dev rendering needs some tweaking.

### WHAT is this pull request doing?

1. Include a consistent `gid` field to recipes, generated once and carried over regens
2. Remove redundant whitespaces from the rendered files
3. Include a disclaimer comment to the shopify.dev's frontmatter so it's clear the file is autogenerated and not meant to be edited manually

#### Post-merge steps

Regenerate the recipes in a followup PR.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
