### PR TITLE
Cookbook: add the copy button target element for shopify.dev renders

### DIFF
--- a/cookbook/src/lib/markdown.ts
+++ b/cookbook/src/lib/markdown.ts
@@ -149,6 +149,15 @@ export function mdQuote(text: string): MDQuote {
   };
 }
 
+export type RawHTML = {
+  type: 'RAW_HTML';
+  html: string;
+};
+
+export function mdRawHTML(html: string): RawHTML {
+  return {type: 'RAW_HTML', html};
+}
+
 export type MDBlock =
   | MDHeading
   | MDImage
@@ -159,7 +168,8 @@ export type MDBlock =
   | MDTable
   | MDQuote
   | MDFrontMatter
-  | MDNote;
+  | MDNote
+  | RawHTML;
 
 export function renderMDBlock(block: MDBlock, format: RenderFormat): string {
   switch (block.type) {
@@ -244,6 +254,8 @@ export function renderMDBlock(block: MDBlock, format: RenderFormat): string {
           .map((line) => `> ${line}`)
           .join('\n'),
       ].join('\n');
+    case 'RAW_HTML':
+      return block.html;
     default:
       assertNever(block);
   }

--- a/cookbook/src/lib/render.ts
+++ b/cookbook/src/lib/render.ts
@@ -382,6 +382,8 @@ function doNotEditComment(recipeName: string): string {
   return `DO NOT EDIT. This file is generated from the shopify/hydrogen repo from this source file: \`cookbook/recipes/${recipeName}/recipe.yaml\``;
 }
 
+const copyPromptTargetClass = 'copy-prompt-target';
+
 function makeCopyPromptTarget(
   recipe: Recipe,
   recipeName: string,
@@ -395,6 +397,6 @@ function makeCopyPromptTarget(
   const dataInstructions = 'Follow this recipe to implement this feature.';
 
   return mdRawHTML(
-    `<div class="copy-prompt-button" data-url="${dataURL}" data-instructions="${dataInstructions}"></div>`,
+    `<div class="${copyPromptTargetClass}" data-url="${dataURL}" data-instructions="${dataInstructions}"></div>`,
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The Copy Prompt button on Shopify.dev needs a target element on the rendered markdown.

### WHAT is this pull request doing?

Add the `.copy-prompt-button` element in shopify.dev renders.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
