### PR TITLE
Supports vite7 exports [.]

### DIFF
--- a/.changeset/silver-apricots-sip.md
+++ b/.changeset/silver-apricots-sip.md
@@ -1,0 +1,5 @@
+---
+"@shopify/cli-hydrogen": patch
+---
+
+Add support for Vite v7 [.] exports

--- a/packages/cli/src/lib/import-utils.ts
+++ b/packages/cli/src/lib/import-utils.ts
@@ -15,10 +15,15 @@ export async function importVite(root: string): Promise<Vite> {
 
   const vitePackageJson = await findUpAndReadPackageJson(vitePath);
 
+  // vite 7
   let viteNodeIndexFile = (vitePackageJson.content as any).exports?.['.']
-    .import;
 
-  // If project still using vite 5
+  // vite 6
+  if (typeof viteNodeIndexFile !== 'string') {
+    viteNodeIndexFile = viteNodeIndexFile?.import
+  }
+  
+  // vite 5
   if (typeof viteNodeIndexFile !== 'string') {
     viteNodeIndexFile = viteNodeIndexFile.default;
   }

--- a/packages/cli/src/lib/import-utils.ts
+++ b/packages/cli/src/lib/import-utils.ts
@@ -16,13 +16,13 @@ export async function importVite(root: string): Promise<Vite> {
   const vitePackageJson = await findUpAndReadPackageJson(vitePath);
 
   // vite 7
-  let viteNodeIndexFile = (vitePackageJson.content as any).exports?.['.']
+  let viteNodeIndexFile = (vitePackageJson.content as any).exports?.['.'];
 
   // vite 6
   if (typeof viteNodeIndexFile !== 'string') {
-    viteNodeIndexFile = viteNodeIndexFile?.import
+    viteNodeIndexFile = viteNodeIndexFile?.import;
   }
-  
+
   // vite 5
   if (typeof viteNodeIndexFile !== 'string') {
     viteNodeIndexFile = viteNodeIndexFile.default;


### PR DESCRIPTION
### WHY are these changes introduced?

Vite7 exports [.] as a string not an object and build fails when updating. "Cannot read properties of undefined (reading 'default')"

![image](https://github.com/user-attachments/assets/5d73c8c4-bb07-43fd-ac9d-ea2f26561c70)

### WHAT is this pull request doing?

Github editor based attempt at solving off of local patch written (build works).

### HOW to test your changes?

1. update vite to v7
2. build

#### Post-merge steps

No clue. Back to day job. Pull requesting in case it helps narrow down 💙. LMK if not and I'll send an issue next time instead

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation