### PR TITLE
Fix missing dependencies for virtual dev routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32616,12 +32616,12 @@
         "@shopify/graphql-client": "1.4.1",
         "@shopify/hydrogen-react": "2025.5.0",
         "content-security-policy-builder": "^2.2.0",
-        "flame-chart-js": "^3.3.0",
-        "isbot": "^5.1.22",
+        "flame-chart-js": "2.3.1",
+        "isbot": "^5.1.21",
         "source-map-support": "^0.5.21",
         "type-fest": "^4.33.0",
         "use-resize-observer": "^9.1.0",
-        "uuid": "^11.0.5",
+        "uuid": "11.1.0",
         "worktop": "^0.7.3"
       },
       "devDependencies": {
@@ -34312,18 +34312,13 @@
       }
     },
     "packages/hydrogen/node_modules/flame-chart-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/flame-chart-js/-/flame-chart-js-3.3.0.tgz",
-      "integrity": "sha512-bjgRBK7o/479BTt1t3piu+UIT0ctxVUkiJblMeIba5mMxc+7rk+/cv9fvEiCmuv+e+86aKm61r5wwza5myDGSw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/flame-chart-js/-/flame-chart-js-2.3.1.tgz",
+      "integrity": "sha512-wi3g+BEYEWcxnFrakPt7A/oXVfMnun6Uvjve3kfscXXCrgP6f1O8o5LOseXfHnVI1jxTWOINnzdXPN/NLw9guQ==",
       "license": "MIT",
       "dependencies": {
         "color": "^3.1.3",
         "events": "^3.2.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "use-resize-observer": "^9.1.0"
       }
     },
     "packages/hydrogen/node_modules/js-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15714,7 +15714,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -32617,10 +32616,12 @@
         "@shopify/graphql-client": "1.4.1",
         "@shopify/hydrogen-react": "2025.5.0",
         "content-security-policy-builder": "^2.2.0",
-        "isbot": "^5.1.21",
+        "flame-chart-js": "^3.3.0",
+        "isbot": "^5.1.22",
         "source-map-support": "^0.5.21",
         "type-fest": "^4.33.0",
         "use-resize-observer": "^9.1.0",
+        "uuid": "^11.0.5",
         "worktop": "^0.7.3"
       },
       "devDependencies": {
@@ -34277,12 +34278,52 @@
         "node": ">= 16"
       }
     },
+    "packages/hydrogen/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "packages/hydrogen/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "packages/hydrogen/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
     "packages/hydrogen/node_modules/deep-eql": {
       "version": "5.0.2",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "packages/hydrogen/node_modules/flame-chart-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/flame-chart-js/-/flame-chart-js-3.3.0.tgz",
+      "integrity": "sha512-bjgRBK7o/479BTt1t3piu+UIT0ctxVUkiJblMeIba5mMxc+7rk+/cv9fvEiCmuv+e+86aKm61r5wwza5myDGSw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "events": "^3.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "use-resize-observer": "^9.1.0"
       }
     },
     "packages/hydrogen/node_modules/js-tokens": {

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -85,10 +85,12 @@
   "dependencies": {
     "@shopify/hydrogen-react": "2025.5.0",
     "content-security-policy-builder": "^2.2.0",
-    "isbot": "^5.1.21",
+    "flame-chart-js": "^3.3.0",
     "source-map-support": "^0.5.21",
     "type-fest": "^4.33.0",
     "use-resize-observer": "^9.1.0",
+    "uuid": "^11.0.5",
+    "isbot": "^5.1.22",
     "worktop": "^0.7.3",
     "@shopify/graphql-client": "1.4.1"
   },

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -85,12 +85,12 @@
   "dependencies": {
     "@shopify/hydrogen-react": "2025.5.0",
     "content-security-policy-builder": "^2.2.0",
-    "flame-chart-js": "^3.3.0",
+    "flame-chart-js": "2.3.1",
+    "isbot": "^5.1.21",
     "source-map-support": "^0.5.21",
     "type-fest": "^4.33.0",
     "use-resize-observer": "^9.1.0",
-    "uuid": "^11.0.5",
-    "isbot": "^5.1.22",
+    "uuid": "11.1.0",
     "worktop": "^0.7.3",
     "@shopify/graphql-client": "1.4.1"
   },


### PR DESCRIPTION
## Summary
Fixes module resolution errors in dev server by adding missing dependencies for virtual routes used in development tooling.

## Why
The Chrome DevTools route and subrequest profiler were importing `uuid` and `flame-chart-js` packages that weren't listed as dependencies. This caused "Cannot find module" errors when running the dev server in scaffolded projects.

## What
- Added `uuid` (11.1.0) - pinned to match existing version in monorepo lock file
- Added `flame-chart-js` (2.3.1) - pinned to original version when feature was added to preserve API compatibility
- Kept `isbot` at ^5.1.21 - unchanged from main branch

## Root Cause
Virtual routes are built without bundling (`bundle: false` in tsup config), so imports aren't resolved at build time. The missing dependencies only manifested when:
1. A new project was scaffolded from @next
2. The dev server tried to serve these routes
3. The packages weren't available in the project's node_modules

## Version Selection Rationale
- **uuid@11.1.0**: Already present in monorepo root, pinned to exact version to ensure consistency
- **flame-chart-js@2.3.1**: Used the original version from when the subrequest profiler was first implemented (commit 71a073743) to avoid breaking API changes (method `recalcChildrenSizes` exists in 2.3.1 but not in newer versions)

## 🎩 Top Hat

### Testing Steps
1. Build the hydrogen package with these changes
2. Create a new project: `npm create @shopify/hydrogen@next`
3. Run `npm run dev`
4. Verify no "Cannot find module 'uuid'" errors appear
5. Open Chrome DevTools - should connect without errors
6. Navigate to `/subrequest-profiler` - should load without errors

### Validation Checklist
- [x] Dependencies added to package.json with correct versions
- [x] package-lock.json updated
- [x] TypeScript checks pass (no `recalcChildrenSizes` errors)
- [ ] Dev server starts without module errors
- [ ] Chrome DevTools route accessible
- [ ] Subrequest profiler loads correctly