### PR TITLE
Fix upgrade tests and monorepo detection for GitHub worktrees

### DIFF
--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -31,6 +31,10 @@ import {
 } from './upgrade.js';
 import {getSkeletonSourceDir} from '../../lib/build.js';
 
+// Test version numbers used to avoid conflicts with duplicate changelog versions
+const TEST_VERSION_DEPENDENCY_UPGRADE = '9999.99.99';
+const TEST_VERSION_DEV_DEPENDENCY_UPGRADE = '9999.99.98';
+
 vi.mock('@shopify/cli-kit/node/session');
 
 vi.mock('../../lib/shell.js', () => ({getCliCommand: vi.fn(() => 'h2')}));
@@ -496,13 +500,12 @@ describe('upgrade', async () => {
 
       // Test with a unique version number to ensure the upgrade is detected
       // This ensures the test works regardless of whether the changelog has duplicates
-      const testVersion = '9999.99.99'; // Use a version that definitely doesn't exist
 
       // Copy of latest release but with increased patch version of a dependency
       // and a unique version number to avoid duplicate filtering
       const upgradedRelease = {
         ...latestRelease,
-        version: testVersion,
+        version: TEST_VERSION_DEPENDENCY_UPGRADE,
         dependencies: {
           ...latestRelease.dependencies,
           ...increasePatchVersion(depName, latestRelease.dependencies),

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -407,31 +407,59 @@ describe('upgrade', async () => {
       await inTemporaryHydrogenRepo(
         async (appPath) => {
           const current = await getHydrogenVersion({appPath});
-          const availableUpgrades = getAvailableUpgrades({
+          const result = getAvailableUpgrades({
             releases,
             ...current,
           });
 
-          const uniqueAvailableUpgrades = releases
-            .slice(0, 2)
-            .reduce((acc, release) => {
-              // @ts-ignore
-              if (acc[release.version]) return acc;
+          // The getAvailableUpgrades function should:
+          // 1. Return all releases newer than the current version
+          // 2. Filter out duplicate versions (keeping only the first/newest)
+          //
+          // To make this test resilient to both duplicate and unique versions,
+          // we need to find the first set of unique versions that are newer
+          // than what's installed (releases[2].version)
+
+          // Find up to 2 unique versions that are newer than releases[2]
+          const newerReleases = [];
+          const seenVersions = new Set();
+
+          for (const release of releases) {
+            // Stop when we reach the installed version
+            if (release.version === releases[2]?.version) break;
+
+            // Only add if we haven't seen this version
+            if (!seenVersions.has(release.version)) {
+              newerReleases.push(release);
+              seenVersions.add(release.version);
+              // Stop after finding 2 unique versions
+              if (newerReleases.length >= 2) break;
+            }
+          }
+
+          // Build expected uniqueAvailableUpgrades
+          const expectedUniqueUpgrades = newerReleases.reduce(
+            (acc, release) => {
               return {
                 ...acc,
                 [release.version]: release,
               };
-            }, {});
+            },
+            {},
+          );
 
-          expect(availableUpgrades).toMatchObject({
-            availableUpgrades: releases.slice(0, 2),
-            uniqueAvailableUpgrades,
-          });
+          // Verify the results
+          expect(result.availableUpgrades).toHaveLength(newerReleases.length);
+          expect(result.availableUpgrades).toEqual(newerReleases);
+          expect(result.uniqueAvailableUpgrades).toEqual(
+            expectedUniqueUpgrades,
+          );
         },
         {
           cleanGitRepo: true,
           packageJson: {
             dependencies: {
+              // Install an older version (3rd in the list)
               '@shopify/hydrogen': releases[2]!.version,
             },
           },
@@ -466,46 +494,49 @@ describe('upgrade', async () => {
         }).availableUpgrades,
       ).toHaveLength(0);
 
+      // Test with a unique version number to ensure the upgrade is detected
+      // This ensures the test works regardless of whether the changelog has duplicates
+      const testVersion = '9999.99.99'; // Use a version that definitely doesn't exist
+
       // Copy of latest release but with increased patch version of a dependency
+      // and a unique version number to avoid duplicate filtering
+      const upgradedRelease = {
+        ...latestRelease,
+        version: testVersion,
+        dependencies: {
+          ...latestRelease.dependencies,
+          ...increasePatchVersion(depName, latestRelease.dependencies),
+        },
+      };
+
       expect(
         getAvailableUpgrades({
           currentVersion: latestRelease.version,
           currentDependencies: {
             [depName]: latestRelease.dependencies[depName]!,
           },
-          releases: [
-            {
-              ...latestRelease,
-              dependencies: {
-                ...latestRelease.dependencies,
-                ...increasePatchVersion(depName, latestRelease.dependencies),
-              },
-            },
-            ...releases,
-          ],
+          releases: [upgradedRelease, ...releases],
         }).availableUpgrades,
       ).toHaveLength(1);
 
       // Copy of latest release but with increased patch version of a dev-dependency
+      // Also use a unique version to avoid duplicate filtering
+      const upgradedDevRelease = {
+        ...latestRelease,
+        version: '9999.99.98', // Different unique version
+        devDependencies: {
+          ...latestRelease.devDependencies,
+          ...increasePatchVersion(devDepName, latestRelease.devDependencies),
+        },
+      };
+
       expect(
         getAvailableUpgrades({
           currentVersion: latestRelease.version,
           currentDependencies: {
             [devDepName]: latestRelease.devDependencies[devDepName]!,
           },
-          releases: [
-            {
-              ...latestRelease,
-              devDependencies: {
-                ...latestRelease.devDependencies,
-                ...increasePatchVersion(
-                  devDepName,
-                  latestRelease.devDependencies,
-                ),
-              },
-            },
-            ...releases,
-          ],
+          releases: [upgradedDevRelease, ...releases],
         }).availableUpgrades,
       ).toHaveLength(1);
     });

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -1,4 +1,5 @@
 import {fileURLToPath} from 'node:url';
+import {existsSync} from 'node:fs';
 import {findPathUp} from '@shopify/cli-kit/node/fs';
 import {AbortError} from '@shopify/cli-kit/node/error';
 import {dirname, joinPath} from '@shopify/cli-kit/node/path';
@@ -6,9 +7,14 @@ import {execAsync} from './process.js';
 
 // Avoid using fileURLToPath here to prevent backslashes nightmare on Windows
 const monorepoPackagesPath = new URL('../../..', import.meta.url).pathname;
-export const isHydrogenMonorepo = monorepoPackagesPath.endsWith(
-  '/hydrogen/packages/',
+// Check if we're in the Hydrogen monorepo by looking for the skeleton template
+// relative to the packages directory
+const skeletonPath = joinPath(
+  dirname(monorepoPackagesPath),
+  'templates',
+  'skeleton',
 );
+export const isHydrogenMonorepo = existsSync(skeletonPath);
 export const hydrogenPackagesPath = isHydrogenMonorepo
   ? monorepoPackagesPath
   : undefined;


### PR DESCRIPTION
> [!IMPORTANT]  
> Should be merged ASAP to fix main for other PRs.

## WHY are these changes introduced?

The unit tests in `upgrade.test.ts` broke because they depend on production data (`changelog.json`). When PR #3030 added duplicate `2025.4.1` entries, tests that assumed unique versions started failing. The tests failed not because of a code bug, but because they couldn't handle the new legitimate duplicate entry versions.

Additionally, monorepo detection was too rigid: it checked if the path ends with `/hydrogen/packages/`, which breaks when developers use GitHub worktrees, forks with different names other than /hydrogen as a base.

## WHAT is this pull request doing?

### 1. Makes test suite resilient to duplicate changelog versions

**In `upgrade.test.ts`:**
- Updates "returns available upgrades" test to dynamically find unique versions instead of assuming the first 2 releases are different
- Updates "it finds outdated dependencies" test to use synthetic versions (`9999.99.99`, `9999.99.98`) to avoid conflicts with duplicate versions in the changelog

### 2. Improves monorepo detection robustness

**In `build.ts`:**
- Changes detection from checking if path ends with `/hydrogen/packages/` to checking for existence of `templates/skeleton` directory
- This allows the repository to work regardless of clone directory name (supports GitHub worktrees, forks, custom names)

## How to test your changes?

Run the fixed upgrade tests:
```bash
cd packages/cli
npm test upgrade.test.ts
# Result: 32 tests pass
```

## Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/.github/contributing.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a changeset if this PR contains user-facing or noteworthy changes
- [x] I've added tests to cover my changes (fixed existing tests to be more robust)