### PR TITLE
[2025-07] Fix source map warnings from @shopify/graphql-client

### DIFF
--- a/.changeset/fix-sourcemap-warnings.md
+++ b/.changeset/fix-sourcemap-warnings.md
@@ -1,0 +1,9 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix source map warnings from @shopify/graphql-client in development
+
+Suppress non-actionable source map warnings from external dependencies that ship with invalid source maps. This fix was previously applied but accidentally removed during the React Router 7 migration.
+
+Fixes #3093


### PR DESCRIPTION
## Summary
Suppress non-actionable source map warnings from external dependencies that ship with invalid source maps.

## Problem
The development console is cluttered with warnings like:
```
npm run dev:app                           16s 08:28:59

> dev:app
> cd templates/skeleton && npm run dev --

npm warn config ignoring workspace config at /Users/juanp.prieto/github.com/Shopify/hydrogen/templates/skeleton/.npmrc

> skeleton@2025.5.2 dev
> shopify hydrogen dev --codegen

Port 3000 is in use, trying another one...

Environment variables injected into MiniOxygen:

SESSION_SECRET   from local .env

  ➜  Local:   http://localhost:3001/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help


╭─ success ───────────────────────────────────────────────────────────────────────╮
│                                                                                 │
│  View Hydrogen app: http://localhost:3001/                                      │
│                                                                                 │
│  View GraphiQL API browser:                                                     │
│  http://localhost:3001/graphiql                                                 │
│                                                                                 │
│  View server network requests:                                                  │
│  http://localhost:3001/subrequest-profiler                                      │
│                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────╯

Sourcemap for "/Users/juanp.prieto/github.com/Shopify/hydrogen/node_modules/@shopify/graphql-client/dist/graphql-client/graphql-client.mjs" points to missing source files
Sourcemap for "/Users/juanp.prieto/github.com/Shopify/hydrogen/node_modules/@shopify/graphql-client/dist/graphql-client/http-fetch.mjs" points to missing source files
Sourcemap for "/Users/juanp.prieto/github.com/Shopify/hydrogen/node_modules/@shopify/graphql-client/dist/graphql-client/constants.mjs" points to missing source files
Sourcemap for "/Users/juanp.prieto/github.com/Shopify/hydrogen/node_modules/@shopify/graphql-client/dist/graphql-client/utilities.mjs" points to missing source files
Sourcemap for "/Users/juanp.prieto/github.com/Shopify/hydrogen/node_modules/@shopify/graphql-client/dist/api-client-utilities/validations.mjs" points to missing source files
Sourcemap for "/Users/juanp.prieto/github.com/Shopify/hydrogen/node_modules/@shopify/graphql-client/dist/api-client-utilities/api-versions.mjs" points to missing source files
Sourcemap for "/Users/juanp.prieto/github.com/Shopify/hydrogen/node_modules/@shopify/graphql-client/dist/api-client-utilities/utilities.mjs" points to missing source files

```

These warnings:
- Provide no actionable information for developers
- Clutter the console output
- Were previously fixed but accidentally removed during React Router 7 migration

## Solution
Added a custom Vite logger to the hydrogen plugin that filters out source map warnings from node_modules while preserving legitimate warnings for user code.

## Test plan
1. Run `npm run dev` in the skeleton template
2. Verify no source map warnings appear for @shopify/graphql-client
3. Run `npm run build` and verify source maps are still generated (check for `.map` files)
4. Verify legitimate warnings for user code still appear

Fixes #3093