### PR TITLE
[2025-06] Fix MiniOxygen/Miniflare v4 redirects handling + Stable --customer-account-push  flag

### DIFF
--- a/.changeset/fix-oauth-redirect-handling.md
+++ b/.changeset/fix-oauth-redirect-handling.md
@@ -1,0 +1,51 @@
+---
+"@shopify/mini-oxygen": major
+"@shopify/cli-hydrogen": major
+---
+
+Fix OAuth redirect handling and stabilize Customer Account API development flag
+
+## MiniOxygen: Fixed redirect handling for OAuth flows
+
+MiniOxygen now correctly handles external redirects by passing them to the browser instead of following them internally. This ensures OAuth/PKCE authentication flows work properly with React Router's `redirectDocument()` function.
+
+**What changed:**
+- Miniflare's `dispatchFetch` now uses `{redirect: 'manual'}` to prevent automatic redirect following
+- Fixed `Headers.getSetCookie()` method for proper multi-cookie support
+- Added comprehensive test coverage for redirect scenarios
+
+**Before:** External redirects were followed internally, breaking OAuth flows
+```js
+// Redirects were automatically followed by Miniflare
+const response = await mf.dispatchFetch(request);
+```
+
+**After:** Redirects are passed to the browser for proper handling
+```js
+// Redirects are now returned as-is for the browser to handle
+const response = await mf.dispatchFetch(request, {redirect: 'manual'});
+```
+
+## CLI: Stabilized Customer Account API development flag
+
+The `--customer-account-push` flag is now stable and ready for production use. This flag enables tunneling for local development with Customer Account API OAuth flows.
+
+**Before:** 
+```bash
+# Flag was experimental with __unstable suffix
+shopify hydrogen dev --customer-account-push__unstable
+```
+
+**After:**
+```bash
+# Flag is now stable
+shopify hydrogen dev --customer-account-push
+
+# Or use environment variable
+SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH=true npm run dev
+```
+
+This flag automatically:
+- Creates a tunnel for your local development server
+- Configures the Customer Account API OAuth callback URLs
+- Enables testing of the full authentication flow locally

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -645,11 +645,10 @@
           "allowNo": false,
           "type": "boolean"
         },
-        "customer-account-push__unstable": {
-          "description": "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's Oauth flow",
+        "customer-account-push": {
+          "description": "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's OAuth flow",
           "env": "SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH",
-          "hidden": true,
-          "name": "customer-account-push__unstable",
+          "name": "customer-account-push",
           "required": false,
           "allowNo": false,
           "type": "boolean"

--- a/packages/cli/src/commands/hydrogen/dev.ts
+++ b/packages/cli/src/commands/hydrogen/dev.ts
@@ -114,7 +114,7 @@ export default class Dev extends Command {
 
     const devParams = {
       ...flagsToCamelObject(flags),
-      customerAccountPush: flags['customer-account-push__unstable'],
+      customerAccountPush: flags['customer-account-push'],
       path: directory,
       cliConfig: this.config,
     };

--- a/packages/cli/src/lib/flags.ts
+++ b/packages/cli/src/lib/flags.ts
@@ -172,10 +172,9 @@ Defaults to the '.env' located in your project path `--path`.",
     }),
   },
   customerAccountPush: {
-    'customer-account-push__unstable': Flags.boolean({
-      hidden: true,
+    'customer-account-push': Flags.boolean({
       description:
-        "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's Oauth flow",
+        "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's OAuth flow",
       required: false,
       env: 'SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH',
     }),

--- a/packages/mini-oxygen/src/node/core.ts
+++ b/packages/mini-oxygen/src/node/core.ts
@@ -128,7 +128,8 @@ export class MiniOxygen {
   }
 
   async dispatchFetch(request: Request): Promise<Response> {
-    return this.miniflare.dispatchFetch(request) as Promise<Response>;
+    const fn = this.miniflare.dispatchFetch;
+    return fn.call(this.miniflare, request, {redirect: 'manual'});
   }
 
   async setOptions(

--- a/packages/mini-oxygen/src/node/core.ts
+++ b/packages/mini-oxygen/src/node/core.ts
@@ -128,8 +128,10 @@ export class MiniOxygen {
   }
 
   async dispatchFetch(request: Request): Promise<Response> {
-    const fn = this.miniflare.dispatchFetch;
-    return fn.call(this.miniflare, request, {redirect: 'manual'});
+    // Miniflare's dispatchFetch accepts (input: RequestInfo, init?: RequestInit)
+    // We need to pass redirect: 'manual' as part of the init parameter
+    const response = await this.miniflare.dispatchFetch(request, {redirect: 'manual'});
+    return response;
   }
 
   async setOptions(

--- a/packages/mini-oxygen/src/node/core.ts
+++ b/packages/mini-oxygen/src/node/core.ts
@@ -130,7 +130,9 @@ export class MiniOxygen {
   async dispatchFetch(request: Request): Promise<Response> {
     // Miniflare's dispatchFetch accepts (input: RequestInfo, init?: RequestInit)
     // We need to pass redirect: 'manual' as part of the init parameter
-    const response = await this.miniflare.dispatchFetch(request, {redirect: 'manual'});
+    const response = await this.miniflare.dispatchFetch(request, {
+      redirect: 'manual',
+    });
     return response;
   }
 

--- a/packages/mini-oxygen/src/node/e2e.test.ts
+++ b/packages/mini-oxygen/src/node/e2e.test.ts
@@ -6,11 +6,11 @@ import {temporaryDirectory} from 'tempy';
 import {it, vi, describe, beforeEach, expect, afterEach} from 'vitest';
 import {EventSource} from 'eventsource';
 
-import {startServer, Response, type MiniOxygenOptions} from './index.js';
+import {startServer, Response, type MiniOxygenPreviewOptions} from './index.js';
 
 describe('start()', () => {
   let fixture: Fixture;
-  const defaultOptions: MiniOxygenOptions = {
+  const defaultOptions: MiniOxygenPreviewOptions = {
     log: vi.fn(),
     port: 0, // Use port 0 to let OS assign a random available port
   };

--- a/packages/mini-oxygen/src/node/e2e.test.ts
+++ b/packages/mini-oxygen/src/node/e2e.test.ts
@@ -12,6 +12,7 @@ describe('start()', () => {
   let fixture: Fixture;
   const defaultOptions: MiniOxygenOptions = {
     log: vi.fn(),
+    port: 0, // Use port 0 to let OS assign a random available port
   };
 
   beforeEach(async () => {
@@ -175,8 +176,17 @@ describe('start()', () => {
 
   it('proxies requests to a proxy server', async () => {
     const mockLogger = vi.fn();
-    const proxyPort = 1338;
-    const proxyServer = createMockProxyServer(proxyPort);
+    const proxyServer = createMockProxyServer(0); // Use dynamic port
+
+    // Get the actual port after server starts
+    const proxyPort = await new Promise<number>((resolve) => {
+      proxyServer.on('listening', () => {
+        const addr = proxyServer.address();
+        if (addr && typeof addr === 'object') {
+          resolve(addr.port);
+        }
+      });
+    });
 
     proxyServer.on('connection', () => {
       mockLogger('Proxy request received');

--- a/packages/mini-oxygen/src/node/index.ts
+++ b/packages/mini-oxygen/src/node/index.ts
@@ -106,7 +106,9 @@ export function createMiniOxygen(
       // which means that it has loaded the initial worker code.
       await mf.getPlugins();
     },
-    dispatchFetch: (request) => mf.dispatchFetch(request),
+    dispatchFetch: (request) => {
+      return mf.dispatchFetch(request);
+    },
     async reload({env, ...nextOptions} = {}) {
       await mf.reload({...nextOptions, ...(env && {bindings: env})});
     },

--- a/packages/mini-oxygen/src/node/index.ts
+++ b/packages/mini-oxygen/src/node/index.ts
@@ -154,7 +154,7 @@ export function createMiniOxygen(
         onResponseError,
       });
 
-      const actualPort = port ?? (await findPort(3000));
+      const actualPort = port === 0 ? 0 : (port ?? (await findPort(3000)));
 
       const sockets = new Set<Socket>();
       app.on('connection', (socket) => {
@@ -164,12 +164,19 @@ export function createMiniOxygen(
 
       return new Promise((res) => {
         app.listen(actualPort, () => {
+          // Get the actual port the server is listening on (important when port is 0)
+          const serverAddress = app.address();
+          const assignedPort =
+            serverAddress && typeof serverAddress === 'object'
+              ? serverAddress.port
+              : actualPort;
+
           log(
-            `\nStarted miniOxygen server. Listening at http://localhost:${actualPort}\n`,
+            `\nStarted miniOxygen server. Listening at http://localhost:${assignedPort}\n`,
           );
 
           res({
-            port: actualPort,
+            port: assignedPort,
             close: () =>
               new Promise((resolve) => {
                 sockets.forEach((socket) => socket.destroy());

--- a/packages/mini-oxygen/src/node/redirect-behavior.test.ts
+++ b/packages/mini-oxygen/src/node/redirect-behavior.test.ts
@@ -2,7 +2,13 @@ import {join} from 'node:path';
 import {writeFile, rm as remove} from 'node:fs/promises';
 import {temporaryDirectory} from 'tempy';
 import {it, vi, describe, beforeEach, expect, afterEach} from 'vitest';
-import {startServer, type MiniOxygenOptions} from './index.js';
+import {
+  startServer,
+  type MiniOxygenPreviewOptions,
+  Request,
+  Response,
+} from './index.js';
+import type {DispatchFetch} from './server.js';
 
 /**
  * Tests that MiniOxygen correctly handles redirects without following them,
@@ -14,7 +20,7 @@ import {startServer, type MiniOxygenOptions} from './index.js';
 describe('MiniOxygen redirect behavior', () => {
   let fixture: RedirectFixture;
   let servers: Array<{close: () => Promise<void>}> = [];
-  const defaultOptions: MiniOxygenOptions = {
+  const defaultOptions: MiniOxygenPreviewOptions = {
     log: vi.fn(),
     port: 0, // Use port 0 to let OS assign a random available port
   };
@@ -32,7 +38,7 @@ describe('MiniOxygen redirect behavior', () => {
   });
 
   // Helper function to start server and track it for cleanup
-  async function startTrackedServer(options: MiniOxygenOptions) {
+  async function startTrackedServer(options: MiniOxygenPreviewOptions) {
     const server = await startServer(options);
     servers.push(server);
     return server;
@@ -163,7 +169,7 @@ describe('MiniOxygen redirect behavior', () => {
     const miniOxygen = await startTrackedServer({
       ...defaultOptions,
       workerFile: fixture.paths.workerFile,
-      onRequest: async (request, dispatchFetch) => {
+      onRequest: async (request: Request, dispatchFetch: DispatchFetch) => {
         const response = await dispatchFetch(request);
 
         // Verify that dispatchFetch doesn't follow redirects

--- a/packages/mini-oxygen/src/node/redirect-behavior.test.ts
+++ b/packages/mini-oxygen/src/node/redirect-behavior.test.ts
@@ -1,0 +1,375 @@
+import {join} from 'node:path';
+import {writeFile, rm as remove} from 'node:fs/promises';
+import {temporaryDirectory} from 'tempy';
+import {it, vi, describe, beforeEach, expect, afterEach} from 'vitest';
+import {startServer, type MiniOxygenOptions} from './index.js';
+
+/**
+ * Tests that MiniOxygen correctly handles redirects without following them,
+ * ensuring React Router's redirect() and redirectDocument() work as expected.
+ * 
+ * The key issue: Miniflare v4 by default follows redirects, which breaks
+ * external redirects (like OAuth) that need to be handled by the browser.
+ */
+describe('MiniOxygen redirect behavior', () => {
+  let fixture: RedirectFixture;
+  const defaultOptions: MiniOxygenOptions = {
+    log: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    fixture = await createRedirectFixture('redirect-fixture');
+  });
+
+  afterEach(async () => {
+    await fixture.destroy();
+  });
+
+  it('should NOT follow 302 redirects (external URLs)', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+    });
+
+    const response = await fetch(`http://localhost:${miniOxygen.port}/external-redirect`, {
+      redirect: 'manual',
+    });
+    
+    // MiniOxygen should return the redirect response, not follow it
+    expect(response.status).toBe(302);
+    expect(response.redirected).toBe(false);
+    expect(response.headers.get('location')).toBe('https://example.com/oauth');
+    
+    await miniOxygen.close();
+  });
+
+  it('should NOT follow 301 redirects', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+    });
+
+    const response = await fetch(`http://localhost:${miniOxygen.port}/permanent-redirect`, {
+      redirect: 'manual',
+    });
+    
+    expect(response.status).toBe(301);
+    expect(response.redirected).toBe(false);
+    expect(response.headers.get('location')).toBe('https://example.com/moved');
+    
+    await miniOxygen.close();
+  });
+
+  it('should preserve all redirect headers (including custom ones)', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+    });
+
+    // Use a raw HTTP request to bypass any fetch quirks
+    const http = await import('node:http');
+    const response = await new Promise<{status: number, headers: Record<string, string>}>((resolve) => {
+      http.get(`http://localhost:${miniOxygen.port}/redirect-with-headers`, (res) => {
+        const headers: Record<string, string> = {};
+        for (const [key, value] of Object.entries(res.headers)) {
+          headers[key] = Array.isArray(value) ? value.join(', ') : value as string;
+        }
+        resolve({ status: res.statusCode!, headers });
+        res.resume(); // Consume the response body
+      });
+    });
+    
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe('https://example.com');
+    expect(response.headers['x-custom-header']).toBe('preserved');
+    expect(response.headers['set-cookie']).toBe('session=abc123');
+    
+    await miniOxygen.close();
+  });
+
+  it('should handle redirectDocument (with X-Remix-Reload-Document)', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+    });
+
+    const response = await fetch(`http://localhost:${miniOxygen.port}/redirect-document`, {
+      redirect: 'manual',
+    });
+    
+    expect(response.status).toBe(302);
+    expect(response.redirected).toBe(false);
+    expect(response.headers.get('location')).toBe('https://external.com');
+    expect(response.headers.get('X-Remix-Reload-Document')).toBe('true');
+    
+    await miniOxygen.close();
+  });
+
+  it('should handle various redirect status codes', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+    });
+
+    const statuses = [301, 302, 303, 307, 308];
+    
+    for (const status of statuses) {
+      const response = await fetch(`http://localhost:${miniOxygen.port}/redirect/${status}`, {
+        redirect: 'manual',
+      });
+      
+      expect(response.status).toBe(status);
+      expect(response.redirected).toBe(false);
+      expect(response.headers.get('location')).toBeTruthy();
+    }
+    
+    await miniOxygen.close();
+  });
+
+  it('should pass redirect: manual through onRequest callback', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+      onRequest: async (request, dispatchFetch) => {
+        const response = await dispatchFetch(request);
+        
+        // Verify that dispatchFetch doesn't follow redirects
+        if (request.url.includes('/external-redirect')) {
+          expect(response.status).toBe(302);
+          expect(response.headers.get('location')).toBe('https://example.com/oauth');
+        }
+        
+        return response;
+      },
+    });
+
+    await fetch(`http://localhost:${miniOxygen.port}/external-redirect`, {
+      redirect: 'manual',
+    });
+    
+    await miniOxygen.close();
+  });
+
+  it('should return null body for redirect responses', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+    });
+
+    const response = await fetch(`http://localhost:${miniOxygen.port}/external-redirect`, {
+      redirect: 'manual',
+    });
+    
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://example.com/oauth');
+    
+    // React Router expects redirect responses to have no body
+    const text = await response.text();
+    expect(text).toBe('');
+    
+    await miniOxygen.close();
+  });
+
+  it('should preserve query parameters in redirect Location header', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+    });
+
+    const response = await fetch(`http://localhost:${miniOxygen.port}/redirect-with-query`, {
+      redirect: 'manual',
+    });
+    
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://example.com/oauth?client_id=abc123&return_url=%2Fdashboard&state=xyz789');
+    
+    await miniOxygen.close();
+  });
+
+  it('should handle multiple Set-Cookie headers in redirects', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+    });
+
+    const response = await fetch(`http://localhost:${miniOxygen.port}/redirect-multiple-cookies`, {
+      redirect: 'manual',
+    });
+    
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://example.com/dashboard');
+    
+    // Check raw headers using Node.js http to see multiple cookies
+    const http = await import('node:http');
+    const rawResponse = await new Promise<{status: number, headers: Record<string, string | string[]>}>((resolve) => {
+      http.get(`http://localhost:${miniOxygen.port}/redirect-multiple-cookies`, (res) => {
+        const headers: Record<string, string | string[]> = {};
+        for (const [key, value] of Object.entries(res.headers)) {
+          headers[key] = value!;
+        }
+        resolve({ status: res.statusCode!, headers });
+        res.resume();
+      });
+    });
+    
+    // Multiple Set-Cookie headers should be preserved
+    const setCookieHeader = rawResponse.headers['set-cookie'];
+    expect(Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader]).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('session_token='),
+        expect.stringContaining('refresh_token='),
+        expect.stringContaining('user_id='),
+      ])
+    );
+    
+    await miniOxygen.close();
+  });
+
+  it('should preserve Content-Security-Policy headers in redirects', async () => {
+    const miniOxygen = await startServer({
+      ...defaultOptions,
+      workerFile: fixture.paths.workerFile,
+    });
+
+    const response = await fetch(`http://localhost:${miniOxygen.port}/redirect-with-csp`, {
+      redirect: 'manual',
+    });
+    
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://secure.example.com');
+    expect(response.headers.get('content-security-policy')).toBe(
+      "default-src 'self'; script-src 'self' 'nonce-abc123'; style-src 'self' 'unsafe-inline'"
+    );
+    expect(response.headers.get('x-frame-options')).toBe('DENY');
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+    
+    await miniOxygen.close();
+  });
+});
+
+interface RedirectFixture {
+  paths: {
+    root: string;
+    workerFile: string;
+  };
+  destroy: () => Promise<void>;
+}
+
+async function createRedirectFixture(name: string): Promise<RedirectFixture> {
+  const directory = await temporaryDirectory({prefix: name});
+  const paths = {
+    root: directory,
+    workerFile: join(directory, 'worker.mjs'),
+  };
+
+  await writeFile(
+    join(directory, 'package.json'),
+    JSON.stringify({
+      name: 'redirect-test-worker',
+      version: '1.0.0',
+      type: 'module',
+    }, null, 2),
+  );
+
+  // Simple worker that tests various redirect scenarios
+  await writeFile(
+    paths.workerFile,
+    `
+// Simulate React Router's redirect function
+function redirect(url, init = {}) {
+  const headers = new Headers(init.headers || {});
+  headers.set('Location', url);
+  
+  return new Response(null, {
+    status: init.status || 302,
+    headers,
+  });
+}
+
+// Simulate React Router's redirectDocument function
+function redirectDocument(url, init = {}) {
+  const headers = new Headers(init.headers || {});
+  headers.set('Location', url);
+  headers.set('X-Remix-Reload-Document', 'true');
+  
+  return new Response(null, {
+    status: init.status || 302,
+    headers,
+  });
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    
+    switch (url.pathname) {
+      case '/external-redirect':
+        // Simulate OAuth redirect to external domain
+        return redirect('https://example.com/oauth');
+      
+      case '/permanent-redirect':
+        // 301 permanent redirect
+        return redirect('https://example.com/moved', { status: 301 });
+      
+      case '/redirect-with-headers':
+        // Redirect with custom headers (like Set-Cookie for sessions)
+        return redirect('https://example.com', {
+          headers: {
+            'X-Custom-Header': 'preserved',
+            'Set-Cookie': 'session=abc123',
+          }
+        });
+      
+      case '/redirect-document':
+        // React Router's redirectDocument for external navigation
+        return redirectDocument('https://external.com');
+      
+      case '/redirect-with-query':
+        // Redirect with query parameters (common in OAuth flows)
+        return redirect('https://example.com/oauth?client_id=abc123&return_url=%2Fdashboard&state=xyz789');
+      
+      case '/redirect-multiple-cookies':
+        // Multiple Set-Cookie headers (auth flow with session + refresh tokens)
+        const headers = new Headers();
+        headers.set('Location', 'https://example.com/dashboard');
+        headers.append('Set-Cookie', 'session_token=sess_abc123; Path=/; HttpOnly; Secure; SameSite=Lax');
+        headers.append('Set-Cookie', 'refresh_token=ref_xyz789; Path=/; HttpOnly; Secure; SameSite=Strict');
+        headers.append('Set-Cookie', 'user_id=12345; Path=/; Secure; SameSite=Lax');
+        
+        return new Response(null, {
+          status: 302,
+          headers,
+        });
+      
+      case '/redirect-with-csp':
+        // Redirect with security headers (CSP, X-Frame-Options, etc.)
+        return redirect('https://secure.example.com', {
+          headers: {
+            'Content-Security-Policy': "default-src 'self'; script-src 'self' 'nonce-abc123'; style-src 'self' 'unsafe-inline'",
+            'X-Frame-Options': 'DENY',
+            'X-Content-Type-Options': 'nosniff',
+          }
+        });
+      
+      default:
+        // Handle /redirect/{status} for various status codes
+        const match = url.pathname.match(/\\/redirect\\/(\\d{3})/);
+        if (match) {
+          const status = parseInt(match[1], 10);
+          return redirect('https://example.com/destination', { status });
+        }
+        
+        return new Response('Not Found', { status: 404 });
+    }
+  }
+}
+    `.trim(),
+  );
+
+  return {
+    paths,
+    destroy: async () => {
+      await remove(directory, {force: true, recursive: true});
+    },
+  };
+}

--- a/packages/mini-oxygen/src/node/server.ts
+++ b/packages/mini-oxygen/src/node/server.ts
@@ -238,7 +238,9 @@ function createRequestMiddleware(
       res.end();
     } catch (err: any) {
       onResponseError?.(request, err as Error);
-      res.writeHead(status || 500, {'Content-Type': 'text/plain; charset=UTF-8'});
+      res.writeHead(status || 500, {
+        'Content-Type': 'text/plain; charset=UTF-8',
+      });
       res.end(err.stack, 'utf8');
     }
   };

--- a/packages/mini-oxygen/src/node/server.ts
+++ b/packages/mini-oxygen/src/node/server.ts
@@ -192,9 +192,11 @@ function createRequestMiddleware(
       for (const key of response.headers.keys()) {
         const val =
           key.toLowerCase() === 'set-cookie'
-            ? (response.headers as any).getAll(key)
+            ? response.headers.getSetCookie()
             : response.headers.get(key);
-        headers[key] = val;
+        if (val !== null) {
+          headers[key] = val;
+        }
       }
 
       let autoReloadScript = autoReloadScriptTemplate;
@@ -236,7 +238,7 @@ function createRequestMiddleware(
       res.end();
     } catch (err: any) {
       onResponseError?.(request, err as Error);
-      res.writeHead(status, {'Content-Type': 'text/plain; charset=UTF-8'});
+      res.writeHead(status || 500, {'Content-Type': 'text/plain; charset=UTF-8'});
       res.end(err.stack, 'utf8');
     }
   };

