### PR TITLE
Cookbook: bump recipes

### DIFF
--- a/.changeset/rare-tigers-train.md
+++ b/.changeset/rare-tigers-train.md
@@ -1,0 +1,5 @@
+---
+"skeleton": patch
+---
+
+Updated recipes: subscriptions, bundles, combined-listings. New recipe: markets.

--- a/cookbook/.cursor/rules/cookbook-recipe-bundles.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-bundles.mdc
@@ -87,7 +87,7 @@ In this recipe, we'll use the [Shopify Bundles app](https://apps.shopify.com/sho
 
 Create a new BundleBadge component to be displayed on bundle product listings.
 
-#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
 
 ```tsx
 export function BundleBadge() {
@@ -114,7 +114,7 @@ export function BundleBadge() {
 
 Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
 
-#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
 
 ```tsx
 import {Link} from '@remix-run/react';

--- a/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -96,7 +96,7 @@ export const combinedListingsSettings = {
 
 Create a new `combined-listings.ts` file that contains utilities and settings for handling combined listings.
 
-#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
 ```ts
 // Edit these values to customize combined listings' behavior

--- a/cookbook/.cursor/rules/cookbook-recipe-markets.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-markets.mdc
@@ -116,7 +116,7 @@ A component that displays a country selector inside the Header.
 
 To handle redirects, use a `Fetcher` that updates the cart buyer identity, that will eventually redirect to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 ```tsx
 import {Form} from '@remix-run/react';
@@ -195,7 +195,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the Remix `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 ```tsx
 import {Link as RemixLink} from '@remix-run/react';
@@ -218,7 +218,7 @@ export function Link({...props}: RemixLinkProps) {
 - Create a helper function to get locale information from the context, and a hook to retrieve the selected locale.
 - Define a default locale that will be used as a fallback when no market is explicitly selected.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 ```ts
 import {useMatches} from '@remix-run/react';
@@ -444,7 +444,7 @@ For brevity, in this example we only focused on two files – the index page and
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -625,7 +625,7 @@ Add the splat to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 ```tsx
 import {type MetaFunction, useLoaderData} from '@remix-run/react';
@@ -756,7 +756,7 @@ export default function Cart() {
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';

--- a/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/cookbook/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -87,7 +87,7 @@ In this step we'll implement the ability to display subscription options on  pro
 
 Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
 
-##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
 
 ```tsx
 import type {
@@ -202,7 +202,7 @@ export function SellingPlanSelector({
 
 Add styles for the `SellingPlanSelector` component.
 
-##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 ```css
 .selling-plan-group {
@@ -775,7 +775,7 @@ In this step we'll implement support for subscription management through an acco
 
 Create GraphQL queries that retrieve the subscription info from the customer account client.
 
-##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
@@ -823,7 +823,7 @@ export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
 
 Create a GraqhQL mutation to cancel an existing subscription.
 
-##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
 
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
@@ -848,7 +848,7 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 Create a new account subpage that lets customers manage their existing  subscriptions based on the new GraphQL queries and mutations.
 
-##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
 
 ```tsx
 import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
@@ -1051,7 +1051,7 @@ Add a `Subscriptions` link to the account menu.
 
 Add styles for the Subscriptions page.
 
-##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
 
 ```css
 .account-subscriptions {

--- a/cookbook/recipes/bundles/README.md
+++ b/cookbook/recipes/bundles/README.md
@@ -26,8 +26,8 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
-| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
+| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
+| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
 
 ## Steps
 
@@ -43,7 +43,7 @@ _New files added to the template by this recipe._
 
 Create a new BundleBadge component to be displayed on bundle product listings.
 
-#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
 
 <details>
 
@@ -74,7 +74,7 @@ export function BundleBadge() {
 
 Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
 
-#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
 
 <details>
 
@@ -153,7 +153,7 @@ export function BundledVariants({
 used to identify bundled products.
 2. Pass the `isBundle` flag to the `ProductImage` component.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -276,7 +276,7 @@ index 2dc6bda2..0339d128 100644
 
 Like the previous step, use the `requiresComponents` field to detect if the product item is a bundle.
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/routes/collections.$handle.tsx)
 
 ```diff
 index f1d7fa3e..ae341f8a 100644
@@ -329,7 +329,7 @@ index f1d7fa3e..ae341f8a 100644
 
 Use the `requiresComponents` field to determine if a cart line item is a bundle.
 
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/lib/fragments.ts)
 
 <details>
 
@@ -394,7 +394,7 @@ index dc4426a9..13cc34e5 100644
 
 If a product is a bundle, show the `BundleBadge` component in the cart line item.
 
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..0790a6f2 100644
@@ -445,7 +445,7 @@ index bd33a2cf..0790a6f2 100644
 
 If a product is a bundle, update the text of the product button.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/ProductForm.tsx)
 
 ```diff
 index e8616a61..07a984dc 100644
@@ -482,7 +482,7 @@ index e8616a61..07a984dc 100644
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductImage` component.
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..c16b947b 100644
@@ -516,7 +516,7 @@ index 5f3ac1cc..c16b947b 100644
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductItem` component.
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/ProductItem.tsx)
 
 <details>
 
@@ -598,7 +598,7 @@ index 62c64b50..970916bd 100644
 
 Make sure the bundle badge is positioned relative to the product image.
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..de48b6c6 100644

--- a/cookbook/recipes/bundles/recipe.yaml
+++ b/cookbook/recipes/bundles/recipe.yaml
@@ -155,4 +155,4 @@ llms:
       solution: Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin. Then make sure you've updated the cart
         fragment to query for bundles.
-commit: c58ddde879b8f1f4c14893ee7cf3db76dee00ae6
+commit: 55f1e46ea602b35806cb594de69291a1ef674118

--- a/cookbook/recipes/combined-listings/README.md
+++ b/cookbook/recipes/combined-listings/README.md
@@ -21,7 +21,7 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
+| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
 
 ## Steps
 
@@ -55,7 +55,7 @@ export const combinedListingsSettings = {
 
 Create a new `combined-listings.ts` file that contains utilities and settings for handling combined listings.
 
-#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
 <details>
 
@@ -105,7 +105,7 @@ export function isCombinedListing(product: unknown) {
 1. Update the `ProductForm` component to hide the **Add to cart** button for the parent products of combined listings and for variants' selected state.
 2. Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -212,7 +212,7 @@ index e8616a61..b6567c21 100644
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..f1c9f2cd 100644
@@ -240,7 +240,7 @@ index 5f3ac1cc..f1c9f2cd 100644
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 62c64b50..034b5660 100644
@@ -281,7 +281,7 @@ index 62c64b50..034b5660 100644
 
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
-#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/lib/redirect.ts)
+#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/lib/redirect.ts)
 
 ```diff
 index ce1feb5a..29fe2ecc 100644
@@ -325,7 +325,7 @@ index ce1feb5a..29fe2ecc 100644
 1. Add the `tags` property to the items returned by the product query.
 2. (Optional) Add the filtering query to the product query to exclude combined listings.
 
-#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/routes/_index.tsx)
+#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/routes/_index.tsx)
 
 <details>
 
@@ -410,7 +410,7 @@ index 34747528..6e485083 100644
 
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/routes/collections.$handle.tsx)
 
 <details>
 
@@ -482,7 +482,7 @@ index f1d7fa3e..17edfb7d 100644
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
-#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/routes/collections.all.tsx)
+#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/routes/collections.all.tsx)
 
 ```diff
 index 3a31b2f7..c756c9e1 100644
@@ -541,7 +541,7 @@ index 3a31b2f7..c756c9e1 100644
 2. Show the featured image of the combined listing parent product instead of the variant image.
 3. (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -681,7 +681,7 @@ index 2dc6bda2..8baafac9 100644
 
 Add a class to the product item to show a range of prices for combined listings.
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..c8fa5109 100644

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -204,4 +204,4 @@ llms:
       solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
-commit: c58ddde879b8f1f4c14893ee7cf3db76dee00ae6
+commit: 55f1e46ea602b35806cb594de69291a1ef674118

--- a/cookbook/recipes/markets/README.md
+++ b/cookbook/recipes/markets/README.md
@@ -27,12 +27,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx) | A component that displays a country selector inside the Header. |
-| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx) | A wrapper around the Remix Link component that uses the selected locale path prefix. |
-| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts) | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
-| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx) | A route that renders a localized version of the home page. |
-| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx) | A localized cart route. |
-| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page. |
+| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx) | A component that displays a country selector inside the Header. |
+| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx) | A wrapper around the Remix Link component that uses the selected locale path prefix. |
+| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts) | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
+| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx) | A route that renders a localized version of the home page. |
+| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx) | A localized cart route. |
+| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page. |
 
 ## Steps
 
@@ -78,7 +78,7 @@ A component that displays a country selector inside the Header.
 
 To handle redirects, use a `Fetcher` that updates the cart buyer identity, that will eventually redirect to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 <details>
 
@@ -161,7 +161,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the Remix `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 <details>
 
@@ -188,7 +188,7 @@ export function Link({...props}: RemixLinkProps) {
 - Create a helper function to get locale information from the context, and a hook to retrieve the selected locale.
 - Define a default locale that will be used as a fallback when no market is explicitly selected.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 <details>
 
@@ -256,7 +256,7 @@ export function useSelectedLocale(): Locale | null {
 
 Update the `ProductItem` component to use the `Link` component from the `app/components/Link.tsx` file.
 
-##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/ProductItem.tsx)
+##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 62c64b50..81ff9ec9 100644
@@ -281,7 +281,7 @@ index 62c64b50..81ff9ec9 100644
 
 Detect the locale from the URL path, and add it to the Hydrogencontext.
 
-##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/lib/context.ts)
+##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/lib/context.ts)
 
 ```diff
 index c424c511..b5d3737a 100644
@@ -318,7 +318,7 @@ index c424c511..b5d3737a 100644
 
 Add a CountrySelector component to the Header.
 
-##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/Header.tsx)
+##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/Header.tsx)
 
 ```diff
 index 8a437a10..757808eb 100644
@@ -357,7 +357,7 @@ index 8a437a10..757808eb 100644
 - Add a key prop to the `PageLayout` component to make sure it re-renders
 when the locale changes.
 
-##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/root.tsx)
+##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/root.tsx)
 
 ```diff
 index 3426476a..4f67b72b 100644
