### PR TITLE
Add countryCode handling in customer login functionality

### DIFF
--- a/.changeset/tall-goats-sink.md
+++ b/.changeset/tall-goats-sink.md
@@ -1,0 +1,38 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Add `countryCode` parameter to Customer Account API login
+
+Adds support for setting the country context during customer authentication. This allows merchants to provide region-specific experiences by passing a `CountryCode` to the login method.
+
+### What's new
+
+- Added `countryCode` optional parameter to `customer.login()` options
+- The country code is passed to Shopify's authentication service as the `region_country` parameter
+- Supports all ISO 3166-1 alpha-2 country codes (e.g., 'US', 'CA', 'GB', 'AU')
+
+### Usage
+
+```tsx
+// Basic usage with country code
+const response = await customer.login({
+  countryCode: 'US'
+});
+
+// Combine with locale for full localization
+const response = await customer.login({
+  uiLocales: 'FR',
+  countryCode: 'CA'  // French-speaking customer in Canada
+});
+
+// Use with dynamic country detection
+const detectedCountry = getCountryFromRequest(request);
+const response = await customer.login({
+  countryCode: detectedCountry
+});
+```
+
+### Migration
+
+This is a non-breaking change. The `countryCode` parameter is optional and existing implementations will continue to work without modification.

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -228,6 +228,88 @@ describe('customer', () => {
           expect(url.searchParams.get('ui_locales')).toBe('fr');
         });
       });
+
+      describe('countryCode', () => {
+        it('Redirects to the customer account api login url with countryCode as param', async () => {
+          const origin = 'https://something-good.com';
+
+          const customer = createCustomerAccountClient({
+            session,
+            customerAccountId: 'customerAccountId',
+            shopId: '1',
+            request: new Request(origin),
+            waitUntil: vi.fn(),
+          });
+
+          const response = await customer.login({
+            countryCode: 'US',
+          });
+          const url = new URL(response.headers.get('location')!);
+
+          expect(url.searchParams.get('region_country')).toBe('US');
+        });
+
+        it('Includes both uiLocales and countryCode when both are provided', async () => {
+          const origin = 'https://something-good.com';
+
+          const customer = createCustomerAccountClient({
+            session,
+            customerAccountId: 'customerAccountId',
+            shopId: '1',
+            request: new Request(origin),
+            waitUntil: vi.fn(),
+          });
+
+          const response = await customer.login({
+            uiLocales: 'FR',
+            countryCode: 'CA',
+          });
+          const url = new URL(response.headers.get('location')!);
+
+          expect(url.searchParams.get('ui_locales')).toBe('fr');
+          expect(url.searchParams.get('region_country')).toBe('CA');
+        });
+
+        it('Does not include region_country param when countryCode is not provided', async () => {
+          const origin = 'https://something-good.com';
+
+          const customer = createCustomerAccountClient({
+            session,
+            customerAccountId: 'customerAccountId',
+            shopId: '1',
+            request: new Request(origin),
+            waitUntil: vi.fn(),
+          });
+
+          const response = await customer.login();
+          const url = new URL(response.headers.get('location')!);
+
+          expect(url.searchParams.get('region_country')).toBeNull();
+        });
+
+        it('Handles different country code formats', async () => {
+          const origin = 'https://something-good.com';
+
+          const customer = createCustomerAccountClient({
+            session,
+            customerAccountId: 'customerAccountId',
+            shopId: '1',
+            request: new Request(origin),
+            waitUntil: vi.fn(),
+          });
+
+          // Test with various country codes
+          const countryCodes = ['GB', 'JP', 'AU', 'DE'];
+
+          for (const code of countryCodes) {
+            const response = await customer.login({
+              countryCode: code as any,
+            });
+            const url = new URL(response.headers.get('location')!);
+            expect(url.searchParams.get('region_country')).toBe(code);
+          }
+        });
+      });
     });
 
     describe('logout', () => {

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -364,6 +364,10 @@ export function createCustomerAccountClient({
         loginUrl.searchParams.append('ui_locales', uiLocales);
       }
 
+      if (options?.countryCode) {
+        loginUrl.searchParams.append('region_country', options.countryCode);
+      }
+
       const verifier = generateCodeVerifier();
       const challenge = await generateCodeChallenge(verifier);
 

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -7,6 +7,7 @@ import type {CrossRuntimeRequest} from '../utils/request';
 import type {HydrogenSession, WaitUntil} from '../types';
 import type {
   LanguageCode,
+  CountryCode,
   BuyerInput,
 } from '@shopify/hydrogen-react/storefront-api-types';
 
@@ -51,6 +52,7 @@ export interface CustomerAccountMutations {
 
 export type LoginOptions = {
   uiLocales?: LanguageCode;
+  countryCode?: CountryCode;
 };
 
 export type LogoutOptions = {


### PR DESCRIPTION
- Introduced new tests for countryCode parameter in customer login API.
- Updated customer.ts to append region_country to login URL when countryCode is provided.
- Enhanced types.ts to include countryCode in LoginOptions interface.

This change improves the customer login experience by allowing the inclusion of country-specific parameters in the login URL, ensuring market contextualization support.

### WHY are these changes introduced?

Fixes https://github.com/shop/issues-customer-accounts-and-login/issues/1445

Currently the region_country is not being passed to the login page, the login page is not market contextualized. This change will fix that.

### WHAT is this pull request doing?

Adds a new argument to the `login` function to accept a countryCode. That country code will be passed along to the login page as the `region_country` parameter.

### HOW to test your changes?

Pass in a valid countryCode to the `customer.login` method. Click on the sign in link on the storefront. You should be redirected to the login page with the `region_country` param set with the value you provided.

#### Post-merge steps

- Update documentation here https://shopify.dev/docs/api/customer#authorization

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation
