### PR TITLE
Better hydrogen-react-router cursor rule

### DIFF
--- a/templates/skeleton/.cursor/rules/hydrogen-react-router.mdc
+++ b/templates/skeleton/.cursor/rules/hydrogen-react-router.mdc
@@ -1,7 +1,7 @@
 ---
-description: This Hydrogen project is based on react-router, NOT @remix-run/react!
-globs: *
-alwaysApply: false
+description: 
+globs: 
+alwaysApply: true
 ---
 
 # React Router Import Rule for Hydrogen
@@ -28,6 +28,8 @@ When you see imports from Remix packages, replace them with their equivalent Rea
 | `@remix-run/serve` | `@react-router/serve` |
 | `@remix-run/server-runtime` | `react-router` |
 | `@remix-run/testing` | `react-router` |
+
+NEVER USE 'react-router-dom' imports!
 
 ## Common Import Examples
 


### PR DESCRIPTION
1. The rule is always used. Since the LLM and all the remix related documentation already has knowledge with remix imports, it is better if this migration guide is always in context.
2. For some unknown reasons the LLM uses `react-router-dom` imports regularly. I emphasized it in the cursor rule that it should not use react-router-dom imports at all.