### PR TITLE
The graphql route is no longer a reserved route

### DIFF
--- a/packages/cli/src/lib/route-validator.test.ts
+++ b/packages/cli/src/lib/route-validator.test.ts
@@ -63,16 +63,6 @@ describe('reserved-routes', () => {
     );
   });
 
-  it('returns an array of reserved routes', async () => {
-    expect(
-      findReservedRoutes(createRoute('api/2025-04/graphql.json')),
-    ).toHaveLength(1);
-
-    expect(
-      findReservedRoutes(createRoute('api/:param/graphql.json')),
-    ).toHaveLength(1);
-  });
-
   it('finds reserved routes /cdn/', async () => {
     expect(findReservedRoutes(createRoute('cdn/'))).toHaveLength(1);
 

--- a/packages/cli/src/lib/route-validator.ts
+++ b/packages/cli/src/lib/route-validator.ts
@@ -1,6 +1,6 @@
 import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui';
 
-const RESERVED_ROUTES = ['^api/[^/]+/graphql.json', '^cdn/', '^_t/'];
+const RESERVED_ROUTES = ['^cdn/', '^_t/'];
 
 export function findReservedRoutes(config: {routes: Routes}) {
   const routes = new Set<string>();


### PR DESCRIPTION
The graphql route is no longer a reserved route, so don't make the CLI warn about. Especially because we scaffold it now, and warn if it's not there!