### PR TITLE
Cookbook copy button typo

### DIFF
--- a/cookbook/src/lib/render.ts
+++ b/cookbook/src/lib/render.ts
@@ -382,7 +382,7 @@ function doNotEditComment(recipeName: string): string {
   return `DO NOT EDIT. This file is generated from the shopify/hydrogen repo from this source file: \`cookbook/recipes/${recipeName}/recipe.yaml\``;
 }
 
-const copyPromptTargetClass = 'copy-prompt-target';
+const copyPromptTargetClass = 'copy-prompt-button';
 
 function makeCopyPromptTarget(
   recipe: Recipe,


### PR DESCRIPTION
### WHAT is this pull request doing?

Fix typo in the class name for the copy prompt button target.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
