### PR TITLE
enhancement: add country code to login function

### DIFF
--- a/.changeset/tall-goats-sink.md
+++ b/.changeset/tall-goats-sink.md
@@ -1,0 +1,45 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Add `countryCode` parameter to Customer Account API login
+
+Adds support for setting the country context during customer authentication. This allows merchants to provide region-specific experiences by passing a `CountryCode` to the login method.
+
+When a `countryCode` is provided, the Customer Accounts login page will be contextualized to the customer's current market. This includes:
+
+- The shop URL will be contextualized to the market.
+- policy URLs will be contextualized to the market.
+
+This enhancement enables seamless multi-market experiences where customers are automatically shown the right context based on their location..
+
+### What's new
+
+- Added `countryCode` optional parameter to `customer.login()` options
+- The country code is passed to Shopify's authentication service as the `region_country` parameter
+- Supports all ISO 3166-1 alpha-2 country codes (e.g., 'US', 'CA', 'GB', 'AU')
+
+### Usage
+
+```tsx
+// Basic usage with country code
+const response = await customer.login({
+  countryCode: 'US',
+});
+
+// Combine with locale for full localization
+const response = await customer.login({
+  uiLocales: 'FR',
+  countryCode: 'CA', // French-speaking customer in Canada
+});
+
+// Use with dynamic country detection
+const detectedCountry = getCountryFromRequest(request);
+const response = await customer.login({
+  countryCode: detectedCountry,
+});
+```
+
+### Migration
+
+This is a non-breaking change. The `countryCode` parameter is optional and existing implementations will continue to work without modification.

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -230,6 +230,88 @@ describe('customer', () => {
       });
     });
 
+    describe('countryCode', () => {
+      it('Redirects to the customer account api login url with countryCode as param', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login({
+          countryCode: 'US',
+        });
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('region_country')).toBe('US');
+      });
+
+      it('Includes both uiLocales and countryCode when both are provided', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login({
+          uiLocales: 'FR',
+          countryCode: 'CA',
+        });
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('ui_locales')).toBe('fr');
+        expect(url.searchParams.get('region_country')).toBe('CA');
+      });
+
+      it('Does not include region_country param when countryCode is not provided', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login();
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('region_country')).toBeNull();
+      });
+
+      it('Handles different country code formats', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        // Test with various country codes
+        const countryCodes = ['GB', 'JP', 'AU', 'DE'];
+
+        for (const code of countryCodes) {
+          const response = await customer.login({
+            countryCode: code as any,
+          });
+          const url = new URL(response.headers.get('location')!);
+          expect(url.searchParams.get('region_country')).toBe(code);
+        }
+      });
+    });
+
     describe('logout', () => {
       describe('using new auth url when shopId is present in env', () => {
         it('Redirects to the customer account api logout url', async () => {

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -365,6 +365,10 @@ export function createCustomerAccountClient({
         loginUrl.searchParams.append('ui_locales', uiLocales);
       }
 
+      if (options?.countryCode) {
+        loginUrl.searchParams.append('region_country', options.countryCode);
+      }
+
       const verifier = generateCodeVerifier();
       const challenge = await generateCodeChallenge(verifier);
 

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -5,8 +5,11 @@ import type {
 import {type GraphQLError} from '../utils/graphql';
 import type {CrossRuntimeRequest} from '../utils/request';
 import type {HydrogenSession, WaitUntil} from '../types';
+import type {
+  LanguageCode,
+  CountryCode,
+} from '@shopify/hydrogen-react/customer-account-api-types';
 import type {BuyerInput} from '@shopify/hydrogen-react/storefront-api-types';
-import type {LanguageCode} from '@shopify/hydrogen-react/customer-account-api-types';
 
 // Return type of unauthorizedHandler = Return type of loader/action function
 // This type is not exported https://github.com/remix-run/react-router/blob/main/packages/router/utils.ts#L167
@@ -49,6 +52,7 @@ export interface CustomerAccountMutations {
 
 export type LoginOptions = {
   uiLocales?: LanguageCode;
+  countryCode?: CountryCode;
 };
 
 export type LogoutOptions = {

--- a/templates/skeleton/app/routes/account_.login.tsx
+++ b/templates/skeleton/app/routes/account_.login.tsx
@@ -1,5 +1,7 @@
 import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
 
 export async function loader({request, context}: LoaderFunctionArgs) {
-  return context.customerAccount.login();
+  return context.customerAccount.login({
+    countryCode: context.storefront.i18n.country,
+  });
 }


### PR DESCRIPTION
- Introduced new tests for countryCode parameter in customer login API.
- Updated customer.ts to append region_country to login URL when countryCode is provided.
- Enhanced types.ts to include countryCode in LoginOptions interface.

This change improves the customer login experience by allowing the inclusion of country-specific parameters in the login URL, ensuring market contextualization support.

### WHY are these changes introduced?

Fixes https://github.com/shop/issues-customer-accounts-and-login/issues/1445

Currently the region_country is not being passed to the login page, the login page is not market contextualized. This change will fix that.

### WHAT is this pull request doing?


  ## Testing Instructions

  ### Basic Testing
  Pass in a valid `countryCode` to the `customer.login` method. Click on the sign in link on the storefront. You should be redirected to the login page with the `region_country` param set with the value you
  provided.

  ### Setting Up Multi-Markets in Admin

  1. **Configure Markets in Shopify Admin:**
     - Navigate to Settings → Markets in your Shopify admin
     - Create separate markets for different regions (e.g., United States, Canada)
     - For each market, configure:
       - Primary domain or subdomain (e.g., `us.example.com`, `ca.example.com`)

  ### How Multi-Markets Affect the Login Page

  When a `countryCode` is passed to `customer.login()`:

  1. **Market Contextualization:**
     - The Shop Logo URL will redirect to the market-specific URL
     - Policy URLs (Privacy Policy, Terms of Service, Refund Policy) will be contextualized to the market
     - For example, with `countryCode: 'CA'`:
       - Canadian-specific legal policies will be shown
       - URLs will reflect the Canadian domain/subdomain
     - With `countryCode: 'US'`:
       - US-specific policies and terms will be displayed
       - URLs will use the US market domain

Verification Steps

  1. Test Different Markets:
    - Access your store from different market URLs/subdomains
    - Verify the login page shop logo links back to the right market-specific URL
    - Check that policy links point to market-specific URLs

  Expected Behavior by Market

  US Market (countryCode: 'US'):
  - Login URL: https://shopify.com/.../authorize?region_country=US&...
  - Policy pages show US-specific terms
  - US domain/subdomain is used throughout

  Canadian Market (countryCode: 'CA'):
  - Login URL: https://shopify.com/.../authorize?region_country=CA&...
  - Policy pages show Canadian-specific terms
  - Canadian domain/subdomain is used throughout

### HOW to test your changes?

Pass in a valid countryCode to the `customer.login` method. Click on the sign in link on the storefront. You should be redirected to the login page with the `region_country` param set with the value you provided.

#### Post-merge steps

- Update documentation here https://shopify.dev/docs/api/customer#authorization

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation
