### PR TITLE
[2025-07] Add Chrome DevTools automatic workspace configuration support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
       "dependencies": {
         "@shopify/cli-hydrogen": "*",
         "react-router": "^7.5.1",
-        "react-router-dom": "^7.5.1"
+        "react-router-dom": "^7.5.1",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
@@ -33215,6 +33216,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/uvu": {
       "version": "0.5.6",
       "dev": true,
@@ -34457,7 +34471,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "11.1.2",
+      "version": "11.1.3",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.34.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   "dependencies": {
     "@shopify/cli-hydrogen": "*",
     "react-router": "^7.5.1",
-    "react-router-dom": "^7.5.1"
+    "react-router-dom": "^7.5.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",

--- a/packages/hydrogen/src/vite/get-virtual-routes.ts
+++ b/packages/hydrogen/src/vite/get-virtual-routes.ts
@@ -54,7 +54,7 @@ export async function getVirtualRoutesV3() {
         path: '.well-known/appspecific/com.chrome.devtools.json',
         file: getVirtualRoutesPath(
           VIRTUAL_ROUTES_ROUTES_DIR_PARTS,
-          '[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.jsx',
+          '[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx',
         ),
         index: false,
       },

--- a/packages/hydrogen/src/vite/get-virtual-routes.ts
+++ b/packages/hydrogen/src/vite/get-virtual-routes.ts
@@ -54,7 +54,7 @@ export async function getVirtualRoutesV3() {
         path: '.well-known/appspecific/com.chrome.devtools.json',
         file: getVirtualRoutesPath(
           VIRTUAL_ROUTES_ROUTES_DIR_PARTS,
-          '[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx',
+          '[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.jsx',
         ),
         index: false,
       },

--- a/packages/hydrogen/src/vite/get-virtual-routes.ts
+++ b/packages/hydrogen/src/vite/get-virtual-routes.ts
@@ -50,6 +50,15 @@ export async function getVirtualRoutesV3() {
         index: false,
       },
       {
+        id: `${VIRTUAL_ROUTES_DIR}/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json`,
+        path: '.well-known/appspecific/com.chrome.devtools.json',
+        file: getVirtualRoutesPath(
+          VIRTUAL_ROUTES_ROUTES_DIR_PARTS,
+          '[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.jsx',
+        ),
+        index: false,
+      },
+      {
         id: `${VIRTUAL_ROUTES_DIR}/index`,
         path: '',
         file: getVirtualRoutesPath(

--- a/packages/hydrogen/src/vite/plugin.ts
+++ b/packages/hydrogen/src/vite/plugin.ts
@@ -107,6 +107,10 @@ export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
 
         oxygenPlugin?.api?.registerPluginOptions?.({
           compatibilityDate: getCompatDate(),
+          env: {
+            // Pass the project root to the worker for Chrome DevTools workspace configuration
+            HYDROGEN_PROJECT_ROOT: resolvedConfig.root,
+          },
           requestHook: ({request, response, meta}) => {
             // Emit events for requests
             emitRequestEvent(

--- a/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
+++ b/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
@@ -2,32 +2,32 @@ import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
 
 /**
  * Chrome DevTools Automatic Workspace Configuration
- * 
+ *
  * This virtual route serves the Chrome DevTools workspace configuration file
  * that enables automatic workspace folder detection in Chrome M-135+.
- * 
+ *
  * When developers open Chrome DevTools on localhost, Chrome requests this file
- * to auto-configure workspace settings. Without this file, developers see 404 
+ * to auto-configure workspace settings. Without this file, developers see 404
  * errors in the console which creates visual noise.
- * 
+ *
  * @see https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
  */
 export async function loader({request}: LoaderFunctionArgs) {
   // Use the request URL as a deterministic seed for the UUID
   const url = new URL(request.url);
   const origin = url.origin;
-  
+
   // Simple hash function for generating a deterministic UUID from the origin
   let hash = 0;
   for (let i = 0; i < origin.length; i++) {
     const char = origin.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
+    hash = (hash << 5) - hash + char;
     hash = hash & hash; // Convert to 32bit integer
   }
-  
+
   // Convert hash to hex and pad to ensure we have enough characters
   const hexHash = Math.abs(hash).toString(16).padEnd(32, '0');
-  
+
   // Format as UUID v4
   const uuid = [
     hexHash.substring(0, 8),
@@ -36,14 +36,14 @@ export async function loader({request}: LoaderFunctionArgs) {
     '8' + hexHash.substring(17, 20), // Variant bits
     hexHash.substring(20, 32),
   ].join('-');
-  
+
   // For development, use a placeholder path that indicates this is a virtual workspace
   const root = '/workspace/hydrogen-dev';
-  
+
   const responseData = {
-    workspace: {root, uuid}
+    workspace: {root, uuid},
   };
-  
+
   return new Response(JSON.stringify(responseData), {
     status: 200,
     headers: {

--- a/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
+++ b/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
@@ -1,4 +1,5 @@
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
+import {v4 as uuidv4, v5 as uuidv5} from 'uuid';
 
 /**
  * Chrome DevTools Automatic Workspace Configuration
@@ -10,38 +11,38 @@ import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
  * to auto-configure workspace settings. Without this file, developers see 404
  * errors in the console which creates visual noise.
  *
+ * Note: The Chrome flag chrome://flags/#devtools-project-settings must be enabled
+ * for automatic workspace detection to work (enabled by default in Chrome M-136+).
+ *
+ * Known Limitations:
+ * - On macOS, Chrome may not be able to access the filesystem even with Full Disk Access
+ *   granted due to sandboxing and security restrictions
+ * - Enterprise policies may prevent automatic workspace detection from functioning
+ * - Manual workspace addition may still show empty folders on macOS despite proper permissions
+ *
  * @see https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
  */
 export async function loader({request, context}: LoaderFunctionArgs) {
   // Get the project root from the environment variable passed by the Hydrogen plugin
   // @ts-ignore - env is injected by MiniOxygen in development
   let root = context?.env?.HYDROGEN_PROJECT_ROOT || '/workspace/hydrogen-dev';
-  
+
   // Normalize Windows paths to Unix style for Chrome DevTools
   root = root.replace(/\\/g, '/');
 
-  // Generate a deterministic UUID based on the project path
-  let hash = 0;
-  for (let i = 0; i < root.length; i++) {
-    const char = root.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash; // Convert to 32bit integer
-  }
+  // Generate a deterministic UUID v5 based on the project path
+  // This ensures the same UUID for the same project path
+  const HYDROGEN_NAMESPACE = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+  const uuid = uuidv5(root, HYDROGEN_NAMESPACE);
 
-  // Convert hash to hex and pad to ensure we have enough characters
-  const hexHash = Math.abs(hash).toString(16).padEnd(32, '0');
-
-  // Format as UUID v4
-  const uuid = [
-    hexHash.substring(0, 8),
-    hexHash.substring(8, 12),
-    '4' + hexHash.substring(13, 16), // Version 4
-    '8' + hexHash.substring(17, 20), // Variant bits
-    hexHash.substring(20, 32),
-  ].join('-');
+  // Chrome expects just the absolute path, not a file:// URL
+  // The automatic workspace detection handles the path format internally
 
   const responseData = {
-    workspace: {root, uuid},
+    workspace: {
+      root,
+      uuid,
+    },
   };
 
   return new Response(JSON.stringify(responseData), {

--- a/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
+++ b/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
@@ -24,7 +24,9 @@ import {v5 as uuidv5} from 'uuid';
  */
 export async function loader({request, context}: LoaderFunctionArgs) {
   // Get the project root from the environment variable passed by the Hydrogen plugin
-  let root = (context?.env as {HYDROGEN_PROJECT_ROOT?: string} | undefined)?.HYDROGEN_PROJECT_ROOT || '/workspace/hydrogen-dev';
+  let root =
+    (context?.env as {HYDROGEN_PROJECT_ROOT?: string} | undefined)
+      ?.HYDROGEN_PROJECT_ROOT || '/workspace/hydrogen-dev';
 
   // Normalize Windows paths to Unix style for Chrome DevTools
   root = root.replace(/\\/g, '/');

--- a/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
+++ b/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
@@ -1,5 +1,5 @@
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
-import {v4 as uuidv4, v5 as uuidv5} from 'uuid';
+import {v5 as uuidv5} from 'uuid';
 
 /**
  * Chrome DevTools Automatic Workspace Configuration
@@ -24,14 +24,16 @@ import {v4 as uuidv4, v5 as uuidv5} from 'uuid';
  */
 export async function loader({request, context}: LoaderFunctionArgs) {
   // Get the project root from the environment variable passed by the Hydrogen plugin
-  // @ts-ignore - env is injected by MiniOxygen in development
-  let root = context?.env?.HYDROGEN_PROJECT_ROOT || '/workspace/hydrogen-dev';
+  let root = (context?.env as {HYDROGEN_PROJECT_ROOT?: string} | undefined)?.HYDROGEN_PROJECT_ROOT || '/workspace/hydrogen-dev';
 
   // Normalize Windows paths to Unix style for Chrome DevTools
   root = root.replace(/\\/g, '/');
 
   // Generate a deterministic UUID v5 based on the project path
   // This ensures the same UUID for the same project path
+  // The namespace UUID is a randomly generated UUID v4 that serves as a constant
+  // namespace for all Hydrogen projects. This allows different projects to have
+  // different UUIDs while the same project always generates the same UUID.
   const HYDROGEN_NAMESPACE = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
   const uuid = uuidv5(root, HYDROGEN_NAMESPACE);
 

--- a/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
+++ b/packages/hydrogen/src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx
@@ -1,0 +1,54 @@
+import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
+
+/**
+ * Chrome DevTools Automatic Workspace Configuration
+ * 
+ * This virtual route serves the Chrome DevTools workspace configuration file
+ * that enables automatic workspace folder detection in Chrome M-135+.
+ * 
+ * When developers open Chrome DevTools on localhost, Chrome requests this file
+ * to auto-configure workspace settings. Without this file, developers see 404 
+ * errors in the console which creates visual noise.
+ * 
+ * @see https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md
+ */
+export async function loader({request}: LoaderFunctionArgs) {
+  // Use the request URL as a deterministic seed for the UUID
+  const url = new URL(request.url);
+  const origin = url.origin;
+  
+  // Simple hash function for generating a deterministic UUID from the origin
+  let hash = 0;
+  for (let i = 0; i < origin.length; i++) {
+    const char = origin.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  
+  // Convert hash to hex and pad to ensure we have enough characters
+  const hexHash = Math.abs(hash).toString(16).padEnd(32, '0');
+  
+  // Format as UUID v4
+  const uuid = [
+    hexHash.substring(0, 8),
+    hexHash.substring(8, 12),
+    '4' + hexHash.substring(13, 16), // Version 4
+    '8' + hexHash.substring(17, 20), // Variant bits
+    hexHash.substring(20, 32),
+  ].join('-');
+  
+  // For development, use a placeholder path that indicates this is a virtual workspace
+  const root = '/workspace/hydrogen-dev';
+  
+  const responseData = {
+    workspace: {root, uuid}
+  };
+  
+  return new Response(JSON.stringify(responseData), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-cache',
+    },
+  });
+}

--- a/packages/hydrogen/tsup.config.ts
+++ b/packages/hydrogen/tsup.config.ts
@@ -106,6 +106,12 @@ export default defineConfig([
         {recursive: true},
       );
 
+      // Copy the Chrome DevTools route TypeScript file for React Router
+      await fs.cp(
+        'src/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx',
+        `${outDir}/vite/virtual-routes/routes/[.]well-known.appspecific.com[.]chrome[.]devtools[.]json.tsx`,
+      );
+
       console.log('\n', 'Copied virtual route assets to build directory', '\n');
     },
   },


### PR DESCRIPTION
## WHY are these changes introduced?

Fixes #3103

The skeleton template generates 404 errors for `/.well-known/appspecific/com.chrome.devtools.json` when running `npm run dev`, creating console noise during development.

## WHAT is this pull request doing?

Implements Chrome DevTools Automatic Workspace Folders support (Chrome M-135+) by:
- Adding a virtual route that serves the workspace configuration JSON
- Passing project root from Vite plugin to worker via environment variable
- Generating deterministic UUID for workspace identification
- Eliminating 404 errors in the console

## HOW to test your changes?

1. Run dev server: `cd templates/skeleton && npm run dev`
2. Open Chrome DevTools - verify no 404 errors for Chrome DevTools JSON
3. Check endpoint: `http://localhost:3000/.well-known/appspecific/com.chrome.devtools.json`

**Note:** Full automatic workspace detection may not work on macOS due to Chrome sandbox restrictions.

## Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/.github/contributing.md)
- [x] I've added a changeset if this PR contains user-facing or noteworthy changes