### PR TITLE
Add Claude doc MCP servers for libraries relevant to Hydrogen

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -20,10 +20,14 @@
       "command": "npx",
       "args": ["mcp-remote", "https://gitmcp.io/facebook/react"]
     },
-    "docs-remix-run": {
+    "docs-react-router": {
       "command": "npx",
-      "args": ["mcp-remote", "https://gitmcp.io/mjackson/remix-the-web"]
+      "args": ["mcp-remote", "https://gitmcp.io/remix-run/react-router"]
     },
+    "docs-remix": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/remix-run/remix"]
+    }
     "docs-hydrogen": {
       "command": "npx",
       "args": ["mcp-remote", "https://gitmcp.io/Shopify/hydrogen"]
@@ -31,10 +35,6 @@
     "docs-xstate": {
       "command": "npx",
       "args": ["mcp-remote", "https://gitmcp.io/statelyai/xstate"]
-    },
-    "docs-react-router": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://gitmcp.io/remix-run/react-router"]
     },
     "shopify-dev-mcp": {
       "command": "npx",

--- a/.mcp.json
+++ b/.mcp.json
@@ -27,7 +27,7 @@
     "docs-remix": {
       "command": "npx",
       "args": ["mcp-remote", "https://gitmcp.io/remix-run/remix"]
-    }
+    },
     "docs-hydrogen": {
       "command": "npx",
       "args": ["mcp-remote", "https://gitmcp.io/Shopify/hydrogen"]

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,44 @@
+{
+  "mcpServers": {
+    "docs-shopify-cli": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/Shopify/cli"]
+    },
+    "docs-cloudflare-workers-sdk": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/cloudflare/workers-sdk"]
+    },
+    "docs-cloudflare-workerd": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/cloudflare/workerd"]
+    },
+    "docs-vite": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/vitejs/vite"]
+    },
+    "docs-react": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/facebook/react"]
+    },
+    "docs-remix-run": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/mjackson/remix-the-web"]
+    },
+    "docs-hydrogen": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/Shopify/hydrogen"]
+    },
+    "docs-xstate": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/statelyai/xstate"]
+    },
+    "docs-react-router": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://gitmcp.io/remix-run/react-router"]
+    },
+    "shopify-dev-mcp": {
+      "command": "npx",
+      "args": ["-y", "@shopify/dev-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
<img width="2346" height="670" alt="Screenshot 2025-07-30 at 12 05 35 PM" src="https://github.com/user-attachments/assets/02195427-e9a4-4cc6-8278-0c23f97acea7" />

### WHY are these changes introduced?

Documentation MCP tools drastically help claude models to hallucinate less. This PR adds MCP servers for libraries heavily used in this monorepo. 


### WHAT is this pull request doing?

Adds `.mcp.json` to the root of the folder. 

```bash 
claude 
```
Should ask the user to use these MCP servers

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

Run claude on this branch and see if claude asks to allow these MCP servers

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
