### PR TITLE
Fix: Major version protection should only run on PRs targeting main or release branches

### DIFF
--- a/.github/workflows/major-protection.yml
+++ b/.github/workflows/major-protection.yml
@@ -9,7 +9,11 @@ on:
 
 jobs:
   check-protection:
-    if: github.event_name == 'pull_request'
+    # Only run protection on PRs targeting main or calver release branches
+    if: |
+      github.event_name == 'pull_request' && 
+      (github.event.pull_request.base.ref == 'main' || 
+       startsWith(github.event.pull_request.base.ref, '20'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### WHY are these changes introduced?

The Major Version Protection workflow was incorrectly blocking ALL pull requests containing major version changes, regardless of their target branch. This was preventing normal feature branch development workflows where branches merge into other feature branches before eventually reaching main.

**Evidence of the issue:**
- PR #3141 targeting `feat/cli-diff-removal` (not main) was blocked by major version protection
- The workflow triggered on all `pull_request` events without checking the base branch
- This breaks common workflows like feature→feature merges and staging branches

### WHAT is this pull request doing?

This PR fixes the Major Version Protection workflow to only run on PRs that are actually targeting protected branches:
- PRs targeting `main` branch
- PRs targeting calver release branches (e.g., `2024-01`, `2025-07`)

**The fix:** Updates the workflow's `if` condition to check `github.event.pull_request.base.ref` before running the protection job.

```yaml
# Before - runs on ALL PRs
if: github.event_name == 'pull_request'

# After - only runs on PRs targeting main or release branches  
if: |
  github.event_name == 'pull_request' && 
  (github.event.pull_request.base.ref == 'main' || 
   startsWith(github.event.pull_request.base.ref, '20'))
```

### HOW to test your changes?

1. Create a PR with major changes targeting a feature branch → Protection should NOT run
2. Create a PR with major changes targeting main → Protection SHOULD run
3. Create a PR with major changes targeting a release branch like `2025-01` → Protection SHOULD run
4. The `/bypass-major-safeguard` command should still work on protected PRs

### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation