### PR TITLE
Fix `hydrogen setup vite`

### DIFF
--- a/packages/cli/assets/vite/vite.config.js
+++ b/packages/cli/assets/vite/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
         v3_fetcherPersist: true,
         v3_relativeSplatPath: true,
         v3_throwAbortReason: true,
-        v3_routeConfig: true,
+        v3_routeConfig: false,
       },
     }),
     tsconfigPaths(),


### PR DESCRIPTION
**Problem**
`npx shopify hydrogen setup vite` erroneously creates a Vite config with the Remix Future Flag `v3_routeConfig` enabled.

**Fix**
Change the template file back to `v3_routeConfig: false`.