### PR TITLE
[2025-04 Back fix] Add `uninstallNodeModules` to Hydrogen upgrade command

### DIFF
--- a/.changeset/late-ducks-search.md
+++ b/.changeset/late-ducks-search.md
@@ -1,0 +1,5 @@
+---
+"@shopify/cli-hydrogen": patch
+---
+
+Improve upgrade command to handle removal of dependencies. This feature is necessary to aid in upgrading from Remix to React Router 7

--- a/.github/workflows/test-upgrade-flow.yml
+++ b/.github/workflows/test-upgrade-flow.yml
@@ -1,0 +1,71 @@
+# Test Upgrade Flow Workflow
+#
+# Purpose:
+# This workflow validates that the Hydrogen CLI upgrade command works correctly when
+# changelog.json is modified. It ensures that users can successfully upgrade their
+# Hydrogen projects to new versions without encountering dependency conflicts or
+# runtime errors.
+#
+# What it tests:
+# 1. Dynamic version detection from local changelog.json
+# 2. Scaffolds a historical Hydrogen project from git history
+# 3. Runs the actual `hydrogen upgrade` command with the latest version
+# 4. Validates that npm install succeeds without dependency conflicts
+# 5. Verifies the dev server starts without import/module errors
+# 6. Makes HTTP requests to ensure the app serves HTML without errors
+#
+# When it runs:
+# - On push/PR when docs/changelog.json is modified
+# - Manual trigger via workflow_dispatch
+#
+# Key validations:
+# - No npm dependency resolution errors (ERESOLVE, peer deps, etc.)
+# - No missing module or import errors during runtime
+# - Dev server successfully serves pages
+# - Build and typecheck commands succeed
+#
+# This is critical for ensuring new releases don't break the upgrade path for users.
+
+name: Test Upgrade Flow
+
+on:
+  push:
+    paths:
+      - 'docs/changelog.json'
+  pull_request:
+    paths:
+      - 'docs/changelog.json'
+  workflow_dispatch:
+
+jobs:
+  test-upgrade-flow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build:pkg
+
+      - name: Run upgrade flow tests
+        run: |
+          cd packages/cli
+          npm test upgrade-flow.test.ts
+        env:
+          FORCE_CHANGELOG_SOURCE: local
+          SHOPIFY_HYDROGEN_FLAG_FORCE: 1
+
+      - name: Report test results
+        if: always()
+        run: |
+          echo "✅ Upgrade flow tests completed"
+          echo "These tests verify dynamic version detection from changelog.json"

