### PR TITLE
delete hydrogen.v3preset as it is no longer in use

### DIFF
--- a/.changeset/fluffy-swans-do.md
+++ b/.changeset/fluffy-swans-do.md
@@ -1,6 +1,5 @@
 ---
 "@shopify/cli-hydrogen": minor
-"@shopify/hydrogen": patch
 ---
 
 Fixing the CLI for Remix-based hydrogen projects

--- a/packages/hydrogen/src/vite/plugin.ts
+++ b/packages/hydrogen/src/vite/plugin.ts
@@ -194,16 +194,3 @@ function mergeOptions(
 
   return {...acc, ...newOptionsWithoutUndefined};
 }
-
-hydrogen.v3preset = () =>
-  ({
-    name: 'hydrogen',
-    remixConfigResolved({remixConfig}) {
-      sharedOptions.remixConfig = remixConfig;
-    },
-    remixConfig() {
-      return {
-        buildDirectory: 'dist',
-      };
-    },
-  }) satisfies RemixPreset;


### PR DESCRIPTION
In #2958 I accidentally included a change to the Remix `hydrogen.v3Preset` preset. But in reality that remix preset is no longer in use, so I should just delete it