### PR TITLE
Replace deprecated `faker.internet.color()` with `faker.color.rgb()`

### DIFF
--- a/.changeset/tender-jeans-build.md
+++ b/.changeset/tender-jeans-build.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen-react": patch
+---
+
+Replace deprecated faker.internet.color() with faker.color.rgb()

--- a/packages/hydrogen-react/src/parse-metafield.test.helpers.ts
+++ b/packages/hydrogen-react/src/parse-metafield.test.helpers.ts
@@ -73,7 +73,7 @@ export function getMetafieldValue(type: MetafieldTypeTypes) {
     case 'boolean':
       return faker.datatype.boolean().toString();
     case 'color':
-      return faker.internet.color();
+      return faker.color.rgb();
     case 'weight':
       return JSON.stringify({
         value: faker.number.int(),


### PR DESCRIPTION
## PR Summary
This small PR replaces the deprecated `faker.internet.color()` with the recommended `faker.color.rgb()` to resolve deprecation warnings which you can find in the [CI logs](https://github.com/Shopify/hydrogen/actions/runs/15543717505/job/43760341540#step:6:558):
```python
[@faker-js/faker]: faker.internet.color() is deprecated since v9.6.0 and will be removed in v10.0.0. Please use faker.color.rgb() instead.
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
