### PR TITLE
Cookbook: validate GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
         working-directory: cookbook
         run: npm ci
 
+      - name: 📝 Validate schema
+        working-directory: cookbook
+        run: npm run cookbook -- schema && git diff --exit-code recipe.schema.json
+
       - name: 🧐 Validate Recipes
         working-directory: cookbook
         run: npm run cookbook -- validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
     name: ⬣ Validate Recipes
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: ci-validate-recipes-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+          cache-dependency-path: 'cookbook/package-lock.json'
 
       - name: 📥 Install dependencies
         working-directory: cookbook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,9 @@ jobs:
       - name: 📥 Install dependencies
         run: npm ci
 
+      - name: 📦 Build packages, templates, and examples
+        run: SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npm run build:all
+
       - name: 📥 Install dependencies (cookbook)
         working-directory: cookbook
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          cache-dependency-path: 'cookbook/package-lock.json'
+          cache-dependency-path: '**/package-lock.json'
 
       - name: 📥 Install dependencies
+        run: npm ci
+
+      - name: 📥 Install dependencies (cookbook)
         working-directory: cookbook
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,26 @@ jobs:
 
       - name: 🔬 Test
         run: npm run test
+
+  validate_recipes:
+    name: ⬣ Validate Recipes
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: 📥 Install dependencies
+        working-directory: cookbook
+        run: npm ci
+
+      - name: 🧐 Validate Recipes
+        working-directory: cookbook
+        run: npm run cookbook -- validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,8 @@ jobs:
       - name: 📥 Install dependencies
         run: npm ci
 
-      - name: 📦 Build packages, templates, and examples
-        run: SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npm run build:all
+      - name: 📦 Build packages
+        run: SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npm run build:pkg
 
       - name: 📥 Install dependencies (cookbook)
         working-directory: cookbook

--- a/cookbook/llms/bundles.prompt.md
+++ b/cookbook/llms/bundles.prompt.md
@@ -81,7 +81,7 @@ In this recipe, we'll use the [Shopify Bundles app](https://apps.shopify.com/sho
 
 Create a new BundleBadge component to be displayed on bundle product listings.
 
-#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
 
 ```tsx
 export function BundleBadge() {
@@ -108,7 +108,7 @@ export function BundleBadge() {
 
 Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
 
-#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
 
 ```tsx
 import {Link} from 'react-router';

