### PR TITLE
Cookbook: substeps

### DIFF
--- a/cookbook/.cursor/rules/cookbook-recipe-bundles.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-bundles.mdc
@@ -177,7 +177,115 @@ export function BundledVariants({
 
 3. From the [**Bundles**](https://admin.shopify.com/apps/shopify-bundles/app) page, [create a new bundle](https://help.shopify.com/en/manual/products/bundles/shopify-bundles).
 
-### Step 2: Update the product fragment to query for bundles and display BundledVariants
+### Step 2: Create the BundleBadge component
+
+Create a new BundleBadge component to be displayed on bundle product listings.
+
+#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+
+<details>
+
+```tsx
+export function BundleBadge() {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        padding: '.5rem .75rem',
+        fontSize: '11px',
+        backgroundColor: '#10804c',
+        color: 'white',
+        top: '1rem',
+        right: '1rem',
+      }}
+    >
+      BUNDLE
+    </div>
+  );
+}
+
+```
+
+</details>
+
+### Step 3: Create a new BundledVariants component
+
+Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
+
+#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+
+<details>
+
+```tsx
+import {Link} from '@remix-run/react';
+import {Image} from '@shopify/hydrogen';
+import type {
+  ProductVariantComponent,
+  Image as ShopifyImage,
+} from '@shopify/hydrogen/storefront-api-types';
+
+export function BundledVariants({
+  variants,
+}: {
+  variants: ProductVariantComponent[];
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        paddingTop: '1rem',
+      }}
+    >
+      {variants
+        ?.map(({productVariant: bundledVariant, quantity}) => {
+          const url = `/products/${bundledVariant.product.handle}`;
+          return (
+            <Link
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                marginBottom: '.5rem',
+              }}
+              to={url}
+              key={bundledVariant.id}
+            >
+              <Image
+                alt={bundledVariant.title}
+                aspectRatio="1/1"
+                height={60}
+                loading="lazy"
+                width={60}
+                data={bundledVariant.image as ShopifyImage}
+              />
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  paddingLeft: '1rem',
+                }}
+              >
+                <small>
+                  {bundledVariant.product.title}
+                  {bundledVariant.title !== 'Default Title'
+                    ? `- ${bundledVariant.title}`
+                    : null}
+                </small>
+                <small>Qty: {quantity}</small>
+              </div>
+            </Link>
+          );
+        })
+        .filter(Boolean)}
+    </div>
+  );
+}
+
+```
+
+</details>
+
+### Step 4: Update the product fragment to query for bundles and display BundledVariants
 
 - Add the `requiresComponents` field to the `Product` fragment, which is used to identify bundled products.
 - Pass the `isBundle` flag to the `ProductImage` component.
@@ -294,7 +402,7 @@ export function BundledVariants({
        title
 ```
 
-### Step 3: Update the collections fragment to query for bundles
+### Step 5: Update the collections fragment to query for bundles
 
 Like the previous step, use the `requiresComponents` field to detect if the product item is a bundle.
 
@@ -344,7 +452,7 @@ Like the previous step, use the `requiresComponents` field to detect if the prod
    query Collection(
 ```
 
-### Step 4: Update the cart fragment to query for bundles
+### Step 6: Update the cart fragment to query for bundles
 
 Use the `requiresComponents` field to determine if a cart line item is a bundle.
 
@@ -402,7 +510,7 @@ Use the `requiresComponents` field to determine if a cart line item is a bundle.
    }
 ```
 
-### Step 5: Conditionally render the BundleBadge in cart line items
+### Step 7: Conditionally render the BundleBadge in cart line items
 
 If a product is a bundle, show the `BundleBadge` component in the cart line item.
 
@@ -450,7 +558,7 @@ If a product is a bundle, show the `BundleBadge` component in the cart line item
          <ul>
 ```
 
-### Step 6: Conditionally render "Add bundle to cart" in ProductForm
+### Step 8: Conditionally render "Add bundle to cart" in ProductForm
 
 If a product is a bundle, update the text of the product button.
 
@@ -484,7 +592,7 @@ If a product is a bundle, update the text of the product button.
    );
 ```
 
-### Step 7: Conditionally render the BundleBadge in ProductImage
+### Step 9: Conditionally render the BundleBadge in ProductImage
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductImage` component.
 
@@ -515,7 +623,7 @@ If a product is a bundle, show the `BundleBadge` component in the `ProductImage`
  }
 ```
 
-### Step 8: Conditionally render the BundleBadge in ProductItem
+### Step 10: Conditionally render the BundleBadge in ProductItem
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductItem` component.
 
@@ -590,7 +698,7 @@ If a product is a bundle, show the `BundleBadge` component in the `ProductItem` 
  }
 ```
 
-### Step 9: Add a product-image class to the app stylesheet
+### Step 11: Add a product-image class to the app stylesheet
 
 Make sure the bundle badge is positioned relative to the product image.
 

--- a/cookbook/.cursor/rules/cookbook-recipe-bundles.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-bundles.mdc
@@ -71,101 +71,8 @@ In this recipe, we'll use the [Shopify Bundles app](https://apps.shopify.com/sho
 
 ## New files added to the template by this recipe
 
-### templates/skeleton/app/components/BundleBadge.tsx
-
-A badge displayed on bundle product listings.
-
-```tsx
-export function BundleBadge() {
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        padding: '.5rem .75rem',
-        fontSize: '11px',
-        backgroundColor: '#10804c',
-        color: 'white',
-        top: '1rem',
-        right: '1rem',
-      }}
-    >
-      BUNDLE
-    </div>
-  );
-}
-
-```
-
-### templates/skeleton/app/components/BundledVariants.tsx
-
-A component that wraps the variants of a bundle product in a single product listing.
-
-```tsx
-import {Link} from '@remix-run/react';
-import {Image} from '@shopify/hydrogen';
-import type {
-  ProductVariantComponent,
-  Image as ShopifyImage,
-} from '@shopify/hydrogen/storefront-api-types';
-
-export function BundledVariants({
-  variants,
-}: {
-  variants: ProductVariantComponent[];
-}) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        paddingTop: '1rem',
-      }}
-    >
-      {variants
-        ?.map(({productVariant: bundledVariant, quantity}) => {
-          const url = `/products/${bundledVariant.product.handle}`;
-          return (
-            <Link
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                marginBottom: '.5rem',
-              }}
-              to={url}
-              key={bundledVariant.id}
-            >
-              <Image
-                alt={bundledVariant.title}
-                aspectRatio="1/1"
-                height={60}
-                loading="lazy"
-                width={60}
-                data={bundledVariant.image as ShopifyImage}
-              />
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  paddingLeft: '1rem',
-                }}
-              >
-                <small>
-                  {bundledVariant.product.title}
-                  {bundledVariant.title !== 'Default Title'
-                    ? `- ${bundledVariant.title}`
-                    : null}
-                </small>
-                <small>Qty: {quantity}</small>
-              </div>
-            </Link>
-          );
-        })
-        .filter(Boolean)}
-    </div>
-  );
-}
-
-```
+- app/components/BundleBadge.tsx
+- app/components/BundledVariants.tsx
 
 ## Steps
 
@@ -183,8 +90,6 @@ Create a new BundleBadge component to be displayed on bundle product listings.
 
 #### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
 
-<details>
-
 ```tsx
 export function BundleBadge() {
   return (
@@ -206,15 +111,11 @@ export function BundleBadge() {
 
 ```
 
-</details>
-
 ### Step 3: Create a new BundledVariants component
 
 Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
 
 #### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
-
-<details>
 
 ```tsx
 import {Link} from '@remix-run/react';
@@ -282,8 +183,6 @@ export function BundledVariants({
 }
 
 ```
-
-</details>
 
 ### Step 4: Update the product fragment to query for bundles and display BundledVariants
 

--- a/cookbook/.cursor/rules/cookbook-recipe-bundles.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-bundles.mdc
@@ -1,6 +1,5 @@
 ---
-description: |
-  Recipe for implementing "Bundles (bundles)" in a Hydrogen storefront. Display product bundles on your Hydrogen storefront.
+description: Recipe for implementing "Bundles (bundles)" in a Hydrogen storefront. Display product bundles on your Hydrogen storefront.
 globs: *
 alwaysApply: false
 ---
@@ -20,7 +19,6 @@ Please note that the recipe steps below are not necessarily ordered in the way t
 # Summary
 
 Display product bundles on your Hydrogen storefront.
-
 
 # User Intent Recognition
 
@@ -50,18 +48,19 @@ Here's the bundles recipe for the base Hydrogen skeleton template:
 
 ## Description
 
-This recipe adds special styling for product bundles on your Hydrogen storefront. Customers will see badges and relevant cover images for bundles when they're viewing product and collection pages.
-
+This recipe adds special styling for product bundles on your Hydrogen
+storefront. Customers will see badges and relevant cover images for bundles
+when they're viewing product and collection pages.
 
 In this recipe you'll make the following changes:
 
-
-1. Set up the Shopify Bundles app in your Shopify admin and create a new product bundle.
-
-2. Update the GraphQL fragments to query for bundles to identify bundled products.
-
-3. Update the product and collection templates to display badges on product listings, update the copy for the cart buttons, and display bundle-specific information on product and collection pages.
-
+1. Set up the Shopify Bundles app in your Shopify admin and create a new
+product bundle.
+2. Update the GraphQL fragments to query for bundles to identify bundled
+products.
+3. Update the product and collection templates to display badges on product
+listings, update the copy for the cart buttons, and display bundle-specific
+information on product and collection pages.
 4. Update the cart line item template to display the bundle badge as needed.
 
 ## Requirements
@@ -186,8 +185,9 @@ export function BundledVariants({
 
 ### Step 4: Update the product fragment to query for bundles and display BundledVariants
 
-- Add the `requiresComponents` field to the `Product` fragment, which is used to identify bundled products.
-- Pass the `isBundle` flag to the `ProductImage` component.
+1. Add the `requiresComponents` field to the `Product` fragment, which is
+used to identify bundled products.
+2. Pass the `isBundle` flag to the `ProductImage` component.
 
 #### File: /app/routes/products.$handle.tsx
 

--- a/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -62,48 +62,7 @@ In this recipe, you'll make the following changes:
 
 ## New files added to the template by this recipe
 
-### templates/skeleton/app/lib/combined-listings.ts
-
-The `combined-listings.ts` file contains utilities and settings for handling combined listings.
-
-```ts
-// Edit these values to customize combined listings' behavior
-export const combinedListingsSettings = {
-  // If true, loading the product page will redirect to the first variant
-  redirectToFirstVariant: false,
-  // The tag that indicates a combined listing
-  combinedListingTag: 'combined',
-  // If true, combined listings will not be shown in the product list
-  hideCombinedListingsFromProductList: true,
-};
-
-export const maybeFilterOutCombinedListingsQuery =
-  combinedListingsSettings.hideCombinedListingsFromProductList
-    ? `NOT tag:${combinedListingsSettings.combinedListingTag}`
-    : '';
-
-interface ProductWithTags {
-  tags: string[];
-}
-
-function isProductWithTags(u: unknown): u is ProductWithTags {
-  const maybe = u as ProductWithTags;
-  return (
-    u != null &&
-    typeof u === 'object' &&
-    'tags' in maybe &&
-    Array.isArray(maybe.tags)
-  );
-}
-
-export function isCombinedListing(product: unknown) {
-  return (
-    isProductWithTags(product) &&
-    product.tags.includes(combinedListingsSettings.combinedListingTag)
-  );
-}
-
-```
+- app/lib/combined-listings.ts
 
 ## Steps
 
@@ -139,8 +98,6 @@ Create a new `combined-listings.ts` file that contains utilities and settings fo
 
 #### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
-<details>
-
 ```ts
 // Edit these values to customize combined listings' behavior
 export const combinedListingsSettings = {
@@ -179,8 +136,6 @@ export function isCombinedListing(product: unknown) {
 }
 
 ```
-
-</details>
 
 ### Step 4: Update the ProductForm component
 

--- a/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -133,7 +133,56 @@ export const combinedListingsSettings = {
 };
 ```
 
-### Step 3: Update the ProductForm component
+### Step 3: Add combined listings utilities
+
+Create a new `combined-listings.ts` file that contains utilities and settings for handling combined listings.
+
+#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+
+<details>
+
+```ts
+// Edit these values to customize combined listings' behavior
+export const combinedListingsSettings = {
+  // If true, loading the product page will redirect to the first variant
+  redirectToFirstVariant: false,
+  // The tag that indicates a combined listing
+  combinedListingTag: 'combined',
+  // If true, combined listings will not be shown in the product list
+  hideCombinedListingsFromProductList: true,
+};
+
+export const maybeFilterOutCombinedListingsQuery =
+  combinedListingsSettings.hideCombinedListingsFromProductList
+    ? `NOT tag:${combinedListingsSettings.combinedListingTag}`
+    : '';
+
+interface ProductWithTags {
+  tags: string[];
+}
+
+function isProductWithTags(u: unknown): u is ProductWithTags {
+  const maybe = u as ProductWithTags;
+  return (
+    u != null &&
+    typeof u === 'object' &&
+    'tags' in maybe &&
+    Array.isArray(maybe.tags)
+  );
+}
+
+export function isCombinedListing(product: unknown) {
+  return (
+    isProductWithTags(product) &&
+    product.tags.includes(combinedListingsSettings.combinedListingTag)
+  );
+}
+
+```
+
+</details>
+
+### Step 4: Update the ProductForm component
 
 1. Update the `ProductForm` component to hide the **Add to cart** button for the parent products of combined listings and for variants' selected state.
 2. Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
@@ -234,7 +283,7 @@ export const combinedListingsSettings = {
  }
 ```
 
-### Step 4: Extend the ProductImage component
+### Step 5: Extend the ProductImage component
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
@@ -259,7 +308,7 @@ Update the `ProductImage` component to support images from both product variants
      return <div className="product-image" />;
 ```
 
-### Step 5: Show a range of prices for combined listings in ProductItem
+### Step 6: Show a range of prices for combined listings in ProductItem
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
@@ -297,7 +346,7 @@ Update `ProductItem.tsx` to show a range of prices for the combined listing pare
  }
 ```
 
-### Step 6: (Optional) Add redirect utility to first variant of a combined listing
+### Step 7: (Optional) Add redirect utility to first variant of a combined listing
 
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
@@ -337,7 +386,7 @@ If you want to redirect automatically to the first variant of a combined listing
 +}
 ```
 
-### Step 7: Update queries for combined listings
+### Step 8: Update queries for combined listings
 
 1. Add the `tags` property to the items returned by the product query.
 2. (Optional) Add the filtering query to the product query to exclude combined listings.
@@ -416,7 +465,7 @@ If you want to redirect automatically to the first variant of a combined listing
        }
 ```
 
-### Step 8: (Optional) Filter out combined listings from collections pages
+### Step 9: (Optional) Filter out combined listings from collections pages
 
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
@@ -481,7 +530,7 @@ Since it's not possible to directly apply query filters when retrieving collecti
            ...ProductItem
 ```
 
-### Step 9: (Optional) Filter out combined listings from the collections index page
+### Step 10: (Optional) Filter out combined listings from the collections index page
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
@@ -535,7 +584,7 @@ Update the `collections.all` route to filter out combined listings from the sear
        }
 ```
 
-### Step 10: Update the product page
+### Step 11: Update the product page
 
 1. Display a range of prices for combined listings instead of the variant price.
 2. Show the featured image of the combined listing parent product instead of the variant image.
@@ -670,7 +719,7 @@ Update the `collections.all` route to filter out combined listings from the sear
        optionValues {
 ```
 
-### Step 11: Update stylesheet
+### Step 12: Update stylesheet
 
 Add a class to the product item to show a range of prices for combined listings.
 

--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -517,58 +517,183 @@ Styles the `SellingPlanSelector` component.
 3. On the [Products](https://admin.shopify.com/products) page, open any products that will be sold as subscriptions and add the relevant subscription plans in the **Purchase options** section.
 The Hydrogen demo storefront comes pre-configured with an example subscription product with the handle `shopify-wax`.
 
-### Step 2: Render the selling plan in the cart
+### Step 2: Showing subscriptions in product pages
 
-1. Update `CartLineItem` to show subscription details when they're available.
-2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
+In this step we'll implement the ability to display and select subscriptions in product pages, alongside the existing one-off purchase options.
 
-#### File: /app/components/CartLineItem.tsx
+#### Step 2.1: Create a SellingPlanSelector component
 
-```diff
-@@ -3,8 +3,8 @@ import type {CartLayout} from '~/components/CartMain';
- import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
- import {useVariantUrl} from '~/lib/variants';
- import {Link} from '@remix-run/react';
--import {ProductPrice} from './ProductPrice';
--import {useAside} from './Aside';
-+import {ProductPrice} from '~/components/ProductPrice';
-+import {useAside} from '~/components/Aside';
- import type {CartApiQueryFragment} from 'storefrontapi.generated';
- 
- type CartLine = OptimisticCartLine<CartApiQueryFragment>;
-@@ -20,7 +20,9 @@ export function CartLineItem({
-   layout: CartLayout;
-   line: CartLine;
- }) {
--  const {id, merchandise} = line;
-+  // Get the selling plan allocation
-+  const {id, merchandise, sellingPlanAllocation} = line;
-+
-   const {product, title, image, selectedOptions} = merchandise;
-   const lineItemUrl = useVariantUrl(product.handle, selectedOptions);
-   const {close} = useAside();
-@@ -54,6 +56,12 @@ export function CartLineItem({
-         </Link>
-         <ProductPrice price={line?.cost?.totalAmount} />
-         <ul>
-+          {/* Optionally render the selling plan name if available */}
-+          {sellingPlanAllocation && (
-+            <li key={sellingPlanAllocation.sellingPlan.name}>
-+              <small>{sellingPlanAllocation.sellingPlan.name}</small>
-+            </li>
-+          )}
-           {selectedOptions.map((option) => (
-             <li key={option.name}>
-               <small>
+Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
+
+##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+
+<details>
+
+```tsx
+import type {
+  ProductFragment,
+  SellingPlanGroupFragment,
+  SellingPlanFragment,
+} from 'storefrontapi.generated';
+import {useMemo} from 'react';
+import {useLocation} from '@remix-run/react';
+
+/* Enriched sellingPlan type including isSelected and url */
+export type SellingPlan = SellingPlanFragment & {
+  isSelected: boolean;
+  url: string;
+};
+
+/* Enriched sellingPlanGroup type including enriched SellingPlan nodes */
+export type SellingPlanGroup = Omit<
+  SellingPlanGroupFragment,
+  'sellingPlans'
+> & {
+  sellingPlans: {
+    nodes: SellingPlan[];
+  };
+};
+
+/**
+ * A component that simplifies selecting sellingPlans subscription options
+ * @example Example use
+ * ```ts
+ *   <SellingPlanSelector
+ *     sellingPlanGroups={sellingPlanGroups}
+ *     selectedSellingPlanId={selectedSellingPlanId}
+ *   >
+ *     {({sellingPlanGroup}) => ( ...your sellingPlanGroup component )}
+ *  </SellingPlanSelector>
+ *  ```
+ **/
+export function SellingPlanSelector({
+  sellingPlanGroups,
+  selectedSellingPlan,
+  children,
+  paramKey = 'selling_plan',
+  selectedVariant,
+}: {
+  sellingPlanGroups: ProductFragment['sellingPlanGroups'];
+  selectedSellingPlan: SellingPlanFragment | null;
+  paramKey?: string;
+  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
+  children: (params: {
+    sellingPlanGroup: SellingPlanGroup;
+    selectedSellingPlan: SellingPlanFragment | null;
+  }) => React.ReactNode;
+}) {
+  const {search, pathname} = useLocation();
+  const params = new URLSearchParams(search);
+
+  const planAllocationIds: string[] =
+    selectedVariant?.sellingPlanAllocations.nodes.map(
+      (node) => node.sellingPlan.id,
+    ) ?? [];
+
+  return useMemo(
+    () =>
+      (sellingPlanGroups.nodes as SellingPlanGroup[])
+        // Filter out groups that don't have plans usable for the selected variant
+        .filter((group) => {
+          return group.sellingPlans.nodes.some((sellingPlan) =>
+            planAllocationIds.includes(sellingPlan.id),
+          );
+        })
+        .map((sellingPlanGroup) => {
+          // Augment each sellingPlan node with isSelected and url
+          const sellingPlans = sellingPlanGroup.sellingPlans.nodes
+            .map((sellingPlan: SellingPlan) => {
+              if (!sellingPlan?.id) {
+                console.warn(
+                  'SellingPlanSelector: sellingPlan.id is missing in the product query',
+                );
+                return null;
+              }
+
+              if (!sellingPlan.id) {
+                return null;
+              }
+
+              params.set(paramKey, sellingPlan.id);
+              sellingPlan.isSelected =
+                selectedSellingPlan?.id === sellingPlan.id;
+              sellingPlan.url = `${pathname}?${params.toString()}`;
+              return sellingPlan;
+            })
+            .filter(Boolean) as SellingPlan[];
+          sellingPlanGroup.sellingPlans.nodes = sellingPlans;
+          return children({sellingPlanGroup, selectedSellingPlan});
+        }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      sellingPlanGroups,
+      children,
+      selectedSellingPlan,
+      paramKey,
+      pathname,
+      selectedVariant,
+    ],
+  );
+}
+
 ```
 
-### Step 3: Update ProductForm to support subscriptions
+</details>
+
+#### Step 2.2: Add styles for the SellingPlanSelector component
+
+Add styles for the `SellingPlanSelector` component.
+
+##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+
+<details>
+
+```css
+.selling-plan-group {
+  margin-bottom: 1rem;
+}
+
+.selling-plan-group-title {
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.selling-plan {
+  border: 1px solid;
+  display: inline-block;
+  padding: 1rem;
+  margin-right: 0.5rem;
+  line-height: 1;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  border-bottom-width: 1.5px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.selling-plan:hover {
+  text-decoration: none;
+}
+
+.selling-plan.selected {
+  border-color: #6b7280; /* Equivalent to 'border-gray-500' */
+}
+
+.selling-plan.unselected {
+  border-color: #fafafa; /* Equivalent to 'border-neutral-50' */
+}
+
+```
+
+</details>
+
+#### Step 2.3: Update ProductForm to support subscriptions
 
 1. Add conditional rendering to display subscription options alongside the standard variant selectors.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
-#### File: /app/components/ProductForm.tsx
+##### File: /app/components/ProductForm.tsx
 
 ```diff
 @@ -6,14 +6,25 @@ import type {
@@ -687,12 +812,12 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 +}
 ```
 
-### Step 4: Update ProductPrice to display subscription pricing
+#### Step 2.4: Update ProductPrice to display subscription pricing
 
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
-#### File: /app/components/ProductPrice.tsx
+##### File: /app/components/ProductPrice.tsx
 
 ```diff
 @@ -1,13 +1,31 @@
@@ -804,46 +929,13 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 +}
 ```
 
-### Step 5: Add selling plan data to cart queries
-
-Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
-
-#### File: /app/lib/fragments.ts
-
-```diff
-@@ -54,6 +54,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
-         }
-       }
-     }
-+    sellingPlanAllocation {
-+      sellingPlan {
-+         name
-+      }
-+    }
-   }
-   fragment CartLineComponent on ComponentizableCartLine {
-     id
-@@ -104,6 +109,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
-         }
-       }
-     }
-+    sellingPlanAllocation {
-+      sellingPlan {
-+         name
-+      }
-+    }
-   }
-   fragment CartApiQuery on Cart {
-     updatedAt
-```
-
-### Step 6: Add SellingPlanSelector to product pages
+#### Step 2.5: Update the product page to display subscription options
 
 1. Add the `SellingPlanSelector` component to display subscription options on product pages.
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
-#### File: /app/routes/products.$handle.tsx
+##### File: /app/routes/products.$handle.tsx
 
 ```diff
 @@ -1,3 +1,5 @@
@@ -1039,11 +1131,365 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
  ` as const;
 ```
 
-### Step 7: Add a link to the Subscriptions page
+### Step 3: Subscriptions in the cart
+
+In this step we'll implement support for showing subscriptions info in the Cart lines.
+
+#### Step 3.1: Add selling plan data to cart queries
+
+Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
+
+##### File: /app/lib/fragments.ts
+
+```diff
+@@ -54,6 +54,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
+         }
+       }
+     }
++    sellingPlanAllocation {
++      sellingPlan {
++         name
++      }
++    }
+   }
+   fragment CartLineComponent on ComponentizableCartLine {
+     id
+@@ -104,6 +109,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
+         }
+       }
+     }
++    sellingPlanAllocation {
++      sellingPlan {
++         name
++      }
++    }
+   }
+   fragment CartApiQuery on Cart {
+     updatedAt
+```
+
+#### Step 3.2: Render the selling plan in the cart
+
+1. Update `CartLineItem` to show subscription details when they're available.
+2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
+
+##### File: /app/components/CartLineItem.tsx
+
+```diff
+@@ -3,8 +3,8 @@ import type {CartLayout} from '~/components/CartMain';
+ import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
+ import {useVariantUrl} from '~/lib/variants';
+ import {Link} from '@remix-run/react';
+-import {ProductPrice} from './ProductPrice';
+-import {useAside} from './Aside';
++import {ProductPrice} from '~/components/ProductPrice';
++import {useAside} from '~/components/Aside';
+ import type {CartApiQueryFragment} from 'storefrontapi.generated';
+ 
+ type CartLine = OptimisticCartLine<CartApiQueryFragment>;
+@@ -20,7 +20,9 @@ export function CartLineItem({
+   layout: CartLayout;
+   line: CartLine;
+ }) {
+-  const {id, merchandise} = line;
++  // Get the selling plan allocation
++  const {id, merchandise, sellingPlanAllocation} = line;
++
+   const {product, title, image, selectedOptions} = merchandise;
+   const lineItemUrl = useVariantUrl(product.handle, selectedOptions);
+   const {close} = useAside();
+@@ -54,6 +56,12 @@ export function CartLineItem({
+         </Link>
+         <ProductPrice price={line?.cost?.totalAmount} />
+         <ul>
++          {/* Optionally render the selling plan name if available */}
++          {sellingPlanAllocation && (
++            <li key={sellingPlanAllocation.sellingPlan.name}>
++              <small>{sellingPlanAllocation.sellingPlan.name}</small>
++            </li>
++          )}
+           {selectedOptions.map((option) => (
+             <li key={option.name}>
+               <small>
+```
+
+### Step 4: Managing account subscriptions
+
+In this step we'll implement support for unsubscribing from active subscriptions via an account subpage which lists existing subscription contracts.
+
+#### Step 4.1: Add queries to retrieve customer subscriptions
+
+Create GraphQL queries that retrieves the subscription info from the customer account client.
+
+##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+
+<details>
+
+```ts
+// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
+
+const SUBSCRIPTION_CONTRACT_FRAGMENT = `#graphql
+  fragment SubscriptionContract on SubscriptionContract {
+    id
+    status
+    createdAt
+    billingPolicy {
+      ...SubscriptionBillingPolicy
+    }
+  }
+  fragment SubscriptionBillingPolicy on SubscriptionBillingPolicy {
+    interval
+    intervalCount {
+      count
+      precision
+    }
+  }
+` as const;
+
+export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
+  query SubscriptionsContractsQuery {
+    customer {
+      subscriptionContracts(first: 100) {
+        nodes {
+          ...SubscriptionContract
+          lines(first: 100) {
+            nodes {
+              name
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+  ${SUBSCRIPTION_CONTRACT_FRAGMENT}
+` as const;
+
+```
+
+</details>
+
+#### Step 4.2: Add mutations to cancel customer subscriptions
+
+Create a GraqhQL mutation to cancel an existing subscription.
+
+##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+
+<details>
+
+```ts
+// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
+
+export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
+  mutation subscriptionContractCancel($subscriptionContractId: ID!) {
+    subscriptionContractCancel(subscriptionContractId: $subscriptionContractId) {
+      contract {
+        id
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+` as const;
+
+```
+
+</details>
+
+#### Step 4.3: Add an account subscriptions page
+
+Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
+
+##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+
+<details>
+
+```tsx
+import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
+import {
+  data,
+  LinksFunction,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from '@shopify/remix-oxygen';
+import {
+  useActionData,
+  useFetcher,
+  useLoaderData,
+  type MetaFunction,
+} from '@remix-run/react';
+import {SUBSCRIPTIONS_CONTRACTS_QUERY} from '../graphql/customer-account/CustomerSubscriptionsQuery';
+import {SUBSCRIPTION_CANCEL_MUTATION} from '../graphql/customer-account/CustomerSubscriptionsMutations';
+
+import accountSubscriptionsStyle from '~/styles/account-subscriptions.css?url';
+
+export type ActionResponse = {
+  error: string | null;
+};
+
+export const meta: MetaFunction = () => {
+  return [{title: 'Subscriptions'}];
+};
+
+export const links: LinksFunction = () => [
+  {rel: 'stylesheet', href: accountSubscriptionsStyle},
+];
+
+export async function loader({context}: LoaderFunctionArgs) {
+  await context.customerAccount.handleAuthStatus();
+
+  const {data: subscriptions} = await context.customerAccount.query(
+    SUBSCRIPTIONS_CONTRACTS_QUERY,
+  );
+
+  return {subscriptions};
+}
+
+export async function action({request, context}: ActionFunctionArgs) {
+  const {customerAccount} = context;
+
+  if (request.method !== 'DELETE') {
+    return data({error: 'Method not allowed'}, {status: 405});
+  }
+
+  const form = await request.formData();
+
+  try {
+    const subId = form.get('subId');
+
+    if (!subId) {
+      throw new Error('Subscription ID is required');
+    }
+
+    await customerAccount.mutate(SUBSCRIPTION_CANCEL_MUTATION, {
+      variables: {
+        subscriptionContractId: subId.toString(),
+      },
+    });
+
+    return {
+      error: null,
+    };
+  } catch (error: any) {
+    return data(
+      {
+        error: error.message,
+      },
+      {
+        status: 400,
+      },
+    );
+  }
+}
+
+export default function AccountProfile() {
+  const action = useActionData<ActionResponse>();
+
+  const {subscriptions} = useLoaderData<typeof loader>();
+
+  const fetcher = useFetcher();
+
+  return (
+    <div className="account-profile">
+      <h2>My subscriptions</h2>
+      {action?.error ? (
+        <p>
+          <mark>
+            <small>{action.error}</small>
+          </mark>
+        </p>
+      ) : null}
+      <div className="account-subscriptions">
+        {subscriptions?.customer?.subscriptionContracts.nodes.map(
+          (subscription) => {
+            const isBeingCancelled =
+              fetcher.state !== 'idle' &&
+              fetcher.formData?.get('subId') === subscription.id;
+            return (
+              <div key={subscription.id} className="subscription-row">
+                <div className="subscription-row-content">
+                  <div>
+                    {subscription.lines.nodes.map((line) => (
+                      <div key={line.id}>{line.name}</div>
+                    ))}
+                  </div>
+                  <div>
+                    Every{' '}
+                    <SubscriptionInterval
+                      billingPolicy={subscription.billingPolicy}
+                    />
+                  </div>
+                </div>
+                <div className="subscription-row-actions">
+                  <div
+                    className={
+                      subscription.status === 'ACTIVE'
+                        ? 'subscription-status-active'
+                        : 'subscription-status-inactive'
+                    }
+                  >
+                    {subscription.status}
+                  </div>
+                  {subscription.status === 'ACTIVE' && (
+                    <fetcher.Form key={subscription.id} method="DELETE">
+                      <input
+                        type="hidden"
+                        id="subId"
+                        name="subId"
+                        value={subscription.id}
+                      />
+                      <button type="submit" disabled={isBeingCancelled}>
+                        {isBeingCancelled ? 'Canceling' : 'Cancel subscription'}
+                      </button>
+                    </fetcher.Form>
+                  )}
+                </div>
+              </div>
+            );
+          },
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SubscriptionInterval({
+  billingPolicy,
+}: {
+  billingPolicy: SubscriptionBillingPolicyFragment;
+}) {
+  const count = billingPolicy.intervalCount?.count;
+  function getInterval() {
+    const suffix = count === 1 ? '' : 's';
+    switch (billingPolicy.interval) {
+      case 'DAY':
+        return 'day' + suffix;
+      case 'WEEK':
+        return 'week' + suffix;
+      case 'MONTH':
+        return 'month' + suffix;
+      case 'YEAR':
+        return 'year' + suffix;
+    }
+  }
+  return (
+    <span>
+      {count} {getInterval()}
+    </span>
+  );
+}
+
+```
+
+</details>
+
+#### Step 4.4: Add a link to the Subscriptions page in the account menu
 
 Add a `Subscriptions` link to the account menu.
 
-#### File: /app/routes/account.tsx
+##### File: /app/routes/account.tsx
 
 ```diff
 @@ -74,6 +74,10 @@ function AccountMenu() {
@@ -1058,5 +1504,52 @@ Add a `Subscriptions` link to the account menu.
      </nav>
    );
 ```
+
+#### Step 4.5: Add styles for the Subscriptions page
+
+Add styles for the Subscriptions page.
+
+##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+
+<details>
+
+```css
+.account-subscriptions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.account-subscriptions .subscription-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  border: 1px solid lightgray;
+  padding: 10px;
+}
+
+.account-subscriptions .subscription-row .subscription-row-content {
+  display: flex;
+  gap: 10px;
+  flex: 1;
+}
+
+.account-subscriptions .subscription-row .subscription-row-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.account-subscriptions .subscription-row .subscription-status-active {
+  color: green;
+}
+
+.account-subscriptions .subscription-row .subscription-status-inactive {
+  color: gray;
+}
+
+```
+
+</details>
 
 </recipe_implementation>

--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -63,450 +63,12 @@ To implement subscriptions in your own store, you need to install a subscription
 
 ## New files added to the template by this recipe
 
-### templates/skeleton/app/components/SellingPlanSelector.tsx
-
-Displays the available subscription options on product pages.
-
-```tsx
-import type {
-  ProductFragment,
-  SellingPlanGroupFragment,
-  SellingPlanFragment,
-} from 'storefrontapi.generated';
-import {useMemo} from 'react';
-import {useLocation} from '@remix-run/react';
-
-/* Enriched sellingPlan type including isSelected and url */
-export type SellingPlan = SellingPlanFragment & {
-  isSelected: boolean;
-  url: string;
-};
-
-/* Enriched sellingPlanGroup type including enriched SellingPlan nodes */
-export type SellingPlanGroup = Omit<
-  SellingPlanGroupFragment,
-  'sellingPlans'
-> & {
-  sellingPlans: {
-    nodes: SellingPlan[];
-  };
-};
-
-/**
- * A component that simplifies selecting sellingPlans subscription options
- * @example Example use
- * ```ts
- *   <SellingPlanSelector
- *     sellingPlanGroups={sellingPlanGroups}
- *     selectedSellingPlanId={selectedSellingPlanId}
- *   >
- *     {({sellingPlanGroup}) => ( ...your sellingPlanGroup component )}
- *  </SellingPlanSelector>
- *  ```
- **/
-export function SellingPlanSelector({
-  sellingPlanGroups,
-  selectedSellingPlan,
-  children,
-  paramKey = 'selling_plan',
-  selectedVariant,
-}: {
-  sellingPlanGroups: ProductFragment['sellingPlanGroups'];
-  selectedSellingPlan: SellingPlanFragment | null;
-  paramKey?: string;
-  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
-  children: (params: {
-    sellingPlanGroup: SellingPlanGroup;
-    selectedSellingPlan: SellingPlanFragment | null;
-  }) => React.ReactNode;
-}) {
-  const {search, pathname} = useLocation();
-  const params = new URLSearchParams(search);
-
-  const planAllocationIds: string[] =
-    selectedVariant?.sellingPlanAllocations.nodes.map(
-      (node) => node.sellingPlan.id,
-    ) ?? [];
-
-  return useMemo(
-    () =>
-      (sellingPlanGroups.nodes as SellingPlanGroup[])
-        // Filter out groups that don't have plans usable for the selected variant
-        .filter((group) => {
-          return group.sellingPlans.nodes.some((sellingPlan) =>
-            planAllocationIds.includes(sellingPlan.id),
-          );
-        })
-        .map((sellingPlanGroup) => {
-          // Augment each sellingPlan node with isSelected and url
-          const sellingPlans = sellingPlanGroup.sellingPlans.nodes
-            .map((sellingPlan: SellingPlan) => {
-              if (!sellingPlan?.id) {
-                console.warn(
-                  'SellingPlanSelector: sellingPlan.id is missing in the product query',
-                );
-                return null;
-              }
-
-              if (!sellingPlan.id) {
-                return null;
-              }
-
-              params.set(paramKey, sellingPlan.id);
-              sellingPlan.isSelected =
-                selectedSellingPlan?.id === sellingPlan.id;
-              sellingPlan.url = `${pathname}?${params.toString()}`;
-              return sellingPlan;
-            })
-            .filter(Boolean) as SellingPlan[];
-          sellingPlanGroup.sellingPlans.nodes = sellingPlans;
-          return children({sellingPlanGroup, selectedSellingPlan});
-        }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      sellingPlanGroups,
-      children,
-      selectedSellingPlan,
-      paramKey,
-      pathname,
-      selectedVariant,
-    ],
-  );
-}
-
-```
-
-### templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts
-
-Mutations for managing customer subscriptions.
-
-```ts
-// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
-
-export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
-  mutation subscriptionContractCancel($subscriptionContractId: ID!) {
-    subscriptionContractCancel(subscriptionContractId: $subscriptionContractId) {
-      contract {
-        id
-      }
-      userErrors {
-        field
-        message
-      }
-    }
-  }
-` as const;
-
-```
-
-### templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts
-
-Queries for managing customer subscriptions.
-
-```ts
-// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
-
-const SUBSCRIPTION_CONTRACT_FRAGMENT = `#graphql
-  fragment SubscriptionContract on SubscriptionContract {
-    id
-    status
-    createdAt
-    billingPolicy {
-      ...SubscriptionBillingPolicy
-    }
-  }
-  fragment SubscriptionBillingPolicy on SubscriptionBillingPolicy {
-    interval
-    intervalCount {
-      count
-      precision
-    }
-  }
-` as const;
-
-export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
-  query SubscriptionsContractsQuery {
-    customer {
-      subscriptionContracts(first: 100) {
-        nodes {
-          ...SubscriptionContract
-          lines(first: 100) {
-            nodes {
-              name
-              id
-            }
-          }
-        }
-      }
-    }
-  }
-  ${SUBSCRIPTION_CONTRACT_FRAGMENT}
-` as const;
-
-```
-
-### templates/skeleton/app/routes/account.subscriptions.tsx
-
-Subscriptions management page.
-
-```tsx
-import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
-import {
-  data,
-  LinksFunction,
-  type ActionFunctionArgs,
-  type LoaderFunctionArgs,
-} from '@shopify/remix-oxygen';
-import {
-  useActionData,
-  useFetcher,
-  useLoaderData,
-  type MetaFunction,
-} from '@remix-run/react';
-import {SUBSCRIPTIONS_CONTRACTS_QUERY} from '../graphql/customer-account/CustomerSubscriptionsQuery';
-import {SUBSCRIPTION_CANCEL_MUTATION} from '../graphql/customer-account/CustomerSubscriptionsMutations';
-
-import accountSubscriptionsStyle from '~/styles/account-subscriptions.css?url';
-
-export type ActionResponse = {
-  error: string | null;
-};
-
-export const meta: MetaFunction = () => {
-  return [{title: 'Subscriptions'}];
-};
-
-export const links: LinksFunction = () => [
-  {rel: 'stylesheet', href: accountSubscriptionsStyle},
-];
-
-export async function loader({context}: LoaderFunctionArgs) {
-  await context.customerAccount.handleAuthStatus();
-
-  const {data: subscriptions} = await context.customerAccount.query(
-    SUBSCRIPTIONS_CONTRACTS_QUERY,
-  );
-
-  return {subscriptions};
-}
-
-export async function action({request, context}: ActionFunctionArgs) {
-  const {customerAccount} = context;
-
-  if (request.method !== 'DELETE') {
-    return data({error: 'Method not allowed'}, {status: 405});
-  }
-
-  const form = await request.formData();
-
-  try {
-    const subId = form.get('subId');
-
-    if (!subId) {
-      throw new Error('Subscription ID is required');
-    }
-
-    await customerAccount.mutate(SUBSCRIPTION_CANCEL_MUTATION, {
-      variables: {
-        subscriptionContractId: subId.toString(),
-      },
-    });
-
-    return {
-      error: null,
-    };
-  } catch (error: any) {
-    return data(
-      {
-        error: error.message,
-      },
-      {
-        status: 400,
-      },
-    );
-  }
-}
-
-export default function AccountProfile() {
-  const action = useActionData<ActionResponse>();
-
-  const {subscriptions} = useLoaderData<typeof loader>();
-
-  const fetcher = useFetcher();
-
-  return (
-    <div className="account-profile">
-      <h2>My subscriptions</h2>
-      {action?.error ? (
-        <p>
-          <mark>
-            <small>{action.error}</small>
-          </mark>
-        </p>
-      ) : null}
-      <div className="account-subscriptions">
-        {subscriptions?.customer?.subscriptionContracts.nodes.map(
-          (subscription) => {
-            const isBeingCancelled =
-              fetcher.state !== 'idle' &&
-              fetcher.formData?.get('subId') === subscription.id;
-            return (
-              <div key={subscription.id} className="subscription-row">
-                <div className="subscription-row-content">
-                  <div>
-                    {subscription.lines.nodes.map((line) => (
-                      <div key={line.id}>{line.name}</div>
-                    ))}
-                  </div>
-                  <div>
-                    Every{' '}
-                    <SubscriptionInterval
-                      billingPolicy={subscription.billingPolicy}
-                    />
-                  </div>
-                </div>
-                <div className="subscription-row-actions">
-                  <div
-                    className={
-                      subscription.status === 'ACTIVE'
-                        ? 'subscription-status-active'
-                        : 'subscription-status-inactive'
-                    }
-                  >
-                    {subscription.status}
-                  </div>
-                  {subscription.status === 'ACTIVE' && (
-                    <fetcher.Form key={subscription.id} method="DELETE">
-                      <input
-                        type="hidden"
-                        id="subId"
-                        name="subId"
-                        value={subscription.id}
-                      />
-                      <button type="submit" disabled={isBeingCancelled}>
-                        {isBeingCancelled ? 'Canceling' : 'Cancel subscription'}
-                      </button>
-                    </fetcher.Form>
-                  )}
-                </div>
-              </div>
-            );
-          },
-        )}
-      </div>
-    </div>
-  );
-}
-
-function SubscriptionInterval({
-  billingPolicy,
-}: {
-  billingPolicy: SubscriptionBillingPolicyFragment;
-}) {
-  const count = billingPolicy.intervalCount?.count;
-  function getInterval() {
-    const suffix = count === 1 ? '' : 's';
-    switch (billingPolicy.interval) {
-      case 'DAY':
-        return 'day' + suffix;
-      case 'WEEK':
-        return 'week' + suffix;
-      case 'MONTH':
-        return 'month' + suffix;
-      case 'YEAR':
-        return 'year' + suffix;
-    }
-  }
-  return (
-    <span>
-      {count} {getInterval()}
-    </span>
-  );
-}
-
-```
-
-### templates/skeleton/app/styles/account-subscriptions.css
-
-Subscriptions management page styles.
-
-```css
-.account-subscriptions {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.account-subscriptions .subscription-row {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  border: 1px solid lightgray;
-  padding: 10px;
-}
-
-.account-subscriptions .subscription-row .subscription-row-content {
-  display: flex;
-  gap: 10px;
-  flex: 1;
-}
-
-.account-subscriptions .subscription-row .subscription-row-actions {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-}
-
-.account-subscriptions .subscription-row .subscription-status-active {
-  color: green;
-}
-
-.account-subscriptions .subscription-row .subscription-status-inactive {
-  color: gray;
-}
-
-```
-
-### templates/skeleton/app/styles/selling-plan.css
-
-Styles the `SellingPlanSelector` component.
-
-```css
-.selling-plan-group {
-  margin-bottom: 1rem;
-}
-
-.selling-plan-group-title {
-  font-weight: 500;
-  margin-bottom: 0.5rem;
-}
-
-.selling-plan {
-  border: 1px solid;
-  display: inline-block;
-  padding: 1rem;
-  margin-right: 0.5rem;
-  line-height: 1;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-  border-bottom-width: 1.5px;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.selling-plan:hover {
-  text-decoration: none;
-}
-
-.selling-plan.selected {
-  border-color: #6b7280; /* Equivalent to 'border-gray-500' */
-}
-
-.selling-plan.unselected {
-  border-color: #fafafa; /* Equivalent to 'border-neutral-50' */
-}
-
-```
+- app/components/SellingPlanSelector.tsx
+- app/graphql/customer-account/CustomerSubscriptionsMutations.ts
+- app/graphql/customer-account/CustomerSubscriptionsQuery.ts
+- app/routes/account.subscriptions.tsx
+- app/styles/account-subscriptions.css
+- app/styles/selling-plan.css
 
 ## Steps
 
@@ -527,8 +89,6 @@ Create a new `SellingPlanSelector` component that displays the available subscri
 
 ##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
 
-<details>
-
 ```tsx
 import type {
   ProductFragment,
@@ -638,15 +198,11 @@ export function SellingPlanSelector({
 
 ```
 
-</details>
-
 #### Step 2.2: Add styles for the SellingPlanSelector component
 
 Add styles for the `SellingPlanSelector` component.
 
 ##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
-
-<details>
 
 ```css
 .selling-plan-group {
@@ -684,8 +240,6 @@ Add styles for the `SellingPlanSelector` component.
 }
 
 ```
-
-</details>
 
 #### Step 2.3: Update ProductForm to support subscriptions
 
@@ -1223,8 +777,6 @@ Create GraphQL queries that retrieves the subscription info from the customer ac
 
 ##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
-<details>
-
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
 
@@ -1267,15 +819,11 @@ export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
 
 ```
 
-</details>
-
 #### Step 4.2: Add mutations to cancel customer subscriptions
 
 Create a GraqhQL mutation to cancel an existing subscription.
 
 ##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
-
-<details>
 
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
@@ -1296,15 +844,11 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 ```
 
-</details>
-
 #### Step 4.3: Add an account subscriptions page
 
 Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
 
 ##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
-
-<details>
 
 ```tsx
 import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
@@ -1483,8 +1027,6 @@ function SubscriptionInterval({
 
 ```
 
-</details>
-
 #### Step 4.4: Add a link to the Subscriptions page in the account menu
 
 Add a `Subscriptions` link to the account menu.
@@ -1510,8 +1052,6 @@ Add a `Subscriptions` link to the account menu.
 Add styles for the Subscriptions page.
 
 ##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
-
-<details>
 
 ```css
 .account-subscriptions {
@@ -1549,7 +1089,5 @@ Add styles for the Subscriptions page.
 }
 
 ```
-
-</details>
 
 </recipe_implementation>

--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -79,9 +79,9 @@ To implement subscriptions in your own store, you need to install a subscription
 3. On the [Products](https://admin.shopify.com/products) page, open any products that will be sold as subscriptions and add the relevant subscription plans in the **Purchase options** section.
 The Hydrogen demo storefront comes pre-configured with an example subscription product with the handle `shopify-wax`.
 
-### Step 2: Showing subscriptions in product pages
+### Step 2: Show subscription options on product pages
 
-In this step we'll implement the ability to display and select subscriptions in product pages, alongside the existing one-off purchase options.
+In this step we'll implement the ability to display subscription options on  product pages, alongside the existing one-off purchase options.
 
 #### Step 2.1: Create a SellingPlanSelector component
 
@@ -685,9 +685,9 @@ Add styles for the `SellingPlanSelector` component.
  ` as const;
 ```
 
-### Step 3: Subscriptions in the cart
+### Step 3: Show subscription details in the cart
 
-In this step we'll implement support for showing subscriptions info in the Cart lines.
+In this step we'll implement support for showing subscription info in the cart's line items.
 
 #### Step 3.1: Add selling plan data to cart queries
 
@@ -767,13 +767,13 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
                <small>
 ```
 
-### Step 4: Managing account subscriptions
+### Step 4: Add subscription management to the account page
 
-In this step we'll implement support for unsubscribing from active subscriptions via an account subpage which lists existing subscription contracts.
+In this step we'll implement support for subscription management through an account subpage that lists existing subscription contracts.
 
 #### Step 4.1: Add queries to retrieve customer subscriptions
 
-Create GraphQL queries that retrieves the subscription info from the customer account client.
+Create GraphQL queries that retrieve the subscription info from the customer account client.
 
 ##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
@@ -846,7 +846,7 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 #### Step 4.3: Add an account subscriptions page
 
-Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
+Create a new account subpage that lets customers manage their existing  subscriptions based on the new GraphQL queries and mutations.
 
 ##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
 

--- a/cookbook/recipe.schema.json
+++ b/cookbook/recipe.schema.json
@@ -77,13 +77,23 @@
             "enum": [
               "PATCH",
               "INFO",
-              "COPY_INGREDIENTS"
+              "COPY_INGREDIENTS",
+              "NEW_FILE"
             ],
             "description": "The type of step"
           },
-          "index": {
-            "type": "number",
-            "description": "The index of the step"
+          "step": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^\\d+(?:\\.\\d+)?$",
+                "description": "The step numerical representation, with optional substep if applicable"
+              }
+            ],
+            "description": "The step numerical representation, with optional substep if applicable"
           },
           "name": {
             "type": "string",
@@ -135,7 +145,7 @@
         },
         "required": [
           "type",
-          "index",
+          "step",
           "name"
         ],
         "additionalProperties": false

--- a/cookbook/recipe.schema.json
+++ b/cookbook/recipe.schema.json
@@ -77,7 +77,6 @@
             "enum": [
               "PATCH",
               "INFO",
-              "COPY_INGREDIENTS",
               "NEW_FILE"
             ],
             "description": "The type of step"

--- a/cookbook/recipes/bundles/README.md
+++ b/cookbook/recipes/bundles/README.md
@@ -25,8 +25,8 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
-| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
+| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
+| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
 
 ## Steps
 
@@ -38,19 +38,120 @@ _New files added to the template by this recipe._
 
 3. From the [**Bundles**](https://admin.shopify.com/apps/shopify-bundles/app) page, [create a new bundle](https://help.shopify.com/en/manual/products/bundles/shopify-bundles).
 
-### Step 2: Add ingredients to your project
+### Step 2: Create the BundleBadge component
 
-Copy all the files found in the `ingredients/` directory into your project.
+Create a new BundleBadge component to be displayed on bundle product listings.
 
-- [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
-- [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
 
-### Step 3: Update the product fragment to query for bundles and display BundledVariants
+<details>
+
+```tsx
+export function BundleBadge() {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        padding: '.5rem .75rem',
+        fontSize: '11px',
+        backgroundColor: '#10804c',
+        color: 'white',
+        top: '1rem',
+        right: '1rem',
+      }}
+    >
+      BUNDLE
+    </div>
+  );
+}
+
+```
+
+</details>
+
+### Step 3: Create a new BundledVariants component
+
+Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
+
+#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+
+<details>
+
+```tsx
+import {Link} from '@remix-run/react';
+import {Image} from '@shopify/hydrogen';
+import type {
+  ProductVariantComponent,
+  Image as ShopifyImage,
+} from '@shopify/hydrogen/storefront-api-types';
+
+export function BundledVariants({
+  variants,
+}: {
+  variants: ProductVariantComponent[];
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        paddingTop: '1rem',
+      }}
+    >
+      {variants
+        ?.map(({productVariant: bundledVariant, quantity}) => {
+          const url = `/products/${bundledVariant.product.handle}`;
+          return (
+            <Link
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                marginBottom: '.5rem',
+              }}
+              to={url}
+              key={bundledVariant.id}
+            >
+              <Image
+                alt={bundledVariant.title}
+                aspectRatio="1/1"
+                height={60}
+                loading="lazy"
+                width={60}
+                data={bundledVariant.image as ShopifyImage}
+              />
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  paddingLeft: '1rem',
+                }}
+              >
+                <small>
+                  {bundledVariant.product.title}
+                  {bundledVariant.title !== 'Default Title'
+                    ? `- ${bundledVariant.title}`
+                    : null}
+                </small>
+                <small>Qty: {quantity}</small>
+              </div>
+            </Link>
+          );
+        })
+        .filter(Boolean)}
+    </div>
+  );
+}
+
+```
+
+</details>
+
+### Step 4: Update the product fragment to query for bundles and display BundledVariants
 
 - Add the `requiresComponents` field to the `Product` fragment, which is used to identify bundled products.
 - Pass the `isBundle` flag to the `ProductImage` component.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -169,11 +270,11 @@ index 2dc6bda2..0339d128 100644
 
 </details>
 
-### Step 4: Update the collections fragment to query for bundles
+### Step 5: Update the collections fragment to query for bundles
 
 Like the previous step, use the `requiresComponents` field to detect if the product item is a bundle.
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/routes/collections.$handle.tsx)
 
 ```diff
 index f1d7fa3e..ae341f8a 100644
@@ -222,11 +323,11 @@ index f1d7fa3e..ae341f8a 100644
    query Collection(
 ```
 
-### Step 5: Update the cart fragment to query for bundles
+### Step 6: Update the cart fragment to query for bundles
 
 Use the `requiresComponents` field to determine if a cart line item is a bundle.
 
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/lib/fragments.ts)
 
 <details>
 
@@ -287,11 +388,11 @@ index dc4426a9..13cc34e5 100644
 
 </details>
 
-### Step 6: Conditionally render the BundleBadge in cart line items
+### Step 7: Conditionally render the BundleBadge in cart line items
 
 If a product is a bundle, show the `BundleBadge` component in the cart line item.
 
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..0790a6f2 100644
@@ -338,11 +439,11 @@ index bd33a2cf..0790a6f2 100644
          <ul>
 ```
 
-### Step 7: Conditionally render "Add bundle to cart" in ProductForm
+### Step 8: Conditionally render "Add bundle to cart" in ProductForm
 
 If a product is a bundle, update the text of the product button.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/ProductForm.tsx)
 
 ```diff
 index e8616a61..07a984dc 100644
@@ -375,11 +476,11 @@ index e8616a61..07a984dc 100644
    );
 ```
 
-### Step 8: Conditionally render the BundleBadge in ProductImage
+### Step 9: Conditionally render the BundleBadge in ProductImage
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductImage` component.
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..c16b947b 100644
@@ -409,11 +510,11 @@ index 5f3ac1cc..c16b947b 100644
  }
 ```
 
-### Step 9: Conditionally render the BundleBadge in ProductItem
+### Step 10: Conditionally render the BundleBadge in ProductItem
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductItem` component.
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/ProductItem.tsx)
 
 <details>
 
@@ -491,11 +592,11 @@ index 62c64b50..970916bd 100644
 
 </details>
 
-### Step 10: Add a product-image class to the app stylesheet
+### Step 11: Add a product-image class to the app stylesheet
 
 Make sure the bundle badge is positioned relative to the product image.
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..de48b6c6 100644

--- a/cookbook/recipes/bundles/README.md
+++ b/cookbook/recipes/bundles/README.md
@@ -1,17 +1,18 @@
 # Bundles
 
-This recipe adds special styling for product bundles on your Hydrogen storefront. Customers will see badges and relevant cover images for bundles when they're viewing product and collection pages.
-
+This recipe adds special styling for product bundles on your Hydrogen
+storefront. Customers will see badges and relevant cover images for bundles
+when they're viewing product and collection pages.
 
 In this recipe you'll make the following changes:
 
-
-1. Set up the Shopify Bundles app in your Shopify admin and create a new product bundle.
-
-2. Update the GraphQL fragments to query for bundles to identify bundled products.
-
-3. Update the product and collection templates to display badges on product listings, update the copy for the cart buttons, and display bundle-specific information on product and collection pages.
-
+1. Set up the Shopify Bundles app in your Shopify admin and create a new
+product bundle.
+2. Update the GraphQL fragments to query for bundles to identify bundled
+products.
+3. Update the product and collection templates to display badges on product
+listings, update the copy for the cart buttons, and display bundle-specific
+information on product and collection pages.
 4. Update the cart line item template to display the bundle badge as needed.
 
 ## Requirements
@@ -148,8 +149,9 @@ export function BundledVariants({
 
 ### Step 4: Update the product fragment to query for bundles and display BundledVariants
 
-- Add the `requiresComponents` field to the `Product` fragment, which is used to identify bundled products.
-- Pass the `isBundle` flag to the `ProductImage` component.
+1. Add the `requiresComponents` field to the `Product` fragment, which is
+used to identify bundled products.
+2. Pass the `isBundle` flag to the `ProductImage` component.
 
 #### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/routes/products.$handle.tsx)
 

--- a/cookbook/recipes/bundles/recipe.yaml
+++ b/cookbook/recipes/bundles/recipe.yaml
@@ -40,12 +40,13 @@ ingredients:
   - path: templates/skeleton/app/components/BundleBadge.tsx
     description: A badge displayed on bundle product listings.
   - path: templates/skeleton/app/components/BundledVariants.tsx
-    description: A component that wraps the variants of a bundle product in a single
+    description:
+      A component that wraps the variants of a bundle product in a single
       product listing.
 deletedFiles: []
 steps:
   - type: INFO
-    index: 1
+    step: 1
     name: Set up the Shopify Bundles app
     description: |
       1. Install the [Shopify Bundles app](https://apps.shopify.com/shopify-bundles) in your Shopify admin.
@@ -54,14 +55,14 @@ steps:
 
       3. From the [**Bundles**](https://admin.shopify.com/apps/shopify-bundles/app) page, [create a new bundle](https://help.shopify.com/en/manual/products/bundles/shopify-bundles).
   - type: COPY_INGREDIENTS
-    index: 2
+    step: 2
     name: Add ingredients to your project
     description: Copy all the files found in the `ingredients/` directory into your project.
     ingredients:
       - templates/skeleton/app/components/BundleBadge.tsx
       - templates/skeleton/app/components/BundledVariants.tsx
   - type: PATCH
-    index: 3
+    step: 3
     name: Update the product fragment to query for bundles and display
       BundledVariants
     description: >
@@ -73,7 +74,7 @@ steps:
       - file: app/routes/products.$handle.tsx
         patchFile: products.$handle.tsx.3e0b7e.patch
   - type: PATCH
-    index: 4
+    step: 4
     name: Update the collections fragment to query for bundles
     description: >
       Like the previous step, use the `requiresComponents` field to detect if
@@ -82,7 +83,7 @@ steps:
       - file: app/routes/collections.$handle.tsx
         patchFile: collections.$handle.tsx.951367.patch
   - type: PATCH
-    index: 5
+    step: 5
     name: Update the cart fragment to query for bundles
     description: >
       Use the `requiresComponents` field to determine if a cart line item is a
@@ -91,7 +92,7 @@ steps:
       - file: app/lib/fragments.ts
         patchFile: fragments.ts.e8eb04.patch
   - type: PATCH
-    index: 6
+    step: 6
     name: Conditionally render the BundleBadge in cart line items
     description: >
       If a product is a bundle, show the `BundleBadge` component in the cart
@@ -100,7 +101,7 @@ steps:
       - file: app/components/CartLineItem.tsx
         patchFile: CartLineItem.tsx.8e657b.patch
   - type: PATCH
-    index: 7
+    step: 7
     name: Conditionally render "Add bundle to cart" in ProductForm
     description: |
       If a product is a bundle, update the text of the product button.
@@ -108,7 +109,7 @@ steps:
       - file: app/components/ProductForm.tsx
         patchFile: ProductForm.tsx.8e409a.patch
   - type: PATCH
-    index: 8
+    step: 8
     name: Conditionally render the BundleBadge in ProductImage
     description: >
       If a product is a bundle, show the `BundleBadge` component in the
@@ -117,7 +118,7 @@ steps:
       - file: app/components/ProductImage.tsx
         patchFile: ProductImage.tsx.4e6c4c.patch
   - type: PATCH
-    index: 9
+    step: 9
     name: Conditionally render the BundleBadge in ProductItem
     description: >
       If a product is a bundle, show the `BundleBadge` component in the
@@ -126,7 +127,7 @@ steps:
       - file: app/components/ProductItem.tsx
         patchFile: ProductItem.tsx.8ddc67.patch
   - type: PATCH
-    index: 10
+    step: 10
     name: Add a product-image class to the app stylesheet
     description: |
       Make sure the bundle badge is positioned relative to the product image.
@@ -141,14 +142,17 @@ llms:
     - How do I detect if a product is a bundle?
   troubleshooting:
     - issue: I'm not seeing product bundles on my storefront.
-      solution: Make sure you've installed the Shopify Bundles app and set up product
+      solution:
+        Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin.
     - issue: I'm not seeing product bundle badges on product pages.
-      solution: Make sure you've installed the Shopify Bundles app and set up product
+      solution:
+        Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin. Then make sure you've updated the product
         fragment to query for bundles and display BundledVariants.
     - issue: I'm not seeing the product bundle badges on my cart line items.
-      solution: Make sure you've installed the Shopify Bundles app and set up product
+      solution:
+        Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin. Then make sure you've updated the cart
         fragment to query for bundles.
 commit: 24a6a51cb6f1790844b207a9ce42d70325043a3d

--- a/cookbook/recipes/bundles/recipe.yaml
+++ b/cookbook/recipes/bundles/recipe.yaml
@@ -54,15 +54,24 @@ steps:
       2. Make sure your store meets the [eligibility requirements](https://help.shopify.com/en/manual/products/bundles/eligibility-and-considerations).
 
       3. From the [**Bundles**](https://admin.shopify.com/apps/shopify-bundles/app) page, [create a new bundle](https://help.shopify.com/en/manual/products/bundles/shopify-bundles).
-  - type: COPY_INGREDIENTS
+  - type: NEW_FILE
     step: 2
-    name: Add ingredients to your project
-    description: Copy all the files found in the `ingredients/` directory into your project.
+    name: Create the BundleBadge component
+    description: >
+      Create a new BundleBadge component to be displayed on bundle product
+      listings.
     ingredients:
       - templates/skeleton/app/components/BundleBadge.tsx
+  - type: NEW_FILE
+    step: 3
+    name: Create a new BundledVariants component
+    description:
+      Create a new `BundledVariants` component that wraps the variants of
+      a bundle product in a single product listing.
+    ingredients:
       - templates/skeleton/app/components/BundledVariants.tsx
   - type: PATCH
-    step: 3
+    step: 4
     name: Update the product fragment to query for bundles and display
       BundledVariants
     description: >
@@ -74,7 +83,7 @@ steps:
       - file: app/routes/products.$handle.tsx
         patchFile: products.$handle.tsx.3e0b7e.patch
   - type: PATCH
-    step: 4
+    step: 5
     name: Update the collections fragment to query for bundles
     description: >
       Like the previous step, use the `requiresComponents` field to detect if
@@ -83,7 +92,7 @@ steps:
       - file: app/routes/collections.$handle.tsx
         patchFile: collections.$handle.tsx.951367.patch
   - type: PATCH
-    step: 5
+    step: 6
     name: Update the cart fragment to query for bundles
     description: >
       Use the `requiresComponents` field to determine if a cart line item is a
@@ -92,7 +101,7 @@ steps:
       - file: app/lib/fragments.ts
         patchFile: fragments.ts.e8eb04.patch
   - type: PATCH
-    step: 6
+    step: 7
     name: Conditionally render the BundleBadge in cart line items
     description: >
       If a product is a bundle, show the `BundleBadge` component in the cart
@@ -101,7 +110,7 @@ steps:
       - file: app/components/CartLineItem.tsx
         patchFile: CartLineItem.tsx.8e657b.patch
   - type: PATCH
-    step: 7
+    step: 8
     name: Conditionally render "Add bundle to cart" in ProductForm
     description: |
       If a product is a bundle, update the text of the product button.
@@ -109,7 +118,7 @@ steps:
       - file: app/components/ProductForm.tsx
         patchFile: ProductForm.tsx.8e409a.patch
   - type: PATCH
-    step: 8
+    step: 9
     name: Conditionally render the BundleBadge in ProductImage
     description: >
       If a product is a bundle, show the `BundleBadge` component in the
@@ -118,7 +127,7 @@ steps:
       - file: app/components/ProductImage.tsx
         patchFile: ProductImage.tsx.4e6c4c.patch
   - type: PATCH
-    step: 9
+    step: 10
     name: Conditionally render the BundleBadge in ProductItem
     description: >
       If a product is a bundle, show the `BundleBadge` component in the
@@ -127,7 +136,7 @@ steps:
       - file: app/components/ProductItem.tsx
         patchFile: ProductItem.tsx.8ddc67.patch
   - type: PATCH
-    step: 10
+    step: 11
     name: Add a product-image class to the app stylesheet
     description: |
       Make sure the bundle badge is positioned relative to the product image.
@@ -155,4 +164,4 @@ llms:
         Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin. Then make sure you've updated the cart
         fragment to query for bundles.
-commit: 24a6a51cb6f1790844b207a9ce42d70325043a3d
+commit: bd55b241191304945704c0b9ef278e945c55d3da

--- a/cookbook/recipes/bundles/recipe.yaml
+++ b/cookbook/recipes/bundles/recipe.yaml
@@ -40,8 +40,7 @@ ingredients:
   - path: templates/skeleton/app/components/BundleBadge.tsx
     description: A badge displayed on bundle product listings.
   - path: templates/skeleton/app/components/BundledVariants.tsx
-    description:
-      A component that wraps the variants of a bundle product in a single
+    description: A component that wraps the variants of a bundle product in a single
       product listing.
 deletedFiles: []
 steps:
@@ -65,8 +64,7 @@ steps:
   - type: NEW_FILE
     step: 3
     name: Create a new BundledVariants component
-    description:
-      Create a new `BundledVariants` component that wraps the variants of
+    description: Create a new `BundledVariants` component that wraps the variants of
       a bundle product in a single product listing.
     ingredients:
       - templates/skeleton/app/components/BundledVariants.tsx
@@ -151,17 +149,14 @@ llms:
     - How do I detect if a product is a bundle?
   troubleshooting:
     - issue: I'm not seeing product bundles on my storefront.
-      solution:
-        Make sure you've installed the Shopify Bundles app and set up product
+      solution: Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin.
     - issue: I'm not seeing product bundle badges on product pages.
-      solution:
-        Make sure you've installed the Shopify Bundles app and set up product
+      solution: Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin. Then make sure you've updated the product
         fragment to query for bundles and display BundledVariants.
     - issue: I'm not seeing the product bundle badges on my cart line items.
-      solution:
-        Make sure you've installed the Shopify Bundles app and set up product
+      solution: Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin. Then make sure you've updated the cart
         fragment to query for bundles.
 commit: bd55b241191304945704c0b9ef278e945c55d3da

--- a/cookbook/recipes/bundles/recipe.yaml
+++ b/cookbook/recipes/bundles/recipe.yaml
@@ -2,32 +2,21 @@
 
 gid: 8495ffc3-e69c-431a-ac0b-1abb16ab50a2
 title: Bundles
-summary: |
-  Display product bundles on your Hydrogen storefront.
-description: >
+summary: Display product bundles on your Hydrogen storefront.
+description: |
   This recipe adds special styling for product bundles on your Hydrogen
   storefront. Customers will see badges and relevant cover images for bundles
   when they're viewing product and collection pages.
 
-
-
   In this recipe you'll make the following changes:
-
-
 
   1. Set up the Shopify Bundles app in your Shopify admin and create a new
   product bundle.
-
-
   2. Update the GraphQL fragments to query for bundles to identify bundled
   products.
-
-
   3. Update the product and collection templates to display badges on product
   listings, update the copy for the cart buttons, and display bundle-specific
   information on product and collection pages.
-
-
   4. Update the cart line item template to display the bundle badge as needed.
 notes: []
 requirements: >
@@ -72,11 +61,10 @@ steps:
     step: 4
     name: Update the product fragment to query for bundles and display
       BundledVariants
-    description: >
-      - Add the `requiresComponents` field to the `Product` fragment, which is
+    description: |
+      1. Add the `requiresComponents` field to the `Product` fragment, which is
       used to identify bundled products.
-
-      - Pass the `isBundle` flag to the `ProductImage` component.
+      2. Pass the `isBundle` flag to the `ProductImage` component.
     diffs:
       - file: app/routes/products.$handle.tsx
         patchFile: products.$handle.tsx.3e0b7e.patch

--- a/cookbook/recipes/combined-listings/README.md
+++ b/cookbook/recipes/combined-listings/README.md
@@ -21,7 +21,7 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
+| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
 
 ## Steps
 
@@ -51,18 +51,61 @@ export const combinedListingsSettings = {
 };
 ```
 
-### Step 3: Add ingredients to your project
+### Step 3: Add combined listings utilities
 
-Copy all the files found in the `ingredients/` directory into your project.
+Create a new `combined-listings.ts` file that contains utilities and settings for handling combined listings.
 
-- [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+
+<details>
+
+```ts
+// Edit these values to customize combined listings' behavior
+export const combinedListingsSettings = {
+  // If true, loading the product page will redirect to the first variant
+  redirectToFirstVariant: false,
+  // The tag that indicates a combined listing
+  combinedListingTag: 'combined',
+  // If true, combined listings will not be shown in the product list
+  hideCombinedListingsFromProductList: true,
+};
+
+export const maybeFilterOutCombinedListingsQuery =
+  combinedListingsSettings.hideCombinedListingsFromProductList
+    ? `NOT tag:${combinedListingsSettings.combinedListingTag}`
+    : '';
+
+interface ProductWithTags {
+  tags: string[];
+}
+
+function isProductWithTags(u: unknown): u is ProductWithTags {
+  const maybe = u as ProductWithTags;
+  return (
+    u != null &&
+    typeof u === 'object' &&
+    'tags' in maybe &&
+    Array.isArray(maybe.tags)
+  );
+}
+
+export function isCombinedListing(product: unknown) {
+  return (
+    isProductWithTags(product) &&
+    product.tags.includes(combinedListingsSettings.combinedListingTag)
+  );
+}
+
+```
+
+</details>
 
 ### Step 4: Update the ProductForm component
 
 1. Update the `ProductForm` component to hide the **Add to cart** button for the parent products of combined listings and for variants' selected state.
 2. Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -169,7 +212,7 @@ index e8616a61..b6567c21 100644
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..f1c9f2cd 100644
@@ -197,7 +240,7 @@ index 5f3ac1cc..f1c9f2cd 100644
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 62c64b50..034b5660 100644
@@ -238,7 +281,7 @@ index 62c64b50..034b5660 100644
 
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
-#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/lib/redirect.ts)
+#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/lib/redirect.ts)
 
 ```diff
 index ce1feb5a..29fe2ecc 100644
@@ -282,7 +325,7 @@ index ce1feb5a..29fe2ecc 100644
 1. Add the `tags` property to the items returned by the product query.
 2. (Optional) Add the filtering query to the product query to exclude combined listings.
 
-#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/routes/_index.tsx)
+#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/routes/_index.tsx)
 
 <details>
 
@@ -367,7 +410,7 @@ index 34747528..6e485083 100644
 
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/routes/collections.$handle.tsx)
 
 <details>
 
@@ -439,7 +482,7 @@ index f1d7fa3e..17edfb7d 100644
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
-#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/routes/collections.all.tsx)
+#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/routes/collections.all.tsx)
 
 ```diff
 index 3a31b2f7..c756c9e1 100644
@@ -498,7 +541,7 @@ index 3a31b2f7..c756c9e1 100644
 2. Show the featured image of the combined listing parent product instead of the variant image.
 3. (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -638,7 +681,7 @@ index 2dc6bda2..8baafac9 100644
 
 Add a class to the product item to show a range of prices for combined listings.
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..c8fa5109 100644

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -37,8 +37,7 @@ requirements: >
   app](https://admin.shopify.com/apps/combined-listings) installed.
 ingredients:
   - path: templates/skeleton/app/lib/combined-listings.ts
-    description:
-      The `combined-listings.ts` file contains utilities and settings for
+    description: The `combined-listings.ts` file contains utilities and settings for
       handling combined listings.
 deletedFiles: []
 steps:
@@ -78,10 +77,11 @@ steps:
       };
 
       ```
-  - type: COPY_INGREDIENTS
+  - type: NEW_FILE
     step: 3
-    name: Add ingredients to your project
-    description: Copy all the files found in the `ingredients/` directory into your project.
+    name: Add combined listings utilities
+    description: Create a new `combined-listings.ts` file that contains utilities
+      and settings for handling combined listings.
     ingredients:
       - templates/skeleton/app/lib/combined-listings.ts
   - type: PATCH
@@ -193,8 +193,7 @@ llms:
       variant price?
   troubleshooting:
     - issue: Combined listings are being displayed in the product list.
-      solution:
-        Make sure to tag combined listing parent products in the Shopify admin
+      solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
-commit: 24a6a51cb6f1790844b207a9ce42d70325043a3d
+commit: bd55b241191304945704c0b9ef278e945c55d3da

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -37,12 +37,13 @@ requirements: >
   app](https://admin.shopify.com/apps/combined-listings) installed.
 ingredients:
   - path: templates/skeleton/app/lib/combined-listings.ts
-    description: The `combined-listings.ts` file contains utilities and settings for
+    description:
+      The `combined-listings.ts` file contains utilities and settings for
       handling combined listings.
 deletedFiles: []
 steps:
   - type: INFO
-    index: 1
+    step: 1
     name: Set up the Combined Listings app
     description: |
       1. Install the [Combined Listings app](https://admin.shopify.com/apps/combined-listings).
@@ -51,7 +52,7 @@ steps:
 
       3. Add tags to the parent products of combined listings to indicate that they're part of a combined listing (for example `combined`).
   - type: INFO
-    index: 2
+    step: 2
     name: Configure combined listings behavior
     description: >
       You can customize how the parent products of combined listings are
@@ -78,13 +79,13 @@ steps:
 
       ```
   - type: COPY_INGREDIENTS
-    index: 3
+    step: 3
     name: Add ingredients to your project
     description: Copy all the files found in the `ingredients/` directory into your project.
     ingredients:
       - templates/skeleton/app/lib/combined-listings.ts
   - type: PATCH
-    index: 4
+    step: 4
     name: Update the ProductForm component
     description: >
       1. Update the `ProductForm` component to hide the **Add to cart** button
@@ -97,7 +98,7 @@ steps:
       - file: app/components/ProductForm.tsx
         patchFile: ProductForm.tsx.8e409a.patch
   - type: PATCH
-    index: 5
+    step: 5
     name: Extend the ProductImage component
     description: >
       Update the `ProductImage` component to support images from both product
@@ -106,7 +107,7 @@ steps:
       - file: app/components/ProductImage.tsx
         patchFile: ProductImage.tsx.4e6c4c.patch
   - type: PATCH
-    index: 6
+    step: 6
     name: Show a range of prices for combined listings in ProductItem
     description: >
       Update `ProductItem.tsx` to show a range of prices for the combined
@@ -115,7 +116,7 @@ steps:
       - file: app/components/ProductItem.tsx
         patchFile: ProductItem.tsx.8ddc67.patch
   - type: PATCH
-    index: 7
+    step: 7
     name: (Optional) Add redirect utility to first variant of a combined listing
     description: >
       If you want to redirect automatically to the first variant of a combined
@@ -125,7 +126,7 @@ steps:
       - file: app/lib/redirect.ts
         patchFile: redirect.ts.1e6242.patch
   - type: PATCH
-    index: 8
+    step: 8
     name: Update queries for combined listings
     description: >
       1. Add the `tags` property to the items returned by the product query.
@@ -136,7 +137,7 @@ steps:
       - file: app/routes/_index.tsx
         patchFile: _index.tsx.8041d5.patch
   - type: PATCH
-    index: 9
+    step: 9
     name: (Optional) Filter out combined listings from collections pages
     description: >
       Since it's not possible to directly apply query filters when retrieving
@@ -146,7 +147,7 @@ steps:
       - file: app/routes/collections.$handle.tsx
         patchFile: collections.$handle.tsx.951367.patch
   - type: PATCH
-    index: 10
+    step: 10
     name: (Optional) Filter out combined listings from the collections index page
     description: >
       Update the `collections.all` route to filter out combined listings from
@@ -155,7 +156,7 @@ steps:
       - file: app/routes/collections.all.tsx
         patchFile: collections.all.tsx.75880b.patch
   - type: PATCH
-    index: 11
+    step: 11
     name: Update the product page
     description: >
       1. Display a range of prices for combined listings instead of the variant
@@ -170,7 +171,7 @@ steps:
       - file: app/routes/products.$handle.tsx
         patchFile: products.$handle.tsx.3e0b7e.patch
   - type: PATCH
-    index: 12
+    step: 12
     name: Update stylesheet
     description: >
       Add a class to the product item to show a range of prices for combined
@@ -192,7 +193,8 @@ llms:
       variant price?
   troubleshooting:
     - issue: Combined listings are being displayed in the product list.
-      solution: Make sure to tag combined listing parent products in the Shopify admin
+      solution:
+        Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
 commit: 24a6a51cb6f1790844b207a9ce42d70325043a3d

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -20,12 +20,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
-| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
-| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
-| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
-| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
-| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
+| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
+| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
+| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
+| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
+| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
+| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
 
 ## Steps
 
@@ -36,72 +36,183 @@ _New files added to the template by this recipe._
 3. On the [Products](https://admin.shopify.com/products) page, open any products that will be sold as subscriptions and add the relevant subscription plans in the **Purchase options** section.
 The Hydrogen demo storefront comes pre-configured with an example subscription product with the handle `shopify-wax`.
 
-### Step 2: Add ingredients to your project
+### Step 2: Showing subscriptions in product pages
 
-Copy all the files found in the `ingredients/` directory into your project.
+In this step we'll implement the ability to display and select subscriptions in product pages, alongside the existing one-off purchase options.
 
-- [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
-- [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
-- [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
-- [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
-- [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
-- [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+#### Step 2.1: Create a SellingPlanSelector component
 
-### Step 3: Render the selling plan in the cart
+Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
 
-1. Update `CartLineItem` to show subscription details when they're available.
-2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
+#### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
 
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/CartLineItem.tsx)
+<details>
 
-```diff
-index bd33a2cf..a18e4b52 100644
---- a/templates/skeleton/app/components/CartLineItem.tsx
-+++ b/templates/skeleton/app/components/CartLineItem.tsx
-@@ -3,8 +3,8 @@ import type {CartLayout} from '~/components/CartMain';
- import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
- import {useVariantUrl} from '~/lib/variants';
- import {Link} from '@remix-run/react';
--import {ProductPrice} from './ProductPrice';
--import {useAside} from './Aside';
-+import {ProductPrice} from '~/components/ProductPrice';
-+import {useAside} from '~/components/Aside';
- import type {CartApiQueryFragment} from 'storefrontapi.generated';
- 
- type CartLine = OptimisticCartLine<CartApiQueryFragment>;
-@@ -20,7 +20,9 @@ export function CartLineItem({
-   layout: CartLayout;
-   line: CartLine;
- }) {
--  const {id, merchandise} = line;
-+  // Get the selling plan allocation
-+  const {id, merchandise, sellingPlanAllocation} = line;
-+
-   const {product, title, image, selectedOptions} = merchandise;
-   const lineItemUrl = useVariantUrl(product.handle, selectedOptions);
-   const {close} = useAside();
-@@ -54,6 +56,12 @@ export function CartLineItem({
-         </Link>
-         <ProductPrice price={line?.cost?.totalAmount} />
-         <ul>
-+          {/* Optionally render the selling plan name if available */}
-+          {sellingPlanAllocation && (
-+            <li key={sellingPlanAllocation.sellingPlan.name}>
-+              <small>{sellingPlanAllocation.sellingPlan.name}</small>
-+            </li>
-+          )}
-           {selectedOptions.map((option) => (
-             <li key={option.name}>
-               <small>
+```tsx
+import type {
+  ProductFragment,
+  SellingPlanGroupFragment,
+  SellingPlanFragment,
+} from 'storefrontapi.generated';
+import {useMemo} from 'react';
+import {useLocation} from '@remix-run/react';
+
+/* Enriched sellingPlan type including isSelected and url */
+export type SellingPlan = SellingPlanFragment & {
+  isSelected: boolean;
+  url: string;
+};
+
+/* Enriched sellingPlanGroup type including enriched SellingPlan nodes */
+export type SellingPlanGroup = Omit<
+  SellingPlanGroupFragment,
+  'sellingPlans'
+> & {
+  sellingPlans: {
+    nodes: SellingPlan[];
+  };
+};
+
+/**
+ * A component that simplifies selecting sellingPlans subscription options
+ * @example Example use
+ * ```ts
+ *   <SellingPlanSelector
+ *     sellingPlanGroups={sellingPlanGroups}
+ *     selectedSellingPlanId={selectedSellingPlanId}
+ *   >
+ *     {({sellingPlanGroup}) => ( ...your sellingPlanGroup component )}
+ *  </SellingPlanSelector>
+ *  ```
+ **/
+export function SellingPlanSelector({
+  sellingPlanGroups,
+  selectedSellingPlan,
+  children,
+  paramKey = 'selling_plan',
+  selectedVariant,
+}: {
+  sellingPlanGroups: ProductFragment['sellingPlanGroups'];
+  selectedSellingPlan: SellingPlanFragment | null;
+  paramKey?: string;
+  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
+  children: (params: {
+    sellingPlanGroup: SellingPlanGroup;
+    selectedSellingPlan: SellingPlanFragment | null;
+  }) => React.ReactNode;
+}) {
+  const {search, pathname} = useLocation();
+  const params = new URLSearchParams(search);
+
+  const planAllocationIds: string[] =
+    selectedVariant?.sellingPlanAllocations.nodes.map(
+      (node) => node.sellingPlan.id,
+    ) ?? [];
+
+  return useMemo(
+    () =>
+      (sellingPlanGroups.nodes as SellingPlanGroup[])
+        // Filter out groups that don't have plans usable for the selected variant
+        .filter((group) => {
+          return group.sellingPlans.nodes.some((sellingPlan) =>
+            planAllocationIds.includes(sellingPlan.id),
+          );
+        })
+        .map((sellingPlanGroup) => {
+          // Augment each sellingPlan node with isSelected and url
+          const sellingPlans = sellingPlanGroup.sellingPlans.nodes
+            .map((sellingPlan: SellingPlan) => {
+              if (!sellingPlan?.id) {
+                console.warn(
+                  'SellingPlanSelector: sellingPlan.id is missing in the product query',
+                );
+                return null;
+              }
+
+              if (!sellingPlan.id) {
+                return null;
+              }
+
+              params.set(paramKey, sellingPlan.id);
+              sellingPlan.isSelected =
+                selectedSellingPlan?.id === sellingPlan.id;
+              sellingPlan.url = `${pathname}?${params.toString()}`;
+              return sellingPlan;
+            })
+            .filter(Boolean) as SellingPlan[];
+          sellingPlanGroup.sellingPlans.nodes = sellingPlans;
+          return children({sellingPlanGroup, selectedSellingPlan});
+        }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      sellingPlanGroups,
+      children,
+      selectedSellingPlan,
+      paramKey,
+      pathname,
+      selectedVariant,
+    ],
+  );
+}
+
 ```
 
-### Step 4: Update ProductForm to support subscriptions
+</details>
+
+#### Step 2.2: Add styles for the SellingPlanSelector component
+
+Add styles for the `SellingPlanSelector` component.
+
+#### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css/ingredients/templates/skeleton/app/styles/selling-plan.css)
+
+<details>
+
+```css
+.selling-plan-group {
+  margin-bottom: 1rem;
+}
+
+.selling-plan-group-title {
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.selling-plan {
+  border: 1px solid;
+  display: inline-block;
+  padding: 1rem;
+  margin-right: 0.5rem;
+  line-height: 1;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  border-bottom-width: 1.5px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.selling-plan:hover {
+  text-decoration: none;
+}
+
+.selling-plan.selected {
+  border-color: #6b7280; /* Equivalent to 'border-gray-500' */
+}
+
+.selling-plan.unselected {
+  border-color: #fafafa; /* Equivalent to 'border-neutral-50' */
+}
+
+```
+
+</details>
+
+#### Step 2.3: Update ProductForm to support subscriptions
 
 1. Add conditional rendering to display subscription options alongside the standard variant selectors.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/ProductForm.tsx)
+##### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -227,12 +338,12 @@ index e8616a61..8b7fe8ca 100644
 
 </details>
 
-### Step 5: Update ProductPrice to display subscription pricing
+#### Step 2.4: Update ProductPrice to display subscription pricing
 
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
-#### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/components/ProductPrice.tsx)
+##### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/ProductPrice.tsx)
 
 <details>
 
@@ -351,49 +462,13 @@ index 32460ae2..59eed1d8 100644
 
 </details>
 
-### Step 6: Add selling plan data to cart queries
-
-Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
-
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/lib/fragments.ts)
-
-```diff
-index dc4426a9..cfe3a938 100644
---- a/templates/skeleton/app/lib/fragments.ts
-+++ b/templates/skeleton/app/lib/fragments.ts
-@@ -54,6 +54,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
-         }
-       }
-     }
-+    sellingPlanAllocation {
-+      sellingPlan {
-+         name
-+      }
-+    }
-   }
-   fragment CartLineComponent on ComponentizableCartLine {
-     id
-@@ -104,6 +109,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
-         }
-       }
-     }
-+    sellingPlanAllocation {
-+      sellingPlan {
-+         name
-+      }
-+    }
-   }
-   fragment CartApiQuery on Cart {
-     updatedAt
-```
-
-### Step 7: Add SellingPlanSelector to product pages
+#### Step 2.5: Update the product page to display subscription options
 
 1. Add the `SellingPlanSelector` component to display subscription options on product pages.
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/routes/products.$handle.tsx)
+##### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -596,11 +671,371 @@ index 2dc6bda2..3507d496 100644
 
 </details>
 
-### Step 8: Add a link to the Subscriptions page
+### Step 3: Subscriptions in the cart
+
+In this step we'll implement support for showing subscriptions info in the Cart lines.
+
+#### Step 3.1: Add selling plan data to cart queries
+
+Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
+
+##### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/lib/fragments.ts)
+
+```diff
+index dc4426a9..cfe3a938 100644
+--- a/templates/skeleton/app/lib/fragments.ts
++++ b/templates/skeleton/app/lib/fragments.ts
+@@ -54,6 +54,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
+         }
+       }
+     }
++    sellingPlanAllocation {
++      sellingPlan {
++         name
++      }
++    }
+   }
+   fragment CartLineComponent on ComponentizableCartLine {
+     id
+@@ -104,6 +109,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
+         }
+       }
+     }
++    sellingPlanAllocation {
++      sellingPlan {
++         name
++      }
++    }
+   }
+   fragment CartApiQuery on Cart {
+     updatedAt
+```
+
+#### Step 3.2: Render the selling plan in the cart
+
+1. Update `CartLineItem` to show subscription details when they're available.
+2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
+
+##### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/components/CartLineItem.tsx)
+
+```diff
+index bd33a2cf..a18e4b52 100644
+--- a/templates/skeleton/app/components/CartLineItem.tsx
++++ b/templates/skeleton/app/components/CartLineItem.tsx
+@@ -3,8 +3,8 @@ import type {CartLayout} from '~/components/CartMain';
+ import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
+ import {useVariantUrl} from '~/lib/variants';
+ import {Link} from '@remix-run/react';
+-import {ProductPrice} from './ProductPrice';
+-import {useAside} from './Aside';
++import {ProductPrice} from '~/components/ProductPrice';
++import {useAside} from '~/components/Aside';
+ import type {CartApiQueryFragment} from 'storefrontapi.generated';
+ 
+ type CartLine = OptimisticCartLine<CartApiQueryFragment>;
+@@ -20,7 +20,9 @@ export function CartLineItem({
+   layout: CartLayout;
+   line: CartLine;
+ }) {
+-  const {id, merchandise} = line;
++  // Get the selling plan allocation
++  const {id, merchandise, sellingPlanAllocation} = line;
++
+   const {product, title, image, selectedOptions} = merchandise;
+   const lineItemUrl = useVariantUrl(product.handle, selectedOptions);
+   const {close} = useAside();
+@@ -54,6 +56,12 @@ export function CartLineItem({
+         </Link>
+         <ProductPrice price={line?.cost?.totalAmount} />
+         <ul>
++          {/* Optionally render the selling plan name if available */}
++          {sellingPlanAllocation && (
++            <li key={sellingPlanAllocation.sellingPlan.name}>
++              <small>{sellingPlanAllocation.sellingPlan.name}</small>
++            </li>
++          )}
+           {selectedOptions.map((option) => (
+             <li key={option.name}>
+               <small>
+```
+
+### Step 4: Managing account subscriptions
+
+In this step we'll implement support for unsubscribing from active subscriptions via an account subpage which lists existing subscription contracts.
+
+#### Step 4.1: Add queries to retrieve customer subscriptions
+
+Create GraphQL queries that retrieves the subscription info from the customer account client.
+
+#### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+
+<details>
+
+```ts
+// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
+
+const SUBSCRIPTION_CONTRACT_FRAGMENT = `#graphql
+  fragment SubscriptionContract on SubscriptionContract {
+    id
+    status
+    createdAt
+    billingPolicy {
+      ...SubscriptionBillingPolicy
+    }
+  }
+  fragment SubscriptionBillingPolicy on SubscriptionBillingPolicy {
+    interval
+    intervalCount {
+      count
+      precision
+    }
+  }
+` as const;
+
+export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
+  query SubscriptionsContractsQuery {
+    customer {
+      subscriptionContracts(first: 100) {
+        nodes {
+          ...SubscriptionContract
+          lines(first: 100) {
+            nodes {
+              name
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+  ${SUBSCRIPTION_CONTRACT_FRAGMENT}
+` as const;
+
+```
+
+</details>
+
+#### Step 4.2: Add mutations to cancel customer subscriptions
+
+Create a GraqhQL mutation to cancel an existing subscription.
+
+#### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+
+<details>
+
+```ts
+// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
+
+export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
+  mutation subscriptionContractCancel($subscriptionContractId: ID!) {
+    subscriptionContractCancel(subscriptionContractId: $subscriptionContractId) {
+      contract {
+        id
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+` as const;
+
+```
+
+</details>
+
+#### Step 4.3: Add an account subscriptions page
+
+Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
+
+#### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+
+<details>
+
+```tsx
+import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
+import {
+  data,
+  LinksFunction,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from '@shopify/remix-oxygen';
+import {
+  useActionData,
+  useFetcher,
+  useLoaderData,
+  type MetaFunction,
+} from '@remix-run/react';
+import {SUBSCRIPTIONS_CONTRACTS_QUERY} from '../graphql/customer-account/CustomerSubscriptionsQuery';
+import {SUBSCRIPTION_CANCEL_MUTATION} from '../graphql/customer-account/CustomerSubscriptionsMutations';
+
+import accountSubscriptionsStyle from '~/styles/account-subscriptions.css?url';
+
+export type ActionResponse = {
+  error: string | null;
+};
+
+export const meta: MetaFunction = () => {
+  return [{title: 'Subscriptions'}];
+};
+
+export const links: LinksFunction = () => [
+  {rel: 'stylesheet', href: accountSubscriptionsStyle},
+];
+
+export async function loader({context}: LoaderFunctionArgs) {
+  await context.customerAccount.handleAuthStatus();
+
+  const {data: subscriptions} = await context.customerAccount.query(
+    SUBSCRIPTIONS_CONTRACTS_QUERY,
+  );
+
+  return {subscriptions};
+}
+
+export async function action({request, context}: ActionFunctionArgs) {
+  const {customerAccount} = context;
+
+  if (request.method !== 'DELETE') {
+    return data({error: 'Method not allowed'}, {status: 405});
+  }
+
+  const form = await request.formData();
+
+  try {
+    const subId = form.get('subId');
+
+    if (!subId) {
+      throw new Error('Subscription ID is required');
+    }
+
+    await customerAccount.mutate(SUBSCRIPTION_CANCEL_MUTATION, {
+      variables: {
+        subscriptionContractId: subId.toString(),
+      },
+    });
+
+    return {
+      error: null,
+    };
+  } catch (error: any) {
+    return data(
+      {
+        error: error.message,
+      },
+      {
+        status: 400,
+      },
+    );
+  }
+}
+
+export default function AccountProfile() {
+  const action = useActionData<ActionResponse>();
+
+  const {subscriptions} = useLoaderData<typeof loader>();
+
+  const fetcher = useFetcher();
+
+  return (
+    <div className="account-profile">
+      <h2>My subscriptions</h2>
+      {action?.error ? (
+        <p>
+          <mark>
+            <small>{action.error}</small>
+          </mark>
+        </p>
+      ) : null}
+      <div className="account-subscriptions">
+        {subscriptions?.customer?.subscriptionContracts.nodes.map(
+          (subscription) => {
+            const isBeingCancelled =
+              fetcher.state !== 'idle' &&
+              fetcher.formData?.get('subId') === subscription.id;
+            return (
+              <div key={subscription.id} className="subscription-row">
+                <div className="subscription-row-content">
+                  <div>
+                    {subscription.lines.nodes.map((line) => (
+                      <div key={line.id}>{line.name}</div>
+                    ))}
+                  </div>
+                  <div>
+                    Every{' '}
+                    <SubscriptionInterval
+                      billingPolicy={subscription.billingPolicy}
+                    />
+                  </div>
+                </div>
+                <div className="subscription-row-actions">
+                  <div
+                    className={
+                      subscription.status === 'ACTIVE'
+                        ? 'subscription-status-active'
+                        : 'subscription-status-inactive'
+                    }
+                  >
+                    {subscription.status}
+                  </div>
+                  {subscription.status === 'ACTIVE' && (
+                    <fetcher.Form key={subscription.id} method="DELETE">
+                      <input
+                        type="hidden"
+                        id="subId"
+                        name="subId"
+                        value={subscription.id}
+                      />
+                      <button type="submit" disabled={isBeingCancelled}>
+                        {isBeingCancelled ? 'Canceling' : 'Cancel subscription'}
+                      </button>
+                    </fetcher.Form>
+                  )}
+                </div>
+              </div>
+            );
+          },
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SubscriptionInterval({
+  billingPolicy,
+}: {
+  billingPolicy: SubscriptionBillingPolicyFragment;
+}) {
+  const count = billingPolicy.intervalCount?.count;
+  function getInterval() {
+    const suffix = count === 1 ? '' : 's';
+    switch (billingPolicy.interval) {
+      case 'DAY':
+        return 'day' + suffix;
+      case 'WEEK':
+        return 'week' + suffix;
+      case 'MONTH':
+        return 'month' + suffix;
+      case 'YEAR':
+        return 'year' + suffix;
+    }
+  }
+  return (
+    <span>
+      {count} {getInterval()}
+    </span>
+  );
+}
+
+```
+
+</details>
+
+#### Step 4.4: Add a link to the Subscriptions page in the account menu
 
 Add a `Subscriptions` link to the account menu.
 
-#### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/24a6a51cb6f1790844b207a9ce42d70325043a3d/templates/skeleton/app/routes/account.tsx)
+##### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/templates/skeleton/app/routes/account.tsx)
 
 ```diff
 index 0941d4e0..976ae9df 100644
@@ -618,3 +1053,50 @@ index 0941d4e0..976ae9df 100644
      </nav>
    );
 ```
+
+#### Step 4.5: Add styles for the Subscriptions page
+
+Add styles for the Subscriptions page.
+
+#### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+
+<details>
+
+```css
+.account-subscriptions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.account-subscriptions .subscription-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  border: 1px solid lightgray;
+  padding: 10px;
+}
+
+.account-subscriptions .subscription-row .subscription-row-content {
+  display: flex;
+  gap: 10px;
+  flex: 1;
+}
+
+.account-subscriptions .subscription-row .subscription-row-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.account-subscriptions .subscription-row .subscription-status-active {
+  color: green;
+}
+
+.account-subscriptions .subscription-row .subscription-status-inactive {
+  color: gray;
+}
+
+```
+
+</details>

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -36,9 +36,9 @@ _New files added to the template by this recipe._
 3. On the [Products](https://admin.shopify.com/products) page, open any products that will be sold as subscriptions and add the relevant subscription plans in the **Purchase options** section.
 The Hydrogen demo storefront comes pre-configured with an example subscription product with the handle `shopify-wax`.
 
-### Step 2: Showing subscriptions in product pages
+### Step 2: Show subscription options on product pages
 
-In this step we'll implement the ability to display and select subscriptions in product pages, alongside the existing one-off purchase options.
+In this step we'll implement the ability to display subscription options on  product pages, alongside the existing one-off purchase options.
 
 #### Step 2.1: Create a SellingPlanSelector component
 
@@ -671,9 +671,9 @@ index 2dc6bda2..3507d496 100644
 
 </details>
 
-### Step 3: Subscriptions in the cart
+### Step 3: Show subscription details in the cart
 
-In this step we'll implement support for showing subscriptions info in the Cart lines.
+In this step we'll implement support for showing subscription info in the cart's line items.
 
 #### Step 3.1: Add selling plan data to cart queries
 
@@ -759,13 +759,13 @@ index bd33a2cf..a18e4b52 100644
                <small>
 ```
 
-### Step 4: Managing account subscriptions
+### Step 4: Add subscription management to the account page
 
-In this step we'll implement support for unsubscribing from active subscriptions via an account subpage which lists existing subscription contracts.
+In this step we'll implement support for subscription management through an account subpage that lists existing subscription contracts.
 
 #### Step 4.1: Add queries to retrieve customer subscriptions
 
-Create GraphQL queries that retrieves the subscription info from the customer account client.
+Create GraphQL queries that retrieve the subscription info from the customer account client.
 
 ##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
@@ -846,7 +846,7 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 #### Step 4.3: Add an account subscriptions page
 
-Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
+Create a new account subpage that lets customers manage their existing  subscriptions based on the new GraphQL queries and mutations.
 
 ##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
 

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -44,7 +44,7 @@ In this step we'll implement the ability to display and select subscriptions in 
 
 Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
 
-#### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
 
 <details>
 
@@ -163,7 +163,7 @@ export function SellingPlanSelector({
 
 Add styles for the `SellingPlanSelector` component.
 
-#### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css/ingredients/templates/skeleton/app/styles/selling-plan.css)
+##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 <details>
 
@@ -767,7 +767,7 @@ In this step we'll implement support for unsubscribing from active subscriptions
 
 Create GraphQL queries that retrieves the subscription info from the customer account client.
 
-#### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
 <details>
 
@@ -819,7 +819,7 @@ export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
 
 Create a GraqhQL mutation to cancel an existing subscription.
 
-#### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
 
 <details>
 
@@ -848,7 +848,7 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
 
-#### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
 
 <details>
 
@@ -1058,7 +1058,7 @@ index 0941d4e0..976ae9df 100644
 
 Add styles for the Subscriptions page.
 
-#### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
 
 <details>
 

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -52,11 +52,10 @@ steps:
       subscription product with the handle `shopify-wax`.
   - type: INFO
     step: 2
-    name: Showing subscriptions in product pages
+    name: Show subscription options on product pages
     description: >
-      In this step we'll implement the ability to display and select
-      subscriptions in product pages, alongside the existing one-off purchase
-      options.
+      In this step we'll implement the ability to display subscription options on 
+      product pages, alongside the existing one-off purchase options.
   - type: NEW_FILE
     step: 2.1
     name: Create a SellingPlanSelector component
@@ -115,10 +114,10 @@ steps:
         patchFile: products.$handle.tsx.3e0b7e.patch
   - type: INFO
     step: 3
-    name: Subscriptions in the cart
+    name: Show subscription details in the cart
     description: >
-      In this step we'll implement support for showing subscriptions info in the
-      Cart lines.
+      In this step we'll implement support for showing subscription info in the
+      cart's line items.
   - type: PATCH
     step: 3.1
     name: Add selling plan data to cart queries
@@ -143,16 +142,15 @@ steps:
         patchFile: CartLineItem.tsx.8e657b.patch
   - type: INFO
     step: 4
-    name: Managing account subscriptions
+    name: Add subscription management to the account page
     description: >
-      In this step we'll implement support for unsubscribing from active
-      subscriptions via an account subpage which lists existing subscription
-      contracts.
+      In this step we'll implement support for subscription management
+      through an account subpage that lists existing subscription contracts.
   - type: NEW_FILE
     step: 4.1
     name: Add queries to retrieve customer subscriptions
     description: >
-      Create GraphQL queries that retrieves the subscription info from the
+      Create GraphQL queries that retrieve the subscription info from the
       customer account client.
     ingredients:
       - templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts
@@ -167,9 +165,8 @@ steps:
     step: 4.3
     name: Add an account subscriptions page
     description: >
-      Create a new account subpage that allows management of existing customer
-      subscriptions based on the new GraphQL queries and mutations created
-      previously.
+      Create a new account subpage that lets customers manage their existing 
+      subscriptions based on the new GraphQL queries and mutations.
     ingredients:
       - templates/skeleton/app/routes/account.subscriptions.tsx
   - type: PATCH

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -50,17 +50,19 @@ steps:
 
       The Hydrogen demo storefront comes pre-configured with an example
       subscription product with the handle `shopify-wax`.
-
   - type: INFO
     step: 2
     name: Showing subscriptions in product pages
-    description: |
-      In this step we'll implement the ability to display and select subscriptions in product pages, alongside the existing one-off purchase options.
+    description: >
+      In this step we'll implement the ability to display and select
+      subscriptions in product pages, alongside the existing one-off purchase
+      options.
   - type: NEW_FILE
     step: 2.1
     name: Create a SellingPlanSelector component
-    description: |
-      Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
+    description: >
+      Create a new `SellingPlanSelector` component that displays the available
+      subscription options for a product.
     ingredients:
       - templates/skeleton/app/components/SellingPlanSelector.tsx
   - type: NEW_FILE
@@ -111,12 +113,12 @@ steps:
     diffs:
       - file: app/routes/products.$handle.tsx
         patchFile: products.$handle.tsx.3e0b7e.patch
-
   - type: INFO
     step: 3
     name: Subscriptions in the cart
-    description: |
-      In this step we'll implement support for showing subscriptions info in the Cart lines.
+    description: >
+      In this step we'll implement support for showing subscriptions info in the
+      Cart lines.
   - type: PATCH
     step: 3.1
     name: Add selling plan data to cart queries
@@ -139,17 +141,19 @@ steps:
     diffs:
       - file: app/components/CartLineItem.tsx
         patchFile: CartLineItem.tsx.8e657b.patch
-
   - type: INFO
     step: 4
     name: Managing account subscriptions
-    description: |
-      In this step we'll implement support for unsubscribing from active subscriptions via an account subpage which lists existing subscription contracts.
+    description: >
+      In this step we'll implement support for unsubscribing from active
+      subscriptions via an account subpage which lists existing subscription
+      contracts.
   - type: NEW_FILE
     step: 4.1
     name: Add queries to retrieve customer subscriptions
-    description: |
-      Create GraphQL queries that retrieves the subscription info from the customer account client.
+    description: >
+      Create GraphQL queries that retrieves the subscription info from the
+      customer account client.
     ingredients:
       - templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts
   - type: NEW_FILE
@@ -162,8 +166,10 @@ steps:
   - type: NEW_FILE
     step: 4.3
     name: Add an account subscriptions page
-    description: |
-      Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
+    description: >
+      Create a new account subpage that allows management of existing customer
+      subscriptions based on the new GraphQL queries and mutations created
+      previously.
     ingredients:
       - templates/skeleton/app/routes/account.subscriptions.tsx
   - type: PATCH
@@ -181,7 +187,6 @@ steps:
       Add styles for the Subscriptions page.
     ingredients:
       - templates/skeleton/app/styles/account-subscriptions.css
-
 llms:
   userQueries:
     - How do I add subscriptions to my Hydrogen storefront?
@@ -189,15 +194,12 @@ llms:
     - How do I display subscription details on applicable line items in the cart?
   troubleshooting:
     - issue: I'm getting an error when I try to add a subscription to my storefront.
-      solution:
-        Make sure you've installed the Shopify Subscriptions app and set up
+      solution: Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
     - issue: I'm not seeing the subscription options on my product pages.
-      solution:
-        Make sure you've installed the Shopify Subscriptions app and set up
+      solution: Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
     - issue: I'm not seeing the subscription details on my cart line items.
-      solution:
-        Make sure you've installed the Shopify Subscriptions app and set up
+      solution: Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
 commit: bd55b241191304945704c0b9ef278e945c55d3da

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -34,7 +34,7 @@ ingredients:
 deletedFiles: []
 steps:
   - type: INFO
-    index: 1
+    step: 1
     name: Set up the Shopify Subscriptions app
     description: >
       1. Install the [Shopify Subscriptions
@@ -50,31 +50,28 @@ steps:
 
       The Hydrogen demo storefront comes pre-configured with an example
       subscription product with the handle `shopify-wax`.
-  - type: COPY_INGREDIENTS
-    index: 2
-    name: Add ingredients to your project
-    description: Copy all the files found in the `ingredients/` directory into your project.
+
+  - type: INFO
+    step: 2
+    name: Showing subscriptions in product pages
+    description: |
+      In this step we'll implement the ability to display and select subscriptions in product pages, alongside the existing one-off purchase options.
+  - type: NEW_FILE
+    step: 2.1
+    name: Create a SellingPlanSelector component
+    description: |
+      Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
     ingredients:
       - templates/skeleton/app/components/SellingPlanSelector.tsx
-      - templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts
-      - templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts
-      - templates/skeleton/app/routes/account.subscriptions.tsx
-      - templates/skeleton/app/styles/account-subscriptions.css
+  - type: NEW_FILE
+    step: 2.2
+    name: Add styles for the SellingPlanSelector component
+    description: |
+      Add styles for the `SellingPlanSelector` component.
+    ingredients:
       - templates/skeleton/app/styles/selling-plan.css
   - type: PATCH
-    index: 3
-    name: Render the selling plan in the cart
-    description: >
-      1. Update `CartLineItem` to show subscription details when they're
-      available.
-
-      2. Extract `sellingPlanAllocation` from cart line data, display the plan
-      name, and standardize component import paths.
-    diffs:
-      - file: app/components/CartLineItem.tsx
-        patchFile: CartLineItem.tsx.8e657b.patch
-  - type: PATCH
-    index: 4
+    step: 2.3
     name: Update ProductForm to support subscriptions
     description: >
       1. Add conditional rendering to display subscription options alongside the
@@ -89,7 +86,7 @@ steps:
       - file: app/components/ProductForm.tsx
         patchFile: ProductForm.tsx.8e409a.patch
   - type: PATCH
-    index: 5
+    step: 2.4
     name: Update ProductPrice to display subscription pricing
     description: >
       1. Add a `SellingPlanPrice` function to calculate adjusted prices based on
@@ -101,18 +98,8 @@ steps:
       - file: app/components/ProductPrice.tsx
         patchFile: ProductPrice.tsx.a5e47f.patch
   - type: PATCH
-    index: 6
-    name: Add selling plan data to cart queries
-    description: >
-      Add a `sellingPlanAllocation` field with the plan name to the standard and
-      componentizable cart line GraphQL fragments. This displays subscription
-      details in the cart.
-    diffs:
-      - file: app/lib/fragments.ts
-        patchFile: fragments.ts.e8eb04.patch
-  - type: PATCH
-    index: 7
-    name: Add SellingPlanSelector to product pages
+    step: 2.5
+    name: Update the product page to display subscription options
     description: >
       1. Add the `SellingPlanSelector` component to display subscription options
       on product pages.
@@ -124,14 +111,77 @@ steps:
     diffs:
       - file: app/routes/products.$handle.tsx
         patchFile: products.$handle.tsx.3e0b7e.patch
+
+  - type: INFO
+    step: 3
+    name: Subscriptions in the cart
+    description: |
+      In this step we'll implement support for showing subscriptions info in the Cart lines.
   - type: PATCH
-    index: 8
-    name: Add a link to the Subscriptions page
+    step: 3.1
+    name: Add selling plan data to cart queries
+    description: >
+      Add a `sellingPlanAllocation` field with the plan name to the standard and
+      componentizable cart line GraphQL fragments. This displays subscription
+      details in the cart.
+    diffs:
+      - file: app/lib/fragments.ts
+        patchFile: fragments.ts.e8eb04.patch
+  - type: PATCH
+    step: 3.2
+    name: Render the selling plan in the cart
+    description: >
+      1. Update `CartLineItem` to show subscription details when they're
+      available.
+
+      2. Extract `sellingPlanAllocation` from cart line data, display the plan
+      name, and standardize component import paths.
+    diffs:
+      - file: app/components/CartLineItem.tsx
+        patchFile: CartLineItem.tsx.8e657b.patch
+
+  - type: INFO
+    step: 4
+    name: Managing account subscriptions
+    description: |
+      In this step we'll implement support for unsubscribing from active subscriptions via an account subpage which lists existing subscription contracts.
+  - type: NEW_FILE
+    step: 4.1
+    name: Add queries to retrieve customer subscriptions
+    description: |
+      Create GraphQL queries that retrieves the subscription info from the customer account client.
+    ingredients:
+      - templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts
+  - type: NEW_FILE
+    step: 4.2
+    name: Add mutations to cancel customer subscriptions
+    description: |
+      Create a GraqhQL mutation to cancel an existing subscription.
+    ingredients:
+      - templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts
+  - type: NEW_FILE
+    step: 4.3
+    name: Add an account subscriptions page
+    description: |
+      Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
+    ingredients:
+      - templates/skeleton/app/routes/account.subscriptions.tsx
+  - type: PATCH
+    step: 4.4
+    name: Add a link to the Subscriptions page in the account menu
     description: |
       Add a `Subscriptions` link to the account menu.
     diffs:
       - file: app/routes/account.tsx
         patchFile: account.tsx.a0203d.patch
+  - type: NEW_FILE
+    step: 4.5
+    name: Add styles for the Subscriptions page
+    description: |
+      Add styles for the Subscriptions page.
+    ingredients:
+      - templates/skeleton/app/styles/account-subscriptions.css
+
 llms:
   userQueries:
     - How do I add subscriptions to my Hydrogen storefront?
@@ -139,12 +189,15 @@ llms:
     - How do I display subscription details on applicable line items in the cart?
   troubleshooting:
     - issue: I'm getting an error when I try to add a subscription to my storefront.
-      solution: Make sure you've installed the Shopify Subscriptions app and set up
+      solution:
+        Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
     - issue: I'm not seeing the subscription options on my product pages.
-      solution: Make sure you've installed the Shopify Subscriptions app and set up
+      solution:
+        Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
     - issue: I'm not seeing the subscription details on my cart line items.
-      solution: Make sure you've installed the Shopify Subscriptions app and set up
+      solution:
+        Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
-commit: 24a6a51cb6f1790844b207a9ce42d70325043a3d
+commit: bd55b241191304945704c0b9ef278e945c55d3da

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -54,8 +54,8 @@ steps:
     step: 2
     name: Show subscription options on product pages
     description: >
-      In this step we'll implement the ability to display subscription options on 
-      product pages, alongside the existing one-off purchase options.
+      In this step we'll implement the ability to display subscription options
+      on  product pages, alongside the existing one-off purchase options.
   - type: NEW_FILE
     step: 2.1
     name: Create a SellingPlanSelector component
@@ -144,8 +144,8 @@ steps:
     step: 4
     name: Add subscription management to the account page
     description: >
-      In this step we'll implement support for subscription management
-      through an account subpage that lists existing subscription contracts.
+      In this step we'll implement support for subscription management through
+      an account subpage that lists existing subscription contracts.
   - type: NEW_FILE
     step: 4.1
     name: Add queries to retrieve customer subscriptions
@@ -165,8 +165,8 @@ steps:
     step: 4.3
     name: Add an account subscriptions page
     description: >
-      Create a new account subpage that lets customers manage their existing 
-      subscriptions based on the new GraphQL queries and mutations.
+      Create a new account subpage that lets customers manage their
+      existing  subscriptions based on the new GraphQL queries and mutations.
     ingredients:
       - templates/skeleton/app/routes/account.subscriptions.tsx
   - type: PATCH

--- a/cookbook/src/lib/generate.ts
+++ b/cookbook/src/lib/generate.ts
@@ -9,7 +9,7 @@ import {
   TEMPLATE_DIRECTORY,
   TEMPLATE_PATH,
 } from './constants';
-import {Ingredient, loadRecipe, Recipe, Step} from './recipe';
+import {Ingredient, isSubstep, loadRecipe, Recipe, Step} from './recipe';
 import {
   createDirectoryIfNotExists,
   getMainCommitHash,
@@ -217,26 +217,14 @@ async function generateSteps(params: {
     newFileSteps.push(step);
   }
 
-  // // add the copy ingredients step if there are ingredients
-  // const maybeCopyIngredientsStep: Step[] =
-  //   params.ingredients.length > 0
-  //     ? [
-  //         copyIngredientsStep(
-  //           params.ingredients,
-  //           params.existingRecipe?.steps.find(
-  //             (step) => step.type === 'COPY_INGREDIENTS',
-  //           ) ?? null,
-  //         ),
-  //       ]
-  //     : [];
-
   const steps = [
     ...existingInfoSteps,
-    // ...maybeCopyIngredientsStep,
-    ...[...patchSteps, ...newFileSteps].sort((a, b) => {
-      return a.step.toString().localeCompare(b.step.toString());
-    }),
-  ];
+    ...[...patchSteps, ...newFileSteps],
+  ].sort((a, b) => {
+    const normalizedA = isSubstep(a) ? `${a.step}` : `${a.step}.0`;
+    const normalizedB = isSubstep(b) ? `${b.step}` : `${b.step}.0`;
+    return normalizedA.localeCompare(normalizedB);
+  });
 
   return steps;
 }
@@ -248,21 +236,6 @@ function maybeLoadExistingRecipe(recipePath: string): Recipe | null {
     return null;
   }
 }
-
-// function _copyIngredientsStep(
-//   ingredients: Ingredient[],
-//   existingStep: Step | null,
-// ): Step {
-//   return {
-//     type: 'COPY_INGREDIENTS',
-//     index: existingStep?.index ?? 0,
-//     step: existingStep?.step ?? 0,
-//     name: 'Add ingredients to your project',
-//     description:
-//       'Copy all the files found in the `ingredients/` directory into your project.',
-//     ingredients: ingredients.map((ingredient) => ingredient.path),
-//   };
-// }
 
 function createPatchFile(params: {file: string; patchesDirPath: string}): {
   fullPath: string;

--- a/cookbook/src/lib/generate.ts
+++ b/cookbook/src/lib/generate.ts
@@ -221,9 +221,15 @@ async function generateSteps(params: {
     ...existingInfoSteps,
     ...[...patchSteps, ...newFileSteps],
   ].sort((a, b) => {
-    const normalizedA = isSubstep(a) ? `${a.step}` : `${a.step}.0`;
-    const normalizedB = isSubstep(b) ? `${b.step}` : `${b.step}.0`;
-    return normalizedA.localeCompare(normalizedB);
+    function normalize(step: Step): string {
+      const expanded = isSubstep(a) ? `${step.step}` : `${step.step}.0`;
+      return expanded
+        .split('.')
+        .map((v) => parseInt(v, 10).toString().padStart(4, '0'))
+        .join('.');
+    }
+
+    return normalize(a).localeCompare(normalize(b));
   });
 
   return steps;

--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import {COOKBOOK_PATH, TEMPLATE_PATH} from './constants';
+import {COOKBOOK_PATH, TEMPLATE_DIRECTORY, TEMPLATE_PATH} from './constants';
 import {
   createDirectoryIfNotExists,
   getPatchesDir,
@@ -8,7 +8,6 @@ import {
 import {
   maybeMDBlock,
   MDBlock,
-  mdCode,
   mdFrontMatter,
   mdHeading,
   mdList,
@@ -98,24 +97,11 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
 
       // ingredients
       mdHeading(2, 'New files added to the template by this recipe'),
-      ...recipe.ingredients.flatMap((ingredient) => {
-        const contents = fs.readFileSync(
-          path.join(
-            COOKBOOK_PATH,
-            'recipes',
-            recipeName,
-            'ingredients',
-            ingredient.path,
-          ),
-          'utf8',
-        );
-        const extension = path.extname(ingredient.path).slice(1);
-        return [
-          mdHeading(3, ingredient.path),
-          mdParagraph(ingredient.description ?? ''),
-          mdCode(extension ?? '', contents, false),
-        ];
-      }),
+      mdList(
+        recipe.ingredients.map((ingredient) =>
+          ingredient.path.replace(TEMPLATE_DIRECTORY, ''),
+        ),
+      ),
 
       mdHeading(2, 'Steps'),
       ...recipe.steps.flatMap((step): MDBlock[] =>

--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -118,21 +118,19 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
       }),
 
       mdHeading(2, 'Steps'),
-      ...recipe.steps
-        .filter((step) => step.type !== 'COPY_INGREDIENTS')
-        .flatMap((step): MDBlock[] =>
-          renderStep(
-            step,
-            recipe,
-            recipeName,
-            getPatchesDir(recipeName),
-            'github',
-            {
-              diffsRelativeToTemplate: true,
-              trimDiffHeaders: true,
-            },
-          ),
+      ...recipe.steps.flatMap((step): MDBlock[] =>
+        renderStep(
+          step,
+          recipe,
+          recipeName,
+          getPatchesDir(recipeName),
+          'github',
+          {
+            diffsRelativeToTemplate: true,
+            trimDiffHeaders: true,
+          },
         ),
+      ),
 
       ...(recipe.deletedFiles != null && recipe.deletedFiles.length > 0
         ? [

--- a/cookbook/src/lib/llms.ts
+++ b/cookbook/src/lib/llms.ts
@@ -120,10 +120,9 @@ Here's the ${recipeName} recipe for the base Hydrogen skeleton template:
       mdHeading(2, 'Steps'),
       ...recipe.steps
         .filter((step) => step.type !== 'COPY_INGREDIENTS')
-        .flatMap((step, index): MDBlock[] =>
+        .flatMap((step): MDBlock[] =>
           renderStep(
             step,
-            index,
             recipe,
             recipeName,
             getPatchesDir(recipeName),

--- a/cookbook/src/lib/markdown.ts
+++ b/cookbook/src/lib/markdown.ts
@@ -177,7 +177,7 @@ export function renderMDBlock(block: MDBlock, format: RenderFormat): string {
           case 'shopify.dev':
             return [
               '<details>\n',
-              '{% codeblock markdown %}',
+              '{% codeblock file %}',
               ...code,
               '{% endcodeblock %}',
               '\n</details>',

--- a/cookbook/src/lib/recipe.ts
+++ b/cookbook/src/lib/recipe.ts
@@ -22,9 +22,7 @@ const DiffSchema = z.object({
 export type Diff = z.infer<typeof DiffSchema>;
 
 const StepSchema = z.object({
-  type: z
-    .enum(['PATCH', 'INFO', 'COPY_INGREDIENTS', 'NEW_FILE'])
-    .describe('The type of step'),
+  type: z.enum(['PATCH', 'INFO', 'NEW_FILE']).describe('The type of step'),
   step: z
     .number()
     .or(

--- a/cookbook/src/lib/recipe.ts
+++ b/cookbook/src/lib/recipe.ts
@@ -23,9 +23,21 @@ export type Diff = z.infer<typeof DiffSchema>;
 
 const StepSchema = z.object({
   type: z
-    .enum(['PATCH', 'INFO', 'COPY_INGREDIENTS'])
+    .enum(['PATCH', 'INFO', 'COPY_INGREDIENTS', 'NEW_FILE'])
     .describe('The type of step'),
-  index: z.number().describe('The index of the step'),
+  step: z
+    .number()
+    .or(
+      z
+        .string()
+        .regex(/^\d+(?:\.\d+)?$/)
+        .describe(
+          'The step numerical representation, with optional substep if applicable',
+        ),
+    )
+    .describe(
+      'The step numerical representation, with optional substep if applicable',
+    ),
   name: z.string().describe('The name of the step'),
   description: z
     .string()
@@ -111,4 +123,8 @@ export function loadRecipe(params: {directory: string}): Recipe {
       `recipe.yaml or recipe.json not found in ${params.directory}`,
     );
   }
+}
+
+export function isSubstep(step: Step): boolean {
+  return `${step.step}`.includes('.');
 }

--- a/cookbook/src/lib/render.ts
+++ b/cookbook/src/lib/render.ts
@@ -187,8 +187,9 @@ export function renderStep(
       return [];
     }
 
+    const baseHeadingLevel = 4;
     return step.diffs.flatMap((diff) => {
-      const headingLevel = 4 + (isSubstep(step) ? 1 : 0);
+      const headingLevel = baseHeadingLevel + (isSubstep(step) ? 1 : 0);
 
       const patchFile = path.join(patchesDir, diff.patchFile);
       const rawPatch = fs.readFileSync(patchFile, 'utf8').trim();
@@ -243,8 +244,9 @@ export function renderStep(
     const collapsed = options.collapseDiffs === true;
 
     let blocks: MDBlock[] = [];
+    const baseHeadingLevel = 4;
     for (const ingredient of step.ingredients) {
-      const headingLevel = 4 + (isSubstep(step) ? 1 : 0);
+      const headingLevel = baseHeadingLevel + (isSubstep(step) ? 1 : 0);
 
       const link =
         hydrogenRepoRecipeBaseURL({
@@ -275,8 +277,8 @@ export function renderStep(
     return blocks;
   }
 
-  const headingLevel =
-    (format === 'github' ? 3 : 2) + (isSubstep(step) ? 1 : 0);
+  const baseHeadingLevel = format === 'github' ? 3 : 2;
+  const headingLevel = baseHeadingLevel + (isSubstep(step) ? 1 : 0);
 
   const markdownStep: MDBlock[] = [
     mdHeading(headingLevel, `Step ${step.step}: ${step.name}`),

--- a/cookbook/src/lib/render.ts
+++ b/cookbook/src/lib/render.ts
@@ -239,6 +239,9 @@ export function renderStep(
     if (step.type !== 'NEW_FILE' || step.ingredients == null) {
       return [];
     }
+
+    const collapsed = options.collapseDiffs === true;
+
     let blocks: MDBlock[] = [];
     for (const ingredient of step.ingredients) {
       const headingLevel = 4 + (isSubstep(step) ? 1 : 0);
@@ -266,7 +269,7 @@ export function renderStep(
             ' ',
           ),
         ),
-        mdCode(path.extname(ingredient).slice(1), content, true),
+        mdCode(path.extname(ingredient).slice(1), content, collapsed),
       );
     }
     return blocks;

--- a/cookbook/src/lib/render.ts
+++ b/cookbook/src/lib/render.ts
@@ -188,6 +188,8 @@ export function renderStep(
     }
 
     return step.diffs.flatMap((diff) => {
+      const headingLevel = 4 + (isSubstep(step) ? 1 : 0);
+
       const patchFile = path.join(patchesDir, diff.patchFile);
       const rawPatch = fs.readFileSync(patchFile, 'utf8').trim();
 
@@ -208,11 +210,6 @@ export function renderStep(
         hash: recipe.commit,
       });
       const link = `${linkPrefixRepo}/templates/skeleton/${diff.file}`;
-
-      let headingLevel = 4;
-      if (isSubstep(step)) {
-        headingLevel++;
-      }
 
       return [
         format === 'github'
@@ -244,6 +241,8 @@ export function renderStep(
     }
     let blocks: MDBlock[] = [];
     for (const ingredient of step.ingredients) {
+      const headingLevel = 4 + (isSubstep(step) ? 1 : 0);
+
       const link =
         hydrogenRepoRecipeBaseURL({
           recipeName,
@@ -259,16 +258,13 @@ export function renderStep(
         ),
         'utf8',
       );
+
       blocks.push(
         mdHeading(
           headingLevel,
-          [
-            'File:',
-            `${mdLinkString(
-              `${link}/ingredients/${ingredient}`,
-              path.basename(ingredient),
-            )}`,
-          ].join(' '),
+          ['File:', `${mdLinkString(link, path.basename(ingredient))}`].join(
+            ' ',
+          ),
         ),
         mdCode(path.extname(ingredient).slice(1), content, true),
       );
@@ -276,15 +272,14 @@ export function renderStep(
     return blocks;
   }
 
-  let headingLevel = format === 'github' ? 3 : 2;
-  if (isSubstep(step)) {
-    headingLevel++;
-  }
+  const headingLevel =
+    (format === 'github' ? 3 : 2) + (isSubstep(step) ? 1 : 0);
+
   const markdownStep: MDBlock[] = [
     mdHeading(headingLevel, `Step ${step.step}: ${step.name}`),
     ...(step.notes?.map(mdNote) ?? []),
     mdParagraph(step.description ?? ''),
-    ...(step.type === 'COPY_INGREDIENTS' && step.ingredients != null
+    ...(step.type !== 'NEW_FILE' && step.ingredients != null
       ? [
           mdList(
             step.ingredients

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-bundles.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-bundles.mdc
@@ -177,7 +177,115 @@ export function BundledVariants({
 
 3. From the [**Bundles**](https://admin.shopify.com/apps/shopify-bundles/app) page, [create a new bundle](https://help.shopify.com/en/manual/products/bundles/shopify-bundles).
 
-### Step 2: Update the product fragment to query for bundles and display BundledVariants
+### Step 2: Create the BundleBadge component
+
+Create a new BundleBadge component to be displayed on bundle product listings.
+
+#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+
+<details>
+
+```tsx
+export function BundleBadge() {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        padding: '.5rem .75rem',
+        fontSize: '11px',
+        backgroundColor: '#10804c',
+        color: 'white',
+        top: '1rem',
+        right: '1rem',
+      }}
+    >
+      BUNDLE
+    </div>
+  );
+}
+
+```
+
+</details>
+
+### Step 3: Create a new BundledVariants component
+
+Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
+
+#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+
+<details>
+
+```tsx
+import {Link} from '@remix-run/react';
+import {Image} from '@shopify/hydrogen';
+import type {
+  ProductVariantComponent,
+  Image as ShopifyImage,
+} from '@shopify/hydrogen/storefront-api-types';
+
+export function BundledVariants({
+  variants,
+}: {
+  variants: ProductVariantComponent[];
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        paddingTop: '1rem',
+      }}
+    >
+      {variants
+        ?.map(({productVariant: bundledVariant, quantity}) => {
+          const url = `/products/${bundledVariant.product.handle}`;
+          return (
+            <Link
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                marginBottom: '.5rem',
+              }}
+              to={url}
+              key={bundledVariant.id}
+            >
+              <Image
+                alt={bundledVariant.title}
+                aspectRatio="1/1"
+                height={60}
+                loading="lazy"
+                width={60}
+                data={bundledVariant.image as ShopifyImage}
+              />
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  paddingLeft: '1rem',
+                }}
+              >
+                <small>
+                  {bundledVariant.product.title}
+                  {bundledVariant.title !== 'Default Title'
+                    ? `- ${bundledVariant.title}`
+                    : null}
+                </small>
+                <small>Qty: {quantity}</small>
+              </div>
+            </Link>
+          );
+        })
+        .filter(Boolean)}
+    </div>
+  );
+}
+
+```
+
+</details>
+
+### Step 4: Update the product fragment to query for bundles and display BundledVariants
 
 - Add the `requiresComponents` field to the `Product` fragment, which is used to identify bundled products.
 - Pass the `isBundle` flag to the `ProductImage` component.
@@ -294,7 +402,7 @@ export function BundledVariants({
        title
 ```
 
-### Step 3: Update the collections fragment to query for bundles
+### Step 5: Update the collections fragment to query for bundles
 
 Like the previous step, use the `requiresComponents` field to detect if the product item is a bundle.
 
@@ -344,7 +452,7 @@ Like the previous step, use the `requiresComponents` field to detect if the prod
    query Collection(
 ```
 
-### Step 4: Update the cart fragment to query for bundles
+### Step 6: Update the cart fragment to query for bundles
 
 Use the `requiresComponents` field to determine if a cart line item is a bundle.
 
@@ -402,7 +510,7 @@ Use the `requiresComponents` field to determine if a cart line item is a bundle.
    }
 ```
 
-### Step 5: Conditionally render the BundleBadge in cart line items
+### Step 7: Conditionally render the BundleBadge in cart line items
 
 If a product is a bundle, show the `BundleBadge` component in the cart line item.
 
@@ -450,7 +558,7 @@ If a product is a bundle, show the `BundleBadge` component in the cart line item
          <ul>
 ```
 
-### Step 6: Conditionally render "Add bundle to cart" in ProductForm
+### Step 8: Conditionally render "Add bundle to cart" in ProductForm
 
 If a product is a bundle, update the text of the product button.
 
@@ -484,7 +592,7 @@ If a product is a bundle, update the text of the product button.
    );
 ```
 
-### Step 7: Conditionally render the BundleBadge in ProductImage
+### Step 9: Conditionally render the BundleBadge in ProductImage
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductImage` component.
 
@@ -515,7 +623,7 @@ If a product is a bundle, show the `BundleBadge` component in the `ProductImage`
  }
 ```
 
-### Step 8: Conditionally render the BundleBadge in ProductItem
+### Step 10: Conditionally render the BundleBadge in ProductItem
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductItem` component.
 
@@ -590,7 +698,7 @@ If a product is a bundle, show the `BundleBadge` component in the `ProductItem` 
  }
 ```
 
-### Step 9: Add a product-image class to the app stylesheet
+### Step 11: Add a product-image class to the app stylesheet
 
 Make sure the bundle badge is positioned relative to the product image.
 

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-bundles.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-bundles.mdc
@@ -71,101 +71,8 @@ In this recipe, we'll use the [Shopify Bundles app](https://apps.shopify.com/sho
 
 ## New files added to the template by this recipe
 
-### templates/skeleton/app/components/BundleBadge.tsx
-
-A badge displayed on bundle product listings.
-
-```tsx
-export function BundleBadge() {
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        padding: '.5rem .75rem',
-        fontSize: '11px',
-        backgroundColor: '#10804c',
-        color: 'white',
-        top: '1rem',
-        right: '1rem',
-      }}
-    >
-      BUNDLE
-    </div>
-  );
-}
-
-```
-
-### templates/skeleton/app/components/BundledVariants.tsx
-
-A component that wraps the variants of a bundle product in a single product listing.
-
-```tsx
-import {Link} from '@remix-run/react';
-import {Image} from '@shopify/hydrogen';
-import type {
-  ProductVariantComponent,
-  Image as ShopifyImage,
-} from '@shopify/hydrogen/storefront-api-types';
-
-export function BundledVariants({
-  variants,
-}: {
-  variants: ProductVariantComponent[];
-}) {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        paddingTop: '1rem',
-      }}
-    >
-      {variants
-        ?.map(({productVariant: bundledVariant, quantity}) => {
-          const url = `/products/${bundledVariant.product.handle}`;
-          return (
-            <Link
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                marginBottom: '.5rem',
-              }}
-              to={url}
-              key={bundledVariant.id}
-            >
-              <Image
-                alt={bundledVariant.title}
-                aspectRatio="1/1"
-                height={60}
-                loading="lazy"
-                width={60}
-                data={bundledVariant.image as ShopifyImage}
-              />
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  paddingLeft: '1rem',
-                }}
-              >
-                <small>
-                  {bundledVariant.product.title}
-                  {bundledVariant.title !== 'Default Title'
-                    ? `- ${bundledVariant.title}`
-                    : null}
-                </small>
-                <small>Qty: {quantity}</small>
-              </div>
-            </Link>
-          );
-        })
-        .filter(Boolean)}
-    </div>
-  );
-}
-
-```
+- app/components/BundleBadge.tsx
+- app/components/BundledVariants.tsx
 
 ## Steps
 
@@ -183,8 +90,6 @@ Create a new BundleBadge component to be displayed on bundle product listings.
 
 #### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
 
-<details>
-
 ```tsx
 export function BundleBadge() {
   return (
@@ -206,15 +111,11 @@ export function BundleBadge() {
 
 ```
 
-</details>
-
 ### Step 3: Create a new BundledVariants component
 
 Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
 
 #### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
-
-<details>
 
 ```tsx
 import {Link} from '@remix-run/react';
@@ -282,8 +183,6 @@ export function BundledVariants({
 }
 
 ```
-
-</details>
 
 ### Step 4: Update the product fragment to query for bundles and display BundledVariants
 

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-bundles.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-bundles.mdc
@@ -1,6 +1,5 @@
 ---
-description: |
-  Recipe for implementing "Bundles (bundles)" in a Hydrogen storefront. Display product bundles on your Hydrogen storefront.
+description: Recipe for implementing "Bundles (bundles)" in a Hydrogen storefront. Display product bundles on your Hydrogen storefront.
 globs: *
 alwaysApply: false
 ---
@@ -20,7 +19,6 @@ Please note that the recipe steps below are not necessarily ordered in the way t
 # Summary
 
 Display product bundles on your Hydrogen storefront.
-
 
 # User Intent Recognition
 
@@ -50,18 +48,19 @@ Here's the bundles recipe for the base Hydrogen skeleton template:
 
 ## Description
 
-This recipe adds special styling for product bundles on your Hydrogen storefront. Customers will see badges and relevant cover images for bundles when they're viewing product and collection pages.
-
+This recipe adds special styling for product bundles on your Hydrogen
+storefront. Customers will see badges and relevant cover images for bundles
+when they're viewing product and collection pages.
 
 In this recipe you'll make the following changes:
 
-
-1. Set up the Shopify Bundles app in your Shopify admin and create a new product bundle.
-
-2. Update the GraphQL fragments to query for bundles to identify bundled products.
-
-3. Update the product and collection templates to display badges on product listings, update the copy for the cart buttons, and display bundle-specific information on product and collection pages.
-
+1. Set up the Shopify Bundles app in your Shopify admin and create a new
+product bundle.
+2. Update the GraphQL fragments to query for bundles to identify bundled
+products.
+3. Update the product and collection templates to display badges on product
+listings, update the copy for the cart buttons, and display bundle-specific
+information on product and collection pages.
 4. Update the cart line item template to display the bundle badge as needed.
 
 ## Requirements
@@ -186,8 +185,9 @@ export function BundledVariants({
 
 ### Step 4: Update the product fragment to query for bundles and display BundledVariants
 
-- Add the `requiresComponents` field to the `Product` fragment, which is used to identify bundled products.
-- Pass the `isBundle` flag to the `ProductImage` component.
+1. Add the `requiresComponents` field to the `Product` fragment, which is
+used to identify bundled products.
+2. Pass the `isBundle` flag to the `ProductImage` component.
 
 #### File: /app/routes/products.$handle.tsx
 

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -62,48 +62,7 @@ In this recipe, you'll make the following changes:
 
 ## New files added to the template by this recipe
 
-### templates/skeleton/app/lib/combined-listings.ts
-
-The `combined-listings.ts` file contains utilities and settings for handling combined listings.
-
-```ts
-// Edit these values to customize combined listings' behavior
-export const combinedListingsSettings = {
-  // If true, loading the product page will redirect to the first variant
-  redirectToFirstVariant: false,
-  // The tag that indicates a combined listing
-  combinedListingTag: 'combined',
-  // If true, combined listings will not be shown in the product list
-  hideCombinedListingsFromProductList: true,
-};
-
-export const maybeFilterOutCombinedListingsQuery =
-  combinedListingsSettings.hideCombinedListingsFromProductList
-    ? `NOT tag:${combinedListingsSettings.combinedListingTag}`
-    : '';
-
-interface ProductWithTags {
-  tags: string[];
-}
-
-function isProductWithTags(u: unknown): u is ProductWithTags {
-  const maybe = u as ProductWithTags;
-  return (
-    u != null &&
-    typeof u === 'object' &&
-    'tags' in maybe &&
-    Array.isArray(maybe.tags)
-  );
-}
-
-export function isCombinedListing(product: unknown) {
-  return (
-    isProductWithTags(product) &&
-    product.tags.includes(combinedListingsSettings.combinedListingTag)
-  );
-}
-
-```
+- app/lib/combined-listings.ts
 
 ## Steps
 
@@ -139,8 +98,6 @@ Create a new `combined-listings.ts` file that contains utilities and settings fo
 
 #### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
-<details>
-
 ```ts
 // Edit these values to customize combined listings' behavior
 export const combinedListingsSettings = {
@@ -179,8 +136,6 @@ export function isCombinedListing(product: unknown) {
 }
 
 ```
-
-</details>
 
 ### Step 4: Update the ProductForm component
 

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -133,7 +133,56 @@ export const combinedListingsSettings = {
 };
 ```
 
-### Step 3: Update the ProductForm component
+### Step 3: Add combined listings utilities
+
+Create a new `combined-listings.ts` file that contains utilities and settings for handling combined listings.
+
+#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+
+<details>
+
+```ts
+// Edit these values to customize combined listings' behavior
+export const combinedListingsSettings = {
+  // If true, loading the product page will redirect to the first variant
+  redirectToFirstVariant: false,
+  // The tag that indicates a combined listing
+  combinedListingTag: 'combined',
+  // If true, combined listings will not be shown in the product list
+  hideCombinedListingsFromProductList: true,
+};
+
+export const maybeFilterOutCombinedListingsQuery =
+  combinedListingsSettings.hideCombinedListingsFromProductList
+    ? `NOT tag:${combinedListingsSettings.combinedListingTag}`
+    : '';
+
+interface ProductWithTags {
+  tags: string[];
+}
+
+function isProductWithTags(u: unknown): u is ProductWithTags {
+  const maybe = u as ProductWithTags;
+  return (
+    u != null &&
+    typeof u === 'object' &&
+    'tags' in maybe &&
+    Array.isArray(maybe.tags)
+  );
+}
+
+export function isCombinedListing(product: unknown) {
+  return (
+    isProductWithTags(product) &&
+    product.tags.includes(combinedListingsSettings.combinedListingTag)
+  );
+}
+
+```
+
+</details>
+
+### Step 4: Update the ProductForm component
 
 1. Update the `ProductForm` component to hide the **Add to cart** button for the parent products of combined listings and for variants' selected state.
 2. Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
@@ -234,7 +283,7 @@ export const combinedListingsSettings = {
  }
 ```
 
-### Step 4: Extend the ProductImage component
+### Step 5: Extend the ProductImage component
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
@@ -259,7 +308,7 @@ Update the `ProductImage` component to support images from both product variants
      return <div className="product-image" />;
 ```
 
-### Step 5: Show a range of prices for combined listings in ProductItem
+### Step 6: Show a range of prices for combined listings in ProductItem
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
@@ -297,7 +346,7 @@ Update `ProductItem.tsx` to show a range of prices for the combined listing pare
  }
 ```
 
-### Step 6: (Optional) Add redirect utility to first variant of a combined listing
+### Step 7: (Optional) Add redirect utility to first variant of a combined listing
 
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
@@ -337,7 +386,7 @@ If you want to redirect automatically to the first variant of a combined listing
 +}
 ```
 
-### Step 7: Update queries for combined listings
+### Step 8: Update queries for combined listings
 
 1. Add the `tags` property to the items returned by the product query.
 2. (Optional) Add the filtering query to the product query to exclude combined listings.
@@ -416,7 +465,7 @@ If you want to redirect automatically to the first variant of a combined listing
        }
 ```
 
-### Step 8: (Optional) Filter out combined listings from collections pages
+### Step 9: (Optional) Filter out combined listings from collections pages
 
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
@@ -481,7 +530,7 @@ Since it's not possible to directly apply query filters when retrieving collecti
            ...ProductItem
 ```
 
-### Step 9: (Optional) Filter out combined listings from the collections index page
+### Step 10: (Optional) Filter out combined listings from the collections index page
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
@@ -535,7 +584,7 @@ Update the `collections.all` route to filter out combined listings from the sear
        }
 ```
 
-### Step 10: Update the product page
+### Step 11: Update the product page
 
 1. Display a range of prices for combined listings instead of the variant price.
 2. Show the featured image of the combined listing parent product instead of the variant image.
@@ -670,7 +719,7 @@ Update the `collections.all` route to filter out combined listings from the sear
        optionValues {
 ```
 
-### Step 11: Update stylesheet
+### Step 12: Update stylesheet
 
 Add a class to the product item to show a range of prices for combined listings.
 

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -517,58 +517,183 @@ Styles the `SellingPlanSelector` component.
 3. On the [Products](https://admin.shopify.com/products) page, open any products that will be sold as subscriptions and add the relevant subscription plans in the **Purchase options** section.
 The Hydrogen demo storefront comes pre-configured with an example subscription product with the handle `shopify-wax`.
 
-### Step 2: Render the selling plan in the cart
+### Step 2: Showing subscriptions in product pages
 
-1. Update `CartLineItem` to show subscription details when they're available.
-2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
+In this step we'll implement the ability to display and select subscriptions in product pages, alongside the existing one-off purchase options.
 
-#### File: /app/components/CartLineItem.tsx
+#### Step 2.1: Create a SellingPlanSelector component
 
-```diff
-@@ -3,8 +3,8 @@ import type {CartLayout} from '~/components/CartMain';
- import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
- import {useVariantUrl} from '~/lib/variants';
- import {Link} from '@remix-run/react';
--import {ProductPrice} from './ProductPrice';
--import {useAside} from './Aside';
-+import {ProductPrice} from '~/components/ProductPrice';
-+import {useAside} from '~/components/Aside';
- import type {CartApiQueryFragment} from 'storefrontapi.generated';
- 
- type CartLine = OptimisticCartLine<CartApiQueryFragment>;
-@@ -20,7 +20,9 @@ export function CartLineItem({
-   layout: CartLayout;
-   line: CartLine;
- }) {
--  const {id, merchandise} = line;
-+  // Get the selling plan allocation
-+  const {id, merchandise, sellingPlanAllocation} = line;
-+
-   const {product, title, image, selectedOptions} = merchandise;
-   const lineItemUrl = useVariantUrl(product.handle, selectedOptions);
-   const {close} = useAside();
-@@ -54,6 +56,12 @@ export function CartLineItem({
-         </Link>
-         <ProductPrice price={line?.cost?.totalAmount} />
-         <ul>
-+          {/* Optionally render the selling plan name if available */}
-+          {sellingPlanAllocation && (
-+            <li key={sellingPlanAllocation.sellingPlan.name}>
-+              <small>{sellingPlanAllocation.sellingPlan.name}</small>
-+            </li>
-+          )}
-           {selectedOptions.map((option) => (
-             <li key={option.name}>
-               <small>
+Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
+
+##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+
+<details>
+
+```tsx
+import type {
+  ProductFragment,
+  SellingPlanGroupFragment,
+  SellingPlanFragment,
+} from 'storefrontapi.generated';
+import {useMemo} from 'react';
+import {useLocation} from '@remix-run/react';
+
+/* Enriched sellingPlan type including isSelected and url */
+export type SellingPlan = SellingPlanFragment & {
+  isSelected: boolean;
+  url: string;
+};
+
+/* Enriched sellingPlanGroup type including enriched SellingPlan nodes */
+export type SellingPlanGroup = Omit<
+  SellingPlanGroupFragment,
+  'sellingPlans'
+> & {
+  sellingPlans: {
+    nodes: SellingPlan[];
+  };
+};
+
+/**
+ * A component that simplifies selecting sellingPlans subscription options
+ * @example Example use
+ * ```ts
+ *   <SellingPlanSelector
+ *     sellingPlanGroups={sellingPlanGroups}
+ *     selectedSellingPlanId={selectedSellingPlanId}
+ *   >
+ *     {({sellingPlanGroup}) => ( ...your sellingPlanGroup component )}
+ *  </SellingPlanSelector>
+ *  ```
+ **/
+export function SellingPlanSelector({
+  sellingPlanGroups,
+  selectedSellingPlan,
+  children,
+  paramKey = 'selling_plan',
+  selectedVariant,
+}: {
+  sellingPlanGroups: ProductFragment['sellingPlanGroups'];
+  selectedSellingPlan: SellingPlanFragment | null;
+  paramKey?: string;
+  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
+  children: (params: {
+    sellingPlanGroup: SellingPlanGroup;
+    selectedSellingPlan: SellingPlanFragment | null;
+  }) => React.ReactNode;
+}) {
+  const {search, pathname} = useLocation();
+  const params = new URLSearchParams(search);
+
+  const planAllocationIds: string[] =
+    selectedVariant?.sellingPlanAllocations.nodes.map(
+      (node) => node.sellingPlan.id,
+    ) ?? [];
+
+  return useMemo(
+    () =>
+      (sellingPlanGroups.nodes as SellingPlanGroup[])
+        // Filter out groups that don't have plans usable for the selected variant
+        .filter((group) => {
+          return group.sellingPlans.nodes.some((sellingPlan) =>
+            planAllocationIds.includes(sellingPlan.id),
+          );
+        })
+        .map((sellingPlanGroup) => {
+          // Augment each sellingPlan node with isSelected and url
+          const sellingPlans = sellingPlanGroup.sellingPlans.nodes
+            .map((sellingPlan: SellingPlan) => {
+              if (!sellingPlan?.id) {
+                console.warn(
+                  'SellingPlanSelector: sellingPlan.id is missing in the product query',
+                );
+                return null;
+              }
+
+              if (!sellingPlan.id) {
+                return null;
+              }
+
+              params.set(paramKey, sellingPlan.id);
+              sellingPlan.isSelected =
+                selectedSellingPlan?.id === sellingPlan.id;
+              sellingPlan.url = `${pathname}?${params.toString()}`;
+              return sellingPlan;
+            })
+            .filter(Boolean) as SellingPlan[];
+          sellingPlanGroup.sellingPlans.nodes = sellingPlans;
+          return children({sellingPlanGroup, selectedSellingPlan});
+        }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      sellingPlanGroups,
+      children,
+      selectedSellingPlan,
+      paramKey,
+      pathname,
+      selectedVariant,
+    ],
+  );
+}
+
 ```
 
-### Step 3: Update ProductForm to support subscriptions
+</details>
+
+#### Step 2.2: Add styles for the SellingPlanSelector component
+
+Add styles for the `SellingPlanSelector` component.
+
+##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+
+<details>
+
+```css
+.selling-plan-group {
+  margin-bottom: 1rem;
+}
+
+.selling-plan-group-title {
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.selling-plan {
+  border: 1px solid;
+  display: inline-block;
+  padding: 1rem;
+  margin-right: 0.5rem;
+  line-height: 1;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  border-bottom-width: 1.5px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.selling-plan:hover {
+  text-decoration: none;
+}
+
+.selling-plan.selected {
+  border-color: #6b7280; /* Equivalent to 'border-gray-500' */
+}
+
+.selling-plan.unselected {
+  border-color: #fafafa; /* Equivalent to 'border-neutral-50' */
+}
+
+```
+
+</details>
+
+#### Step 2.3: Update ProductForm to support subscriptions
 
 1. Add conditional rendering to display subscription options alongside the standard variant selectors.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
-#### File: /app/components/ProductForm.tsx
+##### File: /app/components/ProductForm.tsx
 
 ```diff
 @@ -6,14 +6,25 @@ import type {
@@ -687,12 +812,12 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 +}
 ```
 
-### Step 4: Update ProductPrice to display subscription pricing
+#### Step 2.4: Update ProductPrice to display subscription pricing
 
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
-#### File: /app/components/ProductPrice.tsx
+##### File: /app/components/ProductPrice.tsx
 
 ```diff
 @@ -1,13 +1,31 @@
@@ -804,46 +929,13 @@ The Hydrogen demo storefront comes pre-configured with an example subscription p
 +}
 ```
 
-### Step 5: Add selling plan data to cart queries
-
-Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
-
-#### File: /app/lib/fragments.ts
-
-```diff
-@@ -54,6 +54,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
-         }
-       }
-     }
-+    sellingPlanAllocation {
-+      sellingPlan {
-+         name
-+      }
-+    }
-   }
-   fragment CartLineComponent on ComponentizableCartLine {
-     id
-@@ -104,6 +109,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
-         }
-       }
-     }
-+    sellingPlanAllocation {
-+      sellingPlan {
-+         name
-+      }
-+    }
-   }
-   fragment CartApiQuery on Cart {
-     updatedAt
-```
-
-### Step 6: Add SellingPlanSelector to product pages
+#### Step 2.5: Update the product page to display subscription options
 
 1. Add the `SellingPlanSelector` component to display subscription options on product pages.
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
-#### File: /app/routes/products.$handle.tsx
+##### File: /app/routes/products.$handle.tsx
 
 ```diff
 @@ -1,3 +1,5 @@
@@ -1039,11 +1131,365 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
  ` as const;
 ```
 
-### Step 7: Add a link to the Subscriptions page
+### Step 3: Subscriptions in the cart
+
+In this step we'll implement support for showing subscriptions info in the Cart lines.
+
+#### Step 3.1: Add selling plan data to cart queries
+
+Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
+
+##### File: /app/lib/fragments.ts
+
+```diff
+@@ -54,6 +54,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
+         }
+       }
+     }
++    sellingPlanAllocation {
++      sellingPlan {
++         name
++      }
++    }
+   }
+   fragment CartLineComponent on ComponentizableCartLine {
+     id
+@@ -104,6 +109,11 @@ export const CART_QUERY_FRAGMENT = `#graphql
+         }
+       }
+     }
++    sellingPlanAllocation {
++      sellingPlan {
++         name
++      }
++    }
+   }
+   fragment CartApiQuery on Cart {
+     updatedAt
+```
+
+#### Step 3.2: Render the selling plan in the cart
+
+1. Update `CartLineItem` to show subscription details when they're available.
+2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
+
+##### File: /app/components/CartLineItem.tsx
+
+```diff
+@@ -3,8 +3,8 @@ import type {CartLayout} from '~/components/CartMain';
+ import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
+ import {useVariantUrl} from '~/lib/variants';
+ import {Link} from '@remix-run/react';
+-import {ProductPrice} from './ProductPrice';
+-import {useAside} from './Aside';
++import {ProductPrice} from '~/components/ProductPrice';
++import {useAside} from '~/components/Aside';
+ import type {CartApiQueryFragment} from 'storefrontapi.generated';
+ 
+ type CartLine = OptimisticCartLine<CartApiQueryFragment>;
+@@ -20,7 +20,9 @@ export function CartLineItem({
+   layout: CartLayout;
+   line: CartLine;
+ }) {
+-  const {id, merchandise} = line;
++  // Get the selling plan allocation
++  const {id, merchandise, sellingPlanAllocation} = line;
++
+   const {product, title, image, selectedOptions} = merchandise;
+   const lineItemUrl = useVariantUrl(product.handle, selectedOptions);
+   const {close} = useAside();
+@@ -54,6 +56,12 @@ export function CartLineItem({
+         </Link>
+         <ProductPrice price={line?.cost?.totalAmount} />
+         <ul>
++          {/* Optionally render the selling plan name if available */}
++          {sellingPlanAllocation && (
++            <li key={sellingPlanAllocation.sellingPlan.name}>
++              <small>{sellingPlanAllocation.sellingPlan.name}</small>
++            </li>
++          )}
+           {selectedOptions.map((option) => (
+             <li key={option.name}>
+               <small>
+```
+
+### Step 4: Managing account subscriptions
+
+In this step we'll implement support for unsubscribing from active subscriptions via an account subpage which lists existing subscription contracts.
+
+#### Step 4.1: Add queries to retrieve customer subscriptions
+
+Create GraphQL queries that retrieves the subscription info from the customer account client.
+
+##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+
+<details>
+
+```ts
+// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
+
+const SUBSCRIPTION_CONTRACT_FRAGMENT = `#graphql
+  fragment SubscriptionContract on SubscriptionContract {
+    id
+    status
+    createdAt
+    billingPolicy {
+      ...SubscriptionBillingPolicy
+    }
+  }
+  fragment SubscriptionBillingPolicy on SubscriptionBillingPolicy {
+    interval
+    intervalCount {
+      count
+      precision
+    }
+  }
+` as const;
+
+export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
+  query SubscriptionsContractsQuery {
+    customer {
+      subscriptionContracts(first: 100) {
+        nodes {
+          ...SubscriptionContract
+          lines(first: 100) {
+            nodes {
+              name
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+  ${SUBSCRIPTION_CONTRACT_FRAGMENT}
+` as const;
+
+```
+
+</details>
+
+#### Step 4.2: Add mutations to cancel customer subscriptions
+
+Create a GraqhQL mutation to cancel an existing subscription.
+
+##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+
+<details>
+
+```ts
+// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
+
+export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
+  mutation subscriptionContractCancel($subscriptionContractId: ID!) {
+    subscriptionContractCancel(subscriptionContractId: $subscriptionContractId) {
+      contract {
+        id
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+` as const;
+
+```
+
+</details>
+
+#### Step 4.3: Add an account subscriptions page
+
+Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
+
+##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+
+<details>
+
+```tsx
+import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
+import {
+  data,
+  LinksFunction,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from '@shopify/remix-oxygen';
+import {
+  useActionData,
+  useFetcher,
+  useLoaderData,
+  type MetaFunction,
+} from '@remix-run/react';
+import {SUBSCRIPTIONS_CONTRACTS_QUERY} from '../graphql/customer-account/CustomerSubscriptionsQuery';
+import {SUBSCRIPTION_CANCEL_MUTATION} from '../graphql/customer-account/CustomerSubscriptionsMutations';
+
+import accountSubscriptionsStyle from '~/styles/account-subscriptions.css?url';
+
+export type ActionResponse = {
+  error: string | null;
+};
+
+export const meta: MetaFunction = () => {
+  return [{title: 'Subscriptions'}];
+};
+
+export const links: LinksFunction = () => [
+  {rel: 'stylesheet', href: accountSubscriptionsStyle},
+];
+
+export async function loader({context}: LoaderFunctionArgs) {
+  await context.customerAccount.handleAuthStatus();
+
+  const {data: subscriptions} = await context.customerAccount.query(
+    SUBSCRIPTIONS_CONTRACTS_QUERY,
+  );
+
+  return {subscriptions};
+}
+
+export async function action({request, context}: ActionFunctionArgs) {
+  const {customerAccount} = context;
+
+  if (request.method !== 'DELETE') {
+    return data({error: 'Method not allowed'}, {status: 405});
+  }
+
+  const form = await request.formData();
+
+  try {
+    const subId = form.get('subId');
+
+    if (!subId) {
+      throw new Error('Subscription ID is required');
+    }
+
+    await customerAccount.mutate(SUBSCRIPTION_CANCEL_MUTATION, {
+      variables: {
+        subscriptionContractId: subId.toString(),
+      },
+    });
+
+    return {
+      error: null,
+    };
+  } catch (error: any) {
+    return data(
+      {
+        error: error.message,
+      },
+      {
+        status: 400,
+      },
+    );
+  }
+}
+
+export default function AccountProfile() {
+  const action = useActionData<ActionResponse>();
+
+  const {subscriptions} = useLoaderData<typeof loader>();
+
+  const fetcher = useFetcher();
+
+  return (
+    <div className="account-profile">
+      <h2>My subscriptions</h2>
+      {action?.error ? (
+        <p>
+          <mark>
+            <small>{action.error}</small>
+          </mark>
+        </p>
+      ) : null}
+      <div className="account-subscriptions">
+        {subscriptions?.customer?.subscriptionContracts.nodes.map(
+          (subscription) => {
+            const isBeingCancelled =
+              fetcher.state !== 'idle' &&
+              fetcher.formData?.get('subId') === subscription.id;
+            return (
+              <div key={subscription.id} className="subscription-row">
+                <div className="subscription-row-content">
+                  <div>
+                    {subscription.lines.nodes.map((line) => (
+                      <div key={line.id}>{line.name}</div>
+                    ))}
+                  </div>
+                  <div>
+                    Every{' '}
+                    <SubscriptionInterval
+                      billingPolicy={subscription.billingPolicy}
+                    />
+                  </div>
+                </div>
+                <div className="subscription-row-actions">
+                  <div
+                    className={
+                      subscription.status === 'ACTIVE'
+                        ? 'subscription-status-active'
+                        : 'subscription-status-inactive'
+                    }
+                  >
+                    {subscription.status}
+                  </div>
+                  {subscription.status === 'ACTIVE' && (
+                    <fetcher.Form key={subscription.id} method="DELETE">
+                      <input
+                        type="hidden"
+                        id="subId"
+                        name="subId"
+                        value={subscription.id}
+                      />
+                      <button type="submit" disabled={isBeingCancelled}>
+                        {isBeingCancelled ? 'Canceling' : 'Cancel subscription'}
+                      </button>
+                    </fetcher.Form>
+                  )}
+                </div>
+              </div>
+            );
+          },
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SubscriptionInterval({
+  billingPolicy,
+}: {
+  billingPolicy: SubscriptionBillingPolicyFragment;
+}) {
+  const count = billingPolicy.intervalCount?.count;
+  function getInterval() {
+    const suffix = count === 1 ? '' : 's';
+    switch (billingPolicy.interval) {
+      case 'DAY':
+        return 'day' + suffix;
+      case 'WEEK':
+        return 'week' + suffix;
+      case 'MONTH':
+        return 'month' + suffix;
+      case 'YEAR':
+        return 'year' + suffix;
+    }
+  }
+  return (
+    <span>
+      {count} {getInterval()}
+    </span>
+  );
+}
+
+```
+
+</details>
+
+#### Step 4.4: Add a link to the Subscriptions page in the account menu
 
 Add a `Subscriptions` link to the account menu.
 
-#### File: /app/routes/account.tsx
+##### File: /app/routes/account.tsx
 
 ```diff
 @@ -74,6 +74,10 @@ function AccountMenu() {
@@ -1058,5 +1504,52 @@ Add a `Subscriptions` link to the account menu.
      </nav>
    );
 ```
+
+#### Step 4.5: Add styles for the Subscriptions page
+
+Add styles for the Subscriptions page.
+
+##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+
+<details>
+
+```css
+.account-subscriptions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.account-subscriptions .subscription-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  border: 1px solid lightgray;
+  padding: 10px;
+}
+
+.account-subscriptions .subscription-row .subscription-row-content {
+  display: flex;
+  gap: 10px;
+  flex: 1;
+}
+
+.account-subscriptions .subscription-row .subscription-row-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.account-subscriptions .subscription-row .subscription-status-active {
+  color: green;
+}
+
+.account-subscriptions .subscription-row .subscription-status-inactive {
+  color: gray;
+}
+
+```
+
+</details>
 
 </recipe_implementation>

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -63,450 +63,12 @@ To implement subscriptions in your own store, you need to install a subscription
 
 ## New files added to the template by this recipe
 
-### templates/skeleton/app/components/SellingPlanSelector.tsx
-
-Displays the available subscription options on product pages.
-
-```tsx
-import type {
-  ProductFragment,
-  SellingPlanGroupFragment,
-  SellingPlanFragment,
-} from 'storefrontapi.generated';
-import {useMemo} from 'react';
-import {useLocation} from '@remix-run/react';
-
-/* Enriched sellingPlan type including isSelected and url */
-export type SellingPlan = SellingPlanFragment & {
-  isSelected: boolean;
-  url: string;
-};
-
-/* Enriched sellingPlanGroup type including enriched SellingPlan nodes */
-export type SellingPlanGroup = Omit<
-  SellingPlanGroupFragment,
-  'sellingPlans'
-> & {
-  sellingPlans: {
-    nodes: SellingPlan[];
-  };
-};
-
-/**
- * A component that simplifies selecting sellingPlans subscription options
- * @example Example use
- * ```ts
- *   <SellingPlanSelector
- *     sellingPlanGroups={sellingPlanGroups}
- *     selectedSellingPlanId={selectedSellingPlanId}
- *   >
- *     {({sellingPlanGroup}) => ( ...your sellingPlanGroup component )}
- *  </SellingPlanSelector>
- *  ```
- **/
-export function SellingPlanSelector({
-  sellingPlanGroups,
-  selectedSellingPlan,
-  children,
-  paramKey = 'selling_plan',
-  selectedVariant,
-}: {
-  sellingPlanGroups: ProductFragment['sellingPlanGroups'];
-  selectedSellingPlan: SellingPlanFragment | null;
-  paramKey?: string;
-  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
-  children: (params: {
-    sellingPlanGroup: SellingPlanGroup;
-    selectedSellingPlan: SellingPlanFragment | null;
-  }) => React.ReactNode;
-}) {
-  const {search, pathname} = useLocation();
-  const params = new URLSearchParams(search);
-
-  const planAllocationIds: string[] =
-    selectedVariant?.sellingPlanAllocations.nodes.map(
-      (node) => node.sellingPlan.id,
-    ) ?? [];
-
-  return useMemo(
-    () =>
-      (sellingPlanGroups.nodes as SellingPlanGroup[])
-        // Filter out groups that don't have plans usable for the selected variant
-        .filter((group) => {
-          return group.sellingPlans.nodes.some((sellingPlan) =>
-            planAllocationIds.includes(sellingPlan.id),
-          );
-        })
-        .map((sellingPlanGroup) => {
-          // Augment each sellingPlan node with isSelected and url
-          const sellingPlans = sellingPlanGroup.sellingPlans.nodes
-            .map((sellingPlan: SellingPlan) => {
-              if (!sellingPlan?.id) {
-                console.warn(
-                  'SellingPlanSelector: sellingPlan.id is missing in the product query',
-                );
-                return null;
-              }
-
-              if (!sellingPlan.id) {
-                return null;
-              }
-
-              params.set(paramKey, sellingPlan.id);
-              sellingPlan.isSelected =
-                selectedSellingPlan?.id === sellingPlan.id;
-              sellingPlan.url = `${pathname}?${params.toString()}`;
-              return sellingPlan;
-            })
-            .filter(Boolean) as SellingPlan[];
-          sellingPlanGroup.sellingPlans.nodes = sellingPlans;
-          return children({sellingPlanGroup, selectedSellingPlan});
-        }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      sellingPlanGroups,
-      children,
-      selectedSellingPlan,
-      paramKey,
-      pathname,
-      selectedVariant,
-    ],
-  );
-}
-
-```
-
-### templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts
-
-Mutations for managing customer subscriptions.
-
-```ts
-// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
-
-export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
-  mutation subscriptionContractCancel($subscriptionContractId: ID!) {
-    subscriptionContractCancel(subscriptionContractId: $subscriptionContractId) {
-      contract {
-        id
-      }
-      userErrors {
-        field
-        message
-      }
-    }
-  }
-` as const;
-
-```
-
-### templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts
-
-Queries for managing customer subscriptions.
-
-```ts
-// NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
-
-const SUBSCRIPTION_CONTRACT_FRAGMENT = `#graphql
-  fragment SubscriptionContract on SubscriptionContract {
-    id
-    status
-    createdAt
-    billingPolicy {
-      ...SubscriptionBillingPolicy
-    }
-  }
-  fragment SubscriptionBillingPolicy on SubscriptionBillingPolicy {
-    interval
-    intervalCount {
-      count
-      precision
-    }
-  }
-` as const;
-
-export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
-  query SubscriptionsContractsQuery {
-    customer {
-      subscriptionContracts(first: 100) {
-        nodes {
-          ...SubscriptionContract
-          lines(first: 100) {
-            nodes {
-              name
-              id
-            }
-          }
-        }
-      }
-    }
-  }
-  ${SUBSCRIPTION_CONTRACT_FRAGMENT}
-` as const;
-
-```
-
-### templates/skeleton/app/routes/account.subscriptions.tsx
-
-Subscriptions management page.
-
-```tsx
-import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
-import {
-  data,
-  LinksFunction,
-  type ActionFunctionArgs,
-  type LoaderFunctionArgs,
-} from '@shopify/remix-oxygen';
-import {
-  useActionData,
-  useFetcher,
-  useLoaderData,
-  type MetaFunction,
-} from '@remix-run/react';
-import {SUBSCRIPTIONS_CONTRACTS_QUERY} from '../graphql/customer-account/CustomerSubscriptionsQuery';
-import {SUBSCRIPTION_CANCEL_MUTATION} from '../graphql/customer-account/CustomerSubscriptionsMutations';
-
-import accountSubscriptionsStyle from '~/styles/account-subscriptions.css?url';
-
-export type ActionResponse = {
-  error: string | null;
-};
-
-export const meta: MetaFunction = () => {
-  return [{title: 'Subscriptions'}];
-};
-
-export const links: LinksFunction = () => [
-  {rel: 'stylesheet', href: accountSubscriptionsStyle},
-];
-
-export async function loader({context}: LoaderFunctionArgs) {
-  await context.customerAccount.handleAuthStatus();
-
-  const {data: subscriptions} = await context.customerAccount.query(
-    SUBSCRIPTIONS_CONTRACTS_QUERY,
-  );
-
-  return {subscriptions};
-}
-
-export async function action({request, context}: ActionFunctionArgs) {
-  const {customerAccount} = context;
-
-  if (request.method !== 'DELETE') {
-    return data({error: 'Method not allowed'}, {status: 405});
-  }
-
-  const form = await request.formData();
-
-  try {
-    const subId = form.get('subId');
-
-    if (!subId) {
-      throw new Error('Subscription ID is required');
-    }
-
-    await customerAccount.mutate(SUBSCRIPTION_CANCEL_MUTATION, {
-      variables: {
-        subscriptionContractId: subId.toString(),
-      },
-    });
-
-    return {
-      error: null,
-    };
-  } catch (error: any) {
-    return data(
-      {
-        error: error.message,
-      },
-      {
-        status: 400,
-      },
-    );
-  }
-}
-
-export default function AccountProfile() {
-  const action = useActionData<ActionResponse>();
-
-  const {subscriptions} = useLoaderData<typeof loader>();
-
-  const fetcher = useFetcher();
-
-  return (
-    <div className="account-profile">
-      <h2>My subscriptions</h2>
-      {action?.error ? (
-        <p>
-          <mark>
-            <small>{action.error}</small>
-          </mark>
-        </p>
-      ) : null}
-      <div className="account-subscriptions">
-        {subscriptions?.customer?.subscriptionContracts.nodes.map(
-          (subscription) => {
-            const isBeingCancelled =
-              fetcher.state !== 'idle' &&
-              fetcher.formData?.get('subId') === subscription.id;
-            return (
-              <div key={subscription.id} className="subscription-row">
-                <div className="subscription-row-content">
-                  <div>
-                    {subscription.lines.nodes.map((line) => (
-                      <div key={line.id}>{line.name}</div>
-                    ))}
-                  </div>
-                  <div>
-                    Every{' '}
-                    <SubscriptionInterval
-                      billingPolicy={subscription.billingPolicy}
-                    />
-                  </div>
-                </div>
-                <div className="subscription-row-actions">
-                  <div
-                    className={
-                      subscription.status === 'ACTIVE'
-                        ? 'subscription-status-active'
-                        : 'subscription-status-inactive'
-                    }
-                  >
-                    {subscription.status}
-                  </div>
-                  {subscription.status === 'ACTIVE' && (
-                    <fetcher.Form key={subscription.id} method="DELETE">
-                      <input
-                        type="hidden"
-                        id="subId"
-                        name="subId"
-                        value={subscription.id}
-                      />
-                      <button type="submit" disabled={isBeingCancelled}>
-                        {isBeingCancelled ? 'Canceling' : 'Cancel subscription'}
-                      </button>
-                    </fetcher.Form>
-                  )}
-                </div>
-              </div>
-            );
-          },
-        )}
-      </div>
-    </div>
-  );
-}
-
-function SubscriptionInterval({
-  billingPolicy,
-}: {
-  billingPolicy: SubscriptionBillingPolicyFragment;
-}) {
-  const count = billingPolicy.intervalCount?.count;
-  function getInterval() {
-    const suffix = count === 1 ? '' : 's';
-    switch (billingPolicy.interval) {
-      case 'DAY':
-        return 'day' + suffix;
-      case 'WEEK':
-        return 'week' + suffix;
-      case 'MONTH':
-        return 'month' + suffix;
-      case 'YEAR':
-        return 'year' + suffix;
-    }
-  }
-  return (
-    <span>
-      {count} {getInterval()}
-    </span>
-  );
-}
-
-```
-
-### templates/skeleton/app/styles/account-subscriptions.css
-
-Subscriptions management page styles.
-
-```css
-.account-subscriptions {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.account-subscriptions .subscription-row {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  border: 1px solid lightgray;
-  padding: 10px;
-}
-
-.account-subscriptions .subscription-row .subscription-row-content {
-  display: flex;
-  gap: 10px;
-  flex: 1;
-}
-
-.account-subscriptions .subscription-row .subscription-row-actions {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-}
-
-.account-subscriptions .subscription-row .subscription-status-active {
-  color: green;
-}
-
-.account-subscriptions .subscription-row .subscription-status-inactive {
-  color: gray;
-}
-
-```
-
-### templates/skeleton/app/styles/selling-plan.css
-
-Styles the `SellingPlanSelector` component.
-
-```css
-.selling-plan-group {
-  margin-bottom: 1rem;
-}
-
-.selling-plan-group-title {
-  font-weight: 500;
-  margin-bottom: 0.5rem;
-}
-
-.selling-plan {
-  border: 1px solid;
-  display: inline-block;
-  padding: 1rem;
-  margin-right: 0.5rem;
-  line-height: 1;
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-  border-bottom-width: 1.5px;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.selling-plan:hover {
-  text-decoration: none;
-}
-
-.selling-plan.selected {
-  border-color: #6b7280; /* Equivalent to 'border-gray-500' */
-}
-
-.selling-plan.unselected {
-  border-color: #fafafa; /* Equivalent to 'border-neutral-50' */
-}
-
-```
+- app/components/SellingPlanSelector.tsx
+- app/graphql/customer-account/CustomerSubscriptionsMutations.ts
+- app/graphql/customer-account/CustomerSubscriptionsQuery.ts
+- app/routes/account.subscriptions.tsx
+- app/styles/account-subscriptions.css
+- app/styles/selling-plan.css
 
 ## Steps
 
@@ -527,8 +89,6 @@ Create a new `SellingPlanSelector` component that displays the available subscri
 
 ##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
 
-<details>
-
 ```tsx
 import type {
   ProductFragment,
@@ -638,15 +198,11 @@ export function SellingPlanSelector({
 
 ```
 
-</details>
-
 #### Step 2.2: Add styles for the SellingPlanSelector component
 
 Add styles for the `SellingPlanSelector` component.
 
 ##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
-
-<details>
 
 ```css
 .selling-plan-group {
@@ -684,8 +240,6 @@ Add styles for the `SellingPlanSelector` component.
 }
 
 ```
-
-</details>
 
 #### Step 2.3: Update ProductForm to support subscriptions
 
@@ -1223,8 +777,6 @@ Create GraphQL queries that retrieves the subscription info from the customer ac
 
 ##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
-<details>
-
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
 
@@ -1267,15 +819,11 @@ export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
 
 ```
 
-</details>
-
 #### Step 4.2: Add mutations to cancel customer subscriptions
 
 Create a GraqhQL mutation to cancel an existing subscription.
 
 ##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
-
-<details>
 
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
@@ -1296,15 +844,11 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 ```
 
-</details>
-
 #### Step 4.3: Add an account subscriptions page
 
 Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
 
 ##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
-
-<details>
 
 ```tsx
 import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
@@ -1483,8 +1027,6 @@ function SubscriptionInterval({
 
 ```
 
-</details>
-
 #### Step 4.4: Add a link to the Subscriptions page in the account menu
 
 Add a `Subscriptions` link to the account menu.
@@ -1510,8 +1052,6 @@ Add a `Subscriptions` link to the account menu.
 Add styles for the Subscriptions page.
 
 ##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
-
-<details>
 
 ```css
 .account-subscriptions {
@@ -1549,7 +1089,5 @@ Add styles for the Subscriptions page.
 }
 
 ```
-
-</details>
 
 </recipe_implementation>

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -79,9 +79,9 @@ To implement subscriptions in your own store, you need to install a subscription
 3. On the [Products](https://admin.shopify.com/products) page, open any products that will be sold as subscriptions and add the relevant subscription plans in the **Purchase options** section.
 The Hydrogen demo storefront comes pre-configured with an example subscription product with the handle `shopify-wax`.
 
-### Step 2: Showing subscriptions in product pages
+### Step 2: Show subscription options on product pages
 
-In this step we'll implement the ability to display and select subscriptions in product pages, alongside the existing one-off purchase options.
+In this step we'll implement the ability to display subscription options on  product pages, alongside the existing one-off purchase options.
 
 #### Step 2.1: Create a SellingPlanSelector component
 
@@ -685,9 +685,9 @@ Add styles for the `SellingPlanSelector` component.
  ` as const;
 ```
 
-### Step 3: Subscriptions in the cart
+### Step 3: Show subscription details in the cart
 
-In this step we'll implement support for showing subscriptions info in the Cart lines.
+In this step we'll implement support for showing subscription info in the cart's line items.
 
 #### Step 3.1: Add selling plan data to cart queries
 
@@ -767,13 +767,13 @@ Add a `sellingPlanAllocation` field with the plan name to the standard and compo
                <small>
 ```
 
-### Step 4: Managing account subscriptions
+### Step 4: Add subscription management to the account page
 
-In this step we'll implement support for unsubscribing from active subscriptions via an account subpage which lists existing subscription contracts.
+In this step we'll implement support for subscription management through an account subpage that lists existing subscription contracts.
 
 #### Step 4.1: Add queries to retrieve customer subscriptions
 
-Create GraphQL queries that retrieves the subscription info from the customer account client.
+Create GraphQL queries that retrieve the subscription info from the customer account client.
 
 ##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
@@ -846,7 +846,7 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 #### Step 4.3: Add an account subscriptions page
 
-Create a new account subpage that allows management of existing customer subscriptions based on the new GraphQL queries and mutations created previously.
+Create a new account subpage that lets customers manage their existing  subscriptions based on the new GraphQL queries and mutations.
 
 ##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/bd55b241191304945704c0b9ef278e945c55d3da/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
 


### PR DESCRIPTION
### WHY are these changes introduced?

Some complex recipes (e.g. the `subscriptions` one) might benefit from having steps organized in substeps blocks.
Additionally, the ingredients should be treated as any other diff in the recipe description, which helps a lot with readability for both humans and LLMs.

### WHAT is this pull request doing?

1. Add the ability to define substeps in a recipe manifest. For ergonomy's sake, this is done with a single `step` field in the recipe step which can be either an integer or a string with dots to separate substeps (e.g. `2.1`). This field replaces the previous `index` field since it achieves the same goal at the same time.
2. Remove the unnecessary `COPY_INGREDIENTS` step type, and instead include steps for new files (`NEW_FILE` step type)
3. Adjust the rendering to accommodate for nesting substeps
4. Refactor the subscriptions recipe to make use of the substeps to express the implementation flow (no logic changes)
5. Updated the bundles and combined listings recipes (no logic changes)

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
