### PR TITLE
Pollyfill `getSetCookie` if not available.

### DIFF
--- a/.changeset/gorgeous-bobcats-yell.md
+++ b/.changeset/gorgeous-bobcats-yell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/remix-oxygen': patch
+---
+
+Pollyfill `getSetCookie` if not available. Fixes [#2959](https://github.com/Shopify/hydrogen/issues/2959)

--- a/package-lock.json
+++ b/package-lock.json
@@ -41688,7 +41688,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "11.0.0",
+      "version": "11.0.1",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -42380,7 +42380,7 @@
     },
     "packages/create-hydrogen": {
       "name": "@shopify/create-hydrogen",
-      "version": "5.0.23",
+      "version": "5.0.24",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.34.1"
@@ -44097,6 +44097,9 @@
       "name": "@shopify/remix-oxygen",
       "version": "3.0.0",
       "license": "MIT",
+      "dependencies": {
+        "headers-polyfill": "^3.0.0"
+      },
       "devDependencies": {
         "@shopify/oxygen-workers-types": "^4.1.6",
         "react-router": "7.6.0"
@@ -44106,8 +44109,14 @@
         "react-router": "7.6.0"
       }
     },
+    "packages/remix-oxygen/node_modules/headers-polyfill": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.3.0.tgz",
+      "integrity": "sha512-5e57etwBpNcDc0b6KCVWEh/Ro063OxPvzVimUdM0/tsYM/T7Hfy3kknIGj78SFTOhNd8AZY41U8mOHoO4LzmIQ==",
+      "license": "MIT"
+    },
     "templates/skeleton": {
-      "version": "2025.5.0",
+      "version": "2025.5.1",
       "dependencies": {
         "@shopify/hydrogen": "2025.5.0",
         "@shopify/remix-oxygen": "^3.0.0",

--- a/packages/remix-oxygen/package.json
+++ b/packages/remix-oxygen/package.json
@@ -44,6 +44,9 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "headers-polyfill": "^3.0.0"
+  },
   "devDependencies": {
     "@shopify/oxygen-workers-types": "^4.1.6",
     "react-router": "7.6.0"

--- a/packages/remix-oxygen/src/server.ts
+++ b/packages/remix-oxygen/src/server.ts
@@ -4,12 +4,16 @@ import {
   type AppLoadContext,
   type ServerBuild,
 } from 'react-router';
+import {Headers as HeadersPolyfill} from 'headers-polyfill';
 import {createEventLogger} from './event-logger';
 
 const originalErrorToString = Error.prototype.toString;
 Error.prototype.toString = function () {
   return this.stack || originalErrorToString.call(this);
 };
+
+Headers.prototype.getSetCookie =
+  Headers.prototype.getSetCookie || HeadersPolyfill.prototype.getSetCookie;
 
 export function createRequestHandler<Context = unknown>({
   build,


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

With the upgrade to React Router 7, we are no longer polyfilling fetch. The local preview of Hydrogen runs in an older version of workerd, which does not have `getSetCookie` implemented. The real solution here is to upgrade to the latest version of miniflare under the hood. This fixes it in the meantime.

Fixes #2959 <!-- link to issue if one exists -->


### HOW to test your changes?

1. Run `npm install and npm run build` from the root.
2. Run `npm run preview` from the skeleton template
3. Add an item to cart.

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
