### PR TITLE
Add ESLint promise handling rules to prevent Cloudflare Workers errors

### DIFF
--- a/.changeset/eslint-promise-rules.md
+++ b/.changeset/eslint-promise-rules.md
@@ -1,0 +1,7 @@
+---
+'skeleton': patch
+---
+
+Add TypeScript ESLint rules for promise handling to prevent Cloudflare Workers errors
+
+Added `@typescript-eslint/no-floating-promises` and `@typescript-eslint/no-misused-promises` rules to help prevent "The script will never generate a response" errors when deploying to Oxygen/Cloudflare Workers. These rules ensure promises are properly handled with await, return, or void operators, as recommended by [Cloudflare's error documentation](https://developers.cloudflare.com/workers/observability/errors/#the-script-will-never-generate-a-response-errors).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -279,6 +279,8 @@ module.exports = [
       'jsx-a11y/control-has-associated-label': 'off',
       'jsx-a11y/label-has-for': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
     },
   })),
 

--- a/templates/skeleton/eslint.config.js
+++ b/templates/skeleton/eslint.config.js
@@ -177,6 +177,8 @@ export default [
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/naming-convention': 'off',
       '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
     },
   },
   {


### PR DESCRIPTION
## Summary
- Added `@typescript-eslint/no-floating-promises` and `@typescript-eslint/no-misused-promises` ESLint rules
- Applied to both root repository config and skeleton template
- Helps prevent "The script will never generate a response" errors on Oxygen/Cloudflare Workers

## Why these changes?
Cloudflare recommends enabling these ESLint rules to catch promise handling issues that can cause runtime errors in Workers environments. When promises are not properly awaited or returned, Workers may terminate the script prematurely, leading to the dreaded "The script will never generate a response" error.

Reference: [Cloudflare Workers Error Documentation](https://developers.cloudflare.com/workers/observability/errors/#the-script-will-never-generate-a-response-errors)

## What's changed
1. **Root `eslint.config.js`**: Added the two promise rules to the TypeScript strict configuration for linted packages
2. **Skeleton template `eslint.config.js`**: Added the same rules so new Hydrogen projects have these safeguards from the start
3. **Changeset**: Added for the skeleton template change (as it affects distributed code)
