### PR TITLE
Add charset meta tag to GraphiQL HTML

### DIFF
--- a/.changeset/tender-brooms-wash.md
+++ b/.changeset/tender-brooms-wash.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Adds charset meta tag to GraphiQL HTML

--- a/package-lock.json
+++ b/package-lock.json
@@ -41688,7 +41688,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "11.0.1",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -44107,7 +44107,7 @@
       }
     },
     "templates/skeleton": {
-      "version": "2025.5.1",
+      "version": "2025.5.2",
       "dependencies": {
         "@shopify/hydrogen": "2025.5.0",
         "@shopify/remix-oxygen": "^3.0.0",

--- a/packages/hydrogen/src/routing/graphiql.ts
+++ b/packages/hydrogen/src/routing/graphiql.ts
@@ -77,6 +77,7 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
       <!DOCTYPE html>
       <html lang="en">
         <head>
+          <meta charset="utf-8" />
           <title>GraphiQL</title>
           <link rel="icon" type="image/x-icon" href="${favicon}" />
           <style>


### PR DESCRIPTION
### WHY are these changes introduced?

The GraphiQL HTML template was missing a charset meta tag, which can cause character encoding issues when the page is rendered.

### WHAT is this pull request doing?

Added `<meta charset="utf-8" />` tag to the GraphiQL HTML template in `packages/hydrogen/src/routing/graphiql.ts`. This ensures proper UTF-8 character encoding for the GraphiQL interface.

### HOW to test your changes?

1. Start a Hydrogen development server
2. Navigate to the GraphiQL endpoint (typically `/graphiql`)
3. Verify the page loads correctly and check the page source to confirm the charset meta tag is present
4. Test with queries containing non-ASCII characters (e.g., accented characters, emojis) to ensure proper encoding

