### PR TITLE
chore: restore changesets after CLI release

### DIFF
--- a/.changeset/beige-carrots-rest.md
+++ b/.changeset/beige-carrots-rest.md
@@ -1,0 +1,7 @@
+---
+"@shopify/mini-oxygen": patch
+"skeleton": patch
+"@shopify/cli-hydrogen": patch
+---
+
+Fix defer/streaming in development & preview

--- a/.changeset/cows-in-space.md
+++ b/.changeset/cows-in-space.md
@@ -1,0 +1,16 @@
+---
+"@shopify/mini-oxygen": minor
+"@shopify/create-hydrogen": patch
+"@shopify/hydrogen-react": patch
+"@shopify/cli-hydrogen": patch
+"skeleton": patch
+---
+
+Upgrade Miniflare from v2 to v4 in mini-oxygen package.
+
+- Internal MiniOxygen API has been refactored to work with Miniflare v4's new architecture.
+- Simplified MiniOxygen class - no longer extends MiniflareCore.
+- Updated global fetch handling to use Miniflare v4's `outboundService` API.
+- Fixed test infrastructure to use project-relative temporary directories.
+- Added support for Oxygen compatibility parameters (`compatibilityDate`, `compatibilityFlags`).
+- Removed dependency on multiple `@miniflare/*` packages in favor of the consolidated `miniflare` package.

--- a/.changeset/giant-buses-care.md
+++ b/.changeset/giant-buses-care.md
@@ -1,0 +1,7 @@
+---
+"skeleton": patch
+"@shopify/cli-hydrogen": patch
+"@shopify/create-hydrogen": patch
+---
+
+Add `fulfillmentStatus` to CAAPI order query and route

--- a/.changeset/hungry-tools-enjoy.md
+++ b/.changeset/hungry-tools-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@shopify/cli-hydrogen": patch
+---
+
+Add `--force-client-sourcemap` flag support to the `deploy` command

--- a/.changeset/lemon-snakes-shout.md
+++ b/.changeset/lemon-snakes-shout.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Fix and upgrade /graphiql route

--- a/.changeset/quiet-socks-smoke.md
+++ b/.changeset/quiet-socks-smoke.md
@@ -1,0 +1,6 @@
+---
+"skeleton": patch
+"@shopify/hydrogen": patch
+---
+
+Add GraphQL @defer directive support to storefront client

--- a/.changeset/red-dryers-rescue.md
+++ b/.changeset/red-dryers-rescue.md
@@ -1,0 +1,7 @@
+---
+"skeleton": patch
+"@shopify/cli-hydrogen": patch
+"@shopify/create-hydrogen": patch
+---
+
+Unpin react-router and react-router-dom versions in the skeleton template

--- a/.changeset/silver-apricots-sip.md
+++ b/.changeset/silver-apricots-sip.md
@@ -1,0 +1,5 @@
+---
+"@shopify/cli-hydrogen": patch
+---
+
+Add support for Vite v7 [.] exports

--- a/.changeset/thin-paws-sit.md
+++ b/.changeset/thin-paws-sit.md
@@ -1,0 +1,8 @@
+---
+"@shopify/hydrogen-react": patch
+"skeleton": patch
+"@shopify/cli-hydrogen": patch
+"@shopify/create-hydrogen": patch
+---
+
+Add `@inContext` language support to Customer Account API mutations


### PR DESCRIPTION
This PR restores all the changesets that were temporarily removed for the CLI-only release.

## Context
We executed a CLI-only release by:
1. Temporarily removing all changesets
2. Merging only the CLI upgrade fix changeset
3. Releasing @shopify/cli-hydrogen with the upgrade command fix

## What this PR does
- Restores the 9 changesets that were temporarily removed
- The CLI changeset (late-ducks-search.md) is NOT included since it was already released

## Next steps
After merging this PR, the CI will create a new Version PR with all these pending changes for the next regular release.