--- a/packages/cli/src/commands/hydrogen/upgrade-flow.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade-flow.test.ts
@@ -1,0 +1,970 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {mkdtemp, readFile, writeFile, mkdir} from 'node:fs/promises';
+import {join} from 'node:path';
+import {tmpdir} from 'node:os';
+import {exec} from '@shopify/cli-kit/node/system';
+import {execAsync} from '../../lib/process.js';
+import * as upgradeModule from './upgrade.js';
+import {spawn, ChildProcess} from 'node:child_process';
+import getPort from 'get-port';
+import {fileExists} from '@shopify/cli-kit/node/fs';
+
+// Mock the UI prompts to avoid interactive prompts during tests
+vi.mock('@shopify/cli-kit/node/ui', async () => {
+  const original = await vi.importActual<
+    typeof import('@shopify/cli-kit/node/ui')
+  >('@shopify/cli-kit/node/ui');
+
+  return {
+    ...original,
+    renderTasks: vi.fn(async (tasks) => {
+      // Execute all tasks to perform the actual upgrade operations
+      for (const task of tasks) {
+        if (task.task && typeof task.task === 'function') {
+          await task.task();
+        }
+      }
+    }),
+    renderSelectPrompt: vi.fn(() => Promise.resolve()),
+    renderConfirmationPrompt: vi.fn(() => Promise.resolve(true)), // Always confirm
+    renderInfo: vi.fn(() => {}), // Mock renderInfo to silence output
+    renderSuccess: vi.fn(() => {}), // Mock renderSuccess to silence output
+  };
+});
+
+describe('upgrade flow integration', () => {
+  beforeEach(() => {
+    // Clear any cached changelog to ensure mocks work properly
+    vi.clearAllMocks();
+  });
+
+  describe('End-to-end upgrade scenarios', () => {
+    // Test 1: Single version upgrade to latest release
+    it('upgrades from previous version to latest release', async () => {
+      const changelog = await upgradeModule.getChangelog();
+      const latestRelease = changelog.releases[0];
+
+      if (!latestRelease) {
+        throw new Error('No releases found in changelog');
+      }
+
+      // Find the previous release (just one version back for clean single-version upgrade)
+      let fromRelease = null;
+      let fromCommit = null;
+
+      // Use the previous release (index 1) for a clean single-version upgrade
+      if (changelog.releases.length > 1) {
+        const candidate = changelog.releases[1];
+        if (candidate) {
+          const commit = await findCommitForVersion(candidate.version);
+          if (commit) {
+            fromRelease = candidate;
+            fromCommit = commit;
+          }
+        }
+      }
+
+      if (!fromRelease || !fromCommit) {
+        const availableVersions = changelog.releases
+          .slice(0, 5)
+          .map((r) => r.version)
+          .join(', ');
+
+        throw new Error(
+          `Could not find commit for latest release version. This indicates a problem with the changelog or Git history. ` +
+            `Tried version: ${changelog.releases[1]?.version}. ` +
+            `Available versions: ${availableVersions}. ` +
+            `Latest version: ${latestRelease.version}.`,
+        );
+      }
+
+      const fromVersion = fromRelease.version;
+      const toVersion = latestRelease.version;
+
+      const projectDir = await scaffoldHistoricalProject(fromCommit);
+
+      // Verify we started with the historical version (not the target version)
+      const initialPackageJson = JSON.parse(
+        await readFile(join(projectDir, 'package.json'), 'utf8'),
+      );
+      const initialHydrogenVersion =
+        initialPackageJson.dependencies?.['@shopify/hydrogen'];
+      expect(
+        initialHydrogenVersion === toVersion ||
+          initialHydrogenVersion === `^${toVersion}`,
+      ).toBe(false);
+
+      // Check what scenarios apply to this upgrade
+      const hasGuide =
+        latestRelease.features?.some((f: any) => f.steps?.length > 0) ||
+        latestRelease.fixes?.some((f: any) => f.steps?.length > 0);
+
+      // Run upgrade (single version upgrade should work cleanly)
+      await runUpgradeCommand(projectDir, toVersion);
+
+      // Verify version was updated
+      const packageJson = JSON.parse(
+        await readFile(join(projectDir, 'package.json'), 'utf8'),
+      );
+      const hydrogenVersion = packageJson.dependencies?.['@shopify/hydrogen'];
+      expect(
+        hydrogenVersion === toVersion || hydrogenVersion === `^${toVersion}`,
+      ).toBe(true);
+
+      // Check guide generation and analyze breaking changes
+      const guideFile = join(
+        projectDir,
+        '.hydrogen',
+        `upgrade-${fromVersion}-to-${toVersion}.md`,
+      );
+      let guideContent = '';
+      let hasBreakingChanges = false;
+
+      if (hasGuide) {
+        guideContent = await readFile(guideFile, 'utf8');
+        expect(guideContent).toContain(
+          `# Hydrogen upgrade guide: ${fromVersion} to ${toVersion}`,
+        );
+        expect(guideContent.length).toBeGreaterThan(100);
+
+        // If guide has steps, expect potential build/dev/typecheck failures
+        hasBreakingChanges =
+          latestRelease.features?.some((f: any) => f.steps?.length > 0) ||
+          latestRelease.fixes?.some((f: any) => f.steps?.length > 0);
+      } else {
+        await expect(readFile(guideFile, 'utf8')).rejects.toThrow();
+      }
+
+      // Test dependency management - validate removals and additions
+      await validateDependencyChanges(projectDir, fromRelease, latestRelease);
+
+      // Test build functionality - strict if no guide steps, graceful if guide has steps
+      await validateProjectBuilds(projectDir, hasBreakingChanges);
+
+      // Test typecheck functionality - strict if no guide steps, graceful if guide has steps
+      await validateTypeCheck(projectDir, hasBreakingChanges);
+
+      // Test dev server functionality - strict if no guide steps, graceful if guide has steps
+      await validateDevServer(projectDir, hasBreakingChanges);
+
+      // Validate critical file integrity (always strict)
+      await validateFileIntegrity(projectDir);
+    }, 180000);
+  });
+
+  describe('Changelog validation', () => {
+    it('validates changelog structure and field compliance', async () => {
+      // First validate that the changelog is valid JSON by reading it directly
+      const changelogPath = join(process.cwd(), '../../docs/changelog.json');
+      const changelogContent = await readFile(changelogPath, 'utf8');
+
+      // Validate JSON syntax
+      let parsedChangelog;
+      try {
+        parsedChangelog = JSON.parse(changelogContent);
+      } catch (error) {
+        throw new Error(
+          `Invalid JSON in changelog.json: ${(error as Error).message}`,
+        );
+      }
+
+      // Also get changelog through the module for consistency
+      const changelog = await upgradeModule.getChangelog();
+
+      // Ensure both are the same
+      expect(changelog).toEqual(parsedChangelog);
+
+      // Validate top-level changelog structure
+      const allowedChangelogFields = ['url', 'version', 'releases'];
+      const changelogKeys = Object.keys(changelog);
+      const rogueChangelogFields = changelogKeys.filter(
+        (key) => !allowedChangelogFields.includes(key),
+      );
+      expect(rogueChangelogFields).toEqual([]);
+
+      // Pre-compile field sets for efficient lookups
+      const allowedReleaseFields = new Set([
+        'title',
+        'version',
+        'date',
+        'hash',
+        'commit',
+        'pr',
+        'dependencies',
+        'devDependencies',
+        'dependenciesMeta',
+        'removeDependencies',
+        'removeDevDependencies',
+        'features',
+        'fixes',
+      ]);
+
+      const allowedItemFields = new Set([
+        'title',
+        'info',
+        'pr',
+        'id',
+        'breaking',
+        'docs',
+        'steps',
+        'desc',
+        'code',
+        'description',
+      ]);
+
+      const allowedStepFields = new Set([
+        'title',
+        'info',
+        'code',
+        'file',
+        'reel',
+        'desc',
+        'docs',
+      ]);
+
+      // Pre-compile regular expressions for better performance
+      const urlRegex = /^https:\/\/.+/;
+      const versionRegex = /^\d{4}\.\d+\.\d+$/;
+      const semverRegex = /^[\^~]?\d+\.\d+\.\d+.*$/;
+
+      // Validate each release efficiently
+      for (
+        let releaseIndex = 0;
+        releaseIndex < changelog.releases.length;
+        releaseIndex++
+      ) {
+        const release = changelog.releases[releaseIndex];
+        if (!release) continue; // Skip if undefined (shouldn't happen in practice)
+
+        // Check for rogue fields in release using Set for O(1) lookup
+        const releaseKeys = Object.keys(release);
+        const rogueReleaseFields = releaseKeys.filter(
+          (key) => !allowedReleaseFields.has(key),
+        );
+        expect(rogueReleaseFields).toEqual([]);
+
+        // Validate required fields
+        expect(release.title).toBeDefined();
+        expect(release.version).toBeDefined();
+        expect(release.hash).toBeDefined();
+        expect(release.commit).toBeDefined();
+        expect(release.dependencies).toBeDefined();
+        expect(release.devDependencies).toBeDefined();
+        expect(release.features).toBeDefined();
+        expect(release.fixes).toBeDefined();
+
+        // Validate URL formats using pre-compiled regex
+        if (release.pr) {
+          expect(typeof release.pr).toBe('string');
+        }
+        expect(release.commit).toMatch(urlRegex);
+
+        // Validate version format using pre-compiled regex
+        expect(release.version).toMatch(versionRegex);
+
+        // Validate date format (flexible format)
+        if (release.date) {
+          expect(typeof release.date).toBe('string');
+          expect(release.date.length).toBeGreaterThan(0);
+        }
+
+        // Validate features efficiently
+        if (release.features) {
+          for (
+            let featureIndex = 0;
+            featureIndex < release.features.length;
+            featureIndex++
+          ) {
+            const feature = release.features[featureIndex];
+            if (!feature) continue; // Skip if undefined
+
+            const featureKeys = Object.keys(feature);
+            const rogueFeatureFields = featureKeys.filter(
+              (key) => !allowedItemFields.has(key),
+            );
+            expect(rogueFeatureFields).toEqual([]);
+
+            // Validate required fields
+            expect(feature.title).toBeDefined();
+
+            // Validate pr field format (can be URL or text)
+            if (feature.pr) {
+              expect(typeof feature.pr).toBe('string');
+            }
+
+            // Validate steps if present
+            if (feature.steps) {
+              expect(Array.isArray(feature.steps)).toBe(true);
+              for (
+                let stepIndex = 0;
+                stepIndex < feature.steps.length;
+                stepIndex++
+              ) {
+                const step = feature.steps[stepIndex];
+                if (!step) continue; // Skip if undefined
+
+                const stepKeys = Object.keys(step);
+                const rogueStepFields = stepKeys.filter(
+                  (key) => !allowedStepFields.has(key),
+                );
+                expect(rogueStepFields).toEqual([]);
+
+                // Validate required step fields
+                expect(step.title).toBeDefined();
+
+                // Validate base64 encoded code
+                if (step.code) {
+                  expect(() =>
+                    Buffer.from(step.code, 'base64').toString(),
+                  ).not.toThrow();
+                }
+              }
+            }
+          }
+        }
+
+        // Validate fixes efficiently
+        if (release.fixes) {
+          for (let fixIndex = 0; fixIndex < release.fixes.length; fixIndex++) {
+            const fix = release.fixes[fixIndex];
+            if (!fix) continue; // Skip if undefined
+
+            const fixKeys = Object.keys(fix);
+            const rogueFixFields = fixKeys.filter(
+              (key) => !allowedItemFields.has(key),
+            );
+            expect(rogueFixFields).toEqual([]);
+
+            // Validate required fields
+            expect(fix.title).toBeDefined();
+
+            // Validate pr field format (can be URL or text)
+            if (fix.pr) {
+              expect(typeof fix.pr).toBe('string');
+            }
+
+            // Validate steps if present
+            if (fix.steps) {
+              expect(Array.isArray(fix.steps)).toBe(true);
+              for (
+                let stepIndex = 0;
+                stepIndex < fix.steps.length;
+                stepIndex++
+              ) {
+                const step = fix.steps[stepIndex];
+                if (!step) continue; // Skip if undefined
+
+                const stepKeys = Object.keys(step);
+                const rogueStepFields = stepKeys.filter(
+                  (key) => !allowedStepFields.has(key),
+                );
+                expect(rogueStepFields).toEqual([]);
+
+                // Validate required step fields
+                expect(step.title).toBeDefined();
+
+                // Validate base64 encoded code
+                if (step.code) {
+                  expect(() =>
+                    Buffer.from(step.code, 'base64').toString(),
+                  ).not.toThrow();
+                }
+              }
+            }
+          }
+        }
+
+        // Validate dependencies are in correct format using pre-compiled regex
+        if (release.dependencies) {
+          for (const [pkg, version] of Object.entries(release.dependencies)) {
+            expect(typeof pkg).toBe('string');
+            expect(typeof version).toBe('string');
+            expect(version).toMatch(semverRegex);
+          }
+        }
+
+        if (release.devDependencies) {
+          for (const [pkg, version] of Object.entries(
+            release.devDependencies,
+          )) {
+            expect(typeof pkg).toBe('string');
+            expect(typeof version).toBe('string');
+            expect(version).toMatch(semverRegex);
+          }
+        }
+
+        // Validate dependenciesMeta structure
+        if (release.dependenciesMeta) {
+          for (const [pkg, meta] of Object.entries(release.dependenciesMeta)) {
+            expect(typeof pkg).toBe('string');
+            expect(typeof meta).toBe('object');
+            expect(typeof meta.required).toBe('boolean');
+            // Check for rogue fields in meta (only 'required' is allowed)
+            const metaKeys = Object.keys(meta);
+            const rogueMetaFields = metaKeys.filter(
+              (key) => key !== 'required',
+            );
+            expect(rogueMetaFields).toEqual([]);
+          }
+        }
+
+        // Validate removeDependencies and removeDevDependencies are string arrays
+        if (release.removeDependencies) {
+          expect(Array.isArray(release.removeDependencies)).toBe(true);
+          for (const dep of release.removeDependencies) {
+            expect(typeof dep).toBe('string');
+          }
+        }
+
+        if (release.removeDevDependencies) {
+          expect(Array.isArray(release.removeDevDependencies)).toBe(true);
+          for (const dep of release.removeDevDependencies) {
+            expect(typeof dep).toBe('string');
+          }
+        }
+      }
+    });
+  });
+});
+
+// Helper function to find commit for a specific version
+async function findCommitForVersion(version: string): Promise<string | null> {
+  try {
+    // Try multiple possible repository root locations
+    const possibleRoots = [
+      join(process.cwd(), '../../'), // Local development
+      process.cwd(), // CI might be at repo root
+      join(process.cwd(), '../../../'), // Nested CI structure
+    ];
+
+    let repoRoot = possibleRoots[0];
+
+    // Find the correct repo root by checking for .git directory
+    for (const root of possibleRoots) {
+      try {
+        await execAsync('git rev-parse --git-dir', {cwd: root});
+        repoRoot = root;
+        break;
+      } catch {
+        // Continue to next candidate
+      }
+    }
+
+    // First try to fetch latest commits from GitHub to ensure we have complete history
+    try {
+      await execAsync('git fetch origin', {cwd: repoRoot});
+    } catch {
+      // Ignore fetch errors, continue with local git history
+    }
+
+    // Strategy 1: Look for GitHub release tags first
+    try {
+      const {stdout: tags} = await execAsync(
+        `git tag -l "*${version}*" | head -10`,
+        {cwd: repoRoot},
+      );
+
+      for (const tag of tags.trim().split('\n').filter(Boolean)) {
+        try {
+          const {stdout: tagCommit} = await execAsync(
+            `git rev-list -n 1 ${tag}`,
+            {cwd: repoRoot},
+          );
+          const commit = tagCommit.trim();
+
+          const {stdout: packageContent} = await execAsync(
+            `git show ${commit}:templates/skeleton/package.json`,
+            {cwd: repoRoot},
+          );
+          const packageJson = JSON.parse(packageContent);
+          if (
+            packageJson.dependencies?.['@shopify/hydrogen'] === version &&
+            packageJson.version === version
+          ) {
+            return commit;
+          }
+        } catch {
+          // Continue to next tag
+        }
+      }
+    } catch {
+      // Continue to next strategy
+    }
+
+    // Strategy 2: Search for official release commits by commit message pattern
+    try {
+      const releasePatterns = [
+        `\\[ci\\] release.*${version.replace(/\./g, '\\.')}`,
+        `\\[ci\\] release.*${version.replace(/\./g, '-')}`, // e.g., 2025-04 format
+        `release.*${version}`,
+      ];
+
+      for (const pattern of releasePatterns) {
+        const {stdout: releaseCommits} = await execAsync(
+          `git log --format=%H --grep="${pattern}" --all | head -10`,
+          {cwd: repoRoot},
+        );
+
+        for (const commit of releaseCommits
+          .trim()
+          .split('\n')
+          .filter(Boolean)) {
+          try {
+            const {stdout: packageContent} = await execAsync(
+              `git show ${commit}:templates/skeleton/package.json`,
+              {cwd: repoRoot},
+            );
+            const packageJson = JSON.parse(packageContent);
+            if (
+              packageJson.dependencies?.['@shopify/hydrogen'] === version &&
+              packageJson.version === version
+            ) {
+              return commit;
+            }
+          } catch {
+            // Continue to next commit
+          }
+        }
+      }
+    } catch {
+      // Continue to next strategy
+    }
+
+    // Strategy 3: Search all commits that touched skeleton package.json for exact version match
+    try {
+      const {stdout: allCommits} = await execAsync(
+        'git log --format=%H --all -- templates/skeleton/package.json | head -200',
+        {cwd: repoRoot},
+      );
+
+      for (const commit of allCommits.trim().split('\n').filter(Boolean)) {
+        try {
+          const {stdout: packageContent} = await execAsync(
+            `git show ${commit}:templates/skeleton/package.json`,
+            {cwd: repoRoot},
+          );
+          const packageJson = JSON.parse(packageContent);
+          if (
+            packageJson.dependencies?.['@shopify/hydrogen'] === version &&
+            packageJson.version === version
+          ) {
+            return commit;
+          }
+        } catch {
+          // Continue to next commit
+        }
+      }
+    } catch {
+      // Continue to end of function
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function scaffoldHistoricalProject(commit: string): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'hydrogen-upgrade-test-'));
+  const projectDir = join(tempDir, 'test-project');
+
+  try {
+    // Extract the skeleton template from the historical commit
+    const repoRoot = join(process.cwd(), '../../');
+    await execAsync(
+      `git archive ${commit} -- templates/skeleton | tar -x -C ${tempDir}`,
+      {
+        cwd: repoRoot,
+      },
+    );
+
+    // Move skeleton to project directory
+    await execAsync(`mv ${join(tempDir, 'templates/skeleton')} ${projectDir}`);
+
+    // Initialize git repo (required for many operations)
+    await exec('git', ['init'], {cwd: projectDir});
+    await exec('git', ['config', 'user.email', 'test@hydrogen.test'], {
+      cwd: projectDir,
+    });
+    await exec('git', ['config', 'user.name', 'Hydrogen Test'], {
+      cwd: projectDir,
+    });
+    await exec('git', ['add', '.'], {cwd: projectDir});
+    await exec('git', ['commit', '-m', 'Initial project setup'], {
+      cwd: projectDir,
+    });
+
+    // Install dependencies for the scaffolded project
+    await exec('npm', ['install'], {cwd: projectDir});
+
+    // Create .env file with required environment variables for testing
+    await writeFile(
+      join(projectDir, '.env'),
+      'SESSION_SECRET=test-session-secret-for-upgrade-test\n',
+    );
+
+    return projectDir;
+  } catch (error) {
+    throw new Error(
+      `Failed to scaffold historical project: ${(error as Error).message}`,
+    );
+  }
+}
+
+async function runUpgradeCommand(
+  projectDir: string,
+  toVersion: string,
+  options?: {skipDependencyValidation?: boolean},
+) {
+  // Set environment to use local changelog
+  process.env.FORCE_CHANGELOG_SOURCE = 'local';
+  process.env.SHOPIFY_HYDROGEN_FLAG_FORCE = '1';
+  process.env.CI = '1'; // Set CI mode to avoid prompts
+
+  try {
+    // Use the runUpgrade function directly
+    await upgradeModule.runUpgrade({
+      appPath: projectDir,
+      version: toVersion,
+      force: true,
+    });
+
+    // Validate dependencies were removed if required
+    if (!options?.skipDependencyValidation) {
+      await validateDependencyRemoval(projectDir, toVersion);
+    }
+  } catch (error) {
+    const err = error as Error;
+    throw new Error(`Upgrade command failed: ${err.message}`);
+  }
+}
+
+async function validateDependencyRemoval(
+  projectDir: string,
+  toVersion: string,
+) {
+  // Get the changelog to find what should be removed for this version
+  const changelog = await upgradeModule.getChangelog();
+  const targetRelease = changelog.releases.find(
+    (r: any) => r.version === toVersion,
+  );
+
+  if (!targetRelease) {
+    return;
+  }
+
+  const depsToRemove = [
+    ...(targetRelease.removeDependencies || []),
+    ...(targetRelease.removeDevDependencies || []),
+  ];
+
+  if (depsToRemove.length === 0) {
+    return;
+  }
+
+  // Read the current package.json
+  const packageJsonPath = join(projectDir, 'package.json');
+  const packageContent = await readFile(packageJsonPath, 'utf8');
+  const packageJson = JSON.parse(packageContent);
+
+  const allDeps = {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+  };
+
+  // Check each dependency that should be removed
+  const failedRemovals: string[] = [];
+  for (const dep of depsToRemove) {
+    if (dep in allDeps) {
+      failedRemovals.push(`${dep} (found with version ${allDeps[dep]})`);
+    }
+  }
+
+  if (failedRemovals.length > 0) {
+    throw new Error(
+      `The following dependencies should have been removed but are still present:\n${failedRemovals.join(
+        '\n',
+      )}\n\n` +
+        `This could cause npm install conflicts. Dependencies marked for removal: ${depsToRemove.join(
+          ', ',
+        )}`,
+    );
+  }
+}
+
+async function testDevServer(projectDir: string, phase: string) {
+  const port = await getPort({port: [3000, 3001, 3002, 3003]});
+  let devProcess: ChildProcess | null = null;
+
+  try {
+    // Add a test route before starting
+    await addTestRoute(projectDir);
+
+    // Start the dev server
+    devProcess = spawn('npm', ['run', 'dev', '--', '--port', port.toString()], {
+      cwd: projectDir,
+      env: {
+        ...process.env,
+        PORT: port.toString(),
+        SESSION_SECRET: 'test-session-secret-for-upgrade-test',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let serverOutput = '';
+    let serverErrors = '';
+
+    devProcess.stdout?.on('data', (data) => {
+      serverOutput += data.toString();
+    });
+
+    devProcess.stderr?.on('data', (data) => {
+      serverErrors += data.toString();
+    });
+
+    // Wait for server to be ready
+    const serverReady = await waitForServer(
+      `http://localhost:${port}`,
+      30000,
+      () => {
+        // Check for critical errors
+        if (
+          serverErrors.includes('Cannot find module') ||
+          serverErrors.includes('Module not found') ||
+          serverErrors.includes('Failed to resolve import')
+        ) {
+          throw new Error(`Import/dependency errors detected: ${serverErrors}`);
+        }
+      },
+    );
+
+    if (!serverReady) {
+      throw new Error(
+        `Dev server failed to start. Output: ${serverOutput}\nErrors: ${serverErrors}`,
+      );
+    }
+
+    // Test the server is responding
+    const response = await fetch(`http://localhost:${port}/`);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).not.toContain('Error:');
+    expect(html).not.toContain('Cannot find module');
+
+    // Test our custom route
+    const testResponse = await fetch(`http://localhost:${port}/test-upgrade`);
+    const testHtml = await testResponse.text();
+
+    expect(testResponse.status).toBe(200);
+    expect(testHtml).toContain('Upgrade Test Route');
+    expect(testHtml).toContain('If you can see this, the server is running!');
+  } catch (error) {
+    throw new Error(
+      `Dev server validation failed in ${phase}: ${(error as Error).message}`,
+    );
+  } finally {
+    if (devProcess) {
+      devProcess.kill('SIGTERM');
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      if (!devProcess.killed) {
+        devProcess.kill('SIGKILL');
+      }
+    }
+  }
+}
+
+async function addTestRoute(projectDir: string) {
+  const testRouteContent = `
+export default function TestRoute() {
+  return (
+    <div>
+      <h1>Upgrade Test Route</h1>
+      <p>If you can see this, the server is running!</p>
+    </div>
+  );
+}
+`;
+
+  const routesDir = join(projectDir, 'app', 'routes');
+  await mkdir(routesDir, {recursive: true});
+  await writeFile(join(routesDir, 'test-upgrade.tsx'), testRouteContent);
+}
+
+async function waitForServer(
+  url: string,
+  timeout: number,
+  errorCheck?: () => void,
+): Promise<boolean> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeout) {
+    try {
+      if (errorCheck) {
+        errorCheck();
+      }
+
+      const response = await fetch(url);
+      if (response.status < 500) {
+        return true;
+      }
+    } catch {
+      // Server not ready yet
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return false;
+}
+
+async function validateDependencyChanges(
+  projectDir: string,
+  fromRelease: any,
+  toRelease: any,
+) {
+  const packageJsonPath = join(projectDir, 'package.json');
+  const packageContent = await readFile(packageJsonPath, 'utf8');
+  const packageJson = JSON.parse(packageContent);
+
+  // Check dependency removals if specified
+  if (toRelease.removeDependencies) {
+    for (const dep of toRelease.removeDependencies) {
+      expect(packageJson.dependencies?.[dep]).toBeUndefined();
+    }
+  }
+
+  if (toRelease.removeDevDependencies) {
+    for (const dep of toRelease.removeDevDependencies) {
+      expect(packageJson.devDependencies?.[dep]).toBeUndefined();
+    }
+  }
+
+  // Check dependency additions if specified (only validate if they're present)
+  if (toRelease.dependencies) {
+    for (const [dep, version] of Object.entries(toRelease.dependencies)) {
+      const actualVersion = packageJson.dependencies?.[dep];
+      // Only validate if the dependency is present (upgrade might not add all deps)
+      if (actualVersion) {
+        const versionStr = String(version);
+        expect(
+          actualVersion === versionStr ||
+            actualVersion === `^${versionStr}` ||
+            actualVersion === `~${versionStr}` ||
+            actualVersion.includes(versionStr),
+        ).toBe(true);
+      }
+    }
+  }
+
+  if (toRelease.devDependencies) {
+    for (const [dep, version] of Object.entries(toRelease.devDependencies)) {
+      const actualVersion = packageJson.devDependencies?.[dep];
+      // Only validate if the dependency is present (upgrade might not add all deps)
+      if (actualVersion) {
+        if (dep === '@shopify/cli') {
+          // CLI releases happen after Hydrogen releases, so exact version matching isn't reliable.
+          // However, we should still validate the version is reasonable (major.minor should be close)
+          expect(actualVersion).toBeDefined();
+          expect(typeof actualVersion).toBe('string');
+          // Ensure it's a valid semver-like version
+          expect(actualVersion).toMatch(/^[~^]?\d+\.\d+\.\d+/);
+        } else {
+          const versionStr = String(version);
+          expect(
+            actualVersion === versionStr ||
+              actualVersion === `^${versionStr}` ||
+              actualVersion === `~${versionStr}` ||
+              actualVersion.includes(versionStr),
+          ).toBe(true);
+        }
+      }
+    }
+  }
+}
+
+async function validateProjectBuilds(
+  projectDir: string,
+  hasGuideSteps: boolean = false,
+) {
+  const originalEnv = process.env.SHOPIFY_UNIT_TEST;
+  delete process.env.SHOPIFY_UNIT_TEST;
+
+  try {
+    await exec('npm', ['run', 'build'], {
+      cwd: projectDir,
+      env: {...process.env, NODE_ENV: 'production'},
+    });
+  } catch (error) {
+    if (hasGuideSteps) {
+      // Build failures are expected when migration guide has steps
+      // Silently continue as this is expected behavior
+    } else {
+      // Build should succeed when no guide steps are present
+      throw new Error(
+        `Build failed unexpectedly (no migration steps documented): ${(error as Error).message}`,
+      );
+    }
+  } finally {
+    if (originalEnv !== undefined) {
+      process.env.SHOPIFY_UNIT_TEST = originalEnv;
+    } else {
+      delete process.env.SHOPIFY_UNIT_TEST;
+    }
+  }
+}
+
+async function validateTypeCheck(
+  projectDir: string,
+  hasGuideSteps: boolean = false,
+) {
+  try {
+    await exec('npm', ['run', 'typecheck'], {cwd: projectDir});
+  } catch (error) {
+    if (hasGuideSteps) {
+      // TypeScript errors are expected when migration guide has steps
+      // Silently continue as this is expected behavior
+    } else {
+      // TypeScript should pass when no guide steps are present
+      throw new Error(
+        `TypeScript validation failed unexpectedly (no migration steps documented): ${(error as Error).message}`,
+      );
+    }
+  }
+}
+
+async function validateDevServer(
+  projectDir: string,
+  hasGuideSteps: boolean = false,
+) {
+  try {
+    await testDevServer(projectDir, 'post-upgrade-validation');
+  } catch (error) {
+    if (hasGuideSteps) {
+      // Dev server failures are expected when migration guide has steps
+      // Silently continue as this is expected behavior
+    } else {
+      // Dev server should work when no guide steps are present
+      throw new Error(
+        `Dev server validation failed unexpectedly (no migration steps documented): ${(error as Error).message}`,
+      );
+    }
+  }
+}
+
+async function validateFileIntegrity(projectDir: string) {
+  const criticalFiles = [
+    'app/lib/redirect.ts',
+    'package.json',
+    'tsconfig.json',
+  ];
+
+  for (const file of criticalFiles) {
+    const filePath = join(projectDir, file);
+    const hasFile = await fileExists(filePath);
+    if (!hasFile) {
+      throw new Error(`Missing critical file after upgrade: ${file}`);
+    }
+  }
+}

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -1,5 +1,4 @@
 import {createRequire} from 'node:module';
-import {execa} from 'execa';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {
   inTemporaryDirectory,
@@ -14,6 +13,7 @@ import {
 } from '@shopify/cli-kit/node/ui';
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output';
 import {type PackageJson} from '@shopify/cli-kit/node/node-package-manager';
+import {exec} from '@shopify/cli-kit/node/system';
 import {
   buildUpgradeCommandArgs,
   displayConfirmation,
@@ -80,6 +80,55 @@ async function createOutdatedSkeletonPackageJson() {
   return packageJson;
 }
 
+async function createOutdatedSkeletonPackageJsonWithReactRouter() {
+  const require = createRequire(import.meta.url);
+  const packageJson: PackageJson = require(
+    joinPath(getSkeletonSourceDir(), 'package.json'),
+  );
+
+  if (!packageJson) throw new Error('Could not parse package.json');
+  if (!packageJson?.dependencies)
+    throw new Error('Could not parse package.json dependencies');
+  if (!packageJson?.devDependencies)
+    throw new Error('Could not parse package.json devDependencies');
+
+  // bump the versions to be outdated
+  packageJson.dependencies['@shopify/hydrogen'] = '^2023.1.6';
+  packageJson.dependencies['react-router'] = '7.0.0';
+  packageJson.dependencies['react-router-dom'] = '7.0.0';
+  packageJson.devDependencies['@shopify/cli-hydrogen'] = '^4.0.8';
+  packageJson.devDependencies['@shopify/remix-oxygen'] = '^1.0.3';
+  packageJson.devDependencies['@react-router/dev'] = '7.0.0';
+  packageJson.devDependencies['typescript'] = '^4.9.5';
+
+  return packageJson;
+}
+
+const REACT_ROUTER_RELEASE = {
+  title: 'React Rotuer 7.5',
+  version: '2025.5.0',
+  hash: '-',
+  commit: 'https://github.com/Shopify/hydrogen/pull/2819',
+  pr: 'https://github.com/Shopify/hydrogen/pull/2819',
+  dependencies: {
+    'react-router': '^7.5.0',
+    '@shopify/hydrogen': '2025.5.0',
+    '@shopify/remix-oxygen': '^2.0.12',
+  },
+  devDependencies: {
+    '@react-router/dev': '^7.5.0',
+    '@shopify/cli': '3.77.1',
+    '@shopify/mini-oxygen': '^3.2.0',
+    '@shopify/hydrogen-codegen': '^0.3.3',
+    '@shopify/oxygen-workers-types': '^4.1.6',
+    vite: '^6.2.4',
+  },
+  dependenciesMeta: {},
+  fixes: [],
+  features: [],
+  date: '2025-04-24',
+} satisfies Release;
+
 /**
  * Creates a temporary directory with a git repo and a package.json
  */
@@ -95,7 +144,7 @@ async function inTemporaryHydrogenRepo(
 ) {
   return inTemporaryDirectory(async (tmpDir) => {
     // init the git repo
-    await execa('git', ['init'], {cwd: tmpDir});
+    await exec('git', ['init'], {cwd: tmpDir});
 
     if (packageJson) {
       const packageJsonPath = joinPath(tmpDir, 'package.json');
@@ -107,17 +156,17 @@ async function inTemporaryHydrogenRepo(
     expect(await fileExists(joinPath(tmpDir, '/.git/config'))).toBeTruthy();
 
     if (cleanGitRepo) {
-      await execa('git', ['add', 'package.json'], {cwd: tmpDir});
+      await exec('git', ['add', 'package.json'], {cwd: tmpDir});
 
       if (process.env.NODE_ENV === 'test' && process.env.CI) {
-        await execa('git', ['config', 'user.email', 'test@hydrogen.shop'], {
+        await exec('git', ['config', 'user.email', 'test@hydrogen.shop'], {
           cwd: tmpDir,
         });
-        await execa('git', ['config', 'user.name', 'Hydrogen Test'], {
+        await exec('git', ['config', 'user.name', 'Hydrogen Test'], {
           cwd: tmpDir,
         });
       }
-      await execa('git', ['commit', '-m', 'initial commit'], {cwd: tmpDir});
+      await exec('git', ['commit', '-m', 'initial commit'], {cwd: tmpDir});
     }
 
     await cb(tmpDir);
@@ -144,6 +193,9 @@ describe('upgrade', async () => {
   // Create an outdated skeleton package.json for all tests
   const OUTDATED_HYDROGEN_PACKAGE_JSON =
     await createOutdatedSkeletonPackageJson();
+
+  const OUTDATED_HYDROGEN_PACKAGE_JSON_WITH_REACT_ROUTER =
+    await createOutdatedSkeletonPackageJsonWithReactRouter();
 
   describe('checkIsGitRepo', () => {
     it('renders an error message when not in a git repo', async () => {
@@ -233,11 +285,97 @@ describe('upgrade', async () => {
     });
   });
 
-  // TODO: finish this test once merged and published so that package.json is accessible
-  describe.skip('fetchChangelog', () => {
-    it('fetches the latest changelog from the hydrogen repo', async () => {});
+  describe('fetchChangelog', () => {
+    it('fetches the latest changelog from the hydrogen repo', async () => {
+      // Force remote changelog usage by clearing local environment
+      const originalForceLocal = process.env.FORCE_CHANGELOG_SOURCE;
+      process.env.FORCE_CHANGELOG_SOURCE = 'remote';
 
-    it('renders an error message if the changelog could not be fetched', async () => {});
+      try {
+        const changelog = await getChangelog();
+
+        // Verify changelog structure
+        expect(changelog).toBeDefined();
+        expect(changelog).toHaveProperty('url');
+        expect(changelog).toHaveProperty('version');
+        expect(changelog).toHaveProperty('releases');
+
+        // Verify URL points to GitHub pulls
+        expect(changelog.url).toMatch(/github\.com\/Shopify\/hydrogen/);
+
+        // Verify releases array structure
+        expect(Array.isArray(changelog.releases)).toBe(true);
+        expect(changelog.releases.length).toBeGreaterThan(0);
+
+        // Verify first release has required fields
+        const latestRelease = changelog.releases[0];
+        expect(latestRelease).toBeDefined();
+
+        if (!latestRelease) {
+          throw new Error('Latest release is undefined');
+        }
+
+        expect(latestRelease).toHaveProperty('title');
+        expect(latestRelease).toHaveProperty('version');
+        expect(latestRelease).toHaveProperty('hash');
+        expect(latestRelease).toHaveProperty('commit');
+        expect(latestRelease).toHaveProperty('dependencies');
+        expect(latestRelease).toHaveProperty('devDependencies');
+        expect(latestRelease).toHaveProperty('features');
+        expect(latestRelease).toHaveProperty('fixes');
+
+        // Verify version format (YYYY.M.P)
+        expect(latestRelease.version).toMatch(/^\d{4}\.\d+\.\d+$/);
+
+        // Verify commit URL format
+        expect(latestRelease.commit).toMatch(
+          /^https:\/\/github\.com\/Shopify\/hydrogen/,
+        );
+
+        // Verify dependencies are objects
+        expect(typeof latestRelease.dependencies).toBe('object');
+        expect(typeof latestRelease.devDependencies).toBe('object');
+
+        // Verify features and fixes are arrays
+        expect(Array.isArray(latestRelease.features)).toBe(true);
+        expect(Array.isArray(latestRelease.fixes)).toBe(true);
+      } finally {
+        // Restore original environment
+        if (originalForceLocal !== undefined) {
+          process.env.FORCE_CHANGELOG_SOURCE = originalForceLocal;
+        } else {
+          delete process.env.FORCE_CHANGELOG_SOURCE;
+        }
+      }
+    }, 10000); // 10 second timeout for network call
+
+    it('successfully loads changelog when network is available', async () => {
+      // This test validates that the changelog function works as expected
+      // Both local and remote sources should provide valid changelog data
+      const changelog = await getChangelog();
+
+      // Test core functionality
+      expect(changelog.releases).toBeDefined();
+      expect(changelog.releases.length).toBeGreaterThan(0);
+
+      // Test that releases have the expected structure
+      const sampleRelease = changelog.releases[0];
+      expect(sampleRelease).toBeDefined();
+
+      if (!sampleRelease) {
+        throw new Error('Sample release is undefined');
+      }
+
+      expect(sampleRelease.version).toBeDefined();
+      expect(sampleRelease.dependencies).toBeDefined();
+      expect(sampleRelease.devDependencies).toBeDefined();
+
+      // Test that the structure matches what upgrade functions expect
+      expect(typeof sampleRelease.dependencies).toBe('object');
+      expect(typeof sampleRelease.devDependencies).toBe('object');
+      expect(Array.isArray(sampleRelease.features)).toBe(true);
+      expect(Array.isArray(sampleRelease.fixes)).toBe(true);
+    });
   });
 
   describe('getAvailableUpgrades', async () => {
@@ -686,32 +824,28 @@ describe('upgrade', async () => {
       expect(args).toEqual(expect.arrayContaining(result));
     });
 
-    it('upgrades and syncs up all available Remix deps if they are out-of-date', async () => {
-      const {releases} = await getChangelog();
-
-      const selectedRelease = releases.find(
-        (release) => release.version === '2023.10.0',
-      ) as (typeof releases)[0];
+    it('upgrades and syncs up all available React Router deps if they are out-of-date', async () => {
+      const selectedRelease = REACT_ROUTER_RELEASE;
 
       const currentDependencies = {
-        ...OUTDATED_HYDROGEN_PACKAGE_JSON.dependencies,
-        '@remix-run/react': '1.3.0',
-        ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
-        '@remix-run/dev': '1.2.0',
-        '@remix-run/css-bundle': '1.7.0',
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON_WITH_REACT_ROUTER.dependencies,
+        'react-router': '7.0.0',
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON_WITH_REACT_ROUTER.devDependencies,
+        '@react-router/dev': '7.0.0',
       };
 
       const result: string[] = [
-        '@shopify/cli-hydrogen@6.0.0',
-        '@shopify/hydrogen@2023.10.0',
-        '@shopify/remix-oxygen@2.0.0',
-        'typescript@5.2.2',
-        '@remix-run/react@2.1.0',
-        '@remix-run/server-runtime@2.1.0',
-        '@remix-run/dev@2.1.0',
-        '@remix-run/fs-routes@2.1.0',
-        '@remix-run/route-config@2.1.0',
-        '@remix-run/css-bundle@2.1.0',
+        '@shopify/hydrogen@2025.5.0',
+        '@shopify/remix-oxygen@2.0.12',
+        '@shopify/cli@3.77.1',
+        '@shopify/mini-oxygen@3.2.0',
+        '@shopify/hydrogen-codegen@0.3.3',
+        '@shopify/oxygen-workers-types@4.1.6',
+        'vite@6.2.4',
+        'react-router@7.5.0',
+        'react-router-dom@7.5.0',
+        '@react-router/dev@7.5.0',
+        '@react-router/fs-routes@7.5.0',
       ];
 
       const args = buildUpgradeCommandArgs({
@@ -722,32 +856,29 @@ describe('upgrade', async () => {
       expect(args).toEqual(result);
     });
 
-    it('upgrades all available Remix deps if they are out-of-date', async () => {
-      const {releases} = await getChangelog();
-
-      const selectedRelease = releases.find(
-        (release) => release.version === '2023.10.0',
-      ) as (typeof releases)[0];
+    it('upgrades all available React Router deps if they are out-of-date', async () => {
+      const selectedRelease = REACT_ROUTER_RELEASE;
 
       const currentDependencies = {
-        ...OUTDATED_HYDROGEN_PACKAGE_JSON.dependencies,
-        '@remix-run/react': '1.8.0',
-        ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
-        '@remix-run/dev': '1.8.0',
-        '@remix-run/css-bundle': '1.8.0',
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON_WITH_REACT_ROUTER.dependencies,
+        'react-router': '7.3.0',
+        'react-router-dom': '7.3.0',
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON_WITH_REACT_ROUTER.devDependencies,
+        '@react-router/dev': '7.3.0',
       };
 
       const result: string[] = [
-        '@shopify/cli-hydrogen@6.0.0',
-        '@shopify/hydrogen@2023.10.0',
-        '@shopify/remix-oxygen@2.0.0',
-        'typescript@5.2.2',
-        '@remix-run/react@2.1.0',
-        '@remix-run/server-runtime@2.1.0',
-        '@remix-run/dev@2.1.0',
-        '@remix-run/fs-routes@2.1.0',
-        '@remix-run/route-config@2.1.0',
-        '@remix-run/css-bundle@2.1.0',
+        '@shopify/hydrogen@2025.5.0',
+        '@shopify/remix-oxygen@2.0.12',
+        '@shopify/cli@3.77.1',
+        '@shopify/mini-oxygen@3.2.0',
+        '@shopify/hydrogen-codegen@0.3.3',
+        '@shopify/oxygen-workers-types@4.1.6',
+        'vite@6.2.4',
+        'react-router@7.5.0',
+        'react-router-dom@7.5.0',
+        '@react-router/dev@7.5.0',
+        '@react-router/fs-routes@7.5.0',
       ];
 
       const args = buildUpgradeCommandArgs({
@@ -758,25 +889,23 @@ describe('upgrade', async () => {
       expect(args).toEqual(result);
     });
 
-    it('does not upgrade Remix deps if they are more up-to-date', async () => {
-      const {releases} = await getChangelog();
-
-      const selectedRelease = releases.find(
-        (release) => release.version === '2023.10.0',
-      ) as (typeof releases)[0];
-
+    it('does not upgrade React Router deps if they are more up-to-date', async () => {
+      const selectedRelease = REACT_ROUTER_RELEASE;
       const currentDependencies = {
-        ...OUTDATED_HYDROGEN_PACKAGE_JSON.dependencies,
-        '@remix-run/react': '2.2.0',
-        ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
-        '@remix-run/dev': '2.2.0',
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON_WITH_REACT_ROUTER.dependencies,
+        'react-router': '7.6.0',
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON_WITH_REACT_ROUTER.devDependencies,
+        'react-router-dom': '7.6.0',
       };
 
       const result: string[] = [
-        '@shopify/cli-hydrogen@6.0.0',
-        '@shopify/hydrogen@2023.10.0',
-        '@shopify/remix-oxygen@2.0.0',
-        'typescript@5.2.2',
+        '@shopify/hydrogen@2025.5.0',
+        '@shopify/remix-oxygen@2.0.12',
+        '@shopify/cli@3.77.1',
+        '@shopify/mini-oxygen@3.2.0',
+        '@shopify/hydrogen-codegen@0.3.3',
+        '@shopify/oxygen-workers-types@4.1.6',
+        'vite@6.2.4',
       ];
 
       const args = buildUpgradeCommandArgs({
@@ -784,6 +913,40 @@ describe('upgrade', async () => {
         currentDependencies,
       });
 
+      expect(args).toEqual(result);
+    });
+
+    it('installs all React Router packages even if only a subset exists', async () => {
+      const selectedRelease = REACT_ROUTER_RELEASE;
+
+      // Project has only react-router but missing other packages
+      const currentDependencies = {
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON.dependencies,
+        'react-router': '7.0.0',
+        // Missing: react-router-dom, @react-router/dev, @react-router/fs-routes
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
+      };
+
+      const result: string[] = [
+        '@shopify/hydrogen@2025.5.0',
+        '@shopify/remix-oxygen@2.0.12',
+        '@shopify/cli@3.77.1',
+        '@shopify/mini-oxygen@3.2.0',
+        '@shopify/hydrogen-codegen@0.3.3',
+        '@shopify/oxygen-workers-types@4.1.6',
+        'vite@6.2.4',
+        'react-router@7.5.0',
+        'react-router-dom@7.5.0',
+        '@react-router/dev@7.5.0',
+        '@react-router/fs-routes@7.5.0',
+      ];
+
+      const args = buildUpgradeCommandArgs({
+        selectedRelease,
+        currentDependencies,
+      });
+
+      // Should install ALL React Router packages, not just upgrade the existing one
       expect(args).toEqual(result);
     });
 
@@ -1091,3 +1254,174 @@ const CUMMLATIVE_RELEASE = {
     },
   ],
 } as CumulativeRelease;
+
+describe('dependency removal', () => {
+  it('removes specified dependencies before upgrading', async () => {
+    const selectedRelease: Release = {
+      title: 'Remix to React Router migration',
+      version: '2025.5.0',
+      hash: 'abc123',
+      commit: 'https://github.com/Shopify/hydrogen/pull/2961',
+      pr: 'https://github.com/Shopify/hydrogen/pull/2961',
+      date: '2025-01-21',
+      dependencies: {
+        '@shopify/hydrogen': '2025.5.0',
+        'react-router': '7.6.0',
+        'react-router-dom': '7.6.0',
+      },
+      devDependencies: {
+        '@react-router/dev': '7.6.0',
+      },
+      removeDependencies: [
+        '@remix-run/react',
+        '@remix-run/server-runtime',
+        '@shopify/hydrogen',
+      ],
+      removeDevDependencies: ['@remix-run/dev', '@remix-run/fs-routes'],
+      dependenciesMeta: {},
+      fixes: [],
+      features: [],
+    };
+
+    const currentDependencies = {
+      '@shopify/hydrogen': '2025.4.0',
+      '@remix-run/react': '2.16.1',
+      '@remix-run/server-runtime': '2.16.1',
+      '@remix-run/dev': '2.16.1',
+      '@remix-run/fs-routes': '2.16.1',
+      react: '^18.2.0',
+    };
+
+    const args = buildUpgradeCommandArgs({
+      selectedRelease,
+      currentDependencies,
+    });
+
+    // Should include new packages to install but not removed packages
+    expect(args).toEqual([
+      '@shopify/hydrogen@2025.5.0',
+      'react-router@7.6.0',
+      'react-router-dom@7.6.0',
+      '@react-router/dev@7.6.0',
+      '@react-router/fs-routes@7.6.0',
+    ]);
+  });
+
+  it('handles empty remove dependencies arrays', async () => {
+    const selectedRelease: Release = {
+      title: 'Normal upgrade',
+      version: '2025.4.1',
+      hash: 'def456',
+      commit: 'https://github.com/Shopify/hydrogen/pull/2950',
+      pr: 'https://github.com/Shopify/hydrogen/pull/2950',
+      date: '2025-01-15',
+      dependencies: {
+        '@shopify/hydrogen': '2025.4.1',
+      },
+      devDependencies: {},
+      removeDependencies: [],
+      removeDevDependencies: [],
+      dependenciesMeta: {},
+      fixes: [],
+      features: [],
+    };
+
+    const currentDependencies = {
+      '@shopify/hydrogen': '2025.4.0',
+      react: '^18.2.0',
+    };
+
+    const args = buildUpgradeCommandArgs({
+      selectedRelease,
+      currentDependencies,
+    });
+
+    expect(args).toEqual(['@shopify/hydrogen@2025.4.1']);
+  });
+
+  it('handles migration with React Router dependency detection', async () => {
+    const selectedRelease: Release = {
+      title: 'React Router 7 migration with removal',
+      version: '2025.5.0',
+      hash: 'ghi789',
+      commit: 'https://github.com/Shopify/hydrogen/pull/2961',
+      pr: 'https://github.com/Shopify/hydrogen/pull/2961',
+      date: '2025-01-21',
+      dependencies: {
+        '@shopify/hydrogen': '2025.5.0',
+        'react-router': '7.6.0',
+        'react-router-dom': '7.6.0',
+      },
+      devDependencies: {
+        '@react-router/dev': '7.6.0',
+        '@react-router/fs-routes': '7.6.0',
+      },
+      removeDependencies: ['@remix-run/react', '@shopify/hydrogen'],
+      removeDevDependencies: ['@remix-run/dev'],
+      dependenciesMeta: {},
+      fixes: [],
+      features: [],
+    };
+
+    // Current project has Remix dependencies but no React Router
+    const currentDependencies = {
+      '@shopify/hydrogen': '2025.4.0',
+      '@remix-run/react': '2.16.1',
+      '@remix-run/dev': '2.16.1',
+      react: '^18.2.0',
+    };
+
+    const args = buildUpgradeCommandArgs({
+      selectedRelease,
+      currentDependencies,
+    });
+
+    // Should install new React Router packages since we're migrating
+    expect(args).toEqual([
+      '@shopify/hydrogen@2025.5.0',
+      'react-router@7.6.0',
+      'react-router-dom@7.6.0',
+      '@react-router/dev@7.6.0',
+      '@react-router/fs-routes@7.6.0',
+    ]);
+  });
+
+  it('handles missing dependencies in removeDependencies gracefully', async () => {
+    const selectedRelease: Release = {
+      title: 'Release with missing dependencies to remove',
+      version: '2025.5.0',
+      hash: 'xyz123',
+      commit: 'https://github.com/Shopify/hydrogen/pull/2962',
+      pr: 'https://github.com/Shopify/hydrogen/pull/2962',
+      date: '2025-01-21',
+      dependencies: {
+        '@shopify/hydrogen': '2025.5.0',
+      },
+      devDependencies: {
+        '@shopify/cli': '~3.80.0',
+      },
+      // Try to remove dependencies that don't exist in the current project
+      removeDependencies: ['@some/missing-package', '@another/nonexistent-dep'],
+      removeDevDependencies: ['@dev/missing-package'],
+      dependenciesMeta: {},
+      fixes: [],
+      features: [],
+    };
+
+    // Current project has only basic dependencies - missing packages listed in removeDependencies
+    const currentDependencies = {
+      '@shopify/hydrogen': '2025.4.0',
+      react: '^18.2.0',
+      '@shopify/cli': '~3.79.0',
+    };
+
+    // Should not crash and should only include packages that need upgrading
+    const args = buildUpgradeCommandArgs({
+      selectedRelease,
+      currentDependencies,
+    });
+
+    // Should upgrade existing packages, ignore missing ones in removeDependencies
+    expect(args).toEqual(['@shopify/hydrogen@2025.5.0', '@shopify/cli@3.80.0']);
+  });
+});


### PR DESCRIPTION
### WHY are these changes introduced?

We need a way to validate that the upgrade command successfully upgrades a project to the latest version available in the /docs/changelog.json

### WHAT is this pull request doing?

This pull request implements enhancements to the Hydrogen upgrade command to support dependency removal and React Router 7 migration, along with comprehensive changelog testing infrastructure.

Enhanced upgrade command to support removing deprecated dependencies before installing new ones
Added React Router 7 migration support with automatic dependency detection and replacement
Introduced comprehensive integration testing for upgrade flows with dynamic version detection

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