@@ -430,7 +430,7 @@ For brevity, in this example we only focused on two files – the index page and
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 <details>
 
@@ -615,7 +615,7 @@ Add the splat to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 <details>
 
@@ -750,7 +750,7 @@ export default function Cart() {
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 <details>
 

--- a/cookbook/recipes/markets/recipe.yaml
+++ b/cookbook/recipes/markets/recipe.yaml
@@ -218,4 +218,4 @@ nextSteps: null
 llms:
   userQueries: []
   troubleshooting: []
-commit: c58ddde879b8f1f4c14893ee7cf3db76dee00ae6
+commit: 55f1e46ea602b35806cb594de69291a1ef674118

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -20,12 +20,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
-| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
-| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
-| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
-| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
-| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
+| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
+| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
+| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
+| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
+| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
+| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
 
 ## Steps
 
@@ -44,7 +44,7 @@ In this step we'll implement the ability to display subscription options on  pro
 
 Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
 
-##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
 
 <details>
 
@@ -163,7 +163,7 @@ export function SellingPlanSelector({
 
 Add styles for the `SellingPlanSelector` component.
 
-##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 <details>
 
@@ -212,7 +212,7 @@ Add styles for the `SellingPlanSelector` component.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
-##### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/ProductForm.tsx)
+##### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -343,7 +343,7 @@ index e8616a61..8b7fe8ca 100644
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
-##### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/ProductPrice.tsx)
+##### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/ProductPrice.tsx)
 
 <details>
 
@@ -468,7 +468,7 @@ index 32460ae2..59eed1d8 100644
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
-##### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/routes/products.$handle.tsx)
+##### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -679,7 +679,7 @@ In this step we'll implement support for showing subscription info in the cart's
 
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
-##### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/lib/fragments.ts)
+##### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/lib/fragments.ts)
 
 ```diff
 index dc4426a9..cfe3a938 100644
@@ -716,7 +716,7 @@ index dc4426a9..cfe3a938 100644
 1. Update `CartLineItem` to show subscription details when they're available.
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
-##### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/components/CartLineItem.tsx)
+##### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index bd33a2cf..a18e4b52 100644
@@ -767,7 +767,7 @@ In this step we'll implement support for subscription management through an acco
 
 Create GraphQL queries that retrieve the subscription info from the customer account client.
 
-##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
 <details>
 
@@ -819,7 +819,7 @@ export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
 
 Create a GraqhQL mutation to cancel an existing subscription.
 
-##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
 
 <details>
 
@@ -848,7 +848,7 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 Create a new account subpage that lets customers manage their existing  subscriptions based on the new GraphQL queries and mutations.
 
-##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
 
 <details>
 
@@ -1035,7 +1035,7 @@ function SubscriptionInterval({
 
 Add a `Subscriptions` link to the account menu.
 
-##### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/templates/skeleton/app/routes/account.tsx)
+##### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/templates/skeleton/app/routes/account.tsx)
 
 ```diff
 index 0941d4e0..976ae9df 100644
@@ -1058,7 +1058,7 @@ index 0941d4e0..976ae9df 100644
 
 Add styles for the Subscriptions page.
 
-##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
 
 <details>
 

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -207,4 +207,4 @@ llms:
     - issue: I'm not seeing the subscription details on my cart line items.
       solution: Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
-commit: c58ddde879b8f1f4c14893ee7cf3db76dee00ae6
+commit: 55f1e46ea602b35806cb594de69291a1ef674118

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-bundles.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-bundles.mdc
@@ -87,7 +87,7 @@ In this recipe, we'll use the [Shopify Bundles app](https://apps.shopify.com/sho
 
 Create a new BundleBadge component to be displayed on bundle product listings.
 
-#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
 
 ```tsx
 export function BundleBadge() {
@@ -114,7 +114,7 @@ export function BundleBadge() {
 
 Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
 
-#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
 
 ```tsx
 import {Link} from '@remix-run/react';

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-combined-listings.mdc
@@ -96,7 +96,7 @@ export const combinedListingsSettings = {
 
 Create a new `combined-listings.ts` file that contains utilities and settings for handling combined listings.
 
-#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
 ```ts
 // Edit these values to customize combined listings' behavior

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-markets.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-markets.mdc
@@ -116,7 +116,7 @@ A component that displays a country selector inside the Header.
 
 To handle redirects, use a `Fetcher` that updates the cart buyer identity, that will eventually redirect to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 ```tsx
 import {Form} from '@remix-run/react';
@@ -195,7 +195,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the Remix `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 ```tsx
 import {Link as RemixLink} from '@remix-run/react';
@@ -218,7 +218,7 @@ export function Link({...props}: RemixLinkProps) {
 - Create a helper function to get locale information from the context, and a hook to retrieve the selected locale.
 - Define a default locale that will be used as a fallback when no market is explicitly selected.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 ```ts
 import {useMatches} from '@remix-run/react';
@@ -444,7 +444,7 @@ For brevity, in this example we only focused on two files – the index page and
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -625,7 +625,7 @@ Add the splat to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 ```tsx
 import {type MetaFunction, useLoaderData} from '@remix-run/react';
@@ -756,7 +756,7 @@ export default function Cart() {
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';

--- a/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
+++ b/templates/skeleton/.cursor/rules/cookbook-recipe-subscriptions.mdc
@@ -87,7 +87,7 @@ In this step we'll implement the ability to display subscription options on  pro
 
 Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
 
-##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
 
 ```tsx
 import type {
@@ -202,7 +202,7 @@ export function SellingPlanSelector({
 
 Add styles for the `SellingPlanSelector` component.
 
-##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 ```css
 .selling-plan-group {
@@ -775,7 +775,7 @@ In this step we'll implement support for subscription management through an acco
 
 Create GraphQL queries that retrieve the subscription info from the customer account client.
 
-##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
@@ -823,7 +823,7 @@ export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
 
 Create a GraqhQL mutation to cancel an existing subscription.
 
-##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
 
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
@@ -848,7 +848,7 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 Create a new account subpage that lets customers manage their existing  subscriptions based on the new GraphQL queries and mutations.
 
-##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
 
 ```tsx
 import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
@@ -1051,7 +1051,7 @@ Add a `Subscriptions` link to the account menu.
 
 Add styles for the Subscriptions page.
 
-##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/c58ddde879b8f1f4c14893ee7cf3db76dee00ae6/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/55f1e46ea602b35806cb594de69291a1ef674118/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
 
 ```css
 .account-subscriptions {


### PR DESCRIPTION
### WHAT is this pull request doing?

Bump and regen cookbook recipes.

Updated: subscriptions, bundles, combined-listings.
New: markets.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