--- a/packages/mini-oxygen/src/worker/index.ts
+++ b/packages/mini-oxygen/src/worker/index.ts
@@ -184,9 +184,11 @@ export function createMiniOxygen({
 
   return {
     ready,
-    dispatchFetch: (request: Request) => {
-      const fn = mf.dispatchFetch;
-      return fn.call(mf, request, {redirect: 'manual'});
+    dispatchFetch: async (request: Request) => {
+      // Miniflare's dispatchFetch accepts (input: RequestInfo, init?: RequestInit)
+      // We need to pass redirect: 'manual' as part of the init parameter
+      const response = await mf.dispatchFetch(request, {redirect: 'manual'});
+      return response;
     },
     getBindings: mf.getBindings,
     getCaches: mf.getCaches,

--- a/packages/mini-oxygen/src/worker/index.ts
+++ b/packages/mini-oxygen/src/worker/index.ts
@@ -184,7 +184,10 @@ export function createMiniOxygen({
 
   return {
     ready,
-    dispatchFetch: mf.dispatchFetch,
+    dispatchFetch: (request: Request) => {
+      const fn = mf.dispatchFetch;
+      return fn.call(mf, request, {redirect: 'manual'});
+    },
     getBindings: mf.getBindings,
     getCaches: mf.getCaches,
     getWorker: mf.getWorker,

--- a/packages/mini-oxygen/src/worker/redirect-behavior.test.ts
+++ b/packages/mini-oxygen/src/worker/redirect-behavior.test.ts
@@ -1,0 +1,300 @@
+import {join} from 'node:path';
+import {writeFile, rm as remove, readFile} from 'node:fs/promises';
+import {temporaryDirectory} from 'tempy';
+import {it, vi, describe, beforeEach, expect, afterEach} from 'vitest';
+import {createMiniOxygen, Request, Response, type MiniOxygenOptions} from './index.js';
+
+/**
+ * Tests that MiniOxygen Worker runtime correctly handles redirects without following them,
+ * ensuring React Router's redirect() and redirectDocument() work as expected.
+ * 
+ * This tests the worker environment specifically, without the Node.js HTTP server layer.
+ */
+describe('MiniOxygen Worker redirect behavior', () => {
+  let fixture: RedirectFixture;
+
+  beforeEach(async () => {
+    fixture = await createRedirectFixture('worker-redirect-fixture');
+  });
+
+  afterEach(async () => {
+    await fixture.destroy();
+  });
+
+  it('should NOT follow 302 redirects in worker runtime', async () => {
+    const miniOxygen = createMiniOxygen({
+      workers: [{
+        name: 'test-worker',
+        modules: true,
+        script: await fixture.getScript(),
+      }],
+    });
+
+    await miniOxygen.ready;
+    
+    const request = new Request('http://localhost/external-redirect');
+    const response = await miniOxygen.dispatchFetch(request);
+    
+    // Worker should return the redirect response, not follow it
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://example.com/oauth');
+    
+    // Verify body is empty for redirects
+    const text = await response.text();
+    expect(text).toBe('');
+    
+    await miniOxygen.dispose();
+  });
+
+  it('should handle redirectDocument in worker runtime', async () => {
+    const miniOxygen = createMiniOxygen({
+      workers: [{
+        name: 'test-worker',
+        modules: true,
+        script: await fixture.getScript(),
+      }],
+    });
+
+    await miniOxygen.ready;
+    
+    const request = new Request('http://localhost/redirect-document');
+    const response = await miniOxygen.dispatchFetch(request);
+    
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://external.com');
+    expect(response.headers.get('X-Remix-Reload-Document')).toBe('true');
+    
+    await miniOxygen.dispose();
+  });
+
+  it('should preserve query parameters in worker runtime', async () => {
+    const miniOxygen = createMiniOxygen({
+      workers: [{
+        name: 'test-worker',
+        modules: true,
+        script: await fixture.getScript(),
+      }],
+    });
+
+    await miniOxygen.ready;
+    
+    const request = new Request('http://localhost/redirect-with-query');
+    const response = await miniOxygen.dispatchFetch(request);
+    
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://example.com/oauth?client_id=abc123&return_url=%2Fdashboard&state=xyz789');
+    
+    await miniOxygen.dispose();
+  });
+
+  it('should handle multiple Set-Cookie headers in worker runtime', async () => {
+    const miniOxygen = createMiniOxygen({
+      workers: [{
+        name: 'test-worker',
+        modules: true,
+        script: await fixture.getScript(),
+      }],
+    });
+
+    await miniOxygen.ready;
+    
+    const request = new Request('http://localhost/redirect-multiple-cookies');
+    const response = await miniOxygen.dispatchFetch(request);
+    
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://example.com/dashboard');
+    
+    // In worker environment, check getSetCookie method
+    const cookies = response.headers.getSetCookie();
+    expect(cookies).toHaveLength(3);
+    expect(cookies).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('session_token='),
+        expect.stringContaining('refresh_token='),
+        expect.stringContaining('user_id='),
+      ])
+    );
+    
+    await miniOxygen.dispose();
+  });
+
+  it('should preserve security headers in worker runtime', async () => {
+    const miniOxygen = createMiniOxygen({
+      workers: [{
+        name: 'test-worker',
+        modules: true,
+        script: await fixture.getScript(),
+      }],
+    });
+
+    await miniOxygen.ready;
+    
+    const request = new Request('http://localhost/redirect-with-csp');
+    const response = await miniOxygen.dispatchFetch(request);
+    
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://secure.example.com');
+    expect(response.headers.get('content-security-policy')).toBe(
+      "default-src 'self'; script-src 'self' 'nonce-abc123'; style-src 'self' 'unsafe-inline'"
+    );
+    expect(response.headers.get('x-frame-options')).toBe('DENY');
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+    
+    await miniOxygen.dispose();
+  });
+
+  it('should handle various redirect status codes in worker runtime', async () => {
+    const miniOxygen = createMiniOxygen({
+      workers: [{
+        name: 'test-worker',
+        modules: true,
+        script: await fixture.getScript(),
+      }],
+    });
+
+    await miniOxygen.ready;
+    
+    const statuses = [301, 302, 303, 307, 308];
+    
+    for (const status of statuses) {
+      const request = new Request(`http://localhost/redirect/${status}`);
+      const response = await miniOxygen.dispatchFetch(request);
+      
+      expect(response.status).toBe(status);
+      expect(response.headers.get('location')).toBeTruthy();
+    }
+    
+    await miniOxygen.dispose();
+  });
+});
+
+interface RedirectFixture {
+  paths: {
+    root: string;
+    workerFile: string;
+  };
+  getScript: () => Promise<string>;
+  destroy: () => Promise<void>;
+}
+
+async function createRedirectFixture(name: string): Promise<RedirectFixture> {
+  const directory = await temporaryDirectory({prefix: name});
+  const paths = {
+    root: directory,
+    workerFile: join(directory, 'worker.mjs'),
+  };
+
+  await writeFile(
+    join(directory, 'package.json'),
+    JSON.stringify({
+      name: 'worker-redirect-test',
+      version: '1.0.0',
+      type: 'module',
+    }, null, 2),
+  );
+
+  // Same worker code as node tests to ensure consistency
+  await writeFile(
+    paths.workerFile,
+    `
+// Simulate React Router's redirect function
+function redirect(url, init = {}) {
+  const headers = new Headers(init.headers || {});
+  headers.set('Location', url);
+  
+  return new Response(null, {
+    status: init.status || 302,
+    headers,
+  });
+}
+
+// Simulate React Router's redirectDocument function
+function redirectDocument(url, init = {}) {
+  const headers = new Headers(init.headers || {});
+  headers.set('Location', url);
+  headers.set('X-Remix-Reload-Document', 'true');
+  
+  return new Response(null, {
+    status: init.status || 302,
+    headers,
+  });
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    
+    switch (url.pathname) {
+      case '/external-redirect':
+        // Simulate OAuth redirect to external domain
+        return redirect('https://example.com/oauth');
+      
+      case '/permanent-redirect':
+        // 301 permanent redirect
+        return redirect('https://example.com/moved', { status: 301 });
+      
+      case '/redirect-with-headers':
+        // Redirect with custom headers (like Set-Cookie for sessions)
+        return redirect('https://example.com', {
+          headers: {
+            'X-Custom-Header': 'preserved',
+            'Set-Cookie': 'session=abc123',
+          }
+        });
+      
+      case '/redirect-document':
+        // React Router's redirectDocument for external navigation
+        return redirectDocument('https://external.com');
+      
+      case '/redirect-with-query':
+        // Redirect with query parameters (common in OAuth flows)
+        return redirect('https://example.com/oauth?client_id=abc123&return_url=%2Fdashboard&state=xyz789');
+      
+      case '/redirect-multiple-cookies':
+        // Multiple Set-Cookie headers (auth flow with session + refresh tokens)
+        const headers = new Headers();
+        headers.set('Location', 'https://example.com/dashboard');
+        headers.append('Set-Cookie', 'session_token=sess_abc123; Path=/; HttpOnly; Secure; SameSite=Lax');
+        headers.append('Set-Cookie', 'refresh_token=ref_xyz789; Path=/; HttpOnly; Secure; SameSite=Strict');
+        headers.append('Set-Cookie', 'user_id=12345; Path=/; Secure; SameSite=Lax');
+        
+        return new Response(null, {
+          status: 302,
+          headers,
+        });
+      
+      case '/redirect-with-csp':
+        // Redirect with security headers (CSP, X-Frame-Options, etc.)
+        return redirect('https://secure.example.com', {
+          headers: {
+            'Content-Security-Policy': "default-src 'self'; script-src 'self' 'nonce-abc123'; style-src 'self' 'unsafe-inline'",
+            'X-Frame-Options': 'DENY',
+            'X-Content-Type-Options': 'nosniff',
+          }
+        });
+      
+      default:
+        // Handle /redirect/{status} for various status codes
+        const match = url.pathname.match(/\\/redirect\\/(\\d{3})/);
+        if (match) {
+          const status = parseInt(match[1], 10);
+          return redirect('https://example.com/destination', { status });
+        }
+        
+        return new Response('Not Found', { status: 404 });
+    }
+  }
+}
+    `.trim(),
+  );
+
+  return {
+    paths,
+    getScript: async () => {
+      return readFile(paths.workerFile, 'utf-8');
+    },
+    destroy: async () => {
+      await remove(directory, {force: true, recursive: true});
+    },
+  };
+}

--- a/templates/skeleton/vite.config.ts
+++ b/templates/skeleton/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     // withtout inlining assets as base64:
     assetsInlineLimit: 0,
   },
+  server: {
+    allowedHosts: ['.tryhydrogen.dev'],
+  },
   ssr: {
     optimizeDeps: {
       /**


### PR DESCRIPTION
### WHY are these changes introduced?

MiniOxygen was breaking OAuth/PKCE authentication flows for the Customer Account API in React Router 7. When customers tried to log in, Miniflare v4 was automatically following external redirects internally instead of passing them to the browser. This prevented the OAuth flow from completing successfully.

The issue occurred because:
- Miniflare v4 by default follows redirects automatically (unlike v3)
- React Router's `redirectDocument()` expects external redirects to be handled by the browser
- OAuth flows require the browser to navigate to external authentication domains

### WHAT is this pull request doing?

This PR fixes redirect handling in MiniOxygen by:

1. **Adding `{redirect: 'manual'}` to all `dispatchFetch` calls** - Prevents Miniflare from automatically following redirects
2. **Fixing `Headers.getSetCookie()` usage** - Properly handles multiple Set-Cookie headers in responses
3. **Stabilizing the `customer-account-push` CLI flag** - Removes the `__unstable` prefix to make it production-ready
4. **Adding comprehensive test coverage** - 16 tests covering redirect behavior in both worker and node environments

The changes ensure that:
- External OAuth redirects are passed to the browser (not followed by the server)
- All redirect status codes (301, 302, 303, 307, 308) are handled correctly
- Security headers and cookies are preserved during redirects
- Query parameters in redirect URLs are maintained

### HOW to test your changes?

1. Navigate to a skeleton template directory
2. Run with Customer Account API support:
   ```bash
   SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH=true npm run dev
   ```
3. Visit the account page (e.g., `/account/orders`)
4. Click login - you should be redirected to Shopify's OAuth page
5. After authentication, you should be redirected back to your app successfully

To run the new tests:
```bash
cd packages/mini-oxygen
npm test src/node/redirect-behavior.test.ts
npm test src/worker/redirect-behavior.test.ts
```

#### Post-merge steps

None required.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation