### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '38 16 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as stale due to inactivity for 60 days. Please comment or update if this is still relevant, otherwise it will be closed in 7 days.'
+        stale-pr-message: 'This pull request has been marked as stale due to inactivity for 60 days. If no further activity occurs, it will be closed in 7 days.'
+        stale-issue-label: 'inactive'
+        stale-pr-label: 'inactive'


### PR DESCRIPTION
Adds a stale workflow to the repo.
Default behavior will mark issues as stale after 60 days.