### PR TITLE
[2025-07] Fix React Context error during client-side hydration

### DIFF
--- a/.changeset/fix-usecontext-error.md
+++ b/.changeset/fix-usecontext-error.md
@@ -1,0 +1,44 @@
+---
+'skeleton': patch
+'@shopify/hydrogen': patch
+---
+
+Fixed React Context error that occurred during client-side hydration when using Content Security Policy (CSP) with nonces. The error "Cannot read properties of null (reading 'useContext')" was caused by the `NonceProvider` being present during server-side rendering but missing during client hydration.
+
+#### Changes for Existing Projects
+
+If you have customized your `app/entry.client.tsx` file, you may need to wrap your app with the `NonceProvider` during hydration to avoid this error:
+
+```diff
+// app/entry.client.tsx
+import {HydratedRouter} from 'react-router/dom';
+import {startTransition, StrictMode} from 'react';
+import {hydrateRoot} from 'react-dom/client';
++ import {NonceProvider} from '@shopify/hydrogen';
+
+if (!window.location.origin.includes('webcache.googleusercontent.com')) {
+  startTransition(() => {
++   // Extract nonce from existing script tags
++   const existingNonce = document
++     .querySelector<HTMLScriptElement>('script[nonce]')
++     ?.nonce;
++
+    hydrateRoot(
+      document,
+      <StrictMode>
+-       <HydratedRouter />
++       <NonceProvider value={existingNonce}>
++         <HydratedRouter />
++       </NonceProvider>
+      </StrictMode>,
+    );
+  });
+}
+```
+
+This ensures the React Context tree matches between server and client rendering, preventing hydration mismatches.
+
+#### Package Changes
+
+- **@shopify/hydrogen**: Exported `NonceProvider` from the main package to allow client-side usage and simplified Vite configuration to improve React Context stability during development
+- **skeleton**: Updated the template's `entry.client.tsx` to include the `NonceProvider` wrapper during hydration

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -68,7 +68,7 @@ export {
   createHydrogenContext,
   type HydrogenContext,
 } from './createHydrogenContext';
-export {createContentSecurityPolicy, useNonce} from './csp/csp';
+export {createContentSecurityPolicy, NonceProvider, useNonce} from './csp/csp';
 export {Script} from './csp/Script';
 export {createCustomerAccountClient} from './customer/customer';
 export type {

--- a/packages/hydrogen/src/vite/plugin.ts
+++ b/packages/hydrogen/src/vite/plugin.ts
@@ -61,7 +61,7 @@ export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
           },
           resolve: {
             // Deduplicate React to ensure single instance for context sharing
-            dedupe: ['react', 'react-dom', '@shopify/hydrogen'],
+            dedupe: ['react', 'react-dom'],
           },
           ssr: {
             optimizeDeps: {
@@ -82,12 +82,9 @@ export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
           // Do it early to avoid the initial reload:
           optimizeDeps: {
             include: [
-              // Always optimize these CJS dependencies
+              // Optimize CJS dependencies that would otherwise cause issues
               'content-security-policy-builder',
               'worktop/cookie',
-              // For regular projects, optimize @shopify/hydrogen to prevent useContext errors.
-              // In monorepo, skip to allow live reload of source changes.
-              ...(!isHydrogenMonorepo ? ['@shopify/hydrogen'] : []),
             ],
           },
         };

--- a/templates/skeleton/app/entry.client.tsx
+++ b/templates/skeleton/app/entry.client.tsx
@@ -1,13 +1,21 @@
-import { HydratedRouter } from 'react-router/dom';
+import {HydratedRouter} from 'react-router/dom';
 import {startTransition, StrictMode} from 'react';
 import {hydrateRoot} from 'react-dom/client';
+import {NonceProvider} from '@shopify/hydrogen';
 
 if (!window.location.origin.includes('webcache.googleusercontent.com')) {
   startTransition(() => {
+    // Extract nonce from existing script tags
+    const existingNonce = document
+      .querySelector<HTMLScriptElement>('script[nonce]')
+      ?.nonce;
+
     hydrateRoot(
       document,
       <StrictMode>
-        <HydratedRouter />
+        <NonceProvider value={existingNonce}>
+          <HydratedRouter />
+        </NonceProvider>
       </StrictMode>,
     );
   });


### PR DESCRIPTION
Fixes #3098

## WHY are these changes introduced?

The skeleton template throws a "Cannot read properties of null (reading 'useContext')" error on first page load when running `npm run dev:app`. This error occurs because of a React Context mismatch between server-side rendering and client-side hydration:

- Server-side: The app is wrapped with `NonceProvider` (in `entry.server.tsx`)  
- Client-side: The app was NOT wrapped with `NonceProvider` (in `entry.client.tsx`)

This mismatch causes React to throw an error when the `useNonce` hook tries to access the context during hydration.

## WHAT is this pull request doing?

1. **Exports NonceProvider** from `@shopify/hydrogen` package to make it available for client-side use
2. **Adds NonceProvider wrapper** to the skeleton template's `entry.client.tsx` during hydration
3. **Simplifies Vite configuration** to improve React Context stability by removing conditional optimization

## HOW to test your changes?

1. Run `npm run dev:app` in the skeleton template
2. Open the browser and check the console - **no errors should appear on first page load**
3. Verify CSP headers are still working correctly by checking the response headers
4. Run all tests with `npm test` - all 381 tests should pass
5. Run typecheck with `npm run typecheck` - no errors

### For existing projects

If you have customized your `app/entry.client.tsx` file, apply this change to fix the error:

```diff
// app/entry.client.tsx
import {HydratedRouter} from 'react-router/dom';
import {startTransition, StrictMode} from 'react';
import {hydrateRoot} from 'react-dom/client';
+ import {NonceProvider} from '@shopify/hydrogen';

if (!window.location.origin.includes('webcache.googleusercontent.com')) {
  startTransition(() => {
+   // Extract nonce from existing script tags
+   const existingNonce = document
+     .querySelector<HTMLScriptElement>('script[nonce]')
+     ?.nonce;
+
    hydrateRoot(
      document,
      <StrictMode>
-       <HydratedRouter />
+       <NonceProvider value={existingNonce}>
+         <HydratedRouter />
+       </NonceProvider>
      </StrictMode>,
    );
  });
}
```

## Post-merge steps

- [ ] Changelog entry