### PR TITLE
2025-7 Fix `useNonce` hydration issue

### DIFF
--- a/.changeset/fifty-beds-shave.md
+++ b/.changeset/fifty-beds-shave.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Fix `useNonce` hydration issue by enforcing only server-side executio

--- a/packages/hydrogen/src/csp/csp.test.ts
+++ b/packages/hydrogen/src/csp/csp.test.ts
@@ -85,9 +85,26 @@ describe('useNonce', () => {
       </DocumentFragment>
     `);
   });
+
+  it('returns undefined when called outside NonceProvider', () => {
+    const {asFragment} = render(createElement(SomeComponentWithOptionalNonce));
+
+    expect(asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <div>
+          No nonce available
+        </div>
+      </DocumentFragment>
+    `);
+  });
 });
 
 function SomeComponent() {
   const nonce = useNonce();
   return createElement('div', null, nonce);
+}
+
+function SomeComponentWithOptionalNonce() {
+  const nonce = useNonce();
+  return createElement('div', null, nonce ? nonce : 'No nonce available');
 }

--- a/packages/hydrogen/src/csp/csp.ts
+++ b/packages/hydrogen/src/csp/csp.ts
@@ -11,7 +11,15 @@ import {generateNonce} from './nonce';
 export const NonceContext = createContext<string | undefined>(undefined);
 export const NonceProvider = NonceContext.Provider;
 
-export const useNonce = () => useContext(NonceContext);
+export const useNonce = () => {
+  // In client-side hydration, the NonceContext might not be available
+  // Return undefined in that case since nonce is only needed for SSR
+  try {
+    return useContext(NonceContext);
+  } catch {
+    return undefined;
+  }
+};
 
 type ContentSecurityPolicy = {
   /** A randomly generated nonce string that should be passed to any custom `script` element */

--- a/packages/hydrogen/src/csp/useNonce.doc.ts
+++ b/packages/hydrogen/src/csp/useNonce.doc.ts
@@ -16,7 +16,9 @@ const data: ReferenceEntityTemplateSchema = {
       url: '/docs/api/hydrogen/components/script',
     },
   ],
-  description: `The \`useNonce\` hook returns the [content security policy](/docs/custom-storefronts/hydrogen/content-security-policy) nonce. Use the hook to manually add a nonce to third party scripts. The \`Script\` component automatically does this for you. Note, the nonce should never be available in the client, and should always return undefined in the browser.`,
+  description: `The \`useNonce\` hook returns the [content security policy](/docs/custom-storefronts/hydrogen/content-security-policy) nonce. Use the hook to manually add a nonce to third party scripts. The \`Script\` component automatically does this for you. 
+
+The nonce is only available during server-side rendering when used within a \`NonceProvider\` context. During client-side hydration or when called outside of a \`NonceProvider\`, it returns \`undefined\`. This is expected behavior as the nonce is only needed for server-rendered inline scripts.`,
   type: 'hook',
   defaultExample: {
     description: 'I am the default example',


### PR DESCRIPTION
### WHY are these changes introduced?

Fix a hydration issue caused by useNonce 

### WHAT is this pull request doing?

Forcing useNonce to be server side only as intended

### HOW to test your changes?

No hydration issues when running h2 dev (first load)

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
