### PR TITLE
[2025-07] Fix race condition causing sporadic failures in `npm run dev:pkg`

### DIFF
--- a/.changeset/fix-race-condition-dev-pkg.md
+++ b/.changeset/fix-race-condition-dev-pkg.md
@@ -1,0 +1,5 @@
+---
+'@shopify/create-hydrogen': patch
+---
+
+Fix race condition in dev mode where create-hydrogen could fail when trying to copy CLI assets before they're created. Implements exponential backoff waiting mechanism to ensure assets exist before copying.

--- a/.changeset/fix-race-condition-dev-pkg.md
+++ b/.changeset/fix-race-condition-dev-pkg.md
@@ -1,5 +1,0 @@
----
-'@shopify/create-hydrogen': patch
----
-
-Fix race condition in dev mode where create-hydrogen could fail when trying to copy CLI assets before they're created. Implements exponential backoff waiting mechanism to ensure assets exist before copying.

--- a/packages/create-hydrogen/tsup.config.ts
+++ b/packages/create-hydrogen/tsup.config.ts
@@ -56,7 +56,7 @@ async function waitForPath(
   initialDelayMs = INITIAL_DELAY_MS,
 ) {
   if (!path) {
-    console.warn('No cliAssetsPath provided to waitForPath');
+    console.warn('No path provided to waitForPath');
     return;
   }
 

--- a/packages/create-hydrogen/tsup.config.ts
+++ b/packages/create-hydrogen/tsup.config.ts
@@ -1,6 +1,10 @@
 import {createRequire} from 'node:module';
 import fs from 'node:fs/promises';
+import {existsSync} from 'node:fs';
 import {defineConfig} from 'tsup';
+
+const MAX_WAIT_MS = 10_000;
+const INITIAL_DELAY_MS = 100;
 
 export default defineConfig({
   entry: ['src/create-app.ts'],
@@ -24,8 +28,15 @@ export default defineConfig({
     js: "import { createRequire as __createRequire } from 'module';globalThis.require = __createRequire(import.meta.url);",
   },
   async onSuccess() {
+    const cliAssetsPath = '../cli/dist/assets';
+
+    // Wait for CLI assets with exponential backoff for reliability
+    if (!existsSync(cliAssetsPath)) {
+      await waitForPath(cliAssetsPath, MAX_WAIT_MS, INITIAL_DELAY_MS);
+    }
+
     // Copy assets to the dist folder
-    await fs.cp('../cli/dist/assets', './dist/assets', {recursive: true});
+    await fs.cp(cliAssetsPath, './dist/assets', {recursive: true});
 
     // This WASM file is used in a dependency, copy it over:
     await fs.copyFile(
@@ -34,3 +45,44 @@ export default defineConfig({
     );
   },
 });
+
+/**
+ * Wait for a path to actually exist with exponential backoff checking
+ * across different machine speeds and build environments
+ */
+async function waitForPath(
+  path: string,
+  maxWaitMs = MAX_WAIT_MS,
+  initialDelayMs = INITIAL_DELAY_MS,
+) {
+  if (!path) {
+    console.warn('No cliAssetsPath provided to waitForPath');
+    return;
+  }
+
+  const startTime = Date.now();
+  let delay = initialDelayMs;
+  let attempts = 0;
+
+  while (Date.now() - startTime < maxWaitMs) {
+    if (existsSync(path)) {
+      // Found  asset path
+      return true;
+    }
+
+    if (attempts === 0) {
+      console.log(`Waiting for ${path} to be created...`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    // Exponential backoff: start at 100ms, increase by 1.5x each time, cap at 2s
+    // This gives us: 100ms, 150ms, 225ms, 337ms, 506ms, 759ms, 1138ms, 1707ms, 2000ms...
+    delay = Math.min(delay * 1.5, 2000);
+    attempts++;
+  }
+
+  throw new Error(
+    `Timeout waiting for ${path} after ${maxWaitMs}ms (${attempts} attempts)`,
+  );
+}

--- a/packages/create-hydrogen/tsup.config.ts
+++ b/packages/create-hydrogen/tsup.config.ts
@@ -66,7 +66,7 @@ async function waitForPath(
 
   while (Date.now() - startTime < maxWaitMs) {
     if (existsSync(path)) {
-      // Found  asset path
+      // Found asset path
       return true;
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3099

When running `npm run dev:pkg` in the Hydrogen monorepo, developers experience sporadic build failures due to a race condition between parallel package builds. The `@shopify/create-hydrogen` package attempts to copy assets from `@shopify/cli-hydrogen` before they exist, causing ENOENT errors. This issue is timing-dependent and more likely to occur on faster machines or with clean dist folders.

### WHAT is this pull request doing?

This PR adds a waiting mechanism with exponential backoff in the `create-hydrogen` build configuration to ensure CLI assets exist before attempting to copy them. The solution:

- Waits for CLI assets directory to be created before copying when it doesn't exist
- Uses exponential backoff (100ms → 150ms → 225ms... up to 2s) for machine-agnostic reliability
- Times out after 10 seconds if assets never appear
- Only applies the waiting logic when assets don't exist (works for both dev and build modes when needed)

The fix is implemented in `packages/create-hydrogen/tsup.config.ts` and handles the race condition where turbo runs packages in parallel but cannot declare dependencies between persistent tasks (watch mode).

### HOW to test your changes?

1. Check out this branch
2. Clean all dist folders: `rm -rf packages/*/dist`
3. Run `npm run dev:pkg`
4. Verify the command succeeds without ENOENT errors
5. The console will show "Waiting for ../cli/dist/assets to be created..." on first run when assets don't exist
6. Subsequent rebuilds in watch mode work without waiting (assets already exist)
7. Test that `npm run build:pkg` works correctly

To verify the race condition is fixed:
- Run the clean and dev steps multiple times
- The build should succeed consistently, regardless of machine speed
- No more sporadic "ENOENT: no such file or directory, lstat '../cli/dist/assets'" errors

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation