### PR TITLE
Include `cdn.shopify.com` by default in CSP connectSrc

### DIFF
--- a/.changeset/sixty-apples-cut.md
+++ b/.changeset/sixty-apples-cut.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Include `cdn.shopify.com` by default in CSP connectSrc

--- a/packages/hydrogen/src/csp/csp.test.ts
+++ b/packages/hydrogen/src/csp/csp.test.ts
@@ -18,7 +18,7 @@ afterEach(() => {
 describe('createContentSecurityPolicy', () => {
   it('creates default policy', () => {
     expect(createContentSecurityPolicy().header).toMatchInlineSnapshot(
-      `"base-uri 'self'; default-src 'self' https://cdn.shopify.com https://shopify.com 'nonce-somenonce'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline' https://cdn.shopify.com; connect-src 'self' https://monorail-edge.shopifysvc.com"`,
+      `"base-uri 'self'; default-src 'self' https://cdn.shopify.com https://shopify.com 'nonce-somenonce'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline' https://cdn.shopify.com; connect-src 'self' https://cdn.shopify.com/ https://monorail-edge.shopifysvc.com"`,
     );
   });
 
@@ -28,7 +28,7 @@ describe('createContentSecurityPolicy', () => {
         styleSrc: ['https://some-custom-css.cdn'],
       }).header,
     ).toMatchInlineSnapshot(
-      `"base-uri 'self'; default-src 'self' https://cdn.shopify.com https://shopify.com 'nonce-somenonce'; frame-ancestors 'none'; style-src https://some-custom-css.cdn 'self' 'unsafe-inline' https://cdn.shopify.com; connect-src 'self' https://monorail-edge.shopifysvc.com"`,
+      `"base-uri 'self'; default-src 'self' https://cdn.shopify.com https://shopify.com 'nonce-somenonce'; frame-ancestors 'none'; style-src https://some-custom-css.cdn 'self' 'unsafe-inline' https://cdn.shopify.com; connect-src 'self' https://cdn.shopify.com/ https://monorail-edge.shopifysvc.com"`,
     );
   });
 
@@ -41,7 +41,7 @@ describe('createContentSecurityPolicy', () => {
         },
       }).header,
     ).toMatchInlineSnapshot(
-      `"base-uri 'self'; default-src 'self' https://cdn.shopify.com https://shopify.com 'nonce-somenonce'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline' https://cdn.shopify.com; connect-src 'self' https://monorail-edge.shopifysvc.com https://checkout.myshopify.com https://test.myshopify.com"`,
+      `"base-uri 'self'; default-src 'self' https://cdn.shopify.com https://shopify.com 'nonce-somenonce'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline' https://cdn.shopify.com; connect-src 'self' https://cdn.shopify.com/ https://monorail-edge.shopifysvc.com https://checkout.myshopify.com https://test.myshopify.com"`,
     );
   });
 
@@ -51,7 +51,7 @@ describe('createContentSecurityPolicy', () => {
         scriptSrc: ['https://some-custom-css.cdn'],
       }).header,
     ).toMatchInlineSnapshot(
-      `"base-uri 'self'; default-src 'self' 'nonce-somenonce' https://cdn.shopify.com https://shopify.com; frame-ancestors 'none'; style-src 'self' 'unsafe-inline' https://cdn.shopify.com; connect-src 'self' https://monorail-edge.shopifysvc.com; script-src https://some-custom-css.cdn 'nonce-somenonce'"`,
+      `"base-uri 'self'; default-src 'self' 'nonce-somenonce' https://cdn.shopify.com https://shopify.com; frame-ancestors 'none'; style-src 'self' 'unsafe-inline' https://cdn.shopify.com; connect-src 'self' https://cdn.shopify.com/ https://monorail-edge.shopifysvc.com; script-src https://some-custom-css.cdn 'nonce-somenonce'"`,
     );
   });
 

--- a/packages/hydrogen/src/csp/csp.ts
+++ b/packages/hydrogen/src/csp/csp.ts
@@ -89,7 +89,11 @@ function createCSPHeader(
   const {shop, ...directives} = props ?? {};
   const nonceString = `'nonce-${nonce}'`;
   const styleSrc = ["'self'", "'unsafe-inline'", 'https://cdn.shopify.com'];
-  const connectSrc = ["'self'", 'https://monorail-edge.shopifysvc.com'];
+  const connectSrc = [
+    "'self'",
+    'https://cdn.shopify.com/',
+    'https://monorail-edge.shopifysvc.com',
+  ];
   if (shop && shop.checkoutDomain) {
     connectSrc.push(`https://${shop.checkoutDomain}`);
   }


### PR DESCRIPTION

### WHY are these changes introduced?

<img width="974" height="452" alt="Screenshot 2025-09-16 at 1 01 47 PM" src="https://github.com/user-attachments/assets/42031184-6033-448f-a8a5-83073bf4ba78" />

### WHAT is this pull request doing?

Adds `cdn.shopify.com` to `connectSrc`

### HOW to test your changes?

h2 link > `hydrogen-preview`

#### Post-merge steps

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [] I've added or updated the documentation

