### PR TITLE
Add  `--force-client-sourcemap` flag support to `h2 deploy` command

### DIFF
--- a/.changeset/hungry-tools-enjoy.md
+++ b/.changeset/hungry-tools-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@shopify/cli-hydrogen": patch
+---
+
+Add `--force-client-sourcemap` flag support to the `deploy` command

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -503,6 +503,13 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "force-client-sourcemap": {
+          "description": "Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP",
+          "name": "force-client-sourcemap",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/cli/src/commands/hydrogen/deploy.test.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.test.ts
@@ -66,12 +66,11 @@ vi.mock('@shopify/cli-kit/node/git', async () => {
 
 async function createHydrogenDependencyPackageJson(version?: string) {
   const require = createRequire(import.meta.url);
-  const packageJson: PackageJson = require(require.resolve(
-    '@shopify/hydrogen/package.json',
-    {
+  const packageJson: PackageJson = require(
+    require.resolve('@shopify/hydrogen/package.json', {
       paths: [getSkeletonSourceDir()],
-    },
-  ));
+    }),
+  );
 
   packageJson.version = version;
 

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -161,6 +161,11 @@ export default class Deploy extends Command {
       hidden: true,
     }),
     ...commonFlags.diff,
+    'force-client-sourcemap': Flags.boolean({
+      description:
+        'Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP',
+    }),
   };
 
   async run() {
@@ -203,6 +208,7 @@ interface OxygenDeploymentOptions {
   envBranch?: string;
   environmentFile?: string;
   force: boolean;
+  forceClientSourcemap?: boolean;
   noVerify: boolean;
   lockfileCheck: boolean;
   jsonOutput: boolean;
@@ -252,6 +258,7 @@ export async function runDeploy(
     envBranch,
     environmentFile,
     force: forceOnUncommitedChanges,
+    forceClientSourcemap = false,
     noVerify,
     lockfileCheck,
     jsonOutput,
@@ -602,10 +609,15 @@ Continue?`.value,
         assetPath,
         lockfileCheck,
         sourcemap: true,
+        forceClientSourcemap,
         useCodegen: false,
         entry: ssrEntry,
       });
     };
+  }
+
+  if (true) {
+    throw new Error('test done');
   }
 
   const uploadStart = async () => {
@@ -692,11 +704,9 @@ export async function getHydrogenVersion({appPath}: {appPath: string}) {
   const {root} = getProjectPaths(appPath);
 
   const require = createRequire(import.meta.url);
-  const {version} = require(
-    require.resolve('@shopify/hydrogen/package.json', {
-      paths: [root],
-    }),
-  );
+  const {version} = require(require.resolve('@shopify/hydrogen/package.json', {
+    paths: [root],
+  }));
 
   return version;
 }

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -700,9 +700,11 @@ export async function getHydrogenVersion({appPath}: {appPath: string}) {
   const {root} = getProjectPaths(appPath);
 
   const require = createRequire(import.meta.url);
-  const {version} = require(require.resolve('@shopify/hydrogen/package.json', {
-    paths: [root],
-  }));
+  const {version} = require(
+    require.resolve('@shopify/hydrogen/package.json', {
+      paths: [root],
+    }),
+  );
 
   return version;
 }

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -19,6 +19,7 @@ import {
 import {joinPath, relativePath, resolvePath} from '@shopify/cli-kit/node/path';
 import {
   renderConfirmationPrompt,
+  renderInfo,
   renderSelectPrompt,
   renderSuccess,
   renderTasks,
@@ -591,6 +592,14 @@ Continue?`.value,
   };
 
   if (buildCommand) {
+    if (forceClientSourcemap) {
+      console.log('');
+      renderInfo({
+        headline:
+          'The `--force-client-sourcemap` flag is not supported with a custom build command',
+        body: 'Client sourcemaps will not be generated.',
+      });
+    }
     config.buildCommand = buildCommand;
   } else {
     hooks.buildFunction = async (
@@ -700,11 +709,9 @@ export async function getHydrogenVersion({appPath}: {appPath: string}) {
   const {root} = getProjectPaths(appPath);
 
   const require = createRequire(import.meta.url);
-  const {version} = require(
-    require.resolve('@shopify/hydrogen/package.json', {
-      paths: [root],
-    }),
-  );
+  const {version} = require(require.resolve('@shopify/hydrogen/package.json', {
+    paths: [root],
+  }));
 
   return version;
 }

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -10,7 +10,7 @@ import {
 } from '@shopify/cli-kit/node/output';
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env';
 import {AbortError} from '@shopify/cli-kit/node/error';
-import {readFile, writeFile} from '@shopify/cli-kit/node/fs';
+import {writeFile} from '@shopify/cli-kit/node/fs';
 import {
   ensureIsClean,
   getLatestGitCommit,
@@ -614,10 +614,6 @@ Continue?`.value,
         entry: ssrEntry,
       });
     };
-  }
-
-  if (true) {
-    throw new Error('test done');
   }
 
   const uploadStart = async () => {

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -709,9 +709,11 @@ export async function getHydrogenVersion({appPath}: {appPath: string}) {
   const {root} = getProjectPaths(appPath);
 
   const require = createRequire(import.meta.url);
-  const {version} = require(require.resolve('@shopify/hydrogen/package.json', {
-    paths: [root],
-  }));
+  const {version} = require(
+    require.resolve('@shopify/hydrogen/package.json', {
+      paths: [root],
+    }),
+  );
 
   return version;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/hydrogen/issues/2965

### WHAT is this pull request doing?

Adds `--force-client-sourcemap` flag support top `h2 deploy` command

### HOW to test your changes?

1. Run `npm run dev:pkg` @ monorepo root folder
2. Run `h2 deploy --force-client-sourcemap` @ /templates/skeleton
3. Validate that `/templates/skeleton/dist/client` folder contains sourcemap files e.g `.map`

![Screenshot 2025-07-08 at 12 16 46 PM](https://github.com/user-attachments/assets/7d780925-9484-4fbc-99e3-f96ee3447e5a)

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