--- a/cookbook/llms/combined-listings.prompt.md
+++ b/cookbook/llms/combined-listings.prompt.md
@@ -90,7 +90,7 @@ export const combinedListingsSettings = {
 
 Create a new `combined-listings.ts` file that contains utilities and settings for handling combined listings.
 
-#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
 ```ts
 // Edit these values to customize combined listings' behavior

--- a/cookbook/llms/markets.prompt.md
+++ b/cookbook/llms/markets.prompt.md
@@ -218,6 +218,7 @@ a hook to retrieve the selected locale.
 ##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 ```ts
+import {useMatches} from 'react-router';
 import {
   CountryCode as CustomerCountryCode,
   LanguageCode as CustomerLanguageCode,

--- a/cookbook/llms/markets.prompt.md
+++ b/cookbook/llms/markets.prompt.md
@@ -116,7 +116,7 @@ Create a new `CountrySelector` component that allows users to select the locale 
 To handle redirects, use a `Form` that updates the cart buyer identity,
 which eventually redirects to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 ```tsx
 import {Form} from 'react-router';
@@ -191,7 +191,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 ```tsx
 import {LinkProps, Link as ReactLink} from 'react-router';
@@ -215,7 +215,7 @@ a hook to retrieve the selected locale.
 2. Define a set of supported locales for the app.
 3. Add a utility function to validate the locale from the route param against the supported locales.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 ```ts
 import {
@@ -226,10 +226,6 @@ import {
   CountryCode as StorefrontCountryCode,
   LanguageCode as StorefrontLanguageCode,
 } from '@shopify/hydrogen/storefront-api-types';
-<<<<<<< HEAD
-import {useMatches} from 'react-router';
-=======
->>>>>>> main
 
 type LanguageCode = CustomerLanguageCode & StorefrontLanguageCode;
 type CountryCode = CustomerCountryCode & StorefrontCountryCode;
@@ -441,7 +437,7 @@ For brevity, we'll focus on the home page, the cart page, and the product page i
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`.
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -622,7 +618,7 @@ Add the dynamic segment to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`.
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 ```tsx
 import {type MetaFunction, useLoaderData} from 'react-router';
@@ -754,7 +750,7 @@ localized prefix.
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`.
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -1017,7 +1013,7 @@ Add a utility route in `$(locale).tsx` that will use `localeMatchesPrefix`
 to validate the locale from the URL params. If the locale is invalid,
 the route will throw a 404 error.
 
-##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
+##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
 
 ```tsx
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';

--- a/cookbook/llms/markets.prompt.md
+++ b/cookbook/llms/markets.prompt.md
@@ -116,7 +116,7 @@ Create a new `CountrySelector` component that allows users to select the locale 
 To handle redirects, use a `Form` that updates the cart buyer identity,
 which eventually redirects to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 ```tsx
 import {Form} from 'react-router';
@@ -191,7 +191,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 ```tsx
 import {LinkProps, Link as ReactLink} from 'react-router';
@@ -215,14 +215,21 @@ a hook to retrieve the selected locale.
 2. Define a set of supported locales for the app.
 3. Add a utility function to validate the locale from the route param against the supported locales.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 ```ts
-import {useMatches} from 'react-router';
 import {
-  LanguageCode,
-  CountryCode,
-} from '@shopify/hydrogen-react/storefront-api-types';
+  CountryCode as CustomerCountryCode,
+  LanguageCode as CustomerLanguageCode,
+} from '@shopify/hydrogen/customer-account-api-types';
+import {
+  CountryCode as StorefrontCountryCode,
+  LanguageCode as StorefrontLanguageCode,
+} from '@shopify/hydrogen/storefront-api-types';
+import {useMatches} from 'react-router';
+
+type LanguageCode = CustomerLanguageCode & StorefrontLanguageCode;
+type CountryCode = CustomerCountryCode & StorefrontCountryCode;
 
 export type Locale = {
   language: LanguageCode;
@@ -431,7 +438,7 @@ For brevity, we'll focus on the home page, the cart page, and the product page i
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`.
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -612,7 +619,7 @@ Add the dynamic segment to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`.
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 ```tsx
 import {type MetaFunction, useLoaderData} from 'react-router';
@@ -744,7 +751,7 @@ localized prefix.
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`.
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -1007,7 +1014,7 @@ Add a utility route in `$(locale).tsx` that will use `localeMatchesPrefix`
 to validate the locale from the URL params. If the locale is invalid,
 the route will throw a 404 error.
 
-##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
+##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
 
 ```tsx
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';

--- a/cookbook/llms/markets.prompt.md
+++ b/cookbook/llms/markets.prompt.md
@@ -116,7 +116,7 @@ Create a new `CountrySelector` component that allows users to select the locale 
 To handle redirects, use a `Form` that updates the cart buyer identity,
 which eventually redirects to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 ```tsx
 import {Form} from 'react-router';
@@ -191,7 +191,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 ```tsx
 import {LinkProps, Link as ReactLink} from 'react-router';
@@ -215,7 +215,7 @@ a hook to retrieve the selected locale.
 2. Define a set of supported locales for the app.
 3. Add a utility function to validate the locale from the route param against the supported locales.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 ```ts
 import {useMatches} from 'react-router';
@@ -320,7 +320,7 @@ Update the `ProductItem` component to use the `Link` component from the
  } from 'storefrontapi.generated';
  import {useVariantUrl} from '~/lib/variants';
 +import {Link} from './Link';
- 
+
  export function ProductItem({
    product,
 ```
@@ -337,13 +337,13 @@ Detect the locale from the URL path, and add it to the HydrogenContext.
  import {AppSession} from '~/lib/session';
  import {CART_QUERY_FRAGMENT} from '~/lib/fragments';
 +import {getLocaleFromRequest} from './i18n';
- 
+
  /**
   * The context implementation is separate from server.ts
 @@ -24,13 +25,15 @@ export async function createAppLoadContext(
      AppSession.init(request, [env.SESSION_SECRET]),
    ]);
- 
+
 +  const i18n = getLocaleFromRequest(request);
 +
    const hydrogenContext = createHydrogenContext({
@@ -371,7 +371,7 @@ This adds a country selector component to the navigation.
  import type {HeaderQuery, CartApiQueryFragment} from 'storefrontapi.generated';
  import {useAside} from '~/components/Aside';
 +import {CountrySelector} from './CountrySelector';
- 
+
  interface HeaderProps {
    header: HeaderQuery;
 @@ -102,6 +103,7 @@ function HeaderCtas({
@@ -438,7 +438,7 @@ For brevity, we'll focus on the home page, the cart page, and the product page i
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`.
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -619,7 +619,7 @@ Add the dynamic segment to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`.
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 ```tsx
 import {type MetaFunction, useLoaderData} from 'react-router';
@@ -751,7 +751,7 @@ localized prefix.
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`.
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -1014,7 +1014,7 @@ Add a utility route in `$(locale).tsx` that will use `localeMatchesPrefix`
 to validate the locale from the URL params. If the locale is invalid,
 the route will throw a 404 error.
 
-##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
+##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
 
 ```tsx
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -1041,7 +1041,7 @@ Update the sitemap route to use the locales included in `SUPPORTED_LOCALES`.
  import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
  import {getSitemap} from '@shopify/hydrogen';
 +import {SUPPORTED_LOCALES} from '../lib/i18n';
- 
+
  export async function loader({
    request,
 @@ -10,7 +11,9 @@ export async function loader({
@@ -1068,7 +1068,7 @@ Remove the `pathname` parameter from the `useVariantUrl` function, and the logic
 -import { useLocation } from 'react-router';
  import type {SelectedOption} from '@shopify/hydrogen/storefront-api-types';
  import {useMemo} from 'react';
- 
+
 @@ -6,35 +5,25 @@ export function useVariantUrl(
    handle: string,
    selectedOptions?: SelectedOption[],
@@ -1085,7 +1085,7 @@ Remove the `pathname` parameter from the `useVariantUrl` function, and the logic
 -  }, [handle, selectedOptions, pathname]);
 +  }, [handle, selectedOptions]);
  }
- 
+
  export function getVariantUrl({
    handle,
 -  pathname,
@@ -1104,7 +1104,7 @@ Remove the `pathname` parameter from the `useVariantUrl` function, and the logic
 -    ? `${match![0]}products/${handle}`
 -    : `/products/${handle}`;
 +  const path = `/products/${handle}`;
- 
+
    selectedOptions?.forEach((option) => {
      searchParams.set(option.name, option.value);
 ```

--- a/cookbook/llms/markets.prompt.md
+++ b/cookbook/llms/markets.prompt.md
@@ -320,7 +320,7 @@ Update the `ProductItem` component to use the `Link` component from the
  } from 'storefrontapi.generated';
  import {useVariantUrl} from '~/lib/variants';
 +import {Link} from './Link';
-
+ 
  export function ProductItem({
    product,
 ```
@@ -337,13 +337,13 @@ Detect the locale from the URL path, and add it to the HydrogenContext.
  import {AppSession} from '~/lib/session';
  import {CART_QUERY_FRAGMENT} from '~/lib/fragments';
 +import {getLocaleFromRequest} from './i18n';
-
+ 
  /**
   * The context implementation is separate from server.ts
 @@ -24,13 +25,15 @@ export async function createAppLoadContext(
      AppSession.init(request, [env.SESSION_SECRET]),
    ]);
-
+ 
 +  const i18n = getLocaleFromRequest(request);
 +
    const hydrogenContext = createHydrogenContext({
@@ -371,7 +371,7 @@ This adds a country selector component to the navigation.
  import type {HeaderQuery, CartApiQueryFragment} from 'storefrontapi.generated';
  import {useAside} from '~/components/Aside';
 +import {CountrySelector} from './CountrySelector';
-
+ 
  interface HeaderProps {
    header: HeaderQuery;
 @@ -102,6 +103,7 @@ function HeaderCtas({
@@ -1041,7 +1041,7 @@ Update the sitemap route to use the locales included in `SUPPORTED_LOCALES`.
  import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
  import {getSitemap} from '@shopify/hydrogen';
 +import {SUPPORTED_LOCALES} from '../lib/i18n';
-
+ 
  export async function loader({
    request,
 @@ -10,7 +11,9 @@ export async function loader({
@@ -1068,7 +1068,7 @@ Remove the `pathname` parameter from the `useVariantUrl` function, and the logic
 -import { useLocation } from 'react-router';
  import type {SelectedOption} from '@shopify/hydrogen/storefront-api-types';
  import {useMemo} from 'react';
-
+ 
 @@ -6,35 +5,25 @@ export function useVariantUrl(
    handle: string,
    selectedOptions?: SelectedOption[],
@@ -1085,7 +1085,7 @@ Remove the `pathname` parameter from the `useVariantUrl` function, and the logic
 -  }, [handle, selectedOptions, pathname]);
 +  }, [handle, selectedOptions]);
  }
-
+ 
  export function getVariantUrl({
    handle,
 -  pathname,
@@ -1104,7 +1104,7 @@ Remove the `pathname` parameter from the `useVariantUrl` function, and the logic
 -    ? `${match![0]}products/${handle}`
 -    : `/products/${handle}`;
 +  const path = `/products/${handle}`;
-
+ 
    selectedOptions?.forEach((option) => {
      searchParams.set(option.name, option.value);
 ```

--- a/cookbook/llms/markets.prompt.md
+++ b/cookbook/llms/markets.prompt.md
@@ -116,7 +116,7 @@ Create a new `CountrySelector` component that allows users to select the locale 
 To handle redirects, use a `Form` that updates the cart buyer identity,
 which eventually redirects to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 ```tsx
 import {Form} from 'react-router';
@@ -191,7 +191,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 ```tsx
 import {LinkProps, Link as ReactLink} from 'react-router';
@@ -215,7 +215,7 @@ a hook to retrieve the selected locale.
 2. Define a set of supported locales for the app.
 3. Add a utility function to validate the locale from the route param against the supported locales.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 ```ts
 import {useMatches} from 'react-router';
@@ -438,7 +438,7 @@ For brevity, we'll focus on the home page, the cart page, and the product page i
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`.
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -619,7 +619,7 @@ Add the dynamic segment to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`.
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 ```tsx
 import {type MetaFunction, useLoaderData} from 'react-router';
@@ -751,7 +751,7 @@ localized prefix.
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`.
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 ```tsx
 import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
@@ -1014,7 +1014,7 @@ Add a utility route in `$(locale).tsx` that will use `localeMatchesPrefix`
 to validate the locale from the URL params. If the locale is invalid,
 the route will throw a 404 error.
 
-##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
+##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
 
 ```tsx
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';

--- a/cookbook/llms/subscriptions.prompt.md
+++ b/cookbook/llms/subscriptions.prompt.md
@@ -81,7 +81,7 @@ In this step we'll implement the ability to display subscription options on  pro
 
 Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
 
-##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
 
 ```tsx
 import type {
@@ -196,7 +196,7 @@ export function SellingPlanSelector({
 
 Add styles for the `SellingPlanSelector` component.
 
-##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 ```css
 .selling-plan-group {
@@ -771,7 +771,7 @@ In this step we'll implement support for subscription management through an acco
 
 Create GraphQL queries that retrieve the subscription info from the customer account client.
 
-##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
@@ -819,7 +819,7 @@ export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
 
 Create a GraqhQL mutation to cancel an existing subscription.
 
-##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
 
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/queries/customer
@@ -844,7 +844,7 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 Create a new account subpage that lets customers manage their existing  subscriptions based on the new GraphQL queries and mutations.
 
-##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
 
 ```tsx
 import type {SubscriptionBillingPolicyFragment} from 'customer-accountapi.generated';
@@ -1058,7 +1058,7 @@ Add a `Subscriptions` link to the account menu.
 
 Add styles for the Subscriptions page.
 
-##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
 
 ```css
 .account-subscriptions {

--- a/cookbook/recipes/bundles/README.md
+++ b/cookbook/recipes/bundles/README.md
@@ -26,8 +26,8 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
-| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
+| [app/components/BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx) | A badge displayed on bundle product listings. |
+| [app/components/BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx) | A component that wraps the variants of a bundle product in a single product listing. |
 
 ## Steps
 
@@ -43,7 +43,7 @@ _New files added to the template by this recipe._
 
 Create a new BundleBadge component to be displayed on bundle product listings.
 
-#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
+#### File: [BundleBadge.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundleBadge.tsx)
 
 <details>
 
@@ -74,7 +74,7 @@ export function BundleBadge() {
 
 Create a new `BundledVariants` component that wraps the variants of a bundle product in a single product listing.
 
-#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
+#### File: [BundledVariants.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/bundles/ingredients/templates/skeleton/app/components/BundledVariants.tsx)
 
 <details>
 
@@ -151,7 +151,7 @@ export function BundledVariants({
 
 Add `maxVariantPrice` to the `RecommendedProducts` query's product fields.
 
-#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/templates/skeleton/app/routes/_index.tsx)
+#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/_index.tsx)
 
 ```diff
 index 543e76be..0e600164 100644
@@ -183,7 +183,7 @@ index 543e76be..0e600164 100644
 used to identify bundled products.
 2. Pass the `isBundle` flag to the `ProductImage` component.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -306,7 +306,7 @@ index 4989ca00..0356b373 100644
 
 Like the previous step, use the `requiresComponents` field to detect if the product item is a bundle.
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/collections.$handle.tsx)
 
 ```diff
 index b44bc1ba..e0c90371 100644
@@ -359,7 +359,7 @@ index b44bc1ba..e0c90371 100644
 
 Use the `requiresComponents` field to determine if a cart line item is a bundle.
 
-#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/templates/skeleton/app/lib/fragments.ts)
+#### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/lib/fragments.ts)
 
 <details>
 
@@ -424,7 +424,7 @@ index dc4426a9..13cc34e5 100644
 
 If a product is a bundle, show the `BundleBadge` component in the cart line item.
 
-#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/templates/skeleton/app/components/CartLineItem.tsx)
+#### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index c96b3d83..61e7c2e3 100644
@@ -475,7 +475,7 @@ index c96b3d83..61e7c2e3 100644
 
 If a product is a bundle, update the text of the product button.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductForm.tsx)
 
 ```diff
 index 61290120..b1eaea07 100644
@@ -512,7 +512,7 @@ index 61290120..b1eaea07 100644
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductImage` component.
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..c16b947b 100644
@@ -546,7 +546,7 @@ index 5f3ac1cc..c16b947b 100644
 
 If a product is a bundle, show the `BundleBadge` component in the `ProductItem` component.
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductItem.tsx)
 
 <details>
 
@@ -628,7 +628,7 @@ index 3b0f6913..1b6cb130 100644
 
 Make sure the bundle badge is positioned relative to the product image.
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/a37399a6a6a668f40194f40a9f3dc988244df303/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..de48b6c6 100644

--- a/cookbook/recipes/bundles/recipe.yaml
+++ b/cookbook/recipes/bundles/recipe.yaml
@@ -149,4 +149,4 @@ llms:
       solution: Make sure you've installed the Shopify Bundles app and set up product
         bundles in your Shopify admin. Then make sure you've updated the cart
         fragment to query for bundles.
-commit: a37399a6a6a668f40194f40a9f3dc988244df303
+commit: 195eefec4c9c752e0ce18de1bc71899389ae4fa0

--- a/cookbook/recipes/combined-listings/README.md
+++ b/cookbook/recipes/combined-listings/README.md
@@ -21,7 +21,7 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
+| [app/lib/combined-listings.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts) | The `combined-listings.ts` file contains utilities and settings for handling combined listings. |
 
 ## Steps
 
@@ -55,7 +55,7 @@ export const combinedListingsSettings = {
 
 Create a new `combined-listings.ts` file that contains utilities and settings for handling combined listings.
 
-#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
+#### File: [combined-listings.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/combined-listings/ingredients/templates/skeleton/app/lib/combined-listings.ts)
 
 <details>
 
@@ -105,7 +105,7 @@ export function isCombinedListing(product: unknown) {
 1. Update the `ProductForm` component to hide the **Add to cart** button for the parent products of combined listings and for variants' selected state.
 2. Update the `Link` component to not replace the current URL when the product is a combined listing parent product.
 
-#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/templates/skeleton/app/components/ProductForm.tsx)
+#### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -212,7 +212,7 @@ index 61290120..e7dbc4d1 100644
 
 Update the `ProductImage` component to support images from both product variants and the product itself.
 
-#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/templates/skeleton/app/components/ProductImage.tsx)
+#### File: [app/components/ProductImage.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductImage.tsx)
 
 ```diff
 index 5f3ac1cc..f1c9f2cd 100644
@@ -240,7 +240,7 @@ index 5f3ac1cc..f1c9f2cd 100644
 
 Update `ProductItem.tsx` to show a range of prices for the combined listing parent product instead of the variant price.
 
-#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/templates/skeleton/app/components/ProductItem.tsx)
+#### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 3b0f6913..07fc73cd 100644
@@ -281,7 +281,7 @@ index 3b0f6913..07fc73cd 100644
 
 If you want to redirect automatically to the first variant of a combined listing when the parent handle is selected, add a redirect utility that's called whenever the parent handle is requested.
 
-#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/templates/skeleton/app/lib/redirect.ts)
+#### File: [app/lib/redirect.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/lib/redirect.ts)
 
 ```diff
 index ce1feb5a..29fe2ecc 100644
@@ -325,7 +325,7 @@ index ce1feb5a..29fe2ecc 100644
 1. Add the `tags` property to the items returned by the product query.
 2. (Optional) Add the filtering query to the product query to exclude combined listings.
 
-#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/templates/skeleton/app/routes/_index.tsx)
+#### File: [app/routes/_index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/_index.tsx)
 
 <details>
 
@@ -410,7 +410,7 @@ index 543e76be..1e75522b 100644
 
 Since it's not possible to directly apply query filters when retrieving collection products, you can manually filter out combined listings after they're retrieved based on their tags.
 
-#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/templates/skeleton/app/routes/collections.$handle.tsx)
+#### File: [app/routes/collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/collections.$handle.tsx)
 
 <details>
 
@@ -482,7 +482,7 @@ index b44bc1ba..fb04d67f 100644
 
 Update the `collections.all` route to filter out combined listings from the search results, and include the price range for combined listings.
 
-#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/templates/skeleton/app/routes/collections.all.tsx)
+#### File: [app/routes/collections.all.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/collections.all.tsx)
 
 ```diff
 index b9d0f33f..d1688772 100644
@@ -541,7 +541,7 @@ index b9d0f33f..d1688772 100644
 2. Show the featured image of the combined listing parent product instead of the variant image.
 3. (Optional) Redirect to the first variant of a combined listing when the handle is requested.
 
-#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/templates/skeleton/app/routes/products.$handle.tsx)
+#### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -681,7 +681,7 @@ index 4989ca00..e087fb10 100644
 
 Add a class to the product item to show a range of prices for combined listings.
 
-#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/2e32e77efa32aca00b18552fbdbfcb8af012f4ca/templates/skeleton/app/styles/app.css)
+#### File: [app/styles/app.css](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/styles/app.css)
 
 ```diff
 index b9294c59..c8fa5109 100644

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -2,7 +2,7 @@
 
 gid: 6bfa1a39-3a16-4351-b34a-2369c495d5a2
 title: Combined Listings
-summary: Handle combined listings on product pages and in search results.
+BROKENsummary: Handle combined listings on product pages and in search results.
 description: |
   This recipe lets you more precisely display and manage [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) on product pages and in search results for your Hydrogen storefront. A combined listing groups separate products together into a single product listing using a shared option like color or size.
   Each product appears as a variant but can have its own title, description, URL, and images.
@@ -19,7 +19,8 @@ requirements: |
   - Your store must have the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) installed.
 ingredients:
   - path: templates/skeleton/app/lib/combined-listings.ts
-    description: The `combined-listings.ts` file contains utilities and settings for
+    description:
+      The `combined-listings.ts` file contains utilities and settings for
       handling combined listings.
 deletedFiles: []
 steps:
@@ -54,7 +55,8 @@ steps:
   - type: NEW_FILE
     step: 3
     name: Add combined listings utilities
-    description: Create a new `combined-listings.ts` file that contains utilities
+    description:
+      Create a new `combined-listings.ts` file that contains utilities
       and settings for handling combined listings.
     ingredients:
       - path: templates/skeleton/app/lib/combined-listings.ts
@@ -151,7 +153,8 @@ llms:
       variant price?
   troubleshooting:
     - issue: Combined listings are being displayed in the product list.
-      solution: Make sure to tag combined listing parent products in the Shopify admin
+      solution:
+        Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
 commit: 2e32e77efa32aca00b18552fbdbfcb8af012f4ca

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -154,4 +154,4 @@ llms:
       solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
-commit: 2e32e77efa32aca00b18552fbdbfcb8af012f4ca
+commit: 195eefec4c9c752e0ce18de1bc71899389ae4fa0

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -19,8 +19,7 @@ requirements: |
   - Your store must have the [Combined Listings app](https://admin.shopify.com/apps/combined-listings) installed.
 ingredients:
   - path: templates/skeleton/app/lib/combined-listings.ts
-    description:
-      The `combined-listings.ts` file contains utilities and settings for
+    description: The `combined-listings.ts` file contains utilities and settings for
       handling combined listings.
 deletedFiles: []
 steps:
@@ -55,8 +54,7 @@ steps:
   - type: NEW_FILE
     step: 3
     name: Add combined listings utilities
-    description:
-      Create a new `combined-listings.ts` file that contains utilities
+    description: Create a new `combined-listings.ts` file that contains utilities
       and settings for handling combined listings.
     ingredients:
       - path: templates/skeleton/app/lib/combined-listings.ts
@@ -153,8 +151,7 @@ llms:
       variant price?
   troubleshooting:
     - issue: Combined listings are being displayed in the product list.
-      solution:
-        Make sure to tag combined listing parent products in the Shopify admin
+      solution: Make sure to tag combined listing parent products in the Shopify admin
         and use that tag to filter out combined listings from the product list
         in the GraphQL query.
 commit: 2e32e77efa32aca00b18552fbdbfcb8af012f4ca

--- a/cookbook/recipes/combined-listings/recipe.yaml
+++ b/cookbook/recipes/combined-listings/recipe.yaml
@@ -2,7 +2,7 @@
 
 gid: 6bfa1a39-3a16-4351-b34a-2369c495d5a2
 title: Combined Listings
-BROKENsummary: Handle combined listings on product pages and in search results.
+summary: Handle combined listings on product pages and in search results.
 description: |
   This recipe lets you more precisely display and manage [combined listings](https://help.shopify.com/en/manual/products/combined-listings-app) on product pages and in search results for your Hydrogen storefront. A combined listing groups separate products together into a single product listing using a shared option like color or size.
   Each product appears as a variant but can have its own title, description, URL, and images.

--- a/cookbook/recipes/markets/README.md
+++ b/cookbook/recipes/markets/README.md
@@ -57,13 +57,13 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx) | A component that displays a country selector inside the Header. |
-| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx) | A wrapper around the Link component that uses the selected locale path prefix. |
-| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts) | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
-| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx) | A route that renders a localized version of the home page. |
-| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx) | A localized cart route. |
-| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page. |
-| [app/routes/($locale).tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx) | A utility route that makes sure the locale is valid. |
+| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx) | A component that displays a country selector inside the Header. |
+| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx) | A wrapper around the Link component that uses the selected locale path prefix. |
+| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts) | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
+| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx) | A route that renders a localized version of the home page. |
+| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx) | A localized cart route. |
+| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page. |
+| [app/routes/($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx) | A utility route that makes sure the locale is valid. |
 
 ## Steps
 
@@ -78,7 +78,7 @@ Create a new `CountrySelector` component that allows users to select the locale 
 To handle redirects, use a `Form` that updates the cart buyer identity,
 which eventually redirects to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 <details>
 
@@ -157,7 +157,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 <details>
 
@@ -185,16 +185,23 @@ a hook to retrieve the selected locale.
 2. Define a set of supported locales for the app.
 3. Add a utility function to validate the locale from the route param against the supported locales.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 <details>
 
 ```ts
-import {useMatches} from 'react-router';
 import {
-  LanguageCode,
-  CountryCode,
-} from '@shopify/hydrogen-react/storefront-api-types';
+  CountryCode as CustomerCountryCode,
+  LanguageCode as CustomerLanguageCode,
+} from '@shopify/hydrogen/customer-account-api-types';
+import {
+  CountryCode as StorefrontCountryCode,
+  LanguageCode as StorefrontLanguageCode,
+} from '@shopify/hydrogen/storefront-api-types';
+import {useMatches} from 'react-router';
+
+type LanguageCode = CustomerLanguageCode & StorefrontLanguageCode;
+type CountryCode = CustomerCountryCode & StorefrontCountryCode;
 
 export type Locale = {
   language: LanguageCode;
@@ -274,7 +281,7 @@ export function localeMatchesPrefix(localeSegment: string | null): boolean {
 Update the `ProductItem` component to use the `Link` component from the
 `app/components/Link.tsx` file.
 
-##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/templates/skeleton/app/components/ProductItem.tsx)
+##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 3b0f6913..81ff9ec9 100644
@@ -299,7 +306,7 @@ index 3b0f6913..81ff9ec9 100644
 
 Detect the locale from the URL path, and add it to the HydrogenContext.
 
-##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/templates/skeleton/app/lib/context.ts)
+##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/lib/context.ts)
 
 ```diff
 index c424c511..b5d3737a 100644
@@ -336,7 +343,7 @@ index c424c511..b5d3737a 100644
 
 This adds a country selector component to the navigation.
 
-##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/templates/skeleton/app/components/Header.tsx)
+##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/components/Header.tsx)
 
 ```diff
 index 6adb9472..988de280 100644
@@ -367,7 +374,7 @@ index 6adb9472..988de280 100644
 3. Add a key prop to the `PageLayout` component to make sure it re-renders
 when the locale changes.
 
-##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/templates/skeleton/app/root.tsx)
+##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/root.tsx)
 
 ```diff
 index 353cb787..4cb70bf4 100644
@@ -417,7 +424,7 @@ For brevity, we'll focus on the home page, the cart page, and the product page i
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`.
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 <details>
 
@@ -602,7 +609,7 @@ Add the dynamic segment to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`.
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 <details>
 
@@ -738,7 +745,7 @@ localized prefix.
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`.
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 <details>
 
@@ -1005,7 +1012,7 @@ Add a utility route in `$(locale).tsx` that will use `localeMatchesPrefix`
 to validate the locale from the URL params. If the locale is invalid,
 the route will throw a 404 error.
 
-##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
+##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
 
 <details>
 
@@ -1029,7 +1036,7 @@ export async function loader({params}: LoaderFunctionArgs) {
 
 Update the sitemap route to use the locales included in `SUPPORTED_LOCALES`.
 
-##### File: [app/routes/sitemap.$type.$page[.xml].tsx](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/templates/skeleton/app/routes/sitemap.$type.$page[.xml].tsx)
+##### File: [app/routes/sitemap.$type.$page[.xml].tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/routes/sitemap.$type.$page[.xml].tsx)
 
 ```diff
 index 20b39d82..8cf08fc6 100644
@@ -1059,7 +1066,7 @@ index 20b39d82..8cf08fc6 100644
 
 Remove the `pathname` parameter from the `useVariantUrl` function, and the logic that prepends the locale to the path.
 
-##### File: [app/lib/variants.ts](https://github.com/Shopify/hydrogen/blob/d63f8518186b4487a445a4ed79139ba4d8b15550/templates/skeleton/app/lib/variants.ts)
+##### File: [app/lib/variants.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/lib/variants.ts)
 
 ```diff
 index 4a0898a8..ffa83131 100644

--- a/cookbook/recipes/markets/README.md
+++ b/cookbook/recipes/markets/README.md
@@ -55,15 +55,15 @@ selected.
 
 _New files added to the template by this recipe._
 
-| File                                                                                                                                                                                                                             | Description                                                                                                                            |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)               | A component that displays a country selector inside the Header.                                                                        |
-| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)                                     | A wrapper around the Link component that uses the selected locale path prefix.                                                         |
-| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)                                                     | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
-| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)                     | A route that renders a localized version of the home page.                                                                             |
-| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)                         | A localized cart route.                                                                                                                |
-| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page.                                                                          |
-| [app/routes/($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)                                   | A utility route that makes sure the locale is valid.                                                                                   |
+| File | Description |
+| --- | --- |
+| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx) | A component that displays a country selector inside the Header. |
+| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx) | A wrapper around the Link component that uses the selected locale path prefix. |
+| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts) | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
+| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx) | A route that renders a localized version of the home page. |
+| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx) | A localized cart route. |
+| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page. |
+| [app/routes/($locale).tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx) | A utility route that makes sure the locale is valid. |
 
 ## Steps
 
@@ -78,7 +78,7 @@ Create a new `CountrySelector` component that allows users to select the locale 
 To handle redirects, use a `Form` that updates the cart buyer identity,
 which eventually redirects to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 <details>
 
@@ -157,7 +157,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 <details>
 
@@ -185,7 +185,7 @@ a hook to retrieve the selected locale.
 2. Define a set of supported locales for the app.
 3. Add a utility function to validate the locale from the route param against the supported locales.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 <details>
 
@@ -280,7 +280,7 @@ export function localeMatchesPrefix(localeSegment: string | null): boolean {
 Update the `ProductItem` component to use the `Link` component from the
 `app/components/Link.tsx` file.
 
-##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/components/ProductItem.tsx)
+##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 3b0f6913..81ff9ec9 100644
@@ -296,7 +296,7 @@ index 3b0f6913..81ff9ec9 100644
  } from 'storefrontapi.generated';
  import {useVariantUrl} from '~/lib/variants';
 +import {Link} from './Link';
-
+ 
  export function ProductItem({
    product,
 ```
@@ -305,7 +305,7 @@ index 3b0f6913..81ff9ec9 100644
 
 Detect the locale from the URL path, and add it to the HydrogenContext.
 
-##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/lib/context.ts)
+##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/lib/context.ts)
 
 ```diff
 index c424c511..b5d3737a 100644
@@ -316,13 +316,13 @@ index c424c511..b5d3737a 100644
  import {AppSession} from '~/lib/session';
  import {CART_QUERY_FRAGMENT} from '~/lib/fragments';
 +import {getLocaleFromRequest} from './i18n';
-
+ 
  /**
   * The context implementation is separate from server.ts
 @@ -24,13 +25,15 @@ export async function createAppLoadContext(
      AppSession.init(request, [env.SESSION_SECRET]),
    ]);
-
+ 
 +  const i18n = getLocaleFromRequest(request);
 +
    const hydrogenContext = createHydrogenContext({
@@ -342,7 +342,7 @@ index c424c511..b5d3737a 100644
 
 This adds a country selector component to the navigation.
 
-##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/components/Header.tsx)
+##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/Header.tsx)
 
 ```diff
 index 6adb9472..988de280 100644
@@ -353,7 +353,7 @@ index 6adb9472..988de280 100644
  import type {HeaderQuery, CartApiQueryFragment} from 'storefrontapi.generated';
  import {useAside} from '~/components/Aside';
 +import {CountrySelector} from './CountrySelector';
-
+ 
  interface HeaderProps {
    header: HeaderQuery;
 @@ -102,6 +103,7 @@ function HeaderCtas({
@@ -373,7 +373,7 @@ index 6adb9472..988de280 100644
 3. Add a key prop to the `PageLayout` component to make sure it re-renders
 when the locale changes.
 
-##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/root.tsx)
+##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/root.tsx)
 
 ```diff
 index 353cb787..4cb70bf4 100644
@@ -423,7 +423,7 @@ For brevity, we'll focus on the home page, the cart page, and the product page i
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`.
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 <details>
 
@@ -608,7 +608,7 @@ Add the dynamic segment to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`.
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 <details>
 
@@ -744,7 +744,7 @@ localized prefix.
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`.
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 <details>
 
@@ -1011,7 +1011,7 @@ Add a utility route in `$(locale).tsx` that will use `localeMatchesPrefix`
 to validate the locale from the URL params. If the locale is invalid,
 the route will throw a 404 error.
 
-##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
+##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
 
 <details>
 
@@ -1035,7 +1035,7 @@ export async function loader({params}: LoaderFunctionArgs) {
 
 Update the sitemap route to use the locales included in `SUPPORTED_LOCALES`.
 
-##### File: [app/routes/sitemap.$type.$page[.xml].tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/routes/sitemap.$type.$page[.xml].tsx)
+##### File: [app/routes/sitemap.$type.$page[.xml].tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/sitemap.$type.$page[.xml].tsx)
 
 ```diff
 index 20b39d82..8cf08fc6 100644
@@ -1045,7 +1045,7 @@ index 20b39d82..8cf08fc6 100644
  import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
  import {getSitemap} from '@shopify/hydrogen';
 +import {SUPPORTED_LOCALES} from '../lib/i18n';
-
+ 
  export async function loader({
    request,
 @@ -10,7 +11,9 @@ export async function loader({
@@ -1065,7 +1065,7 @@ index 20b39d82..8cf08fc6 100644
 
 Remove the `pathname` parameter from the `useVariantUrl` function, and the logic that prepends the locale to the path.
 
-##### File: [app/lib/variants.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/lib/variants.ts)
+##### File: [app/lib/variants.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/lib/variants.ts)
 
 ```diff
 index 4a0898a8..ffa83131 100644
@@ -1075,7 +1075,7 @@ index 4a0898a8..ffa83131 100644
 -import { useLocation } from 'react-router';
  import type {SelectedOption} from '@shopify/hydrogen/storefront-api-types';
  import {useMemo} from 'react';
-
+ 
 @@ -6,35 +5,25 @@ export function useVariantUrl(
    handle: string,
    selectedOptions?: SelectedOption[],
@@ -1092,7 +1092,7 @@ index 4a0898a8..ffa83131 100644
 -  }, [handle, selectedOptions, pathname]);
 +  }, [handle, selectedOptions]);
  }
-
+ 
  export function getVariantUrl({
    handle,
 -  pathname,
@@ -1111,7 +1111,7 @@ index 4a0898a8..ffa83131 100644
 -    ? `${match![0]}products/${handle}`
 -    : `/products/${handle}`;
 +  const path = `/products/${handle}`;
-
+ 
    selectedOptions?.forEach((option) => {
      searchParams.set(option.name, option.value);
 ```

--- a/cookbook/recipes/markets/README.md
+++ b/cookbook/recipes/markets/README.md
@@ -190,6 +190,7 @@ a hook to retrieve the selected locale.
 <details>
 
 ```ts
+import {useMatches} from 'react-router';
 import {
   CountryCode as CustomerCountryCode,
   LanguageCode as CustomerLanguageCode,

--- a/cookbook/recipes/markets/README.md
+++ b/cookbook/recipes/markets/README.md
@@ -57,13 +57,13 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx) | A component that displays a country selector inside the Header. |
-| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx) | A wrapper around the Link component that uses the selected locale path prefix. |
-| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts) | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
-| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx) | A route that renders a localized version of the home page. |
-| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx) | A localized cart route. |
-| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page. |
-| [app/routes/($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx) | A utility route that makes sure the locale is valid. |
+| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx) | A component that displays a country selector inside the Header. |
+| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx) | A wrapper around the Link component that uses the selected locale path prefix. |
+| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts) | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
+| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx) | A route that renders a localized version of the home page. |
+| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx) | A localized cart route. |
+| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page. |
+| [app/routes/($locale).tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx) | A utility route that makes sure the locale is valid. |
 
 ## Steps
 
@@ -78,7 +78,7 @@ Create a new `CountrySelector` component that allows users to select the locale 
 To handle redirects, use a `Form` that updates the cart buyer identity,
 which eventually redirects to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 <details>
 
@@ -157,7 +157,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 <details>
 
@@ -185,7 +185,7 @@ a hook to retrieve the selected locale.
 2. Define a set of supported locales for the app.
 3. Add a utility function to validate the locale from the route param against the supported locales.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 <details>
 
@@ -281,7 +281,7 @@ export function localeMatchesPrefix(localeSegment: string | null): boolean {
 Update the `ProductItem` component to use the `Link` component from the
 `app/components/Link.tsx` file.
 
-##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/components/ProductItem.tsx)
+##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 3b0f6913..81ff9ec9 100644
@@ -306,7 +306,7 @@ index 3b0f6913..81ff9ec9 100644
 
 Detect the locale from the URL path, and add it to the HydrogenContext.
 
-##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/lib/context.ts)
+##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/lib/context.ts)
 
 ```diff
 index c424c511..b5d3737a 100644
@@ -343,7 +343,7 @@ index c424c511..b5d3737a 100644
 
 This adds a country selector component to the navigation.
 
-##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/components/Header.tsx)
+##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/Header.tsx)
 
 ```diff
 index 6adb9472..988de280 100644
@@ -374,7 +374,7 @@ index 6adb9472..988de280 100644
 3. Add a key prop to the `PageLayout` component to make sure it re-renders
 when the locale changes.
 
-##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/root.tsx)
+##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/root.tsx)
 
 ```diff
 index 353cb787..4cb70bf4 100644
@@ -424,7 +424,7 @@ For brevity, we'll focus on the home page, the cart page, and the product page i
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`.
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 <details>
 
@@ -609,7 +609,7 @@ Add the dynamic segment to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`.
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 <details>
 
@@ -745,7 +745,7 @@ localized prefix.
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`.
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 <details>
 
@@ -1012,7 +1012,7 @@ Add a utility route in `$(locale).tsx` that will use `localeMatchesPrefix`
 to validate the locale from the URL params. If the locale is invalid,
 the route will throw a 404 error.
 
-##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
+##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
 
 <details>
 
@@ -1036,7 +1036,7 @@ export async function loader({params}: LoaderFunctionArgs) {
 
 Update the sitemap route to use the locales included in `SUPPORTED_LOCALES`.
 
-##### File: [app/routes/sitemap.$type.$page[.xml].tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/routes/sitemap.$type.$page[.xml].tsx)
+##### File: [app/routes/sitemap.$type.$page[.xml].tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/sitemap.$type.$page[.xml].tsx)
 
 ```diff
 index 20b39d82..8cf08fc6 100644
@@ -1066,7 +1066,7 @@ index 20b39d82..8cf08fc6 100644
 
 Remove the `pathname` parameter from the `useVariantUrl` function, and the logic that prepends the locale to the path.
 
-##### File: [app/lib/variants.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/lib/variants.ts)
+##### File: [app/lib/variants.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/lib/variants.ts)
 
 ```diff
 index 4a0898a8..ffa83131 100644

--- a/cookbook/recipes/markets/README.md
+++ b/cookbook/recipes/markets/README.md
@@ -57,13 +57,13 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx) | A component that displays a country selector inside the Header. |
-| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx) | A wrapper around the Link component that uses the selected locale path prefix. |
-| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts) | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
-| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx) | A route that renders a localized version of the home page. |
-| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx) | A localized cart route. |
-| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page. |
-| [app/routes/($locale).tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx) | A utility route that makes sure the locale is valid. |
+| [app/components/CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx) | A component that displays a country selector inside the Header. |
+| [app/components/Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx) | A wrapper around the Link component that uses the selected locale path prefix. |
+| [app/lib/i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts) | A helper function to get locale information from the context, a hook to retrieve the selected locale, and a list of available locales. |
+| [app/routes/($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx) | A route that renders a localized version of the home page. |
+| [app/routes/($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx) | A localized cart route. |
+| [app/routes/($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx) | A route that renders a localized version of the product page. |
+| [app/routes/($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx) | A utility route that makes sure the locale is valid. |
 
 ## Steps
 
@@ -78,7 +78,7 @@ Create a new `CountrySelector` component that allows users to select the locale 
 To handle redirects, use a `Form` that updates the cart buyer identity,
 which eventually redirects to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 <details>
 
@@ -157,7 +157,7 @@ const LocaleLink = ({locale}: {locale: Locale}) => {
 
 Create a wrapper component around the `Link` component that prepends the selected locale path prefix (if any) to the actual links.
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 <details>
 
@@ -185,7 +185,7 @@ a hook to retrieve the selected locale.
 2. Define a set of supported locales for the app.
 3. Add a utility function to validate the locale from the route param against the supported locales.
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 <details>
 
@@ -281,7 +281,7 @@ export function localeMatchesPrefix(localeSegment: string | null): boolean {
 Update the `ProductItem` component to use the `Link` component from the
 `app/components/Link.tsx` file.
 
-##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductItem.tsx)
+##### File: [app/components/ProductItem.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/components/ProductItem.tsx)
 
 ```diff
 index 3b0f6913..81ff9ec9 100644
@@ -306,7 +306,7 @@ index 3b0f6913..81ff9ec9 100644
 
 Detect the locale from the URL path, and add it to the HydrogenContext.
 
-##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/lib/context.ts)
+##### File: [app/lib/context.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/lib/context.ts)
 
 ```diff
 index c424c511..b5d3737a 100644
@@ -343,7 +343,7 @@ index c424c511..b5d3737a 100644
 
 This adds a country selector component to the navigation.
 
-##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/Header.tsx)
+##### File: [app/components/Header.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/components/Header.tsx)
 
 ```diff
 index 6adb9472..988de280 100644
@@ -374,7 +374,7 @@ index 6adb9472..988de280 100644
 3. Add a key prop to the `PageLayout` component to make sure it re-renders
 when the locale changes.
 
-##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/root.tsx)
+##### File: [app/root.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/root.tsx)
 
 ```diff
 index 353cb787..4cb70bf4 100644
@@ -424,7 +424,7 @@ For brevity, we'll focus on the home page, the cart page, and the product page i
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`.
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 <details>
 
@@ -609,7 +609,7 @@ Add the dynamic segment to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`.
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 <details>
 
@@ -745,7 +745,7 @@ localized prefix.
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`.
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 <details>
 
@@ -1012,7 +1012,7 @@ Add a utility route in `$(locale).tsx` that will use `localeMatchesPrefix`
 to validate the locale from the URL params. If the locale is invalid,
 the route will throw a 404 error.
 
-##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
+##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
 
 <details>
 
@@ -1036,7 +1036,7 @@ export async function loader({params}: LoaderFunctionArgs) {
 
 Update the sitemap route to use the locales included in `SUPPORTED_LOCALES`.
 
-##### File: [app/routes/sitemap.$type.$page[.xml].tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/sitemap.$type.$page[.xml].tsx)
+##### File: [app/routes/sitemap.$type.$page[.xml].tsx](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/routes/sitemap.$type.$page[.xml].tsx)
 
 ```diff
 index 20b39d82..8cf08fc6 100644
@@ -1066,7 +1066,7 @@ index 20b39d82..8cf08fc6 100644
 
 Remove the `pathname` parameter from the `useVariantUrl` function, and the logic that prepends the locale to the path.
 
-##### File: [app/lib/variants.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/lib/variants.ts)
+##### File: [app/lib/variants.ts](https://github.com/Shopify/hydrogen/blob/4129da578f9d603187bd10945ae60e1934df0e8a/templates/skeleton/app/lib/variants.ts)
 
 ```diff
 index 4a0898a8..ffa83131 100644

--- a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts
+++ b/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts
@@ -1,8 +1,15 @@
-import {useMatches} from 'react-router';
 import {
-  LanguageCode,
-  CountryCode,
-} from '@shopify/hydrogen-react/storefront-api-types';
+  CountryCode as CustomerCountryCode,
+  LanguageCode as CustomerLanguageCode,
+} from '@shopify/hydrogen/customer-account-api-types';
+import {
+  CountryCode as StorefrontCountryCode,
+  LanguageCode as StorefrontLanguageCode,
+} from '@shopify/hydrogen/storefront-api-types';
+import {useMatches} from 'react-router';
+
+type LanguageCode = CustomerLanguageCode & StorefrontLanguageCode;
+type CountryCode = CustomerCountryCode & StorefrontCountryCode;
 
 export type Locale = {
   language: LanguageCode;

--- a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts
+++ b/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts
@@ -1,3 +1,4 @@
+import {useMatches} from 'react-router';
 import {
   CountryCode as CustomerCountryCode,
   LanguageCode as CustomerLanguageCode,

--- a/cookbook/recipes/markets/recipe.yaml
+++ b/cookbook/recipes/markets/recipe.yaml
@@ -234,4 +234,4 @@ llms:
       solution: Make sure you update *all* routes that need localization (not only the
         routes for the home page, the cart page, and the product page). See step
         2.1 for details.
-commit: d63f8518186b4487a445a4ed79139ba4d8b15550
+commit: 4129da578f9d603187bd10945ae60e1934df0e8a

--- a/cookbook/recipes/markets/recipe.yaml
+++ b/cookbook/recipes/markets/recipe.yaml
@@ -234,4 +234,4 @@ llms:
       solution: Make sure you update *all* routes that need localization (not only the
         routes for the home page, the cart page, and the product page). See step
         2.1 for details.
-commit: 4129da578f9d603187bd10945ae60e1934df0e8a
+commit: 195eefec4c9c752e0ce18de1bc71899389ae4fa0

--- a/cookbook/recipes/markets/recipe.yaml
+++ b/cookbook/recipes/markets/recipe.yaml
@@ -60,7 +60,8 @@ ingredients:
   - path: templates/skeleton/app/components/CountrySelector.tsx
     description: A component that displays a country selector inside the Header.
   - path: templates/skeleton/app/components/Link.tsx
-    description: A wrapper around the Link component that uses the selected locale
+    description:
+      A wrapper around the Link component that uses the selected locale
       path prefix.
   - path: templates/skeleton/app/lib/i18n.ts
     description: A helper function to get locale information from the context, a
@@ -81,7 +82,8 @@ steps:
   - type: INFO
     step: 1
     name: Add localization utilities and update core components
-    description: In this section, we'll create utilities to handle localization and
+    description:
+      In this section, we'll create utilities to handle localization and
       country selection, and update the core components to use these utilities.
   - type: NEW_FILE
     step: 1.1
@@ -225,13 +227,15 @@ llms:
     - Help me segment my customers based on their location
   troubleshooting:
     - issue: I'm not seeing the localized content on my storefront.
-      solution: In your Shopify admin, make sure you've set up your store's regions
+      solution:
+        In your Shopify admin, make sure you've set up your store's regions
         and langauges using Shopify Markets, then check that your products are
         appropriately configured for each market. In your Hydrogen app, make
         sure you've added the dynamic segment to the desired routes and that the
         routes are correctly named.
     - issue: Some pages are showing localized content, but others aren't.
-      solution: Make sure you update *all* routes that need localization (not only the
+      solution:
+        Make sure you update *all* routes that need localization (not only the
         routes for the home page, the cart page, and the product page). See step
         2.1 for details.
-commit: 195eefec4c9c752e0ce18de1bc71899389ae4fa0
+commit: 4129da578f9d603187bd10945ae60e1934df0e8a

--- a/cookbook/recipes/markets/recipe.yaml
+++ b/cookbook/recipes/markets/recipe.yaml
@@ -60,8 +60,7 @@ ingredients:
   - path: templates/skeleton/app/components/CountrySelector.tsx
     description: A component that displays a country selector inside the Header.
   - path: templates/skeleton/app/components/Link.tsx
-    description:
-      A wrapper around the Link component that uses the selected locale
+    description: A wrapper around the Link component that uses the selected locale
       path prefix.
   - path: templates/skeleton/app/lib/i18n.ts
     description: A helper function to get locale information from the context, a
@@ -82,8 +81,7 @@ steps:
   - type: INFO
     step: 1
     name: Add localization utilities and update core components
-    description:
-      In this section, we'll create utilities to handle localization and
+    description: In this section, we'll create utilities to handle localization and
       country selection, and update the core components to use these utilities.
   - type: NEW_FILE
     step: 1.1
@@ -227,15 +225,13 @@ llms:
     - Help me segment my customers based on their location
   troubleshooting:
     - issue: I'm not seeing the localized content on my storefront.
-      solution:
-        In your Shopify admin, make sure you've set up your store's regions
+      solution: In your Shopify admin, make sure you've set up your store's regions
         and langauges using Shopify Markets, then check that your products are
         appropriately configured for each market. In your Hydrogen app, make
         sure you've added the dynamic segment to the desired routes and that the
         routes are correctly named.
     - issue: Some pages are showing localized content, but others aren't.
-      solution:
-        Make sure you update *all* routes that need localization (not only the
+      solution: Make sure you update *all* routes that need localization (not only the
         routes for the home page, the cart page, and the product page). See step
         2.1 for details.
 commit: 4129da578f9d603187bd10945ae60e1934df0e8a

--- a/cookbook/recipes/subscriptions/README.md
+++ b/cookbook/recipes/subscriptions/README.md
@@ -20,12 +20,12 @@ _New files added to the template by this recipe._
 
 | File | Description |
 | --- | --- |
-| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
-| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
-| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
-| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
-| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
-| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
+| [app/components/SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx) | Displays the available subscription options on product pages. |
+| [app/graphql/customer-account/CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts) | Mutations for managing customer subscriptions. |
+| [app/graphql/customer-account/CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts) | Queries for managing customer subscriptions. |
+| [app/routes/account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx) | Subscriptions management page. |
+| [app/styles/account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css) | Subscriptions management page styles. |
+| [app/styles/selling-plan.css](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css) | Styles the `SellingPlanSelector` component. |
 
 ## Steps
 
@@ -44,7 +44,7 @@ In this step we'll implement the ability to display subscription options on  pro
 
 Create a new `SellingPlanSelector` component that displays the available subscription options for a product.
 
-##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
+##### File: [SellingPlanSelector.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/components/SellingPlanSelector.tsx)
 
 <details>
 
@@ -163,7 +163,7 @@ export function SellingPlanSelector({
 
 Add styles for the `SellingPlanSelector` component.
 
-##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
+##### File: [selling-plan.css](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/selling-plan.css)
 
 <details>
 
@@ -212,7 +212,7 @@ Add styles for the `SellingPlanSelector` component.
 2. Implement `SellingPlanSelector` and `SellingPlanGroup` components to handle subscription plan selection.
 3. Update `AddToCartButton` to include selling plan data when subscriptions are selected.
 
-##### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/templates/skeleton/app/components/ProductForm.tsx)
+##### File: [app/components/ProductForm.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductForm.tsx)
 
 <details>
 
@@ -343,7 +343,7 @@ index 61290120..234b151a 100644
 1. Add a `SellingPlanPrice` function to calculate adjusted prices based on subscription plan type (fixed amount, fixed price, or percentage).
 2. Add logic to handle different price adjustment types and render the appropriate subscription price when a selling plan is selected.
 
-##### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/templates/skeleton/app/components/ProductPrice.tsx)
+##### File: [app/components/ProductPrice.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/ProductPrice.tsx)
 
 <details>
 
@@ -468,7 +468,7 @@ index 32460ae2..59eed1d8 100644
 2. Add logic to handle pricing adjustments, maintain selection state using URL parameters, and update the add-to-cart functionality.
 3. Fetch subscription data through the updated cart GraphQL fragments.
 
-##### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/templates/skeleton/app/routes/products.$handle.tsx)
+##### File: [app/routes/products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/products.$handle.tsx)
 
 <details>
 
@@ -681,7 +681,7 @@ In this step we'll implement support for showing subscription info in the cart's
 
 Add a `sellingPlanAllocation` field with the plan name to the standard and componentizable cart line GraphQL fragments. This displays subscription details in the cart.
 
-##### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/templates/skeleton/app/lib/fragments.ts)
+##### File: [app/lib/fragments.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/lib/fragments.ts)
 
 ```diff
 index dc4426a9..cfe3a938 100644
@@ -718,7 +718,7 @@ index dc4426a9..cfe3a938 100644
 1. Update `CartLineItem` to show subscription details when they're available.
 2. Extract `sellingPlanAllocation` from cart line data, display the plan name, and standardize component import paths.
 
-##### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/templates/skeleton/app/components/CartLineItem.tsx)
+##### File: [app/components/CartLineItem.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/components/CartLineItem.tsx)
 
 ```diff
 index c96b3d83..cf9fdeaf 100644
@@ -769,7 +769,7 @@ In this step we'll implement support for subscription management through an acco
 
 Create GraphQL queries that retrieve the subscription info from the customer account client.
 
-##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
+##### File: [CustomerSubscriptionsQuery.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsQuery.ts)
 
 <details>
 
@@ -821,7 +821,7 @@ export const SUBSCRIPTIONS_CONTRACTS_QUERY = `#graphql
 
 Create a GraqhQL mutation to cancel an existing subscription.
 
-##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
+##### File: [CustomerSubscriptionsMutations.ts](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/graphql/customer-account/CustomerSubscriptionsMutations.ts)
 
 <details>
 
@@ -850,7 +850,7 @@ export const SUBSCRIPTION_CANCEL_MUTATION = `#graphql
 
 Create a new account subpage that lets customers manage their existing  subscriptions based on the new GraphQL queries and mutations.
 
-##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
+##### File: [account.subscriptions.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx)
 
 <details>
 
@@ -1037,7 +1037,7 @@ function SubscriptionInterval({
 
 Add a `Subscriptions` link to the account menu.
 
-##### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/templates/skeleton/app/routes/account.tsx)
+##### File: [app/routes/account.tsx](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/templates/skeleton/app/routes/account.tsx)
 
 ```diff
 index 29e641f4..9ee30fd4 100644
@@ -1071,7 +1071,7 @@ index 29e641f4..9ee30fd4 100644
 
 Add styles for the Subscriptions page.
 
-##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/71cffb0da4cb247948a36ac8adcd4a381cca6df7/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
+##### File: [account-subscriptions.css](https://github.com/Shopify/hydrogen/blob/195eefec4c9c752e0ce18de1bc71899389ae4fa0/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css)
 
 <details>
 

--- a/cookbook/recipes/subscriptions/recipe.yaml
+++ b/cookbook/recipes/subscriptions/recipe.yaml
@@ -168,4 +168,4 @@ llms:
     - issue: I'm not seeing the subscription details on my cart line items.
       solution: Make sure you've installed the Shopify Subscriptions app and set up
         selling plans for subscription products in your Shopify admin.
-commit: 71cffb0da4cb247948a36ac8adcd4a381cca6df7
+commit: 195eefec4c9c752e0ce18de1bc71899389ae4fa0

--- a/cookbook/src/commands/validate.ts
+++ b/cookbook/src/commands/validate.ts
@@ -39,18 +39,18 @@ async function handler(args: ValidateArgs) {
 
   let failed: string[] = [];
   for (const recipe of recipes) {
-    try {
-      console.log(`🧐 Validating recipe '${recipe}'`);
-      validateRecipe({
-        recipeTitle: recipe,
-        hydrogenPackagesVersion: args.hydrogenPackagesVersion,
-      });
-      // clean up the skeleton template directory on success
-      execSync(`git checkout -- ${TEMPLATE_PATH}`);
-      execSync(`git clean -fd ${TEMPLATE_PATH}`);
-    } catch (error) {
+    console.log(`🧐 Validating recipe '${recipe}'`);
+
+    const ok = await validateRecipe({
+      recipeTitle: recipe,
+      hydrogenPackagesVersion: args.hydrogenPackagesVersion,
+    });
+    // clean up the skeleton template directory on success
+    execSync(`git checkout -- ${TEMPLATE_PATH}`);
+    execSync(`git clean -fd ${TEMPLATE_PATH}`);
+
+    if (!ok) {
       console.error(`❌ Recipe '${recipe}' is invalid`);
-      console.error(error);
       failed.push(recipe);
     }
     console.log(separator());

--- a/cookbook/src/commands/validate.ts
+++ b/cookbook/src/commands/validate.ts
@@ -1,6 +1,8 @@
 import {CommandModule} from 'yargs';
 import {listRecipes, separator} from '../lib/util';
 import {validateRecipe} from '../lib/validate';
+import {execSync} from 'child_process';
+import {TEMPLATE_PATH} from '../lib/constants';
 
 type ValidateArgs = {
   recipe?: string;
@@ -46,6 +48,9 @@ async function handler(args: ValidateArgs) {
       recipeTitle: recipe,
       hydrogenPackagesVersion: args.hydrogenPackagesVersion,
     });
+
+    execSync(`git clean -fd ${TEMPLATE_PATH}`);
+
     if (!ok) {
       console.error(`❌ Recipe '${recipe}' is invalid`);
       failed.push(recipe);

--- a/cookbook/src/commands/validate.ts
+++ b/cookbook/src/commands/validate.ts
@@ -1,6 +1,4 @@
-import {execSync} from 'child_process';
 import {CommandModule} from 'yargs';
-import {TEMPLATE_PATH} from '../lib/constants';
 import {listRecipes, separator} from '../lib/util';
 import {validateRecipe} from '../lib/validate';
 
@@ -48,9 +46,6 @@ async function handler(args: ValidateArgs) {
       recipeTitle: recipe,
       hydrogenPackagesVersion: args.hydrogenPackagesVersion,
     });
-    // clean up the skeleton template directory on success
-    execSync(`git checkout -- ${TEMPLATE_PATH}`);
-    execSync(`git clean -fd ${TEMPLATE_PATH}`);
 
     if (!ok) {
       console.error(`❌ Recipe '${recipe}' is invalid`);

--- a/cookbook/src/commands/validate.ts
+++ b/cookbook/src/commands/validate.ts
@@ -38,8 +38,11 @@ async function handler(args: ValidateArgs) {
   }
 
   let failed: string[] = [];
-  for (const recipe of recipes) {
-    console.log(`🧐 Validating recipe '${recipe}'`);
+  for (let i = 0; i < recipes.length; i++) {
+    const recipe = recipes[i];
+    console.log(
+      `(${i + 1}/${recipes.length}) 🧐 Validating recipe '${recipe}'`,
+    );
 
     const ok = await validateRecipe({
       recipeTitle: recipe,

--- a/cookbook/src/commands/validate.ts
+++ b/cookbook/src/commands/validate.ts
@@ -42,11 +42,10 @@ async function handler(args: ValidateArgs) {
       `(${i + 1}/${recipes.length}) 🧐 Validating recipe '${recipe}'`,
     );
 
-    const ok = await validateRecipe({
+    const ok = validateRecipe({
       recipeTitle: recipe,
       hydrogenPackagesVersion: args.hydrogenPackagesVersion,
     });
-
     if (!ok) {
       console.error(`❌ Recipe '${recipe}' is invalid`);
       failed.push(recipe);

--- a/cookbook/src/lib/validate.ts
+++ b/cookbook/src/lib/validate.ts
@@ -1,38 +1,29 @@
 import {execSync} from 'child_process';
-import fs, {rmSync} from 'fs';
+import {rmSync} from 'fs';
 import {applyRecipe} from './apply';
 import {TEMPLATE_PATH} from './constants';
-import {makeRandomTempDir} from './util';
 import path from 'path';
 /**
  * Validate a recipe.
  * @param params - The parameters for the validation.
  */
-export function validateRecipe(params: {
+export async function validateRecipe(params: {
   recipeTitle: string;
   hydrogenPackagesVersion?: string;
 }) {
   let start = Date.now();
 
   const {recipeTitle, hydrogenPackagesVersion} = params;
-  const tempDir = makeRandomTempDir({prefix: 'validate-recipe'});
+
   try {
     console.log(`- 🧑‍🍳 Applying recipe '${recipeTitle}'`);
     applyRecipe({
       recipeTitle,
     });
 
-    // copy the skeleton template to a temporary directory, except for the node_modules directory and its contents
-    fs.cpSync(TEMPLATE_PATH, tempDir, {
-      recursive: true,
-      filter: (src) => {
-        return !src.includes('node_modules');
-      },
-    });
-
     if (hydrogenPackagesVersion != null) {
       console.log(`- 🔼 Applying Hydrogen version ${hydrogenPackagesVersion}…`);
-      rmSync(path.join(tempDir, 'package-lock.json'), {force: true});
+      rmSync(path.join(TEMPLATE_PATH, 'package-lock.json'), {force: true});
       const packages = [
         'https://registry.npmjs.org/@shopify/cli-hydrogen/-/cli-hydrogen',
         'https://registry.npmjs.org/@shopify/hydrogen/-/hydrogen',
@@ -40,29 +31,41 @@ export function validateRecipe(params: {
       ];
       execSync(
         `npm install ${packages.map((p) => `${p}-${hydrogenPackagesVersion}.tgz`).join(' ')}`,
-        {cwd: tempDir},
+        {cwd: TEMPLATE_PATH},
       );
     }
 
     // run npm install in the template directory
     console.log(`- 📦 Installing dependencies…`);
-    execSync(`npm install`, {cwd: tempDir});
+    execSync(`npm install`, {cwd: TEMPLATE_PATH});
 
     console.log(`- 🔄 Running codegen…`);
-    execSync(`npm run codegen`, {cwd: tempDir});
+    execSync(`npm run codegen`, {cwd: TEMPLATE_PATH});
+    await wait(1000);
 
     // run typecheck in the template directory
     console.log(`- 🔨 Running typecheck…`);
-    execSync(`npm run typecheck`, {cwd: tempDir});
+    execSync(`npm run typecheck`, {cwd: TEMPLATE_PATH});
 
     // run npm run build in the template directory
     console.log(`- 🏗️ Building…`);
-    execSync(`npm run build`, {cwd: tempDir});
+    execSync(`npm run build`, {cwd: TEMPLATE_PATH});
 
     const duration = Date.now() - start;
     console.log(`✅ Recipe '${recipeTitle}' is valid (${duration}ms)`);
+
+    return true;
+  } catch (error) {
+    console.error(error);
+    return false;
   } finally {
-    // cleanup the temp folder
-    fs.rmSync(tempDir, {recursive: true});
+    // rewind the changes to the template directory
+    execSync(`git checkout -- .`, {cwd: TEMPLATE_PATH});
+    // wait a bit to make sure the changes are reverted
+    await wait(1000);
   }
+}
+
+async function wait(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/cookbook/src/lib/validate.ts
+++ b/cookbook/src/lib/validate.ts
@@ -37,7 +37,7 @@ export async function validateRecipe(params: {
 
     // run npm install in the template directory
     console.log(`- 📦 Installing dependencies…`);
-    execSync(`npm ci`, {cwd: TEMPLATE_PATH});
+    execSync(`npm install`, {cwd: TEMPLATE_PATH});
 
     console.log(`- 🔄 Running codegen…`);
     execSync(`npm run codegen`, {cwd: TEMPLATE_PATH});

--- a/cookbook/src/lib/validate.ts
+++ b/cookbook/src/lib/validate.ts
@@ -37,11 +37,10 @@ export async function validateRecipe(params: {
 
     // run npm install in the template directory
     console.log(`- 📦 Installing dependencies…`);
-    execSync(`npm install`, {cwd: TEMPLATE_PATH});
+    execSync(`npm ci`, {cwd: TEMPLATE_PATH});
 
     console.log(`- 🔄 Running codegen…`);
     execSync(`npm run codegen`, {cwd: TEMPLATE_PATH});
-    await wait(1000);
 
     // run typecheck in the template directory
     console.log(`- 🔨 Running typecheck…`);
@@ -61,11 +60,5 @@ export async function validateRecipe(params: {
   } finally {
     // rewind the changes to the template directory
     execSync(`git checkout -- .`, {cwd: TEMPLATE_PATH});
-    // wait a bit to make sure the changes are reverted
-    await wait(1000);
   }
-}
-
-async function wait(ms: number) {
-  await new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We should run the recipes validation as part of the PR GHA workflow.

### WHAT is this pull request doing?

1. Add a `validate_recipes` step to the `ci.yml` GHA workflow that runs the `validate` command against all the available recipes.
2. Update the `validate` command to be easier to read, and to work directly on the skeleton template.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
