### PR TITLE
Add ESLint rule to prevent accidental single-character JSX text

### DIFF
--- a/cookbook/llms/b2b.prompt.md
+++ b/cookbook/llms/b2b.prompt.md
@@ -139,7 +139,7 @@ with buyer information (company location + customer token) to ensure accurate B2
 
 
 
-#### File: [B2BLocationProvider.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/b2b/ingredients/templates/skeleton/app/components/B2BLocationProvider.tsx)
+#### File: [B2BLocationProvider.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/b2b/ingredients/templates/skeleton/app/components/B2BLocationProvider.tsx)
 
 ```tsx
 import {createContext, useContext, useEffect, useState, useMemo} from 'react';
@@ -244,7 +244,7 @@ export function useB2BLocation(): B2BLocationContextValue {
 
 
 
-#### File: [B2BLocationSelector.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/b2b/ingredients/templates/skeleton/app/components/B2BLocationSelector.tsx)
+#### File: [B2BLocationSelector.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/b2b/ingredients/templates/skeleton/app/components/B2BLocationSelector.tsx)
 
 ```tsx
 import {CartForm} from '@shopify/hydrogen';
@@ -381,7 +381,7 @@ export function B2BLocationSelector() {
 
 
 
-#### File: [PriceBreaks.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/b2b/ingredients/templates/skeleton/app/components/PriceBreaks.tsx)
+#### File: [PriceBreaks.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/b2b/ingredients/templates/skeleton/app/components/PriceBreaks.tsx)
 
 ```tsx
 import {Money} from '@shopify/hydrogen';
@@ -464,7 +464,7 @@ export function PriceBreaks({priceBreaks}: PriceBreaksProps) {
 
 
 
-#### File: [QuantityRules.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/b2b/ingredients/templates/skeleton/app/components/QuantityRules.tsx)
+#### File: [QuantityRules.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/b2b/ingredients/templates/skeleton/app/components/QuantityRules.tsx)
 
 ```tsx
 import type {Maybe} from '@shopify/hydrogen/customer-account-api-types';
@@ -570,7 +570,7 @@ export function QuantityRules({
 
 
 
-#### File: [CustomerLocationsQuery.ts](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/b2b/ingredients/templates/skeleton/app/graphql/customer-account/CustomerLocationsQuery.ts)
+#### File: [CustomerLocationsQuery.ts](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/b2b/ingredients/templates/skeleton/app/graphql/customer-account/CustomerLocationsQuery.ts)
 
 ```ts
 // NOTE: https://shopify.dev/docs/api/customer/latest/objects/Customer
@@ -660,7 +660,7 @@ export const CUSTOMER_LOCATIONS_QUERY = `#graphql
        consent={data.consent}
      >
 -      <PageLayout {...data}>
--        <Outlet />;
+-        <Outlet />
 -      </PageLayout>
 +      {/* @description Wrap PageLayout with B2B location provider for company location management */}
 +      <B2BLocationProvider>
@@ -678,7 +678,7 @@ export const CUSTOMER_LOCATIONS_QUERY = `#graphql
 
 
 
-#### File: [b2blocations.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/b2b/ingredients/templates/skeleton/app/routes/b2blocations.tsx)
+#### File: [b2blocations.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/b2b/ingredients/templates/skeleton/app/routes/b2blocations.tsx)
 
 ```tsx
 import {useLoaderData} from 'react-router';

--- a/cookbook/llms/express.prompt.md
+++ b/cookbook/llms/express.prompt.md
@@ -241,7 +241,7 @@ Key changes:
 
 
 
-#### File: [env.ts](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/express/ingredients/templates/skeleton/app/env.ts)
+#### File: [env.ts](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/express/ingredients/templates/skeleton/app/env.ts)
 
 ```ts
 // This file extends the Hydrogen types for this project
@@ -312,7 +312,7 @@ export {};
 
 
 
-#### File: [favicon.svg](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/express/ingredients/templates/skeleton/public/favicon.svg)
+#### File: [favicon.svg](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/express/ingredients/templates/skeleton/public/favicon.svg)
 
 ```svg
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="none">
@@ -473,7 +473,7 @@ export {};
 
 
 
-#### File: [dev.mjs](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/express/ingredients/templates/skeleton/scripts/dev.mjs)
+#### File: [dev.mjs](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/express/ingredients/templates/skeleton/scripts/dev.mjs)
 
 ```mjs
 #!/usr/bin/env node
@@ -749,12 +749,11 @@ process.on('SIGTERM', () => {
        consent={data.consent}
      >
 -      <PageLayout {...data}>
--        <Outlet />;
--      </PageLayout>
 +      <div className="PageLayout">
 +        <h1>{data.layout?.shop?.name} (Express example)</h1>
 +        <h2>{data.layout?.shop?.description}</h2>
-+        <Outlet />
+         <Outlet />
+-      </PageLayout>
 +      </div>
      </Analytics.Provider>
    );
@@ -785,7 +784,7 @@ process.on('SIGTERM', () => {
 
 
 
-#### File: [server.mjs](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/express/ingredients/templates/skeleton/server.mjs)
+#### File: [server.mjs](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/express/ingredients/templates/skeleton/server.mjs)
 
 ```mjs
 import {createRequestHandler} from '@react-router/express';

--- a/cookbook/llms/gtm.prompt.md
+++ b/cookbook/llms/gtm.prompt.md
@@ -220,7 +220,7 @@ Updates README with GTM-specific documentation and setup instructions
 
 
 
-#### File: [GoogleTagManager.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/gtm/ingredients/templates/skeleton/app/components/GoogleTagManager.tsx)
+#### File: [GoogleTagManager.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/gtm/ingredients/templates/skeleton/app/components/GoogleTagManager.tsx)
 
 ```tsx
 import {useAnalytics} from '@shopify/hydrogen';
@@ -303,12 +303,9 @@ export function GoogleTagManager() {
          {children}
          <ScrollRestoration nonce={nonce} />
          <Scripts nonce={nonce} />
-@@ -177,8 +202,10 @@ export default function App() {
-       consent={data.consent}
-     >
+@@ -179,6 +204,8 @@ export default function App() {
        <PageLayout {...data}>
--        <Outlet />;
-+        <Outlet />
+         <Outlet />
        </PageLayout>
 +      {/* @description Initialize Google Tag Manager analytics integration */}
 +      <GoogleTagManager />

--- a/cookbook/llms/markets.prompt.md
+++ b/cookbook/llms/markets.prompt.md
@@ -154,7 +154,7 @@ Create a new `CountrySelector` component that allows users to select the locale 
 To handle redirects, use a `Form` that updates the cart buyer identity,
 which eventually redirects to the localized root of the app.
 
-##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
+##### File: [CountrySelector.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx)
 
 ```tsx
 import {Form, useLocation} from 'react-router';
@@ -246,7 +246,7 @@ This component automatically:
 - Cleans invalid locale prefixes from menu URLs
 - Enables locale switching while preserving paths
 
-##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
+##### File: [Link.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/Link.tsx)
 
 ```tsx
 import type {LinkProps, NavLinkProps} from 'react-router';
@@ -324,7 +324,7 @@ Create a centralized i18n module that includes:
 6. Locale validation utilities for route params
 7. Support for case-insensitive locale matching
 
-##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
+##### File: [i18n.ts](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/lib/i18n.ts)
 
 ```ts
 import {useMatches, useLocation} from 'react-router';
@@ -694,20 +694,18 @@ when the locale changes.
      publicStoreDomain: env.PUBLIC_STORE_DOMAIN,
      shop: getShopAnalytics({
        storefront,
-@@ -176,8 +177,11 @@ export default function App() {
+@@ -176,7 +177,10 @@ export default function App() {
        shop={data.shop}
        consent={data.consent}
      >
 -      <PageLayout {...data}>
--        <Outlet />;
 +      <PageLayout
 +        key={`${data.selectedLocale.language}-${data.selectedLocale.country}`}
 +        {...data}
 +      >
-+        <Outlet />
+         <Outlet />
        </PageLayout>
      </Analytics.Provider>
-   );
 ```
 
 ### Step 2: Localizing the individual routes
@@ -746,7 +744,7 @@ For brevity, we'll focus on the home page, the cart page, and the product page i
 > [!NOTE]
 > Rename `app/routes/_index.tsx` to `app/routes/($locale)._index.tsx`.
 
-##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
+##### File: [($locale)._index.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale)._index.tsx)
 
 ```tsx
 import {Await, useLoaderData} from 'react-router';
@@ -927,7 +925,7 @@ Add the dynamic segment to the cart page route.
 > [!NOTE]
 > Rename `app/routes/cart.tsx` to `app/routes/($locale).cart.tsx`.
 
-##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
+##### File: [($locale).cart.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).cart.tsx)
 
 ```tsx
 import {useLoaderData, data} from 'react-router';
@@ -1054,7 +1052,7 @@ localized prefix.
 > [!NOTE]
 > Rename `app/routes/products.$handle.tsx` to `app/routes/($locale).products.$handle.tsx`.
 
-##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
+##### File: [($locale).products.$handle.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).products.$handle.tsx)
 
 ```tsx
 import {useLoaderData} from 'react-router';
@@ -1318,7 +1316,7 @@ Add a utility route in `$(locale).tsx` that will use `localeMatchesPrefix`
 to validate the locale from the URL params. If the locale is invalid,
 the route will throw a 404 error.
 
-##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
+##### File: [($locale).tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).tsx)
 
 ```tsx
 import type {Route} from './+types/($locale)';
@@ -1338,7 +1336,7 @@ export async function loader({params}: Route.LoaderArgs) {
 
 Fallback route for unauthenticated account pages with locale support
 
-#### File: [($locale).account.$.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.$.tsx)
+#### File: [($locale).account.$.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.$.tsx)
 
 ```tsx
 import {redirect} from 'react-router';
@@ -1357,7 +1355,7 @@ export async function loader({context}: Route.LoaderArgs) {
 
 Localized account dashboard redirect route
 
-#### File: [($locale).account._index.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account._index.tsx)
+#### File: [($locale).account._index.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account._index.tsx)
 
 ```tsx
 import {redirect} from 'react-router';
@@ -1372,7 +1370,7 @@ export async function loader() {
 
 Customer address management page with locale-aware forms and links
 
-#### File: [($locale).account.addresses.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.addresses.tsx)
+#### File: [($locale).account.addresses.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.addresses.tsx)
 
 ```tsx
 import type {CustomerAddressInput} from '@shopify/hydrogen/customer-account-api-types';
@@ -1898,7 +1896,7 @@ export function AddressForm({
 
 Individual order details page with localized currency and date formatting
 
-#### File: [($locale).account.orders.$id.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.orders.$id.tsx)
+#### File: [($locale).account.orders.$id.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.orders.$id.tsx)
 
 ```tsx
 import {redirect, useLoaderData} from 'react-router';
@@ -2128,7 +2126,7 @@ function OrderLineRow({lineItem}: {lineItem: OrderLineItemFullFragment}) {
 
 Customer order history listing with locale-specific pagination
 
-#### File: [($locale).account.orders._index.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.orders._index.tsx)
+#### File: [($locale).account.orders._index.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.orders._index.tsx)
 
 ```tsx
 import {
@@ -2235,7 +2233,7 @@ function OrderItem({order}: {order: OrderItemFragment}) {
 
 Customer profile editing form with localized field labels
 
-#### File: [($locale).account.profile.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.profile.tsx)
+#### File: [($locale).account.profile.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.profile.tsx)
 
 ```tsx
 import type {CustomerFragment} from 'customer-accountapi.generated';
@@ -2378,7 +2376,7 @@ export default function AccountProfile() {
 
 Account layout wrapper with locale-aware navigation tabs
 
-#### File: [($locale).account.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.tsx)
+#### File: [($locale).account.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account.tsx)
 
 ```tsx
 import {
@@ -2487,7 +2485,7 @@ function Logout() {
 
 OAuth authorization callback route with locale preservation
 
-#### File: [($locale).account_.authorize.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account_.authorize.tsx)
+#### File: [($locale).account_.authorize.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account_.authorize.tsx)
 
 ```tsx
 import type {Route} from './+types/($locale).account_.authorize';
@@ -2502,7 +2500,7 @@ export async function loader({context}: Route.LoaderArgs) {
 
 Customer login redirect with locale-specific return URL
 
-#### File: [($locale).account_.login.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account_.login.tsx)
+#### File: [($locale).account_.login.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account_.login.tsx)
 
 ```tsx
 import type {Route} from './+types/($locale).account_.login';
@@ -2517,7 +2515,7 @@ export async function loader({context}: Route.LoaderArgs) {
 
 Logout handler that maintains locale after sign out
 
-#### File: [($locale).account_.logout.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account_.logout.tsx)
+#### File: [($locale).account_.logout.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).account_.logout.tsx)
 
 ```tsx
 import {redirect} from 'react-router';
@@ -2538,7 +2536,7 @@ export async function action({context}: Route.ActionArgs) {
 
 Blog article page with locale-specific content and SEO metadata
 
-#### File: [($locale).blogs.$blogHandle.$articleHandle.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).blogs.$blogHandle.$articleHandle.tsx)
+#### File: [($locale).blogs.$blogHandle.$articleHandle.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).blogs.$blogHandle.$articleHandle.tsx)
 
 ```tsx
 import {useLoaderData} from 'react-router';
@@ -2677,7 +2675,7 @@ const ARTICLE_QUERY = `#graphql
 
 Blog listing page with localized article previews and pagination
 
-#### File: [($locale).blogs.$blogHandle._index.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).blogs.$blogHandle._index.tsx)
+#### File: [($locale).blogs.$blogHandle._index.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).blogs.$blogHandle._index.tsx)
 
 ```tsx
 import {
@@ -2869,7 +2867,7 @@ const BLOGS_QUERY = `#graphql
 
 All blogs overview page with locale-aware navigation links
 
-#### File: [($locale).blogs._index.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).blogs._index.tsx)
+#### File: [($locale).blogs._index.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).blogs._index.tsx)
 
 ```tsx
 import {useLoaderData} from 'react-router';
@@ -2989,7 +2987,7 @@ const BLOGS_QUERY = `#graphql
 
 Collection page displaying products with locale-specific pricing and availability
 
-#### File: [($locale).collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).collections.$handle.tsx)
+#### File: [($locale).collections.$handle.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).collections.$handle.tsx)
 
 ```tsx
 import {redirect, useLoaderData} from 'react-router';
@@ -3160,7 +3158,7 @@ const COLLECTION_QUERY = `#graphql
 
 Collections listing page with localized collection names and images
 
-#### File: [($locale).collections._index.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).collections._index.tsx)
+#### File: [($locale).collections._index.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).collections._index.tsx)
 
 ```tsx
 import {useLoaderData} from 'react-router';
@@ -3304,7 +3302,7 @@ const COLLECTIONS_QUERY = `#graphql
 
 All products page with locale-based filtering and sorting
 
-#### File: [($locale).collections.all.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).collections.all.tsx)
+#### File: [($locale).collections.all.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).collections.all.tsx)
 
 ```tsx
 import type {Route} from './+types/($locale).collections.all';
@@ -3438,7 +3436,7 @@ const CATALOG_QUERY = `#graphql
 
 Dynamic page route for locale-specific content pages
 
-#### File: [($locale).pages.$handle.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).pages.$handle.tsx)
+#### File: [($locale).pages.$handle.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).pages.$handle.tsx)
 
 ```tsx
 import {
@@ -3542,7 +3540,7 @@ const PAGE_QUERY = `#graphql
 
 Policy page (privacy, terms, etc.) with locale-specific legal content
 
-#### File: [($locale).policies.$handle.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).policies.$handle.tsx)
+#### File: [($locale).policies.$handle.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).policies.$handle.tsx)
 
 ```tsx
 import {
@@ -3648,7 +3646,7 @@ const POLICY_CONTENT_QUERY = `#graphql
 
 Policies index page listing all available store policies
 
-#### File: [($locale).policies._index.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).policies._index.tsx)
+#### File: [($locale).policies._index.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).policies._index.tsx)
 
 ```tsx
 import {useLoaderData} from 'react-router';
@@ -3728,7 +3726,7 @@ const POLICIES_QUERY = `#graphql
 
 Search results page with locale-aware product matching and predictive search
 
-#### File: [($locale).search.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).search.tsx)
+#### File: [($locale).search.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/markets/ingredients/templates/skeleton/app/routes/($locale).search.tsx)
 
 ```tsx
 import {

--- a/cookbook/llms/partytown.prompt.md
+++ b/cookbook/llms/partytown.prompt.md
@@ -92,7 +92,7 @@ Add public/~partytown to ignore Partytown library files
 
 Add GTM component that loads scripts in web worker
 
-#### File: [PartytownGoogleTagManager.tsx](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/partytown/ingredients/templates/skeleton/app/components/PartytownGoogleTagManager.tsx)
+#### File: [PartytownGoogleTagManager.tsx](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/partytown/ingredients/templates/skeleton/app/components/PartytownGoogleTagManager.tsx)
 
 ```tsx
 import {useEffect, useRef} from 'react';
@@ -268,7 +268,7 @@ Document Partytown setup and configuration instructions
 
 Reverse proxy route for third-party scripts requiring CORS headers
 
-#### File: [reverse-proxy.ts](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/partytown/ingredients/templates/skeleton/app/routes/reverse-proxy.ts)
+#### File: [reverse-proxy.ts](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/partytown/ingredients/templates/skeleton/app/routes/reverse-proxy.ts)
 
 ```ts
 // Reverse proxies partytown libs that require CORS. Used by Partytown resolveUrl
@@ -510,7 +510,7 @@ Configure CSP headers for GTM and Google Analytics domains
 
 URL resolver to control which scripts should be reverse-proxied
 
-#### File: [maybeProxyRequest.ts](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/partytown/ingredients/templates/skeleton/app/utils/partytown/maybeProxyRequest.ts)
+#### File: [maybeProxyRequest.ts](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/partytown/ingredients/templates/skeleton/app/utils/partytown/maybeProxyRequest.ts)
 
 ```ts
 /**
@@ -623,23 +623,21 @@ Initialize Partytown and GTM in the root layout
  export default function App() {
    const data = useRouteLoaderData<RootLoader>('root');
  
-@@ -177,7 +217,8 @@ export default function App() {
+@@ -177,6 +217,7 @@ export default function App() {
        consent={data.consent}
      >
        <PageLayout {...data}>
--        <Outlet />;
 +        <PartyTownScripts gtmContainerId={data.gtmContainerId} />
-+        <Outlet />
+         <Outlet />
        </PageLayout>
      </Analytics.Provider>
-   );
 ```
 
 ### Step 4: app/utils/partytown/partytownAtomicHeaders.ts
 
 Helper utility to enable Partytown atomic mode for better performance
 
-#### File: [partytownAtomicHeaders.ts](https://github.com/Shopify/hydrogen/blob/147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7/cookbook/recipes/partytown/ingredients/templates/skeleton/app/utils/partytown/partytownAtomicHeaders.ts)
+#### File: [partytownAtomicHeaders.ts](https://github.com/Shopify/hydrogen/blob/25290311dd1d135ab90bca26fb496d2b92c8631a/cookbook/recipes/partytown/ingredients/templates/skeleton/app/utils/partytown/partytownAtomicHeaders.ts)
 
 ```ts
 /*

--- a/cookbook/recipes/b2b/patches/CartLineItem.tsx.2c9a50.patch
+++ b/cookbook/recipes/b2b/patches/CartLineItem.tsx.2c9a50.patch
@@ -1,4 +1,4 @@
-index 80e34be28..1d09318c0 100644
+index 80e34be2..1d09318c 100644
 --- a/templates/skeleton/app/components/CartLineItem.tsx
 +++ b/templates/skeleton/app/components/CartLineItem.tsx
 @@ -76,8 +76,13 @@ export function CartLineItem({

--- a/cookbook/recipes/b2b/patches/Header.tsx.e25645.patch
+++ b/cookbook/recipes/b2b/patches/Header.tsx.e25645.patch
@@ -1,4 +1,4 @@
-index 45b620b49..12f7f1650 100644
+index 45b620b4..12f7f165 100644
 --- a/templates/skeleton/app/components/Header.tsx
 +++ b/templates/skeleton/app/components/Header.tsx
 @@ -7,6 +7,9 @@ import {

--- a/cookbook/recipes/b2b/patches/ProductForm.tsx.649d3b.patch
+++ b/cookbook/recipes/b2b/patches/ProductForm.tsx.649d3b.patch
@@ -1,4 +1,4 @@
-index 47c8f3056..5e3ec2c17 100644
+index 47c8f305..5e3ec2c1 100644
 --- a/templates/skeleton/app/components/ProductForm.tsx
 +++ b/templates/skeleton/app/components/ProductForm.tsx
 @@ -8,12 +8,15 @@ import {AddToCartButton} from './AddToCartButton';

--- a/cookbook/recipes/b2b/patches/README.md.db10ed.patch
+++ b/cookbook/recipes/b2b/patches/README.md.db10ed.patch
@@ -1,4 +1,4 @@
-index c584e5370..e3231cba4 100644
+index c584e537..e3231cba 100644
 --- a/templates/skeleton/README.md
 +++ b/templates/skeleton/README.md
 @@ -18,6 +18,45 @@ Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dov

--- a/cookbook/recipes/b2b/patches/account_.logout.tsx.a1f12e.patch
+++ b/cookbook/recipes/b2b/patches/account_.logout.tsx.a1f12e.patch
@@ -1,4 +1,4 @@
-index 5e67cc857..6d331155e 100644
+index 5e67cc85..6d331155 100644
 --- a/templates/skeleton/app/routes/account_.logout.tsx
 +++ b/templates/skeleton/app/routes/account_.logout.tsx
 @@ -7,5 +7,10 @@ export async function loader() {

--- a/cookbook/recipes/b2b/patches/fragments.ts.026109.patch
+++ b/cookbook/recipes/b2b/patches/fragments.ts.026109.patch
@@ -1,4 +1,4 @@
-index cf35c25ea..6866c19af 100644
+index cf35c25e..6866c19a 100644
 --- a/templates/skeleton/app/lib/fragments.ts
 +++ b/templates/skeleton/app/lib/fragments.ts
 @@ -52,6 +52,21 @@ export const CART_QUERY_FRAGMENT = `#graphql

--- a/cookbook/recipes/b2b/patches/products.$handle.tsx.6f2e82.patch
+++ b/cookbook/recipes/b2b/patches/products.$handle.tsx.6f2e82.patch
@@ -1,4 +1,4 @@
-index 422a2eb95..f05fd79c1 100644
+index 422a2eb9..f05fd79c 100644
 --- a/templates/skeleton/app/routes/products.$handle.tsx
 +++ b/templates/skeleton/app/routes/products.$handle.tsx
 @@ -15,6 +15,19 @@ import {ProductPrice} from '~/components/ProductPrice';

--- a/cookbook/recipes/b2b/patches/root.tsx.5e9998.patch
+++ b/cookbook/recipes/b2b/patches/root.tsx.5e9998.patch
@@ -1,4 +1,4 @@
-index fa83da97e..5a0fef093 100644
+index df87425c..5a0fef09 100644
 --- a/templates/skeleton/app/root.tsx
 +++ b/templates/skeleton/app/root.tsx
 @@ -16,9 +16,39 @@ import {FOOTER_QUERY, HEADER_QUERY} from '~/lib/fragments';
@@ -46,7 +46,7 @@ index fa83da97e..5a0fef093 100644
        consent={data.consent}
      >
 -      <PageLayout {...data}>
--        <Outlet />;
+-        <Outlet />
 -      </PageLayout>
 +      {/* @description Wrap PageLayout with B2B location provider for company location management */}
 +      <B2BLocationProvider>

--- a/cookbook/recipes/b2b/recipe.yaml
+++ b/cookbook/recipes/b2b/recipe.yaml
@@ -49,7 +49,7 @@ steps:
     description: null
     diffs:
       - file: README.md
-        patchFile: README.md.49f8fa.patch
+        patchFile: README.md.db10ed.patch
   - type: NEW_FILE
     step: "1"
     name: app/components/B2BLocationProvider.tsx
@@ -62,7 +62,7 @@ steps:
     description: null
     diffs:
       - file: app/components/CartLineItem.tsx
-        patchFile: CartLineItem.tsx.f93ff4.patch
+        patchFile: CartLineItem.tsx.2c9a50.patch
   - type: NEW_FILE
     step: "2"
     name: app/components/B2BLocationSelector.tsx
@@ -75,7 +75,7 @@ steps:
     description: null
     diffs:
       - file: app/components/Header.tsx
-        patchFile: Header.tsx.82c1ce.patch
+        patchFile: Header.tsx.e25645.patch
   - type: NEW_FILE
     step: "3"
     name: app/components/PriceBreaks.tsx
@@ -88,7 +88,7 @@ steps:
     description: null
     diffs:
       - file: app/components/ProductForm.tsx
-        patchFile: ProductForm.tsx.252e88.patch
+        patchFile: ProductForm.tsx.649d3b.patch
   - type: NEW_FILE
     step: "4"
     name: app/components/QuantityRules.tsx
@@ -101,7 +101,7 @@ steps:
     description: null
     diffs:
       - file: app/lib/fragments.ts
-        patchFile: fragments.ts.18726b.patch
+        patchFile: fragments.ts.026109.patch
   - type: NEW_FILE
     step: "5"
     name: app/graphql/customer-account/CustomerLocationsQuery.ts
@@ -114,7 +114,7 @@ steps:
     description: null
     diffs:
       - file: app/root.tsx
-        patchFile: root.tsx.8c182c.patch
+        patchFile: root.tsx.5e9998.patch
   - type: NEW_FILE
     step: "6"
     name: app/routes/b2blocations.tsx
@@ -127,16 +127,16 @@ steps:
     description: null
     diffs:
       - file: app/routes/account_.logout.tsx
-        patchFile: account_.logout.tsx.1da785.patch
+        patchFile: account_.logout.tsx.a1f12e.patch
   - type: PATCH
     step: "8"
     name: app/routes/products.$handle.tsx
     description: null
     diffs:
       - file: app/routes/products.$handle.tsx
-        patchFile: products.$handle.tsx.7addea.patch
+        patchFile: products.$handle.tsx.6f2e82.patch
 nextSteps: null
 llms:
   userQueries: []
   troubleshooting: []
-commit: 147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7
+commit: 25290311dd1d135ab90bca26fb496d2b92c8631a

--- a/cookbook/recipes/express/patches/.graphqlrc.ts.dbb3fe.patch
+++ b/cookbook/recipes/express/patches/.graphqlrc.ts.dbb3fe.patch
@@ -1,4 +1,4 @@
-index 62df77106..44994a7c0 100644
+index 62df7710..44994a7c 100644
 --- a/templates/skeleton/.graphqlrc.ts
 +++ b/templates/skeleton/.graphqlrc.ts
 @@ -17,10 +17,11 @@ export default {

--- a/cookbook/recipes/express/patches/README.md.db10ed.patch
+++ b/cookbook/recipes/express/patches/README.md.db10ed.patch
@@ -1,4 +1,4 @@
-index c584e5370..4cecca6db 100644
+index c584e537..4cecca6d 100644
 --- a/templates/skeleton/README.md
 +++ b/templates/skeleton/README.md
 @@ -1,45 +1,89 @@

--- a/cookbook/recipes/express/patches/_index.tsx.243e26.patch
+++ b/cookbook/recipes/express/patches/_index.tsx.243e26.patch
@@ -1,4 +1,4 @@
-index 28102dbe6..dc121c804 100644
+index 28102dbe..dc121c80 100644
 --- a/templates/skeleton/app/routes/_index.tsx
 +++ b/templates/skeleton/app/routes/_index.tsx
 @@ -1,171 +1,28 @@

--- a/cookbook/recipes/express/patches/app.css.881a99.patch
+++ b/cookbook/recipes/express/patches/app.css.881a99.patch
@@ -1,4 +1,4 @@
-index a280aba13..5ede7d95e 100644
+index a280aba1..5ede7d95 100644
 --- a/templates/skeleton/app/styles/app.css
 +++ b/templates/skeleton/app/styles/app.css
 @@ -1,584 +1,40 @@

--- a/cookbook/recipes/express/patches/entry.client.tsx.0b6923.patch
+++ b/cookbook/recipes/express/patches/entry.client.tsx.0b6923.patch
@@ -1,4 +1,4 @@
-index 9b7b86cbd..c1aa68ad8 100644
+index 9b7b86cb..c1aa68ad 100644
 --- a/templates/skeleton/app/entry.client.tsx
 +++ b/templates/skeleton/app/entry.client.tsx
 @@ -1,21 +1,13 @@

--- a/cookbook/recipes/express/patches/entry.server.tsx.b35f11.patch
+++ b/cookbook/recipes/express/patches/entry.server.tsx.b35f11.patch
@@ -1,4 +1,4 @@
-index 6f5c4abfc..a407bed64 100644
+index 6f5c4abf..a407bed6 100644
 --- a/templates/skeleton/app/entry.server.tsx
 +++ b/templates/skeleton/app/entry.server.tsx
 @@ -1,53 +1,77 @@

--- a/cookbook/recipes/express/patches/eslint.config.js.e5f62b.patch
+++ b/cookbook/recipes/express/patches/eslint.config.js.e5f62b.patch
@@ -1,4 +1,4 @@
-index 6c972c781..fa8054776 100644
+index 6c972c78..fa805477 100644
 --- a/templates/skeleton/eslint.config.js
 +++ b/templates/skeleton/eslint.config.js
 @@ -1,246 +1,2 @@

--- a/cookbook/recipes/express/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/express/patches/package.json.f30b0a.patch
@@ -1,4 +1,4 @@
-index 8f26b4224..dac1d9cfa 100644
+index 8f26b422..dac1d9cf 100644
 --- a/templates/skeleton/package.json
 +++ b/templates/skeleton/package.json
 @@ -5,58 +5,51 @@

--- a/cookbook/recipes/express/patches/products.$handle.tsx.6f2e82.patch
+++ b/cookbook/recipes/express/patches/products.$handle.tsx.6f2e82.patch
@@ -1,4 +1,4 @@
-index 422a2eb95..061b059ca 100644
+index 422a2eb9..061b059c 100644
 --- a/templates/skeleton/app/routes/products.$handle.tsx
 +++ b/templates/skeleton/app/routes/products.$handle.tsx
 @@ -1,50 +1,7 @@

--- a/cookbook/recipes/express/patches/root.tsx.5e9998.patch
+++ b/cookbook/recipes/express/patches/root.tsx.5e9998.patch
@@ -1,4 +1,4 @@
-index fa83da97e..1ba9888f0 100644
+index df87425c..1ba9888f 100644
 --- a/templates/skeleton/app/root.tsx
 +++ b/templates/skeleton/app/root.tsx
 @@ -11,46 +11,20 @@ import {
@@ -164,12 +164,11 @@ index fa83da97e..1ba9888f0 100644
        consent={data.consent}
      >
 -      <PageLayout {...data}>
--        <Outlet />;
--      </PageLayout>
 +      <div className="PageLayout">
 +        <h1>{data.layout?.shop?.name} (Express example)</h1>
 +        <h2>{data.layout?.shop?.description}</h2>
-+        <Outlet />
+         <Outlet />
+-      </PageLayout>
 +      </div>
      </Analytics.Provider>
    );

--- a/cookbook/recipes/express/patches/routes.ts.87938f.patch
+++ b/cookbook/recipes/express/patches/routes.ts.87938f.patch
@@ -1,4 +1,4 @@
-index 7df8a1b9c..a1610c2bc 100644
+index 7df8a1b9..a1610c2b 100644
 --- a/templates/skeleton/app/routes.ts
 +++ b/templates/skeleton/app/routes.ts
 @@ -1,9 +1,8 @@

--- a/cookbook/recipes/express/patches/vite.config.ts.475b4c.patch
+++ b/cookbook/recipes/express/patches/vite.config.ts.475b4c.patch
@@ -1,4 +1,4 @@
-index a17024462..058b559de 100644
+index a1702446..058b559d 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
 @@ -5,13 +5,15 @@ import {reactRouter} from '@react-router/dev/vite';

--- a/cookbook/recipes/express/recipe.yaml
+++ b/cookbook/recipes/express/recipe.yaml
@@ -107,14 +107,14 @@ steps:
     description: null
     diffs:
       - file: .graphqlrc.ts
-        patchFile: .graphqlrc.ts.891c10.patch
+        patchFile: .graphqlrc.ts.dbb3fe.patch
   - type: PATCH
     step: "1"
     name: README.md
     description: null
     diffs:
       - file: README.md
-        patchFile: README.md.49f8fa.patch
+        patchFile: README.md.db10ed.patch
   - type: NEW_FILE
     step: "1"
     name: app/env.ts
@@ -127,7 +127,7 @@ steps:
     description: null
     diffs:
       - file: app/entry.client.tsx
-        patchFile: entry.client.tsx.11faa5.patch
+        patchFile: entry.client.tsx.0b6923.patch
   - type: NEW_FILE
     step: "2"
     name: public/favicon.svg
@@ -140,7 +140,7 @@ steps:
     description: null
     diffs:
       - file: app/entry.server.tsx
-        patchFile: entry.server.tsx.6d386f.patch
+        patchFile: entry.server.tsx.b35f11.patch
   - type: NEW_FILE
     step: "3"
     name: scripts/dev.mjs
@@ -153,7 +153,7 @@ steps:
     description: null
     diffs:
       - file: app/root.tsx
-        patchFile: root.tsx.8c182c.patch
+        patchFile: root.tsx.5e9998.patch
   - type: NEW_FILE
     step: "4"
     name: server.mjs
@@ -166,49 +166,49 @@ steps:
     description: null
     diffs:
       - file: app/routes.ts
-        patchFile: routes.ts.e77b9b.patch
+        patchFile: routes.ts.87938f.patch
   - type: PATCH
     step: "6"
     name: app/routes/_index.tsx
     description: null
     diffs:
       - file: app/routes/_index.tsx
-        patchFile: _index.tsx.ee5996.patch
+        patchFile: _index.tsx.243e26.patch
   - type: PATCH
     step: "7"
     name: app/routes/products.$handle.tsx
     description: null
     diffs:
       - file: app/routes/products.$handle.tsx
-        patchFile: products.$handle.tsx.7addea.patch
+        patchFile: products.$handle.tsx.6f2e82.patch
   - type: PATCH
     step: "8"
     name: app/styles/app.css
     description: null
     diffs:
       - file: app/styles/app.css
-        patchFile: app.css.48239a.patch
+        patchFile: app.css.881a99.patch
   - type: PATCH
     step: "9"
     name: eslint.config.js
     description: null
     diffs:
       - file: eslint.config.js
-        patchFile: eslint.config.js.63bcba.patch
+        patchFile: eslint.config.js.e5f62b.patch
   - type: PATCH
     step: "10"
     name: package.json
     description: null
     diffs:
       - file: package.json
-        patchFile: package.json.47be7b.patch
+        patchFile: package.json.f30b0a.patch
   - type: PATCH
     step: "13"
     name: vite.config.ts
     description: null
     diffs:
       - file: vite.config.ts
-        patchFile: vite.config.ts.93b90b.patch
+        patchFile: vite.config.ts.475b4c.patch
 nextSteps: |
   - Create a .env file with your Shopify Storefront API credentials:
     PUBLIC_STOREFRONT_API_TOKEN="your-token"
@@ -242,4 +242,4 @@ llms:
     - issue: TypeScript errors about missing @react-router/node types
       solution: Run 'npm install' to ensure all dependencies including @types packages
         are installed.
-commit: 147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7
+commit: 25290311dd1d135ab90bca26fb496d2b92c8631a

--- a/cookbook/recipes/gtm/patches/README.md.db10ed.patch
+++ b/cookbook/recipes/gtm/patches/README.md.db10ed.patch
@@ -1,4 +1,4 @@
-index c584e5370..a31bfebf0 100644
+index c584e537..a31bfebf 100644
 --- a/templates/skeleton/README.md
 +++ b/templates/skeleton/README.md
 @@ -1,6 +1,6 @@

--- a/cookbook/recipes/gtm/patches/entry.server.tsx.b35f11.patch
+++ b/cookbook/recipes/gtm/patches/entry.server.tsx.b35f11.patch
@@ -1,4 +1,4 @@
-index 6f5c4abfc..b8eb74f4b 100644
+index 6f5c4abf..b8eb74f4 100644
 --- a/templates/skeleton/app/entry.server.tsx
 +++ b/templates/skeleton/app/entry.server.tsx
 @@ -15,6 +15,24 @@ export default async function handleRequest(

--- a/cookbook/recipes/gtm/patches/root.tsx.5e9998.patch
+++ b/cookbook/recipes/gtm/patches/root.tsx.5e9998.patch
@@ -1,4 +1,4 @@
-index fa83da97e..aa25c6d7c 100644
+index df87425c..aa25c6d7 100644
 --- a/templates/skeleton/app/root.tsx
 +++ b/templates/skeleton/app/root.tsx
 @@ -1,4 +1,4 @@
@@ -48,12 +48,9 @@ index fa83da97e..aa25c6d7c 100644
          {children}
          <ScrollRestoration nonce={nonce} />
          <Scripts nonce={nonce} />
-@@ -177,8 +202,10 @@ export default function App() {
-       consent={data.consent}
-     >
+@@ -179,6 +204,8 @@ export default function App() {
        <PageLayout {...data}>
--        <Outlet />;
-+        <Outlet />
+         <Outlet />
        </PageLayout>
 +      {/* @description Initialize Google Tag Manager analytics integration */}
 +      <GoogleTagManager />

--- a/cookbook/recipes/gtm/recipe.yaml
+++ b/cookbook/recipes/gtm/recipe.yaml
@@ -54,14 +54,14 @@ steps:
     description: Updates README with GTM-specific documentation and setup instructions
     diffs:
       - file: README.md
-        patchFile: README.md.49f8fa.patch
+        patchFile: README.md.db10ed.patch
   - type: PATCH
     step: "1"
     name: app/entry.server.tsx
     description: null
     diffs:
       - file: app/entry.server.tsx
-        patchFile: entry.server.tsx.6d386f.patch
+        patchFile: entry.server.tsx.b35f11.patch
   - type: NEW_FILE
     step: "1"
     name: app/components/GoogleTagManager.tsx
@@ -74,7 +74,7 @@ steps:
     description: null
     diffs:
       - file: app/root.tsx
-        patchFile: root.tsx.8c182c.patch
+        patchFile: root.tsx.5e9998.patch
 nextSteps: |
   After applying this recipe:
 
@@ -100,4 +100,4 @@ nextSteps: |
 llms:
   userQueries: []
   troubleshooting: []
-commit: 147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7
+commit: 25290311dd1d135ab90bca26fb496d2b92c8631a

--- a/cookbook/recipes/markets/patches/CartLineItem.tsx.2c9a50.patch
+++ b/cookbook/recipes/markets/patches/CartLineItem.tsx.2c9a50.patch
@@ -1,4 +1,4 @@
-index 80e34be28..bd520a033 100644
+index 80e34be2..bd520a03 100644
 --- a/templates/skeleton/app/components/CartLineItem.tsx
 +++ b/templates/skeleton/app/components/CartLineItem.tsx
 @@ -2,7 +2,7 @@ import type {CartLineUpdateInput} from '@shopify/hydrogen/storefront-api-types';

--- a/cookbook/recipes/markets/patches/CartMain.tsx.035161.patch
+++ b/cookbook/recipes/markets/patches/CartMain.tsx.035161.patch
@@ -1,4 +1,4 @@
-index b16094294..6fb9c1a80 100644
+index b1609429..6fb9c1a8 100644
 --- a/templates/skeleton/app/components/CartMain.tsx
 +++ b/templates/skeleton/app/components/CartMain.tsx
 @@ -1,5 +1,5 @@

--- a/cookbook/recipes/markets/patches/Header.tsx.e25645.patch
+++ b/cookbook/recipes/markets/patches/Header.tsx.e25645.patch
@@ -1,4 +1,4 @@
-index 45b620b49..00c29ecc9 100644
+index 45b620b4..00c29ecc 100644
 --- a/templates/skeleton/app/components/Header.tsx
 +++ b/templates/skeleton/app/components/Header.tsx
 @@ -1,5 +1,6 @@

--- a/cookbook/recipes/markets/patches/ProductItem.tsx.d3223b.patch
+++ b/cookbook/recipes/markets/patches/ProductItem.tsx.d3223b.patch
@@ -1,4 +1,4 @@
-index 3b0f69133..81ff9ec9f 100644
+index 3b0f6913..81ff9ec9 100644
 --- a/templates/skeleton/app/components/ProductItem.tsx
 +++ b/templates/skeleton/app/components/ProductItem.tsx
 @@ -1,4 +1,3 @@

--- a/cookbook/recipes/markets/patches/context.ts.1877b3.patch
+++ b/cookbook/recipes/markets/patches/context.ts.1877b3.patch
@@ -1,4 +1,4 @@
-index 3989ec05e..385d12f04 100644
+index 3989ec05..385d12f0 100644
 --- a/templates/skeleton/app/lib/context.ts
 +++ b/templates/skeleton/app/lib/context.ts
 @@ -1,6 +1,7 @@

--- a/cookbook/recipes/markets/patches/root.tsx.5e9998.patch
+++ b/cookbook/recipes/markets/patches/root.tsx.5e9998.patch
@@ -1,4 +1,4 @@
-index fa83da97e..97ca81746 100644
+index df87425c..97ca8174 100644
 --- a/templates/skeleton/app/root.tsx
 +++ b/templates/skeleton/app/root.tsx
 @@ -77,6 +77,7 @@ export async function loader(args: Route.LoaderArgs) {
@@ -9,17 +9,15 @@ index fa83da97e..97ca81746 100644
      publicStoreDomain: env.PUBLIC_STORE_DOMAIN,
      shop: getShopAnalytics({
        storefront,
-@@ -176,8 +177,11 @@ export default function App() {
+@@ -176,7 +177,10 @@ export default function App() {
        shop={data.shop}
        consent={data.consent}
      >
 -      <PageLayout {...data}>
--        <Outlet />;
 +      <PageLayout
 +        key={`${data.selectedLocale.language}-${data.selectedLocale.country}`}
 +        {...data}
 +      >
-+        <Outlet />
+         <Outlet />
        </PageLayout>
      </Analytics.Provider>
-   );

--- a/cookbook/recipes/markets/recipe.yaml
+++ b/cookbook/recipes/markets/recipe.yaml
@@ -153,7 +153,7 @@ steps:
     description: Update cart line items to use the unified Link component for product links
     diffs:
       - file: app/components/CartLineItem.tsx
-        patchFile: CartLineItem.tsx.f93ff4.patch
+        patchFile: CartLineItem.tsx.2c9a50.patch
   - type: NEW_FILE
     step: 1.1
     name: Create a CountrySelector component
@@ -198,7 +198,7 @@ steps:
       This ensures all product links automatically include the correct locale prefix.
     diffs:
       - file: app/components/ProductItem.tsx
-        patchFile: ProductItem.tsx.f84e8c.patch
+        patchFile: ProductItem.tsx.d3223b.patch
   - type: PATCH
     step: 1.5
     name: Add the selected locale to the context
@@ -206,7 +206,7 @@ steps:
       Detect the locale from the URL path, and add it to the HydrogenContext.
     diffs:
       - file: app/lib/context.ts
-        patchFile: context.ts.cfd9da.patch
+        patchFile: context.ts.1877b3.patch
   - type: PATCH
     step: 1.6
     name: Update Header with CountrySelector and locale-aware Links
@@ -216,7 +216,7 @@ steps:
       3. Menu URLs are automatically cleaned of invalid locale prefixes
     diffs:
       - file: app/components/Header.tsx
-        patchFile: Header.tsx.82c1ce.patch
+        patchFile: Header.tsx.e25645.patch
   - type: PATCH
     step: 1.7
     name: Add the selected locale to the root route
@@ -227,7 +227,7 @@ steps:
       when the locale changes.
     diffs:
       - file: app/root.tsx
-        patchFile: root.tsx.8c182c.patch
+        patchFile: root.tsx.5e9998.patch
   - type: INFO
     step: 2
     name: Localizing the individual routes
@@ -240,7 +240,7 @@ steps:
       component for consistent navigation
     diffs:
       - file: app/components/CartMain.tsx
-        patchFile: CartMain.tsx.6d121b.patch
+        patchFile: CartMain.tsx.035161.patch
   - type: INFO
     step: 2.1
     name: Add language dynamic segment to the desired routes
@@ -430,4 +430,4 @@ llms:
       solution: Make sure you update *all* routes that need localization (not only the
         routes for the home page, the cart page, and the product page). See step
         2.1 for details.
-commit: 147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7
+commit: 25290311dd1d135ab90bca26fb496d2b92c8631a

--- a/cookbook/recipes/partytown/patches/.gitignore.0c7440.patch
+++ b/cookbook/recipes/partytown/patches/.gitignore.0c7440.patch
@@ -1,4 +1,4 @@
-index 4a0c4ce52..b47aa7338 100644
+index 4a0c4ce5..b47aa733 100644
 --- a/templates/skeleton/.gitignore
 +++ b/templates/skeleton/.gitignore
 @@ -4,6 +4,7 @@ node_modules

--- a/cookbook/recipes/partytown/patches/README.md.db10ed.patch
+++ b/cookbook/recipes/partytown/patches/README.md.db10ed.patch
@@ -1,4 +1,4 @@
-index c584e5370..1ac3a34cb 100644
+index c584e537..1ac3a34c 100644
 --- a/templates/skeleton/README.md
 +++ b/templates/skeleton/README.md
 @@ -1,6 +1,6 @@

--- a/cookbook/recipes/partytown/patches/entry.server.tsx.b35f11.patch
+++ b/cookbook/recipes/partytown/patches/entry.server.tsx.b35f11.patch
@@ -1,4 +1,4 @@
-index 6f5c4abfc..a2443e77b 100644
+index 6f5c4abf..a2443e77 100644
 --- a/templates/skeleton/app/entry.server.tsx
 +++ b/templates/skeleton/app/entry.server.tsx
 @@ -19,6 +19,19 @@ export default async function handleRequest(

--- a/cookbook/recipes/partytown/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/partytown/patches/package.json.f30b0a.patch
@@ -1,4 +1,4 @@
-index 8f26b4224..54739b4e0 100644
+index 8f26b422..54739b4e 100644
 --- a/templates/skeleton/package.json
 +++ b/templates/skeleton/package.json
 @@ -8,12 +8,14 @@

--- a/cookbook/recipes/partytown/patches/root.tsx.5e9998.patch
+++ b/cookbook/recipes/partytown/patches/root.tsx.5e9998.patch
@@ -1,4 +1,4 @@
-index fa83da97e..a2b8986a6 100644
+index df87425c..a2b8986a 100644
 --- a/templates/skeleton/app/root.tsx
 +++ b/templates/skeleton/app/root.tsx
 @@ -1,4 +1,4 @@
@@ -68,13 +68,11 @@ index fa83da97e..a2b8986a6 100644
  export default function App() {
    const data = useRouteLoaderData<RootLoader>('root');
  
-@@ -177,7 +217,8 @@ export default function App() {
+@@ -177,6 +217,7 @@ export default function App() {
        consent={data.consent}
      >
        <PageLayout {...data}>
--        <Outlet />;
 +        <PartyTownScripts gtmContainerId={data.gtmContainerId} />
-+        <Outlet />
+         <Outlet />
        </PageLayout>
      </Analytics.Provider>
-   );

--- a/cookbook/recipes/partytown/patches/vite.config.ts.475b4c.patch
+++ b/cookbook/recipes/partytown/patches/vite.config.ts.475b4c.patch
@@ -1,4 +1,4 @@
-index a17024462..a2e3dda9c 100644
+index a1702446..a2e3dda9 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
 @@ -23,7 +23,12 @@ export default defineConfig({

--- a/cookbook/recipes/partytown/recipe.yaml
+++ b/cookbook/recipes/partytown/recipe.yaml
@@ -40,7 +40,7 @@ steps:
     description: Add public/~partytown to ignore Partytown library files
     diffs:
       - file: .gitignore
-        patchFile: .gitignore.0d4d92.patch
+        patchFile: .gitignore.0c7440.patch
   - type: NEW_FILE
     step: "1"
     name: app/components/PartytownGoogleTagManager.tsx
@@ -53,7 +53,7 @@ steps:
     description: Document Partytown setup and configuration instructions
     diffs:
       - file: README.md
-        patchFile: README.md.49f8fa.patch
+        patchFile: README.md.db10ed.patch
   - type: NEW_FILE
     step: "2"
     name: app/routes/reverse-proxy.ts
@@ -66,7 +66,7 @@ steps:
     description: Configure CSP headers for GTM and Google Analytics domains
     diffs:
       - file: app/entry.server.tsx
-        patchFile: entry.server.tsx.6d386f.patch
+        patchFile: entry.server.tsx.b35f11.patch
   - type: NEW_FILE
     step: "3"
     name: app/utils/partytown/maybeProxyRequest.ts
@@ -79,7 +79,7 @@ steps:
     description: Initialize Partytown and GTM in the root layout
     diffs:
       - file: app/root.tsx
-        patchFile: root.tsx.8c182c.patch
+        patchFile: root.tsx.5e9998.patch
   - type: NEW_FILE
     step: "4"
     name: app/utils/partytown/partytownAtomicHeaders.ts
@@ -92,14 +92,14 @@ steps:
     description: Add Partytown dependency and npm script for copying library files
     diffs:
       - file: package.json
-        patchFile: package.json.47be7b.patch
+        patchFile: package.json.f30b0a.patch
   - type: PATCH
     step: "6"
     name: vite.config.ts
     description: null
     diffs:
       - file: vite.config.ts
-        patchFile: vite.config.ts.93b90b.patch
+        patchFile: vite.config.ts.475b4c.patch
 nextSteps: |
   After applying this recipe:
 
@@ -125,4 +125,4 @@ nextSteps: |
 llms:
   userQueries: []
   troubleshooting: []
-commit: 147c5bdb47b2fa51d4da79cd94f5dd6c1cce2cc7
+commit: 25290311dd1d135ab90bca26fb496d2b92c8631a

--- a/packages/hydrogen-react/src/ShopifyProvider.test.tsx
+++ b/packages/hydrogen-react/src/ShopifyProvider.test.tsx
@@ -20,7 +20,7 @@ describe('<ShopifyProvider/>', () => {
   it('renders its children', () => {
     render(
       <ShopifyProvider {...SHOPIFY_CONFIG}>
-        <div>child</div>;
+        <div>child</div>
       </ShopifyProvider>,
     );
 

--- a/packages/hydrogen/src/analytics-manager/AnalyticsProvider.test.tsx
+++ b/packages/hydrogen/src/analytics-manager/AnalyticsProvider.test.tsx
@@ -131,7 +131,7 @@ describe('<Analytics.Provider />', () => {
   it('renders its children', async () => {
     render(
       <Analytics.Provider cart={null} shop={SHOP_DATA} consent={CONSENT_DATA}>
-        <div>child</div>;
+        <div>child</div>
       </Analytics.Provider>,
     );
 


### PR DESCRIPTION
### WHY are these changes introduced?

This custom rule catches stray semicolons and commas that appear as JSX text,
which are almost always unintentional. A trailing semicolon recently made it
to production in our skeleton template and was rendered on every route.

Since these are technically valid JSX text content, no existing ESLint rules
catch them. This custom rule specifically targets single-character text nodes
that are likely typos (currently ';' and ',').

The rule is added at the root project level rather than in individual
templates to ensure consistent coverage across all packages.

### WHAT is this pull request doing?

Adds a new, custom ESLint rule
- Accidental trailing semicolons (like what we fixed in [this PR](https://github.com/Shopify/hydrogen/pull/3186/files)) will now error when the linter runs


#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
