### PR TITLE
Fix CalVer major changeset detection for single-quoted YAML

### DIFF
--- a/.changeset/calver-shared.js
+++ b/.changeset/calver-shared.js
@@ -100,7 +100,8 @@ function hasMajorChangesets() {
       
       // Check for major bumps in any CalVer package
       for (const pkg of CALVER_PACKAGES) {
-        if (content.includes(`"${pkg}": major`)) {
+        // Check for both single and double quotes (changesets can use either)
+        if (content.includes(`"${pkg}": major`) || content.includes(`'${pkg}': major`)) {
           return true;
         }
       }
@@ -128,9 +129,10 @@ function hasCalVerChangesets() {
       
       // Check for any bumps (patch, minor, major) in CalVer packages
       for (const pkg of CALVER_PACKAGES) {
-        if (content.includes(`"${pkg}": patch`) || 
-            content.includes(`"${pkg}": minor`) || 
-            content.includes(`"${pkg}": major`)) {
+        // Check for both single and double quotes (changesets can use either)
+        if (content.includes(`"${pkg}": patch`) || content.includes(`'${pkg}': patch`) ||
+            content.includes(`"${pkg}": minor`) || content.includes(`'${pkg}': minor`) ||
+            content.includes(`"${pkg}": major`) || content.includes(`'${pkg}': major`)) {
           return true;
         }
       }

--- a/.github/workflows/test-calver.yml
+++ b/.github/workflows/test-calver.yml
@@ -227,6 +227,18 @@ jobs:
           echo "Expected: Correctly detect current and next release branches"
           echo ""
           
+          # First check if there are already major changesets in the repo
+          HAS_EXISTING_MAJOR=$(node .changeset/calver-shared.js has-major-changesets)
+          echo "Repository has existing major changesets: $HAS_EXISTING_MAJOR"
+          echo ""
+          
+          # Store and temporarily remove existing changesets to test clean state
+          if [ "$HAS_EXISTING_MAJOR" = "true" ]; then
+            echo "Temporarily moving existing changesets for isolated testing..."
+            mkdir -p .changeset-backup
+            mv .changeset/*.md .changeset-backup/ 2>/dev/null || true
+          fi
+          
           # Test without major changesets
           echo "Testing branch detection without major changesets:"
           BRANCH=$(node .changeset/get-calver-version-branch.js)
@@ -235,6 +247,11 @@ jobs:
             echo "✅ Correctly detected current branch (2025-05)"
           else
             echo "❌ Branch detection failed, expected 2025-05, got $BRANCH"
+            # Restore changesets before failing
+            if [ "$HAS_EXISTING_MAJOR" = "true" ]; then
+              mv .changeset-backup/*.md .changeset/ 2>/dev/null || true
+              rmdir .changeset-backup 2>/dev/null || true
+            fi
             exit 1
           fi
           
@@ -254,10 +271,25 @@ jobs:
             echo "✅ Correctly detected next quarter branch (2025-07)"
           else
             echo "❌ Branch detection failed, expected 2025-07, got $BRANCH"
+            # Restore changesets before failing
+            rm .changeset/test-major-branch.md 2>/dev/null || true
+            if [ "$HAS_EXISTING_MAJOR" = "true" ]; then
+              mv .changeset-backup/*.md .changeset/ 2>/dev/null || true
+              rmdir .changeset-backup 2>/dev/null || true
+            fi
             exit 1
           fi
           
           rm .changeset/test-major-branch.md
+          
+          # Restore original changesets
+          if [ "$HAS_EXISTING_MAJOR" = "true" ]; then
+            echo ""
+            echo "Restoring original changesets..."
+            mv .changeset-backup/*.md .changeset/ 2>/dev/null || true
+            rmdir .changeset-backup 2>/dev/null || true
+          fi
+          
           echo "::endgroup::"
 
       - name: Test 6 - Shared Utilities CLI


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes CI failure: https://github.com/Shopify/hydrogen/actions/runs/17656282664/job/50179717816

The CI release workflow was failing with: `Error: Invalid quarter in version 2026.0.1: 0 not in [1,4,7,10]`

This occurred because the CalVer enforcement script wasn't detecting major changesets that use single quotes in their YAML frontmatter, causing it to miscalculate versions.

### WHAT is this pull request doing?

Updates the changeset detection functions in `.changeset/calver-shared.js` to handle both single and double quotes in YAML frontmatter.

<details>
<summary>Technical Details</summary>

The issue flow:
1. Changesets use single quotes: `'@shopify/hydrogen': major`
2. Detection functions only checked for double quotes: `"@shopify/hydrogen": major`
3. This caused `hasMajorChangesets()` to return `false` instead of `true`
4. CI calculated patch version (2025.5.1) instead of major (2025.7.0)
5. Changesets generated invalid version 2026.0.x
6. CalVer validation failed with quarter value 0

</details>

**Changes:**
```diff
// Check for major bumps in any CalVer package
for (const pkg of CALVER_PACKAGES) {
-  if (content.includes(`"${pkg}": major`)) {
+  // Check for both single and double quotes (changesets can use either)
+  if (content.includes(`"${pkg}": major`) || content.includes(`'${pkg}': major`)) {
    return true;
  }
}
```

### HOW to test your changes?

#### 1. Verify Detection Works

```bash
# Confirm major changesets are now detected
node .changeset/calver-shared.js has-major-changesets
# Expected: true

# Verify correct branch calculation
npm run test:calver:branch
# Expected: 2025-07

# Run comprehensive CalVer test
npm run test:calver
# Expected: CalVer versions show 2025.7.0
```

#### 2. Simulate CI Workflow

```bash
# Dry run to see version calculations
npm run test:calver:dry
# Expected output:
# @shopify/hydrogen: 2025.5.0 → 2025.7.0
# @shopify/hydrogen-react: 2025.5.0 → 2025.7.0
# skeleton: 2025.5.2 → 2025.7.0
```

#### 3. Validate Fix Impact

| Package | Current | Will Be | Type |
|---------|---------|---------|------|
| @shopify/hydrogen | 2025.5.0 | 2025.7.0 | CalVer major |
| @shopify/hydrogen-react | 2025.5.0 | 2025.7.0 | CalVer major |
| skeleton | 2025.5.2 | 2025.7.0 | CalVer major |
| @shopify/cli-hydrogen | 11.1.3 | 12.0.0 | SemVer major |
| @shopify/mini-oxygen | 3.2.1 | 4.0.0 | SemVer major |
| @shopify/create-hydrogen | 5.0.24 | 5.0.25 | SemVer patch |

#### Post-merge steps

None required - CI will automatically create the correct version PR once this merges.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes (N/A - CI fix)
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes (existing test suite validates)
- [ ] I've added or updated the documentation (N/A - internal CI fix)