### PR TITLE
[2025.7.0] Add changelog entry for Hydrogen 2025.7.0 release 

### DIFF
--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -15,7 +15,7 @@
         "react-router-dom": "7.8.2"
       },
       "devDependencies": {
-        "@shopify/mini-oxygen": "^4.0.0",
+        "@shopify/mini-oxygen": "4.0.0",
         "@shopify/cli": "3.83.3",
         "@react-router/dev": "7.8.2",
         "@react-router/fs-routes": "7.8.2"
@@ -31,7 +31,41 @@
         "@remix-run/fs-routes",
         "@remix-run/route-config"
       ],
-      "dependenciesMeta": {},
+      "dependenciesMeta": {
+        "@shopify/cli": {
+          "required": true
+        },
+        "react-router": {
+          "required": true
+        },
+        "@react-router/dev": {
+          "required": true
+        },
+        "@react-router/fs-routes": {
+          "required": true
+        },
+        "@shopify/mini-oxygen": {
+          "required": true
+        },
+        "@shopify/remix-oxygen": {
+          "required": false
+        },
+        "@remix-run/react": {
+          "required": false
+        },
+        "@remix-run/server-runtime": {
+          "required": false
+        },
+        "@remix-run/dev": {
+          "required": false
+        },
+        "@remix-run/fs-routes": {
+          "required": false
+        },
+        "@remix-run/route-config": {
+          "required": false
+        }
+      },
       "fixes": [
         {
           "title": "Fix OAuth redirect handling for Customer Account API flows",

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -11,8 +11,8 @@
       "pr": "https://github.com/Shopify/hydrogen/pull/3166",
       "dependencies": {
         "@shopify/hydrogen": "2025.7.0",
-        "react-router": "7.9.1",
-        "react-router-dom": "7.9.1"
+        "react-router": "7.8.2",
+        "react-router-dom": "7.8.2"
       },
       "devDependencies": {
         "@shopify/mini-oxygen": "^4.0.0",

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -3,34 +3,42 @@
   "version": "1",
   "releases": [
     {
-      "title": "React Router 7.9.x migration with API version 2025-07",
+      "title": "React Router 7 migration with API version 2025-07",
       "version": "2025.7.0",
-      "date": "2025-09-24",
+      "date": "2025-09-17",
       "hash": "pending-merge",
       "commit": "https://github.com/Shopify/hydrogen/pull/3166",
       "pr": "https://github.com/Shopify/hydrogen/pull/3166",
       "dependencies": {
         "@shopify/hydrogen": "2025.7.0",
-        "react-router": "7.9.1",
-        "react-router-dom": "7.9.1"
+        "react-router": "7.9.2",
+        "react-router-dom": "7.9.2",
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
       },
       "devDependencies": {
         "@shopify/mini-oxygen": "4.0.0",
-        "@shopify/cli": "3.84.1",
-        "@react-router/dev": "7.9.1",
-        "@react-router/fs-routes": "7.9.1"
+        "@shopify/cli": "3.83.3",
+        "@react-router/dev": "7.9.2",
+        "@react-router/fs-routes": "7.9.2"
       },
       "removeDependencies": [
         "@shopify/hydrogen",
         "@shopify/remix-oxygen",
         "@remix-run/react",
-        "@remix-run/server-runtime"
+        "@remix-run/server-runtime",
+        "react-router",
+        "react-router-dom",
+        "react",
+        "react-dom",
+        "@react-router/node"
       ],
       "removeDevDependencies": [
         "@remix-run/dev",
         "@remix-run/fs-routes",
-        "@remix-run/eslint-config",
-        "@remix-run/route-config"
+        "@remix-run/route-config",
+        "@react-router/fs-routes",
+        "@react-router/dev"
       ],
       "dependenciesMeta": {
         "@shopify/cli": {
@@ -65,39 +73,23 @@
         },
         "@remix-run/route-config": {
           "required": false
-        },
-        "@remix-run/eslint-config": {
-          "required": false
         }
       },
       "fixes": [
         {
-          "title": "Fix OAuth redirect handling for Customer Account API flows",
-          "info": "MiniOxygen now correctly handles external redirects by passing them to the browser instead of following them internally, ensuring OAuth/PKCE authentication flows work properly.",
-          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
-          "id": "3082"
-        },
-        {
           "title": "Stabilize Customer Account API development flag",
-          "info": "The --customer-account-push flag is now stable and ready for production use, enabling tunneling for local development with Customer Account API OAuth flows.",
+          "info": "The --customer-account-push flag is now stable, enabling tunneling for local development with Customer Account API OAuth flows.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3082",
           "id": "3082-flag"
         },
         {
           "title": "Fix defer/streaming in development & preview",
-          "info": "Resolves issues with GraphQL @defer directive and streaming responses in development and preview environments, ensuring proper async data loading behavior matches production.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039"
         },
         {
-          "title": "Fix CSP NonceProvider hydration error",
-          "info": "Fixed React Context error that occurred during client-side hydration when using Content Security Policy (CSP) with nonces.",
-          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
-          "id": "3082-nonce"
-        },
-        {
           "title": "Fix GraphQL client development warnings",
-          "info": "Eliminates sourcemap warnings and prevents unexpected page reloads during development.",
+          "info": "Remove sourcemap warnings and page reloads during development.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3108",
           "id": "3108"
         },
@@ -120,14 +112,8 @@
           "id": "3139"
         },
         {
-          "title": "Display cart user errors in skeleton template",
-          "info": "Cart mutations now properly display user errors such as invalid discount codes or gift cards.",
-          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
-          "id": "3082-errors"
-        },
-        {
           "title": "Add TypeScript ESLint rules for promise handling",
-          "info": "Prevents 'The script will never generate a response' errors when deploying to Oxygen/Cloudflare Workers.",
+          "info": "Add TypeScript ESLint rules for promise handling to avoid deployment errors on Oxygen/Cloudflare Workers.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3146",
           "id": "3146"
         },
@@ -139,19 +125,16 @@
         },
         {
           "title": "Add --force-client-sourcemap flag to deploy command",
-          "info": "New CLI flag that forces inclusion of client-side sourcemaps in production deployments for enhanced debugging capabilities when needed.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-sourcemap"
         },
         {
           "title": "Add Vite v7 exports support",
-          "info": "Adds compatibility with Vite 7's new module export patterns, ensuring smooth builds and proper tree-shaking with the latest Vite version.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-vite"
         },
         {
           "title": "Fix and upgrade GraphiQL route",
-          "info": "Updates the GraphiQL development tool to the latest version with improved UI and fixes for query execution in the development environment.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-graphiql"
         },
@@ -165,7 +148,7 @@
       "features": [
         {
           "title": "Migrate to React Router 7.9.x",
-          "info": "This major release migrates Hydrogen to React Router 7.9.x, introducing automatic type generation, enhanced type safety, and modernized APIs. The @shopify/remix-oxygen package is no longer needed.",
+          "info": "Migrates Hydrogen to React Router 7.9.x with automatic type generation and improved type safety. Removes @shopify/remix-oxygen package.",
           "breaking": true,
           "steps": [
             {
@@ -174,13 +157,27 @@
               "code": "YGBgZGlmZgpucHggQGNvZGVtb2QuY29tL2NvZGVtb2QgcmVtaXgvMi9yZWFjdC1yb3V0ZXIvdXBncmFkZQpgYGAK"
             },
             {
-              "title": "Update remaining import statements manually",
-              "info": "Change all @shopify/remix-oxygen and @remix-run/* imports to react-router or @shopify/hydrogen/oxygen",
-              "code": "YGBgZGlmZgotIGltcG9ydCB7cmVkaXJlY3QsIHR5cGUgTG9hZGVyRnVuY3Rpb25BcmdzfSBmcm9tICJAc2hvcGlmeS9yZW1peC1veHlnZW4iOwotIGltcG9ydCB7dXNlTG9hZGVyRGF0YSwgdHlwZSBNZXRhRnVuY3Rpb259IGZyb20gIkByZW1peC1ydW4vcmVhY3QiOworIGltcG9ydCB7cmVkaXJlY3QsIHVzZUxvYWRlckRhdGF9IGZyb20gInJlYWN0LXJvdXRlciI7CisgaW1wb3J0IHR5cGUge1JvdXRlfSBmcm9tICIuLyt0eXBlcy9yb3V0ZS1uYW1lIjsKYGBgCg=="
+              "title": "Update @shopify/remix-oxygen imports",
+              "info": "Replace @shopify/remix-oxygen imports with react-router equivalents",
+              "code": "YGBgZGlmZgotIGltcG9ydCB7cmVkaXJlY3QsIHR5cGUgTG9hZGVyRnVuY3Rpb25BcmdzfSBmcm9tICJAc2hvcGlmeS9yZW1peC1veHlnZW4iOworIGltcG9ydCB7cmVkaXJlY3R9IGZyb20gInJlYWN0LXJvdXRlciI7CisgaW1wb3J0IHR5cGUge0xvYWRlckZ1bmN0aW9uQXJnc30gZnJvbSAiQHNob3BpZnkvaHlkcm9nZW4vb3h5Z2VuIjsKYGBgCg=="
+            },
+            {
+              "title": "Update @remix-run/react imports",
+              "info": "Replace @remix-run/react imports with react-router equivalents",
+              "code": "YGBgZGlmZgotIGltcG9ydCB7dXNlTG9hZGVyRGF0YSwgdHlwZSBNZXRhRnVuY3Rpb259IGZyb20gIkByZW1peC1ydW4vcmVhY3QiOworIGltcG9ydCB7dXNlTG9hZGVyRGF0YX0gZnJvbSAicmVhY3Qtcm91dGVyIjsKYGBgCg=="
+            },
+            {
+              "title": "Add React Router 7 route type imports",
+              "info": "Import route-specific types from React Router 7's new type generation system",
+              "code": "YGBgZGlmZgorIGltcG9ydCB0eXBlIHtSb3V0ZX0gZnJvbSAiLi8rdHlwZXMvcm91dGUtbmFtZSI7CmBgYAo="
             },
             {
               "title": "Add .react-router to .gitignore",
               "info": "React Router 7 generates type files that should not be committed to version control",
+              "code": "YGBgZGlmZgplY2hvICIucmVhY3Qtcm91dGVyLyIgPj4gLmdpdGlnbm9yZQpgYGAK"
+            },
+            {
+              "title": "Update applicable package.json scripts to use react-router typegen",
               "code": "YGBgZGlmZgplY2hvICIucmVhY3Qtcm91dGVyLyIgPj4gLmdpdGlnbm9yZQpgYGAK"
             },
             {
@@ -193,27 +190,57 @@
           "id": "3141"
         },
         {
-          "title": "Update to Storefront API and Customer Account API version 2025-07",
-          "info": "Updated API version constants, regenerated GraphQL types, and updated all API references. Breaking changes may occur due to API schema changes between versions.",
+          "title": "Adopt new React Router context infrastructure and preset",
+          "info": "Major infrastructure changes including new createRequestHandler, hydrogenPreset configuration, enhanced context patterns, and React Context hydration fixes.",
           "breaking": true,
-          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
-          "id": "3082-api"
-        },
-        {
-          "title": "Add React Router 7.9.x context infrastructure",
-          "info": "New createRequestHandler export from @shopify/hydrogen/oxygen and hydrogenPreset for React Router configuration.",
+          "steps": [
+            {
+              "title": "Update server.ts to use new createRequestHandler",
+              "info": "Replace @shopify/remix-oxygen import with @shopify/hydrogen/oxygen for enhanced functionality",
+              "code": "YGBgZGlmZgovLyBzZXJ2ZXIudHMKLSBpbXBvcnQge2NyZWF0ZVJlcXVlc3RIYW5kbGVyfSBmcm9tICJAc2hvcGlmeS9yZW1peC1veHlnZW4iOworIGltcG9ydCB7Y3JlYXRlUmVxdWVzdEhhbmRsZXJ9IGZyb20gIkBzaG9waWZ5L2h5ZHJvZ2VuL294eWdlbiI7CmBgYAo="
+            },
+            {
+              "title": "Add react-router.config.ts with hydrogenPreset",
+              "info": "Create configuration file with Hydrogen's optimized React Router settings",
+              "code": "YGBgdHlwZXNjcmlwdAovLyByZWFjdC1yb3V0ZXIuY29uZmlnLnRzCmltcG9ydCB0eXBlIHtDb25maWd9IGZyb20gIkByZWFjdC1yb3V0ZXIvZGV2L2NvbmZpZyI7CmltcG9ydCB7aHlkcm9nZW5QcmVzZXR9IGZyb20gIkBzaG9waWZ5L2h5ZHJvZ2VuL3JlYWN0LXJvdXRlci1wcmVzZXQiOwoKZXhwb3J0IGRlZmF1bHQgewogIHByZXNldHM6IFtoeWRyb2dlblByZXNldCgpXSwKfSBzYXRpc2ZpZXMgQ29uZmlnOwpgYGEK"
+            },
+            {
+              "title": "Update entry.server.tsx type annotations",
+              "info": "Replace AppLoadContext with HydrogenRouterContextProvider for enhanced type safety",
+              "code": "YGBgZGlmZgovLyBhcHAvZW50cnkuc2VydmVyLnRzeAotIGltcG9ydCB0eXBlIHtBcHBMb2FkQ29udGV4dH0gZnJvbSAiQHNob3BpZnkvcmVtaXgtb3h5Z2VuIjsKaW1wb3J0IHtTZXJ2ZXJSb3V0ZXJ9IGZyb20gInJlYWN0LXJvdXRlciI7CmltcG9ydCB7CiAgY3JlYXRlQ29udGVudFNlY3VyaXR5UG9saWN5LAorIHR5cGUgSHlkcm9nZW5Sb3V0ZXJDb250ZXh0UHJvdmlkZXIsCn0gZnJvbSAiQHNob3BpZnkvaHlkcm9nZW4iOwppbXBvcnQgdHlwZSB7RW50cnlDb250ZXh0fSBmcm9tICJyZWFjdC1yb3V0ZXIiOwoKZXhwb3J0IGRlZmF1bHQgYXN5bmMgZnVuY3Rpb24gaGFuZGxlUmVxdWVzdCgKICByZXF1ZXN0OiBSZXF1ZXN0LAogIHJlc3BvbnNlU3RhdHVzQ29kZTogbnVtYmVyLAogIHJlc3BvbnNlSGVhZGVyczogSGVhZGVycywKICByZWFjdFJvdXRlckNvbnRleHQ6IEVudHJ5Q29udGV4dCwKLSBjb250ZXh0OiBBcHBMb2FkQ29udGV4dCwKKyBjb250ZXh0OiBIeWRyb2dlblJvdXRlckNvbnRleHRQcm92aWRlciwKKSB7CiAgLy8gUmVzdCBvZiBpbXBsZW1lbnRhdGlvbiB1bmNoYW5nZWQKfQpgYGAK"
+            }
+          ],
           "pr": "https://github.com/Shopify/hydrogen/pull/3142",
           "id": "3142"
         },
         {
-          "title": "Add countryCode parameter to Customer Account API login",
-          "info": "Enables region-specific experiences by passing a CountryCode to the login method for contextualized authentication.",
+          "title": "Adopt new NonceProvider in entry client",
+          "breaking": true,
+          "steps": [
+            {
+              "title": "Update entry.client.tsx to include NonceProvider wrapper",
+              "info": "Wrap your app with NonceProvider during hydration to avoid 'Cannot read properties of null (reading 'useContext')' errors",
+              "code": "YGBgZGlmZgovLyBhcHAvZW50cnkuY2xpZW50LnRzeAppbXBvcnQge0h5ZHJhdGVkUm91dGVyfSBmcm9tICJyZWFjdC1yb3V0ZXIvZG9tIjsKaW1wb3J0IHtzdGFydFRyYW5zaXRpb24sIFN0cmljdE1vZGV9IGZyb20gInJlYWN0IjsKaW1wb3J0IHtoeWRyYXRlUm9vdH0gZnJvbSAicmVhY3QtZG9tL2NsaWVudCI7CisgaW1wb3J0IHtOb25jZVByb3ZpZGVyfSBmcm9tICJAc2hvcGlmeS9oeWRyb2dlbiI7CgppZiAoIXdpbmRvdy5sb2NhdGlvbi5vcmlnaW4uaW5jbHVkZXMoIndlYmNhY2hlLmdvb2dsZXVzZXJjb250ZW50LmNvbSIpKSB7CiAgc3RhcnRUcmFuc2l0aW9uKCgpID0+IHsKKyAgIC8vIEV4dHJhY3Qgbm9uY2UgZnJvbSBleGlzdGluZyBzY3JpcHQgdGFncworICAgY29uc3QgZXhpc3RpbmdOb25jZSA9IGRvY3VtZW50CisgICAgIC5xdWVyeVNlbGVjdG9yPEhUTUxTY3JpcHRFbGVtZW50Pigic2NyaXB0W25vbmNlXSIpCisgICAgID8ubm9uY2U7CisKICAgIGh5ZHJhdGVSb290KAogICAgICBkb2N1bWVudCwKICAgICAgPFN0cmljdE1vZGU+Ci0gICAgICAgPEh5ZHJhdGVkUm91dGVyIC8+CisgICAgICAgPE5vbmNlUHJvdmlkZXIgdmFsdWU9e2V4aXN0aW5nTm9uY2V9PgorICAgICAgICAgPEh5ZHJhdGVkUm91dGVyIC8+CisgICAgICAgPC9Ob25jZVByb3ZpZGVyPgogICAgICA8L1N0cmljdE1vZGU+LAogICAgKTsKICB9KTsKfQpgYGAK"
+            }
+          ],
+          "pr": "https://github.com/Shopify/hydrogen/pull/3142",
+          "id": "3142"
+        },
+        {
+          "title": "Updated Storefront API and Customer Account API version 2025-07",
+          "breaking": false,
+          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
+          "id": "3082"
+        },
+        {
+          "title": "Added countryCode parameter to Customer Account API login",
+          "info": "Add countryCode parameter to Customer Account API login method.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3148",
           "id": "3148"
         },
         {
           "title": "Add support for removing individual gift cards from cart",
-          "info": "Introduces cartGiftCardCodesRemove mutation to remove specific gift cards by their IDs, solving the limitation where only the last 4 digits were available.",
+          "info": "Add cartGiftCardCodesRemove mutation to remove specific gift cards by their IDs.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3128",
           "id": "3128"
         },
@@ -221,29 +248,26 @@
           "title": "Upgrade Miniflare from v2 to v3",
           "info": "Internal MiniOxygen API refactored to work with Miniflare v3's new architecture, improving development server performance and compatibility.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
-          "id": "3039-miniflare"
+          "id": "3039"
         },
         {
           "title": "Add order filtering support to Customer Account API orders route",
-          "info": "Skeleton template now supports order filtering in the /account/orders route for improved user experience.",
+          "info": "Add order filtering support to /account/orders route in skeleton template.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3125",
           "id": "3125"
         },
         {
           "title": "Add fulfillmentStatus to Customer Account API order query",
-          "info": "Extends the Customer Account API order query to include fulfillmentStatus field, enabling tracking of order shipping and delivery states in customer-facing interfaces.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-fulfillment"
         },
         {
           "title": "Add @inContext language support to Customer Account API mutations",
-          "info": "Enables language-specific responses in Customer Account API mutations using the @inContext directive for improved internationalization support.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-incontext"
         },
         {
           "title": "Add GraphQL @defer directive support to storefront client",
-          "info": "Implements support for GraphQL's @defer directive in the storefront client, allowing incremental data loading for improved perceived performance on complex queries.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-defer"
         },

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -21,6 +21,7 @@
         "@react-router/fs-routes": "7.8.2"
       },
       "removeDependencies": [
+        "@shopify/hydrogen",
         "@shopify/remix-oxygen",
         "@remix-run/react",
         "@remix-run/server-runtime"

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@shopify/mini-oxygen": "^4.0.0",
-        "@shopify/cli": "~3.83.3",
+        "@shopify/cli": "3.83.3",
         "@react-router/dev": "7.8.2",
         "@react-router/fs-routes": "7.8.2"
       },

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -154,7 +154,7 @@
             {
               "title": "Run the automated migration codemod",
               "info": "This codemod will automatically update most imports and references from Remix to React Router",
-              "code": "YGBgZGlmZgpucHggQGNvZGVtb2QuY29tL2NvZGVtb2QgcmVtaXgvMi9yZWFjdC1yb3V0ZXIvdXBncmFkZQpgYGAK"
+              "code": "YGBgZGlmZgpucHggY29kZW1vZEBsYXRlc3QgcmVtaXgvMi9yZWFjdC1yb3V0ZXIvdXBncmFkZQpgYGAK"
             },
             {
               "title": "Update @shopify/remix-oxygen imports",

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -3,6 +3,203 @@
   "version": "1",
   "releases": [
     {
+      "title": "React Router 7 migration with API version 2025-07",
+      "version": "2025.7.0",
+      "date": "2025-09-17",
+      "hash": "pending-merge",
+      "commit": "https://github.com/Shopify/hydrogen/pull/3166",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3166",
+      "dependencies": {
+        "@shopify/hydrogen": "2025.7.0",
+        "react-router": "7.9.1",
+        "react-router-dom": "7.9.1"
+      },
+      "devDependencies": {
+        "@shopify/mini-oxygen": "^4.0.0",
+        "@shopify/cli": "~3.83.3"
+      },
+      "removeDependencies": ["@shopify/remix-oxygen"],
+      "removeDevDependencies": [],
+      "dependenciesMeta": {},
+      "fixes": [
+        {
+          "title": "Fix OAuth redirect handling for Customer Account API flows",
+          "info": "MiniOxygen now correctly handles external redirects by passing them to the browser instead of following them internally, ensuring OAuth/PKCE authentication flows work properly.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
+          "id": "3082"
+        },
+        {
+          "title": "Stabilize Customer Account API development flag",
+          "info": "The --customer-account-push flag is now stable and ready for production use, enabling tunneling for local development with Customer Account API OAuth flows.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
+          "id": "3082-flag"
+        },
+        {
+          "title": "Fix defer/streaming in development & preview",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3039",
+          "id": "3039"
+        },
+        {
+          "title": "Fix CSP NonceProvider hydration error",
+          "info": "Fixed React Context error that occurred during client-side hydration when using Content Security Policy (CSP) with nonces.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
+          "id": "3082-nonce"
+        },
+        {
+          "title": "Fix GraphQL client development warnings",
+          "info": "Eliminates sourcemap warnings and prevents unexpected page reloads during development.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3108",
+          "id": "3108"
+        },
+        {
+          "title": "Fix Money component compatibility with USDC currency",
+          "info": "Updates Money component to handle unsupported currency codes like USDC from Customer Account API.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
+          "id": "3082-money"
+        },
+        {
+          "title": "Fix parseMetafield money type currency handling",
+          "info": "Transform currency_code (from Storefront API) to currencyCode (expected by MoneyV2 type).",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3072",
+          "id": "3072"
+        },
+        {
+          "title": "Fix TypeScript enum compatibility between APIs",
+          "info": "Updated codegen to reference Storefront API's LanguageCode and CurrencyCode enums for Customer Account API types.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3139",
+          "id": "3139"
+        },
+        {
+          "title": "Display cart user errors in skeleton template",
+          "info": "Cart mutations now properly display user errors such as invalid discount codes or gift cards.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
+          "id": "3082-errors"
+        },
+        {
+          "title": "Add TypeScript ESLint rules for promise handling",
+          "info": "Prevents 'The script will never generate a response' errors when deploying to Oxygen/Cloudflare Workers.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3146",
+          "id": "3146"
+        },
+        {
+          "title": "Fix environment variable quoting in env pull command",
+          "info": "Properly handles shell metacharacters in environment variables.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3050",
+          "id": "3050"
+        },
+        {
+          "title": "Add --force-client-sourcemap flag to deploy command",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3039",
+          "id": "3039-sourcemap"
+        },
+        {
+          "title": "Add Vite v7 exports support",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3039",
+          "id": "3039-vite"
+        },
+        {
+          "title": "Fix and upgrade GraphiQL route",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3039",
+          "id": "3039-graphiql"
+        },
+        {
+          "title": "Replace deprecated faker.internet.color()",
+          "info": "Updated to use faker.color.rgb() instead.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/2985",
+          "id": "2985"
+        }
+      ],
+      "features": [
+        {
+          "title": "Migrate to React Router 7.8.x",
+          "info": "This major release migrates Hydrogen to React Router 7.8.x, introducing automatic type generation, enhanced type safety, and modernized APIs. The @shopify/remix-oxygen package is no longer needed.",
+          "breaking": true,
+          "steps": [
+            {
+              "title": "Run the automated migration codemod",
+              "info": "This codemod will automatically update most imports and references from Remix to React Router",
+              "code": "YGBgZGlmZgpucHggQGNvZGVtb2QuY29tL2NvZGVtb2QgcmVtaXgvMi9yZWFjdC1yb3V0ZXIvdXBncmFkZQpgYGAK"
+            },
+            {
+              "title": "Update remaining import statements manually",
+              "info": "Change all @shopify/remix-oxygen and @remix-run/* imports to react-router or @shopify/hydrogen/oxygen",
+              "code": "YGBgZGlmZgotIGltcG9ydCB7cmVkaXJlY3QsIHR5cGUgTG9hZGVyRnVuY3Rpb25BcmdzfSBmcm9tICJAc2hvcGlmeS9yZW1peC1veHlnZW4iOwotIGltcG9ydCB7dXNlTG9hZGVyRGF0YSwgdHlwZSBNZXRhRnVuY3Rpb259IGZyb20gIkByZW1peC1ydW4vcmVhY3QiOworIGltcG9ydCB7cmVkaXJlY3QsIHVzZUxvYWRlckRhdGF9IGZyb20gInJlYWN0LXJvdXRlciI7CisgaW1wb3J0IHR5cGUge1JvdXRlfSBmcm9tICIuLyt0eXBlcy9yb3V0ZS1uYW1lIjsKYGBgCg=="
+            },
+            {
+              "title": "Add .react-router to .gitignore",
+              "info": "React Router 7 generates type files that should not be committed to version control",
+              "code": "YGBgZGlmZgplY2hvICIucmVhY3Qtcm91dGVyLyIgPj4gLmdpdGlnbm9yZQpgYGAK"
+            },
+            {
+              "title": "Verify your app starts and builds correctly",
+              "info": "Test that your application runs without errors after the migration",
+              "code": "YGBgZGlmZgpucG0gcnVuIGRldgpucG0gcnVuIGJ1aWxkCmBgYAo="
+            }
+          ],
+          "pr": "https://github.com/Shopify/hydrogen/pull/3141",
+          "id": "3141"
+        },
+        {
+          "title": "Update to Storefront API and Customer Account API version 2025-07",
+          "info": "Updated API version constants, regenerated GraphQL types, and updated all API references. Breaking changes may occur due to API schema changes between versions.",
+          "breaking": true,
+          "pr": "https://github.com/Shopify/hydrogen/pull/3082",
+          "id": "3082-api"
+        },
+        {
+          "title": "Add React Router 7.8.x context infrastructure",
+          "info": "New createRequestHandler export from @shopify/hydrogen/oxygen and hydrogenPreset for React Router configuration.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3142",
+          "id": "3142"
+        },
+        {
+          "title": "Add countryCode parameter to Customer Account API login",
+          "info": "Enables region-specific experiences by passing a CountryCode to the login method for contextualized authentication.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3148",
+          "id": "3148"
+        },
+        {
+          "title": "Add support for removing individual gift cards from cart",
+          "info": "Introduces cartGiftCardCodesRemove mutation to remove specific gift cards by their IDs, solving the limitation where only the last 4 digits were available.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3128",
+          "id": "3128"
+        },
+        {
+          "title": "Upgrade Miniflare from v2 to v4",
+          "info": "Internal MiniOxygen API refactored to work with Miniflare v4's new architecture, improving development server performance and compatibility.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3039",
+          "id": "3039-miniflare"
+        },
+        {
+          "title": "Add order filtering support to Customer Account API orders route",
+          "info": "Skeleton template now supports order filtering in the /account/orders route for improved user experience.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3125",
+          "id": "3125"
+        },
+        {
+          "title": "Add fulfillmentStatus to Customer Account API order query",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3039",
+          "id": "3039-fulfillment"
+        },
+        {
+          "title": "Add @inContext language support to Customer Account API mutations",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3039",
+          "id": "3039-incontext"
+        },
+        {
+          "title": "Add GraphQL @defer directive support to storefront client",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3039",
+          "id": "3039-defer"
+        },
+        {
+          "title": "Include cdn.shopify.com by default in CSP connectSrc",
+          "info": "Improves Content Security Policy defaults for Shopify CDN resources.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3172",
+          "id": "3172"
+        }
+      ]
+    },
+    {
       "title": "[COMPLETE BEFORE ATTEMPTING 2025.5 UPGRADE] Bump Shopify CLI version",
       "version": "2025.4.1",
       "hash": "e4f44954a5dc53e6dfccd1b7e96de593bbb0887a",

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -3,22 +3,22 @@
   "version": "1",
   "releases": [
     {
-      "title": "React Router 7 migration with API version 2025-07",
+      "title": "React Router 7.9.x migration with API version 2025-07",
       "version": "2025.7.0",
-      "date": "2025-09-17",
+      "date": "2025-09-24",
       "hash": "pending-merge",
       "commit": "https://github.com/Shopify/hydrogen/pull/3166",
       "pr": "https://github.com/Shopify/hydrogen/pull/3166",
       "dependencies": {
         "@shopify/hydrogen": "2025.7.0",
-        "react-router": "7.8.2",
-        "react-router-dom": "7.8.2"
+        "react-router": "7.9.1"
+        "react-router-dom": "7.9.1"
       },
       "devDependencies": {
         "@shopify/mini-oxygen": "4.0.0",
-        "@shopify/cli": "3.83.3",
-        "@react-router/dev": "7.8.2",
-        "@react-router/fs-routes": "7.8.2"
+        "@shopify/cli": "3.84.1",
+        "@react-router/dev": "7.9.1",
+        "@react-router/fs-routes": "7.9.1"
       },
       "removeDependencies": [
         "@shopify/hydrogen",
@@ -29,6 +29,7 @@
       "removeDevDependencies": [
         "@remix-run/dev",
         "@remix-run/fs-routes",
+        "@remix-run/eslint-config",
         "@remix-run/route-config"
       ],
       "dependenciesMeta": {
@@ -63,6 +64,9 @@
           "required": false
         },
         "@remix-run/route-config": {
+          "required": false
+        },
+        "@remix-run/eslint-config": {
           "required": false
         }
       },
@@ -156,8 +160,8 @@
       ],
       "features": [
         {
-          "title": "Migrate to React Router 7.8.x",
-          "info": "This major release migrates Hydrogen to React Router 7.8.x, introducing automatic type generation, enhanced type safety, and modernized APIs. The @shopify/remix-oxygen package is no longer needed.",
+          "title": "Migrate to React Router 7.9.x",
+          "info": "This major release migrates Hydrogen to React Router 7.9.x, introducing automatic type generation, enhanced type safety, and modernized APIs. The @shopify/remix-oxygen package is no longer needed.",
           "breaking": true,
           "steps": [
             {
@@ -192,7 +196,7 @@
           "id": "3082-api"
         },
         {
-          "title": "Add React Router 7.8.x context infrastructure",
+          "title": "Add React Router 7.9.x context infrastructure",
           "info": "New createRequestHandler export from @shopify/hydrogen/oxygen and hydrogenPreset for React Router configuration.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3142",
           "id": "3142"
@@ -210,8 +214,8 @@
           "id": "3128"
         },
         {
-          "title": "Upgrade Miniflare from v2 to v4",
-          "info": "Internal MiniOxygen API refactored to work with Miniflare v4's new architecture, improving development server performance and compatibility.",
+          "title": "Upgrade Miniflare from v2 to v3",
+          "info": "Internal MiniOxygen API refactored to work with Miniflare v3's new architecture, improving development server performance and compatibility.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-miniflare"
         },

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -11,7 +11,7 @@
       "pr": "https://github.com/Shopify/hydrogen/pull/3166",
       "dependencies": {
         "@shopify/hydrogen": "2025.7.0",
-        "react-router": "7.9.1"
+        "react-router": "7.9.1",
         "react-router-dom": "7.9.1"
       },
       "devDependencies": {
@@ -85,6 +85,7 @@
         },
         {
           "title": "Fix defer/streaming in development & preview",
+          "info": "Resolves issues with GraphQL @defer directive and streaming responses in development and preview environments, ensuring proper async data loading behavior matches production.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039"
         },
@@ -138,16 +139,19 @@
         },
         {
           "title": "Add --force-client-sourcemap flag to deploy command",
+          "info": "New CLI flag that forces inclusion of client-side sourcemaps in production deployments for enhanced debugging capabilities when needed.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-sourcemap"
         },
         {
           "title": "Add Vite v7 exports support",
+          "info": "Adds compatibility with Vite 7's new module export patterns, ensuring smooth builds and proper tree-shaking with the latest Vite version.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-vite"
         },
         {
           "title": "Fix and upgrade GraphiQL route",
+          "info": "Updates the GraphiQL development tool to the latest version with improved UI and fixes for query execution in the development environment.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-graphiql"
         },
@@ -227,16 +231,19 @@
         },
         {
           "title": "Add fulfillmentStatus to Customer Account API order query",
+          "info": "Extends the Customer Account API order query to include fulfillmentStatus field, enabling tracking of order shipping and delivery states in customer-facing interfaces.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-fulfillment"
         },
         {
           "title": "Add @inContext language support to Customer Account API mutations",
+          "info": "Enables language-specific responses in Customer Account API mutations using the @inContext directive for improved internationalization support.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-incontext"
         },
         {
           "title": "Add GraphQL @defer directive support to storefront client",
+          "info": "Implements support for GraphQL's @defer directive in the storefront client, allowing incremental data loading for improved perceived performance on complex queries.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3039",
           "id": "3039-defer"
         },

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -16,10 +16,20 @@
       },
       "devDependencies": {
         "@shopify/mini-oxygen": "^4.0.0",
-        "@shopify/cli": "~3.83.3"
+        "@shopify/cli": "~3.83.3",
+        "@react-router/dev": "7.8.2",
+        "@react-router/fs-routes": "7.8.2"
       },
-      "removeDependencies": ["@shopify/remix-oxygen"],
-      "removeDevDependencies": [],
+      "removeDependencies": [
+        "@shopify/remix-oxygen",
+        "@remix-run/react",
+        "@remix-run/server-runtime"
+      ],
+      "removeDevDependencies": [
+        "@remix-run/dev",
+        "@remix-run/fs-routes",
+        "@remix-run/route-config"
+      ],
       "dependenciesMeta": {},
       "fixes": [
         {

--- a/packages/cli/src/commands/hydrogen/upgrade-flow.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade-flow.test.ts
@@ -86,19 +86,32 @@ describe('upgrade flow integration', () => {
       console.log('Test project created at:', projectDir);
       console.log('From version:', fromVersion, 'commit:', fromCommit);
       console.log('To version:', toVersion);
-      
+
       // Check package.json content
       const pkgJsonPath = join(projectDir, 'package.json');
       let pkgJsonContent = await readFile(pkgJsonPath, 'utf8');
-      console.log('Initial package.json dependencies:', JSON.stringify(JSON.parse(pkgJsonContent).dependencies, null, 2));
-      console.log('Initial package.json devDependencies:', JSON.stringify(JSON.parse(pkgJsonContent).devDependencies, null, 2));
-      
+      console.log(
+        'Initial package.json dependencies:',
+        JSON.stringify(JSON.parse(pkgJsonContent).dependencies, null, 2),
+      );
+      console.log(
+        'Initial package.json devDependencies:',
+        JSON.stringify(JSON.parse(pkgJsonContent).devDependencies, null, 2),
+      );
+
       // Update @shopify/cli to 3.83.3 if the changelog has removeDependencies
       // This version is required to handle removeDependencies properly
-      if (latestRelease.removeDependencies || latestRelease.removeDevDependencies) {
+      if (
+        latestRelease.removeDependencies ||
+        latestRelease.removeDevDependencies
+      ) {
         const pkg = JSON.parse(pkgJsonContent);
         if (pkg.devDependencies?.['@shopify/cli']) {
-          console.log('Updating @shopify/cli from', pkg.devDependencies['@shopify/cli'], 'to 3.83.3 for removeDependencies support');
+          console.log(
+            'Updating @shopify/cli from',
+            pkg.devDependencies['@shopify/cli'],
+            'to 3.83.3 for removeDependencies support',
+          );
           pkg.devDependencies['@shopify/cli'] = '3.83.3';
           pkgJsonContent = JSON.stringify(pkg, null, 2);
           await writeFile(pkgJsonPath, pkgJsonContent, 'utf8');


### PR DESCRIPTION
### WHY are these changes introduced?

The Hydrogen 2025.7.0 release introduces major breaking changes including the migration from Remix to React Router 7.8.x and updates to Storefront API version 2025-07. The changelog.json file needs to be updated to enable the `h2 upgrade` command for developers migrating to this version.

Without this changelog entry, developers cannot use the CLI upgrade command to migrate their projects from 2025.4.x to 2025.7.0, leaving them to manually update dependencies and apply migration steps.

### WHAT is this pull request doing?

This PR adds a comprehensive changelog entry for the Hydrogen 2025.7.0 release to `docs/changelog.json`. The entry documents all changes from the CI release PR #3166.

**Summary of changes:**
- Documents 2 major breaking changes (React Router 7 migration, API version 2025-07)
- Includes 11 new features across 27 merged changesets
- Lists 15 bug fixes and improvements
- Provides 4-step migration guide with base64-encoded code snippets
- Updates dependencies to remove `@shopify/remix-oxygen` and add pinned React Router 7.8.2

<details>
<summary>Dependency Changes</summary>

```diff
dependencies:
+ "@shopify/hydrogen": "2025.7.0"
+ "react-router": "7.8.2"        # Pinned version
+ "react-router-dom": "7.8.2"    # Pinned version
- "@shopify/remix-oxygen"

devDependencies:
+ "@shopify/mini-oxygen": "^4.0.0"
+ "@shopify/cli": "~3.83.3"
```
</details>

<details>
<summary>All Documented PRs (27 changesets)</summary>

Breaking Changes:
- #3141: Migrate skeleton template to React Router 7.8.x
- #3082: Update APIs to 2025-07
- #3142: React Router context infrastructure

Features:
- #3148: Add countryCode parameter to CAAPI login
- #3128: Add support for removing individual gift cards
- #3039: Upgrade Miniflare from v2 to v4
- #3125: Add order filtering support
- #3172: Include cdn.shopify.com in CSP by default

Fixes:
- #3082: Fix OAuth redirect handling, CSP NonceProvider, cart errors
- #3108: Fix GraphQL client warnings
- #3072: Fix parseMetafield money currency
- #3139: Fix TypeScript enum compatibility
- #3146: Add ESLint promise rules
- #3050: Fix env pull quoting
- #2985: Replace deprecated faker method
- Multiple fixes from #3039 (defer, GraphiQL, Vite v7, etc.)
</details>

### HOW to test your changes?

TODO:

#### Post-merge steps

After merging:
1. Changelog will be available at https://hydrogen.shopify.dev/changelog.json
2. Developers can immediately use `h2 upgrade` to migrate to 2025.7.0

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation
