### PR TITLE
Add buyer identity to cart handler and hydrogen context

### DIFF
--- a/.changeset/sweet-hotels-hunt.md
+++ b/.changeset/sweet-hotels-hunt.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Add a `buyerIdentity` parameter to `createHydrogenContext` and `createCartHandler`. This buyer identity will be used as the default buyer identity for all new cart creations.

--- a/.changeset/sweet-hotels-hunt.md
+++ b/.changeset/sweet-hotels-hunt.md
@@ -1,5 +1,14 @@
 ---
-"@shopify/hydrogen": patch
+'@shopify/hydrogen': patch
 ---
 
-Add a `buyerIdentity` parameter to `createHydrogenContext` and `createCartHandler`. This buyer identity will be used as the default buyer identity for all new cart creations.
+Add a `buyerIdentity` parameter to `createHydrogenContext` and `createCartHandler`. This buyer identity will be used as the default buyer identity for all new cart creations:
+
+```ts
+const hydrogenContext = createHydrogenContext({
+  // ...
+  buyerIdentity: {
+    companyLocationId: '...',
+  },
+});
+```

--- a/packages/hydrogen/src/cart/createCartHandler.test.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.test.ts
@@ -8,10 +8,8 @@ import {
 import {
   mockCreateCustomerAccountClient,
   mockCreateStorefrontClient,
-  mockHeaders,
 } from './cart-test-helper';
 import {Storefront} from '../storefront';
-import {CART_CREATE_MUTATION} from './queries/cartCreateDefault';
 
 type MockCarthandler = {
   cartId?: string;
@@ -470,21 +468,14 @@ describe('createCartHandler', () => {
       },
     ]);
 
-    expect(storefront.mutate).toHaveBeenCalledWith(CART_CREATE_MUTATION(), {
+    expect(storefront.mutate).toHaveBeenCalledWith(expect.any(String), {
       variables: {
         input: {
           buyerIdentity: {
             companyLocationId: 'someLocation',
-            customerAccessToken: 'sha123',
+            customerAccessToken: expect.any(String),
           },
-          lines: [
-            {
-              attributes: undefined,
-              merchandiseId: '1',
-              quantity: 1,
-              sellingPlanId: undefined,
-            },
-          ],
+          lines: expect.any(Array),
         },
       },
     });
@@ -509,21 +500,14 @@ describe('createCartHandler', () => {
       ],
     });
 
-    expect(storefront.mutate).toHaveBeenCalledWith(CART_CREATE_MUTATION(), {
+    expect(storefront.mutate).toHaveBeenCalledWith(expect.any(String), {
       variables: {
         input: {
           buyerIdentity: {
             companyLocationId: 'someLocation',
-            customerAccessToken: 'sha123',
+            customerAccessToken: expect.any(String),
           },
-          lines: [
-            {
-              attributes: undefined,
-              merchandiseId: '1',
-              quantity: 1,
-              sellingPlanId: undefined,
-            },
-          ],
+          lines: expect.any(Array),
         },
       },
     });
@@ -551,21 +535,14 @@ describe('createCartHandler', () => {
       },
     });
 
-    expect(storefront.mutate).toHaveBeenCalledWith(CART_CREATE_MUTATION(), {
+    expect(storefront.mutate).toHaveBeenCalledWith(expect.any(String), {
       variables: {
         input: {
           buyerIdentity: {
             companyLocationId: 'newLocation',
-            customerAccessToken: 'sha123',
+            customerAccessToken: expect.any(String),
           },
-          lines: [
-            {
-              attributes: undefined,
-              merchandiseId: '1',
-              quantity: 1,
-              sellingPlanId: undefined,
-            },
-          ],
+          lines: expect.any(Array),
         },
       },
     });

--- a/packages/hydrogen/src/cart/createCartHandler.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.ts
@@ -61,6 +61,7 @@ import {
   type CartDeliveryAddressesUpdateFunction,
   cartDeliveryAddressesUpdateDefault,
 } from './queries/cartDeliveryAddressesUpdateDefault';
+import type {CartBuyerIdentityInput} from '@shopify/hydrogen-react/storefront-api-types';
 
 export type CartHandlerOptions = {
   storefront: Storefront;
@@ -69,6 +70,7 @@ export type CartHandlerOptions = {
   setCartId: (cartId: string) => Headers;
   cartQueryFragment?: string;
   cartMutateFragment?: string;
+  buyerIdentity?: CartBuyerIdentityInput;
 };
 
 export type CustomMethodsBase = Record<string, Function>;
@@ -196,6 +198,7 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
     customerAccount,
     cartQueryFragment,
     cartMutateFragment,
+    buyerIdentity,
   } = options;
 
   let cartId = _getCartId();
@@ -239,7 +242,7 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
 
       return cartId || optionalParams?.cartId
         ? await cartLinesAddDefault(mutateOptions)(lines, optionalParams)
-        : await cartCreate({lines}, optionalParams);
+        : await cartCreate({lines, buyerIdentity}, optionalParams);
     },
     updateLines: cartLinesUpdateDefault(mutateOptions),
     removeLines: cartLinesRemoveDefault(mutateOptions),

--- a/packages/hydrogen/src/cart/createCartHandler.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.ts
@@ -215,6 +215,13 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
   const _cartCreate = cartCreateDefault(mutateOptions);
 
   const cartCreate: CartCreateFunction = async function (...args) {
+    // Default buyerIdentity to what is passed into the handler
+    // Only override if buyerIdentity is passed directly to the method
+    args[0].buyerIdentity = {
+      ...buyerIdentity,
+      ...args[0].buyerIdentity,
+    };
+
     const result = await _cartCreate(...args);
     cartId = result?.cart?.id;
     return result;
@@ -339,6 +346,11 @@ export type CartHandlerOptionsForDocs<
    * See the [example usage](/docs/api/hydrogen/2025-04/utilities/createcarthandler#example-custom-methods) in the documentation.
    */
   customMethods?: TCustomMethods;
+
+  /**
+   * Buyer identity. Default buyer identity is passed to cartCreate.
+   */
+  buyerIdentity?: CartBuyerIdentityInput;
 };
 
 export type HydrogenCartForDocs = {

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -26,6 +26,7 @@ import type {
 } from './types';
 import {type CrossRuntimeRequest, getHeader} from './utils/request';
 import {warnOnce} from './utils/warning';
+import type {CartBuyerIdentityInput} from '@shopify/hydrogen-react/storefront-api-types';
 
 export type HydrogenContextOptions<
   TSession extends HydrogenSession = HydrogenSession,
@@ -87,6 +88,7 @@ export type HydrogenContextOptions<
      */
     customMethods?: TCustomMethods;
   };
+  buyerIdentity?: CartBuyerIdentityInput;
 };
 
 export interface HydrogenContext<
@@ -157,6 +159,7 @@ export function createHydrogenContext<
     storefront: storefrontOptions = {},
     customerAccount: customerAccountOptions,
     cart: cartOptions = {},
+    buyerIdentity,
   } = options;
 
   if (!session) {
@@ -224,6 +227,7 @@ export function createHydrogenContext<
     cartQueryFragment: cartOptions.queryFragment,
     cartMutateFragment: cartOptions.mutateFragment,
     customMethods: cartOptions.customMethods,
+    buyerIdentity,
 
     // defaults
     storefront,

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -312,4 +312,8 @@ export type HydrogenContextOptionsForDocs<
      */
     customMethods?: Record<string, Function>;
   };
+  /**
+   * Buyer identity. Default buyer identity is passed to cartCreate.
+   */
+  buyerIdentity?: CartBuyerIdentityInput;
 };

--- a/templates/skeleton/app/routes/cart.tsx
+++ b/templates/skeleton/app/routes/cart.tsx
@@ -1,7 +1,12 @@
 import {type MetaFunction, useLoaderData} from '@remix-run/react';
 import type {CartQueryDataReturn} from '@shopify/hydrogen';
 import {CartForm} from '@shopify/hydrogen';
-import {data, type LoaderFunctionArgs, type ActionFunctionArgs, type HeadersFunction} from '@shopify/remix-oxygen';
+import {
+  data,
+  type LoaderFunctionArgs,
+  type ActionFunctionArgs,
+  type HeadersFunction,
+} from '@shopify/remix-oxygen';
 import {CartMain} from '~/components/CartMain';
 
 export const meta: MetaFunction = () => {


### PR DESCRIPTION
Add an optional parameter to the hydrogen context and cart handler for defining the buyer identity.

A b2b storefront requires a buyer identity with a company location. We already have a mutation `buyerIdentityUpdate` to define it, but for storefronts that are only b2b, it's not ideal to force people to call `addLines()` and immediately after to update the buyer identity. Instead we should allow passing in the buyer identity directly to the cart handler, so it gets used  directly when the cart is created.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
