### PR TITLE
Fix and upgrade /graphiql  to latest version

### DIFF
--- a/.changeset/lemon-snakes-shout.md
+++ b/.changeset/lemon-snakes-shout.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Fix and upgrade /graphiql route

--- a/package-lock.json
+++ b/package-lock.json
@@ -41688,7 +41688,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "11.0.1",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.11.0",
@@ -44107,7 +44107,7 @@
       }
     },
     "templates/skeleton": {
-      "version": "2025.5.1",
+      "version": "2025.5.2",
       "dependencies": {
         "@shopify/hydrogen": "2025.5.0",
         "@shopify/remix-oxygen": "^3.0.0",

--- a/packages/hydrogen/src/routing/graphiql.ts
+++ b/packages/hydrogen/src/routing/graphiql.ts
@@ -82,6 +82,7 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
         <head>
           <title>GraphiQL</title>
           <link rel="icon" type="image/x-icon" href="${favicon}" />
+          <meta charset="utf-8" />
           <style>
             body {
               height: 100%;

--- a/packages/hydrogen/src/routing/graphiql.ts
+++ b/packages/hydrogen/src/routing/graphiql.ts
@@ -45,6 +45,8 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
     };
   }
 
+  // In order to authenticate the CAAPI requests the user must be logged in via the CAAPI.
+  // The graphiql request will then use the correct
   if (customerAccount) {
     // CustomerAccount API does not support introspection to the same URL.
     // Read it from a file using the asset server:
@@ -221,15 +223,13 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
 
               // We create a custom fetcher because createGraphiQLFetcher attempts to introspect the schema
               // and the Customer Account API does not support introspection.
+              // We  override the fetcher to return the schema directly only for the CAAPI introspection query.
               function createJsonFetcher(options, httpFetch) {
-                console.log('createJsonFetcher', {options, httpFetch});
-
                 if (activeSchema === 'storefront') {
                   return fetcher(options, httpFetch);
                 } else {
                   // CAAPI requires a custom fetcher
                   if (options.operationName === 'IntrospectionQuery') {
-                    // return the prefetch schema
                     return {data: schema.value};
                   } else {
                     return fetcher(options, httpFetch);
@@ -240,7 +240,6 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
               const keys = Object.keys(schemas);
 
               function onTabChange(state) {
-                console.log('onTabChange', state);
                 const {activeTabIndex, tabs} = state;
                 const activeTab = tabs[activeTabIndex];
 
@@ -326,7 +325,6 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
                           key: 'icon',
                           style: {
                             textAlign: 'center',
-                            // color: 'hsl(var(--color-base))',
                           },
                         },
                         [
@@ -377,7 +375,8 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
                 ],
               );
 
-              const children = [CustomToolbar, CustomLogo];
+              // const children = [CustomToolbar, CustomLogo];
+              const children = [CustomToolbar];
 
               return React.createElement(GraphiQL, props, children);
             }

--- a/packages/hydrogen/src/routing/graphiql.ts
+++ b/packages/hydrogen/src/routing/graphiql.ts
@@ -375,8 +375,7 @@ export const graphiqlLoader: GraphiQLLoader = async function graphiqlLoader({
                 ],
               );
 
-              // const children = [CustomToolbar, CustomLogo];
-              const children = [CustomToolbar];
+              const children = [CustomToolbar, CustomLogo];
 
               return React.createElement(GraphiQL, props, children);
             }


### PR DESCRIPTION
### WHY are these changes introduced?

closes https://github.com/Shopify/hydrogen/issues/2996
closes https://github.com/Shopify/hydrogen/issues/3016

The graphiql version we relied upon has been deprecated and removed from the CDN which caused this route to break.



![Screenshot 2025-07-08 at 11 08 51 AM](https://github.com/user-attachments/assets/c06c3c03-28eb-454d-8c59-a4f338eef85e)

### WHAT is this pull request doing?

This PR re-implements graphiql based on their latest v5 cdn-version guidelines.

![Screenshot 2025-07-08 at 11 10 16 AM](https://github.com/user-attachments/assets/2945586f-8999-43a9-9bb8-bb91f883a024)


### HOW to test your changes?

SFAPI: 
1. `h2 dev` @ /packages/hydrogen
2. `h2 login` @ /templates/skeleton
3. `h2 dev` /templates/skeleton
4. visit http://localhost:3000/graphiql
5. Make a query e.g shop { name }

CAAPI
1. `h2 dev` @ /packages/hydrogen
2. `h2 login` @ /templates/skeleton
3. `h2 dev --customer-account-push__unstable` @ /templates/skeleton
4. Update vite.config.ts `server.allowedHosts` adding the tryhydrogen.dev url
5. Login to your user @ tryhydrogen.dev url
6. visit xyz.tryhydrogen.dev/graphiql
7. Toggle the CAAPI under the query run
8. Make a CAAPI query e.g shop { name }

