### PR TITLE
Add Dynamic Customer Account Endpoint Discovery

### DIFF
--- a/.changeset/customer-account-discovery-endpoints.md
+++ b/.changeset/customer-account-discovery-endpoints.md
@@ -2,26 +2,13 @@
 '@shopify/hydrogen': minor
 ---
 
-Discover Customer Account API and authentication URLs dynamically via .well-known endpoints on the storefront domain. This eliminates hardcoded shopify.com URLs and reduces maintenance burden as authentication paths evolve.
+Customer Account API and authentication URLs are now dynamically discovered via .well-known endpoints on the storefront domain. This eliminates hardcoded shopify.com URLs and reduces maintenance burden as authentication paths evolve.
 
-## New Features
+Discovery is always enabled and happens automatically in the background. If discovery fails or is unavailable, the system seamlessly falls back to legacy shopify.com URLs, ensuring continued functionality without any required changes.
+
+## Features
 
 - Dynamic discovery of Customer Account endpoints via `.well-known/openid-configuration` and `.well-known/customer-account-api`
 - Automatic fallback to legacy shopify.com URLs when discovery fails
 - In-memory caching with 1-hour TTL to minimize network requests
-- Configurable via `useDiscovery` and `storefrontDomain` options in `createCustomerAccountClient`
-
-## Breaking Changes
-
-None. Discovery is enabled by default but gracefully falls back to legacy URLs, maintaining full backward compatibility.
-
-## Migration
-
-No action required. Discovery is enabled automatically and uses the storefront domain from `env.PUBLIC_STORE_DOMAIN` or extracts it from the request URL. To disable discovery:
-
-```typescript
-const customerAccount = createCustomerAccountClient({
-  // ... other options
-  useDiscovery: false, // Disable discovery, use legacy URLs
-});
-```
+- Optional `storefrontDomain` parameter in `createCustomerAccountClient` to specify the domain for discovery (defaults to extracting from request URL)

--- a/.changeset/customer-account-discovery-endpoints.md
+++ b/.changeset/customer-account-discovery-endpoints.md
@@ -1,0 +1,27 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Discover Customer Account API and authentication URLs dynamically via .well-known endpoints on the storefront domain. This eliminates hardcoded shopify.com URLs and reduces maintenance burden as authentication paths evolve.
+
+## New Features
+
+- Dynamic discovery of Customer Account endpoints via `.well-known/openid-configuration` and `.well-known/customer-account-api`
+- Automatic fallback to legacy shopify.com URLs when discovery fails
+- In-memory caching with 1-hour TTL to minimize network requests
+- Configurable via `useDiscovery` and `storefrontDomain` options in `createCustomerAccountClient`
+
+## Breaking Changes
+
+None. Discovery is enabled by default but gracefully falls back to legacy URLs, maintaining full backward compatibility.
+
+## Migration
+
+No action required. Discovery is enabled automatically and uses the storefront domain from `env.PUBLIC_STORE_DOMAIN` or extracts it from the request URL. To disable discovery:
+
+```typescript
+const customerAccount = createCustomerAccountClient({
+  // ... other options
+  useDiscovery: false, // Disable discovery, use legacy URLs
+});
+```

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -219,6 +219,7 @@ export function createHydrogenContext<
     // defaults
     customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID,
     shopId: env.SHOP_ID,
+    storefrontDomain: env.PUBLIC_STORE_DOMAIN,
   });
 
   /*

--- a/packages/hydrogen/src/customer/customer-account-helper.test.ts
+++ b/packages/hydrogen/src/customer/customer-account-helper.test.ts
@@ -4,6 +4,7 @@ import {
   createCustomerAccountHelperWithDiscovery,
   URL_TYPE,
 } from './customer-account-helper';
+import type {DiscoveredEndpoints} from './discovery';
 
 // Mock the discovery module
 vi.mock('./discovery', () => ({
@@ -11,161 +12,60 @@ vi.mock('./discovery', () => ({
 }));
 
 const shopId = '1';
-const customerAccountUrl = `https://shopify.com/${shopId}`;
+const storefrontDomain = 'test-shop.myshopify.com';
 
-describe('return correct urls', () => {
-  describe('when shopId is provided', () => {
-    const getAccountUrl = createCustomerAccountHelper('2025-07', shopId);
+describe('createCustomerAccountHelper', () => {
+  const discoveredEndpoints: DiscoveredEndpoints = {
+    graphqlApiUrl:
+      'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
+    authorizationUrl: 'https://test-shop.account.myshopify.com/oauth/authorize',
+    tokenUrl: 'https://test-shop.account.myshopify.com/oauth/token',
+    logoutUrl: 'https://test-shop.account.myshopify.com/logout',
+  };
 
-    it('returns customer account base url', () => {
-      expect(getAccountUrl(URL_TYPE.CA_BASE_URL)).toBe(customerAccountUrl);
-    });
+  const getAccountUrl = createCustomerAccountHelper(
+    '2025-07',
+    shopId,
+    storefrontDomain,
+    discoveredEndpoints,
+  );
 
-    it('returns customer account auth url', () => {
-      expect(getAccountUrl(URL_TYPE.CA_BASE_AUTH_URL)).toBe(
-        `https://shopify.com/authentication/${shopId}`,
-      );
-    });
-
-    it('returns customer account graphql url', () => {
-      expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
-        `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
-      );
-    });
-
-    it('returns customer account authorize url', () => {
-      expect(getAccountUrl(URL_TYPE.AUTH)).toBe(
-        `https://shopify.com/authentication/${shopId}/oauth/authorize`,
-      );
-    });
-
-    it('returns customer account login scope', () => {
-      expect(getAccountUrl(URL_TYPE.LOGIN_SCOPE)).toBe(
-        'openid email customer-account-api:full',
-      );
-    });
-
-    it('returns customer account token exchange url', () => {
-      expect(getAccountUrl(URL_TYPE.TOKEN_EXCHANGE)).toBe(
-        `https://shopify.com/authentication/${shopId}/oauth/token`,
-      );
-    });
-
-    it('returns customer account logout url', () => {
-      expect(getAccountUrl(URL_TYPE.LOGOUT)).toBe(
-        `https://shopify.com/authentication/${shopId}/logout`,
-      );
-    });
-  });
-});
-
-describe('legacy behavior without discovery', () => {
-  it('maintains backward compatibility with existing API', () => {
-    const getAccountUrl = createCustomerAccountHelper('2025-07', shopId);
-    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
-      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
-    );
-  });
-
-  it('works with discovery disabled', () => {
-    const storefrontDomain = 'test-shop.myshopify.com';
-    const getAccountUrl = createCustomerAccountHelper(
-      '2025-07',
-      shopId,
-      storefrontDomain,
-      false, // discovery disabled
-    );
-    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
-      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
-    );
-  });
-});
-
-describe('discovery functionality', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('uses discovered GraphQL endpoint when available', () => {
-    const storefrontDomain = 'test-shop.myshopify.com';
-    const discoveredEndpoints = {
-      graphqlApiUrl:
-        'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
-      authorizationUrl:
-        'https://test-shop.account.myshopify.com/oauth/authorize',
-      tokenUrl: 'https://test-shop.account.myshopify.com/oauth/token',
-      logoutUrl: 'https://test-shop.account.myshopify.com/logout',
-    };
-
-    const getAccountUrl = createCustomerAccountHelper(
-      '2025-07',
-      shopId,
-      storefrontDomain,
-      true,
-      discoveredEndpoints,
-    );
-
+  it('returns discovered GraphQL endpoint', () => {
     expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
       discoveredEndpoints.graphqlApiUrl,
     );
+  });
+
+  it('returns discovered authorization endpoint', () => {
     expect(getAccountUrl(URL_TYPE.AUTH)).toBe(
       discoveredEndpoints.authorizationUrl,
     );
+  });
+
+  it('returns discovered token exchange endpoint', () => {
     expect(getAccountUrl(URL_TYPE.TOKEN_EXCHANGE)).toBe(
       discoveredEndpoints.tokenUrl,
     );
+  });
+
+  it('returns discovered logout endpoint', () => {
     expect(getAccountUrl(URL_TYPE.LOGOUT)).toBe(discoveredEndpoints.logoutUrl);
   });
 
-  it('falls back to legacy URLs when discovery fails', () => {
-    const storefrontDomain = 'test-shop.myshopify.com';
-
-    const getAccountUrl = createCustomerAccountHelper(
-      '2025-07',
-      shopId,
-      storefrontDomain,
-      true,
-      null, // No discovered endpoints
-    );
-
-    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
-      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
-    );
-    expect(getAccountUrl(URL_TYPE.AUTH)).toBe(
-      `https://shopify.com/authentication/${shopId}/oauth/authorize`,
-    );
-  });
-
-  it('extracts base URLs from discovered endpoints', () => {
-    const storefrontDomain = 'test-shop.myshopify.com';
-    const discoveredEndpoints = {
-      graphqlApiUrl:
-        'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
-      authorizationUrl:
-        'https://test-shop.account.myshopify.com/authentication/oauth/authorize',
-      tokenUrl: 'https://test-shop.account.myshopify.com/oauth/token',
-      logoutUrl: 'https://test-shop.account.myshopify.com/logout',
-    };
-
-    const getAccountUrl = createCustomerAccountHelper(
-      '2025-07',
-      shopId,
-      storefrontDomain,
-      true,
-      discoveredEndpoints,
-    );
-
+  it('extracts base URL from discovered GraphQL endpoint', () => {
     expect(getAccountUrl(URL_TYPE.CA_BASE_URL)).toBe(
       'https://test-shop.account.myshopify.com',
     );
+  });
+
+  it('extracts base auth URL from discovered authorization endpoint', () => {
     expect(getAccountUrl(URL_TYPE.CA_BASE_AUTH_URL)).toBe(
       'https://test-shop.account.myshopify.com',
     );
   });
 
   it('replaces API version in discovered GraphQL URL', () => {
-    const storefrontDomain = 'test-shop.myshopify.com';
-    const discoveredEndpoints = {
+    const endpointsWithOldVersion: DiscoveredEndpoints = {
       graphqlApiUrl:
         'https://test-shop.account.myshopify.com/customer/api/2024-01/graphql',
       authorizationUrl:
@@ -174,31 +74,41 @@ describe('discovery functionality', () => {
       logoutUrl: 'https://test-shop.account.myshopify.com/logout',
     };
 
+    const expectedVersion = '2025-07';
     const getAccountUrl = createCustomerAccountHelper(
-      '2025-07', // Different version than discovered URL
+      expectedVersion,
       shopId,
       storefrontDomain,
-      true,
-      discoveredEndpoints,
+      endpointsWithOldVersion,
     );
 
-    // Should use discovered domain but replace version with the one provided
     expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
-      'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
+      `https://test-shop.account.myshopify.com/customer/api/${expectedVersion}/graphql`,
     );
   });
 
-  it('handles missing storefront domain with discovery enabled', () => {
+  it('returns correct login scope for shopId', () => {
+    expect(getAccountUrl(URL_TYPE.LOGIN_SCOPE)).toBe(
+      'openid email customer-account-api:full',
+    );
+  });
+
+  it('returns correct login scope without shopId', () => {
     const getAccountUrl = createCustomerAccountHelper(
       '2025-07',
-      shopId,
-      undefined, // no domain
-      true, // discovery enabled
+      '', // empty shopId
+      storefrontDomain,
+      discoveredEndpoints,
     );
 
-    // Should fall back to legacy URLs
-    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
-      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
+    expect(getAccountUrl(URL_TYPE.LOGIN_SCOPE)).toBe(
+      'openid email https://api.customers.com/auth/customer.graphql',
+    );
+  });
+
+  it('throws error for unknown URL type', () => {
+    expect(() => getAccountUrl('UNKNOWN' as URL_TYPE)).toThrow(
+      'Unknown URL type: UNKNOWN',
     );
   });
 });
@@ -206,14 +116,11 @@ describe('discovery functionality', () => {
 describe('createCustomerAccountHelperWithDiscovery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset console methods
-    vi.spyOn(console, 'log').mockImplementation(() => {});
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   it('successfully creates helper with discovery', async () => {
     const {discoverCustomerAccountEndpoints} = await import('./discovery');
-    const mockEndpoints = {
+    const mockEndpoints: DiscoveredEndpoints = {
       graphqlApiUrl:
         'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
       authorizationUrl:
@@ -229,34 +136,55 @@ describe('createCustomerAccountHelperWithDiscovery', () => {
     const helper = await createCustomerAccountHelperWithDiscovery(
       '2025-07',
       shopId,
-      'test-shop.myshopify.com',
+      storefrontDomain,
     );
 
     expect(helper(URL_TYPE.GRAPHQL)).toBe(mockEndpoints.graphqlApiUrl);
     expect(discoverCustomerAccountEndpoints).toHaveBeenCalledWith(
-      'test-shop.myshopify.com',
+      storefrontDomain,
     );
   });
 
-  it('falls back to legacy URLs when discovery fails', async () => {
+  it('throws error when discovery fails', async () => {
     const {discoverCustomerAccountEndpoints} = await import('./discovery');
 
     vi.mocked(discoverCustomerAccountEndpoints).mockRejectedValue(
-      new Error('Discovery failed'),
+      new Error('Network error'),
+    );
+
+    await expect(
+      createCustomerAccountHelperWithDiscovery(
+        '2025-07',
+        shopId,
+        storefrontDomain,
+      ),
+    ).rejects.toThrow('Network error');
+  });
+
+  it('uses discovered endpoints for all URL types', async () => {
+    const {discoverCustomerAccountEndpoints} = await import('./discovery');
+    const mockEndpoints: DiscoveredEndpoints = {
+      graphqlApiUrl:
+        'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
+      authorizationUrl:
+        'https://test-shop.account.myshopify.com/oauth/authorize',
+      tokenUrl: 'https://test-shop.account.myshopify.com/oauth/token',
+      logoutUrl: 'https://test-shop.account.myshopify.com/logout',
+    };
+
+    vi.mocked(discoverCustomerAccountEndpoints).mockResolvedValue(
+      mockEndpoints,
     );
 
     const helper = await createCustomerAccountHelperWithDiscovery(
       '2025-07',
       shopId,
-      'test-shop.myshopify.com',
+      storefrontDomain,
     );
 
-    expect(helper(URL_TYPE.GRAPHQL)).toBe(
-      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
-    );
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Discovery failed'),
-      expect.any(Error),
-    );
+    expect(helper(URL_TYPE.GRAPHQL)).toBe(mockEndpoints.graphqlApiUrl);
+    expect(helper(URL_TYPE.AUTH)).toBe(mockEndpoints.authorizationUrl);
+    expect(helper(URL_TYPE.TOKEN_EXCHANGE)).toBe(mockEndpoints.tokenUrl);
+    expect(helper(URL_TYPE.LOGOUT)).toBe(mockEndpoints.logoutUrl);
   });
 });

--- a/packages/hydrogen/src/customer/customer-account-helper.test.ts
+++ b/packages/hydrogen/src/customer/customer-account-helper.test.ts
@@ -1,5 +1,14 @@
-import {describe, it, expect} from 'vitest';
-import {createCustomerAccountHelper, URL_TYPE} from './customer-account-helper';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {
+  createCustomerAccountHelper,
+  createCustomerAccountHelperWithDiscovery,
+  URL_TYPE,
+} from './customer-account-helper';
+
+// Mock the discovery module
+vi.mock('./discovery', () => ({
+  discoverCustomerAccountEndpoints: vi.fn(),
+}));
 
 const shopId = '1';
 const customerAccountUrl = `https://shopify.com/${shopId}`;
@@ -47,5 +56,168 @@ describe('return correct urls', () => {
         `https://shopify.com/authentication/${shopId}/logout`,
       );
     });
+  });
+});
+
+describe('legacy behavior without discovery', () => {
+  it('maintains backward compatibility with existing API', () => {
+    const getAccountUrl = createCustomerAccountHelper('2025-07', shopId);
+    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
+      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
+    );
+  });
+
+  it('works with discovery disabled', () => {
+    const storefrontDomain = 'test-shop.myshopify.com';
+    const getAccountUrl = createCustomerAccountHelper(
+      '2025-07',
+      shopId,
+      storefrontDomain,
+      false, // discovery disabled
+    );
+    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
+      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
+    );
+  });
+});
+
+describe('discovery functionality', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses discovered GraphQL endpoint when available', () => {
+    const storefrontDomain = 'test-shop.myshopify.com';
+    const discoveredEndpoints = {
+      graphqlApiUrl:
+        'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
+      authorizationUrl:
+        'https://test-shop.account.myshopify.com/oauth/authorize',
+      tokenUrl: 'https://test-shop.account.myshopify.com/oauth/token',
+      logoutUrl: 'https://test-shop.account.myshopify.com/logout',
+    };
+
+    const getAccountUrl = createCustomerAccountHelper(
+      '2025-07',
+      shopId,
+      storefrontDomain,
+      true,
+      discoveredEndpoints,
+    );
+
+    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
+      discoveredEndpoints.graphqlApiUrl,
+    );
+    expect(getAccountUrl(URL_TYPE.AUTH)).toBe(
+      discoveredEndpoints.authorizationUrl,
+    );
+    expect(getAccountUrl(URL_TYPE.TOKEN_EXCHANGE)).toBe(
+      discoveredEndpoints.tokenUrl,
+    );
+    expect(getAccountUrl(URL_TYPE.LOGOUT)).toBe(discoveredEndpoints.logoutUrl);
+  });
+
+  it('falls back to legacy URLs when discovery fails', () => {
+    const storefrontDomain = 'test-shop.myshopify.com';
+
+    const getAccountUrl = createCustomerAccountHelper(
+      '2025-07',
+      shopId,
+      storefrontDomain,
+      true,
+      null, // No discovered endpoints
+    );
+
+    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
+      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
+    );
+    expect(getAccountUrl(URL_TYPE.AUTH)).toBe(
+      `https://shopify.com/authentication/${shopId}/oauth/authorize`,
+    );
+  });
+
+  it('extracts base URLs from discovered endpoints', () => {
+    const storefrontDomain = 'test-shop.myshopify.com';
+    const discoveredEndpoints = {
+      graphqlApiUrl:
+        'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
+      authorizationUrl:
+        'https://test-shop.account.myshopify.com/authentication/oauth/authorize',
+      tokenUrl: 'https://test-shop.account.myshopify.com/oauth/token',
+      logoutUrl: 'https://test-shop.account.myshopify.com/logout',
+    };
+
+    const getAccountUrl = createCustomerAccountHelper(
+      '2025-07',
+      shopId,
+      storefrontDomain,
+      true,
+      discoveredEndpoints,
+    );
+
+    expect(getAccountUrl(URL_TYPE.CA_BASE_URL)).toBe(
+      'https://test-shop.account.myshopify.com',
+    );
+    expect(getAccountUrl(URL_TYPE.CA_BASE_AUTH_URL)).toBe(
+      'https://test-shop.account.myshopify.com',
+    );
+  });
+});
+
+describe('createCustomerAccountHelperWithDiscovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset console methods
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('successfully creates helper with discovery', async () => {
+    const {discoverCustomerAccountEndpoints} = await import('./discovery');
+    const mockEndpoints = {
+      graphqlApiUrl:
+        'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
+      authorizationUrl:
+        'https://test-shop.account.myshopify.com/oauth/authorize',
+      tokenUrl: 'https://test-shop.account.myshopify.com/oauth/token',
+      logoutUrl: 'https://test-shop.account.myshopify.com/logout',
+    };
+
+    vi.mocked(discoverCustomerAccountEndpoints).mockResolvedValue(
+      mockEndpoints,
+    );
+
+    const helper = await createCustomerAccountHelperWithDiscovery(
+      '2025-07',
+      shopId,
+      'test-shop.myshopify.com',
+    );
+
+    expect(helper(URL_TYPE.GRAPHQL)).toBe(mockEndpoints.graphqlApiUrl);
+    expect(discoverCustomerAccountEndpoints).toHaveBeenCalledWith(
+      'test-shop.myshopify.com',
+    );
+  });
+
+  it('falls back to legacy URLs when discovery fails', async () => {
+    const {discoverCustomerAccountEndpoints} = await import('./discovery');
+
+    vi.mocked(discoverCustomerAccountEndpoints).mockRejectedValue(
+      new Error('Discovery failed'),
+    );
+
+    const helper = await createCustomerAccountHelperWithDiscovery(
+      '2025-07',
+      shopId,
+      'test-shop.myshopify.com',
+    );
+
+    expect(helper(URL_TYPE.GRAPHQL)).toBe(
+      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Discovery failed'),
+      expect.any(Error),
+    );
   });
 });

--- a/packages/hydrogen/src/customer/customer-account-helper.test.ts
+++ b/packages/hydrogen/src/customer/customer-account-helper.test.ts
@@ -162,6 +162,45 @@ describe('discovery functionality', () => {
       'https://test-shop.account.myshopify.com',
     );
   });
+
+  it('replaces API version in discovered GraphQL URL', () => {
+    const storefrontDomain = 'test-shop.myshopify.com';
+    const discoveredEndpoints = {
+      graphqlApiUrl:
+        'https://test-shop.account.myshopify.com/customer/api/2024-01/graphql',
+      authorizationUrl:
+        'https://test-shop.account.myshopify.com/oauth/authorize',
+      tokenUrl: 'https://test-shop.account.myshopify.com/oauth/token',
+      logoutUrl: 'https://test-shop.account.myshopify.com/logout',
+    };
+
+    const getAccountUrl = createCustomerAccountHelper(
+      '2025-07', // Different version than discovered URL
+      shopId,
+      storefrontDomain,
+      true,
+      discoveredEndpoints,
+    );
+
+    // Should use discovered domain but replace version with the one provided
+    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
+      'https://test-shop.account.myshopify.com/customer/api/2025-07/graphql',
+    );
+  });
+
+  it('handles missing storefront domain with discovery enabled', () => {
+    const getAccountUrl = createCustomerAccountHelper(
+      '2025-07',
+      shopId,
+      undefined, // no domain
+      true, // discovery enabled
+    );
+
+    // Should fall back to legacy URLs
+    expect(getAccountUrl(URL_TYPE.GRAPHQL)).toBe(
+      `${customerAccountUrl}/account/customer/api/2025-07/graphql`,
+    );
+  });
 });
 
 describe('createCustomerAccountHelperWithDiscovery', () => {

--- a/packages/hydrogen/src/customer/customer-account-helper.ts
+++ b/packages/hydrogen/src/customer/customer-account-helper.ts
@@ -1,3 +1,8 @@
+import {
+  discoverCustomerAccountEndpoints,
+  type DiscoveredEndpoints,
+} from './discovery';
+
 export enum URL_TYPE {
   CA_BASE_URL = 'CA_BASE_URL',
   CA_BASE_AUTH_URL = 'CA_BASE_AUTH_URL',
@@ -11,28 +16,120 @@ export enum URL_TYPE {
 export function createCustomerAccountHelper(
   customerApiVersion: string,
   shopId: string,
+  storefrontDomain?: string,
+  useDiscovery = true,
+  discovered?: DiscoveredEndpoints | null,
 ) {
-  const customerAccountUrl = `https://shopify.com/${shopId}`;
-  const customerAccountAuthUrl = `https://shopify.com/authentication/${shopId}`;
-
   return function getCustomerAccountUrl(urlType: URL_TYPE): string {
+    // If discovery is disabled or no storefront domain is provided, use legacy fallback URLs
+    if (!useDiscovery || !storefrontDomain || !discovered) {
+      return getLegacyUrl(urlType, shopId, customerApiVersion);
+    }
+
     switch (urlType) {
       case URL_TYPE.CA_BASE_URL:
-        return customerAccountUrl;
+        return new URL(discovered.graphqlApiUrl).origin;
+
       case URL_TYPE.CA_BASE_AUTH_URL:
-        return customerAccountAuthUrl;
+        return new URL(discovered.authorizationUrl).origin;
+
       case URL_TYPE.GRAPHQL:
-        return `${customerAccountUrl}/account/customer/api/${customerApiVersion}/graphql`;
+        if (customerApiVersion)
+          return discovered.graphqlApiUrl.replace(
+            /\/api\/[^\/]+\//,
+            `/api/${customerApiVersion}/`,
+          );
+        return discovered.graphqlApiUrl;
+
       case URL_TYPE.AUTH:
-        return `${customerAccountAuthUrl}/oauth/authorize`;
+        return discovered.authorizationUrl;
+
       case URL_TYPE.LOGIN_SCOPE:
         return shopId
           ? 'openid email customer-account-api:full'
           : 'openid email https://api.customers.com/auth/customer.graphql';
+
       case URL_TYPE.TOKEN_EXCHANGE:
-        return `${customerAccountAuthUrl}/oauth/token`;
+        return discovered.tokenUrl;
+
       case URL_TYPE.LOGOUT:
-        return `${customerAccountAuthUrl}/logout`;
+        return discovered.logoutUrl;
+
+      default:
+        throw new Error(`Unknown URL type: ${urlType}`);
     }
   };
+}
+
+function getLegacyUrl(
+  urlType: URL_TYPE,
+  shopId: string,
+  customerApiVersion?: string,
+): string {
+  const customerAccountUrl = `https://shopify.com/${shopId}`;
+  const customerAccountAuthUrl = `https://shopify.com/authentication/${shopId}`;
+
+  switch (urlType) {
+    case URL_TYPE.CA_BASE_URL:
+      return customerAccountUrl;
+    case URL_TYPE.CA_BASE_AUTH_URL:
+      return customerAccountAuthUrl;
+    case URL_TYPE.GRAPHQL:
+      return `${customerAccountUrl}/account/customer/api/${customerApiVersion}/graphql`;
+    case URL_TYPE.AUTH:
+      return `${customerAccountAuthUrl}/oauth/authorize`;
+    case URL_TYPE.LOGIN_SCOPE:
+      return shopId
+        ? 'openid email customer-account-api:full'
+        : 'openid email https://api.customers.com/auth/customer.graphql';
+    case URL_TYPE.TOKEN_EXCHANGE:
+      return `${customerAccountAuthUrl}/oauth/token`;
+    case URL_TYPE.LOGOUT:
+      return `${customerAccountAuthUrl}/logout`;
+    default:
+      throw new Error(`Unknown URL type: ${urlType}`);
+  }
+}
+
+export async function createCustomerAccountHelperWithDiscovery(
+  customerApiVersion: string,
+  shopId: string,
+  storefrontDomain: string,
+  useDiscovery = true,
+): Promise<(urlType: URL_TYPE) => string> {
+  let discoveredEndpoints: DiscoveredEndpoints | null = null;
+
+  if (useDiscovery && storefrontDomain) {
+    try {
+      discoveredEndpoints =
+        await discoverCustomerAccountEndpoints(storefrontDomain);
+
+      if (
+        discoveredEndpoints &&
+        Object.values(discoveredEndpoints).some(Boolean)
+      ) {
+        console.log(
+          `[h2:info:discovery] Successfully discovered Customer Account endpoints for ${storefrontDomain}`,
+        );
+      }
+    } catch (error) {
+      console.warn(
+        `[h2:warn:discovery] Discovery failed for ${storefrontDomain}, falling back to legacy URLs:`,
+        error,
+      );
+      discoveredEndpoints = null; // Ensure fallback behavior
+    }
+  } else if (useDiscovery && !storefrontDomain) {
+    console.warn(
+      '[h2:warn:discovery] Discovery is enabled but no storefront domain provided, using legacy URLs',
+    );
+  }
+
+  return createCustomerAccountHelper(
+    customerApiVersion,
+    shopId,
+    storefrontDomain,
+    useDiscovery && Boolean(discoveredEndpoints),
+    discoveredEndpoints,
+  );
 }

--- a/packages/hydrogen/src/customer/customer-account-helper.ts
+++ b/packages/hydrogen/src/customer/customer-account-helper.ts
@@ -16,16 +16,10 @@ export enum URL_TYPE {
 export function createCustomerAccountHelper(
   customerApiVersion: string,
   shopId: string,
-  storefrontDomain?: string,
-  useDiscovery = true,
-  discovered?: DiscoveredEndpoints | null,
+  storefrontDomain: string,
+  discovered: DiscoveredEndpoints,
 ) {
   return function getCustomerAccountUrl(urlType: URL_TYPE): string {
-    // If discovery is disabled or no storefront domain is provided, use legacy fallback URLs
-    if (!useDiscovery || !storefrontDomain || !discovered) {
-      return getLegacyUrl(urlType, shopId, customerApiVersion);
-    }
-
     switch (urlType) {
       case URL_TYPE.CA_BASE_URL:
         return new URL(discovered.graphqlApiUrl).origin;
@@ -61,67 +55,19 @@ export function createCustomerAccountHelper(
   };
 }
 
-function getLegacyUrl(
-  urlType: URL_TYPE,
-  shopId: string,
-  customerApiVersion?: string,
-): string {
-  const customerAccountUrl = `https://shopify.com/${shopId}`;
-  const customerAccountAuthUrl = `https://shopify.com/authentication/${shopId}`;
-
-  switch (urlType) {
-    case URL_TYPE.CA_BASE_URL:
-      return customerAccountUrl;
-    case URL_TYPE.CA_BASE_AUTH_URL:
-      return customerAccountAuthUrl;
-    case URL_TYPE.GRAPHQL:
-      return `${customerAccountUrl}/account/customer/api/${customerApiVersion}/graphql`;
-    case URL_TYPE.AUTH:
-      return `${customerAccountAuthUrl}/oauth/authorize`;
-    case URL_TYPE.LOGIN_SCOPE:
-      return shopId
-        ? 'openid email customer-account-api:full'
-        : 'openid email https://api.customers.com/auth/customer.graphql';
-    case URL_TYPE.TOKEN_EXCHANGE:
-      return `${customerAccountAuthUrl}/oauth/token`;
-    case URL_TYPE.LOGOUT:
-      return `${customerAccountAuthUrl}/logout`;
-    default:
-      throw new Error(`Unknown URL type: ${urlType}`);
-  }
-}
-
 export async function createCustomerAccountHelperWithDiscovery(
   customerApiVersion: string,
   shopId: string,
   storefrontDomain: string,
-  useDiscovery = true,
 ): Promise<(urlType: URL_TYPE) => string> {
-  let discoveredEndpoints: DiscoveredEndpoints | null = null;
+  const discoveredEndpoints =
+    await discoverCustomerAccountEndpoints(storefrontDomain);
 
-  if (useDiscovery && storefrontDomain) {
-    try {
-      discoveredEndpoints =
-        await discoverCustomerAccountEndpoints(storefrontDomain);
-
-      if (
-        discoveredEndpoints &&
-        Object.values(discoveredEndpoints).some(Boolean)
-      ) {
-        console.log(
-          `[h2:info:discovery] Successfully discovered Customer Account endpoints for ${storefrontDomain}`,
-        );
-      }
-    } catch (error) {
-      console.warn(
-        `[h2:warn:discovery] Discovery failed for ${storefrontDomain}, falling back to legacy URLs:`,
-        error,
-      );
-      discoveredEndpoints = null; // Ensure fallback behavior
-    }
-  } else if (useDiscovery && !storefrontDomain) {
-    console.warn(
-      '[h2:warn:discovery] Discovery is enabled but no storefront domain provided, using legacy URLs',
+  if (!discoveredEndpoints) {
+    throw new Error(
+      `[h2:error:discovery] Failed to discover Customer Account endpoints for ${storefrontDomain}. ` +
+        `Endpoint discovery is required for Customer Account API. ` +
+        `Ensure your storefront domain is correctly configured and the discovery endpoints are accessible.`,
     );
   }
 
@@ -129,7 +75,6 @@ export async function createCustomerAccountHelperWithDiscovery(
     customerApiVersion,
     shopId,
     storefrontDomain,
-    useDiscovery && Boolean(discoveredEndpoints),
     discoveredEndpoints,
   );
 }

--- a/packages/hydrogen/src/customer/customer.example.tsx
+++ b/packages/hydrogen/src/customer/customer.example.tsx
@@ -27,6 +27,7 @@ export default {
       customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_ID,
       /* Shop Id */
       shopId: env.SHOP_ID,
+      storefrontDomain: env.PUBLIC_STOREFRONT_DOMAIN,
       request,
       session,
     });

--- a/packages/hydrogen/src/customer/customer.opt-out-handler.example.tsx
+++ b/packages/hydrogen/src/customer/customer.opt-out-handler.example.tsx
@@ -34,6 +34,7 @@ export default {
       customerAccountId: env.PUBLIC_CUSTOMER_ACCOUNT_ID,
       /* Shop Id */
       shopId: env.SHOP_ID,
+      storefrontDomain: env.PUBLIC_STOREFRONT_DOMAIN,
       request,
       session,
       customAuthStatusHandler,

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -8,6 +8,11 @@ if (!globalThis.crypto) {
   globalThis.crypto = crypto as any;
 }
 
+// Mock the discovery module to prevent actual discovery fetch calls in tests
+vi.mock('./discovery', () => ({
+  discoverCustomerAccountEndpoints: vi.fn(),
+}));
+
 vi.mock('./BadRequest', () => {
   return {
     BadRequest: class BadRequest {
@@ -60,7 +65,17 @@ const mockBuyerSession = {
 };
 
 describe('customer', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Mock discovery endpoints for all tests
+    const {discoverCustomerAccountEndpoints} = await import('./discovery');
+    vi.mocked(discoverCustomerAccountEndpoints).mockResolvedValue({
+      graphqlApiUrl:
+        'https://shopify.com/1/account/customer/api/2025-07/graphql',
+      authorizationUrl: 'https://shopify.com/authentication/1/oauth/authorize',
+      tokenUrl: 'https://shopify.com/authentication/1/oauth/token',
+      logoutUrl: 'https://shopify.com/authentication/1/logout',
+    });
+
     session = {
       commit: vi.fn(() => Promise.resolve('cookie')),
       get: vi.fn(() => {
@@ -83,6 +98,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request('https://localhost'),
           waitUntil: vi.fn(),
         });
@@ -128,6 +144,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request(origin),
           waitUntil: vi.fn(),
           authUrl,
@@ -153,6 +170,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request(origin),
           waitUntil: vi.fn(),
           authUrl,
@@ -178,6 +196,7 @@ describe('customer', () => {
             session,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
             language: 'FR',
@@ -196,6 +215,7 @@ describe('customer', () => {
             session,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
           });
@@ -215,6 +235,7 @@ describe('customer', () => {
             session,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
             language: 'IT',
@@ -238,6 +259,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request(origin),
           waitUntil: vi.fn(),
         });
@@ -257,6 +279,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request(origin),
           waitUntil: vi.fn(),
         });
@@ -278,6 +301,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request(origin),
           waitUntil: vi.fn(),
         });
@@ -295,6 +319,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request(origin),
           waitUntil: vi.fn(),
         });
@@ -321,6 +346,7 @@ describe('customer', () => {
             session,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
           });
@@ -356,6 +382,7 @@ describe('customer', () => {
             session,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
           });
@@ -386,6 +413,7 @@ describe('customer', () => {
             session,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
           });
@@ -413,6 +441,7 @@ describe('customer', () => {
             session,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
           });
@@ -445,6 +474,7 @@ describe('customer', () => {
             session: mockSession,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
           });
@@ -476,6 +506,7 @@ describe('customer', () => {
             session: mockSession,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
           });
@@ -510,6 +541,7 @@ describe('customer', () => {
             session: mockSession,
             customerAccountId: 'customerAccountId',
             shopId: '1',
+            storefrontDomain: 'test-shop.myshopify.com',
             request: new Request(origin),
             waitUntil: vi.fn(),
           });
@@ -538,6 +570,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request,
           waitUntil: vi.fn(),
         });
@@ -564,6 +597,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request,
           waitUntil: vi.fn(),
         });
@@ -587,6 +621,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request,
           waitUntil: vi.fn(),
         });
@@ -606,6 +641,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request('https://localhost'),
           waitUntil: vi.fn(),
         });
@@ -632,6 +668,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request,
           waitUntil: vi.fn(),
         });
@@ -658,6 +695,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request,
           waitUntil: vi.fn(),
         });
@@ -681,6 +719,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request,
           waitUntil: vi.fn(),
         });
@@ -700,6 +739,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request('https://localhost'),
           waitUntil: vi.fn(),
         });
@@ -723,6 +763,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request('https://localhost'),
           waitUntil: vi.fn(),
         });
@@ -737,6 +778,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request('https://localhost?state=nomatch&code=code'),
           waitUntil: vi.fn(),
         });
@@ -751,6 +793,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request('https://localhost?state=state&code=code'),
           waitUntil: vi.fn(),
         });
@@ -765,6 +808,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request('https://localhost?state=state&code=code'),
           waitUntil: vi.fn(),
         });
@@ -793,6 +837,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request('https://localhost?state=state&code=code'),
           waitUntil: vi.fn(),
         });
@@ -841,6 +886,7 @@ describe('customer', () => {
           session,
           customerAccountId: 'customerAccountId',
           shopId: '1',
+          storefrontDomain: 'test-shop.myshopify.com',
           request: new Request('https://localhost?state=state&code=code'),
           waitUntil: vi.fn(),
         });
@@ -881,6 +927,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });
@@ -893,6 +940,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });
@@ -907,9 +955,9 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
-        useDiscovery: false,
       });
 
       (session.get as any).mockImplementation(() => ({
@@ -932,6 +980,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });
@@ -952,6 +1001,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });
@@ -966,6 +1016,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });
@@ -980,9 +1031,9 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
-        useDiscovery: false,
       });
 
       (session.get as any).mockImplementation(() => ({
@@ -1005,6 +1056,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });
@@ -1025,6 +1077,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost/account/orders'),
         waitUntil: vi.fn(),
       });
@@ -1045,6 +1098,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost/account/orders'),
         waitUntil: vi.fn(),
       });
@@ -1058,6 +1112,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost/account/orders'),
         waitUntil: vi.fn(),
         customAuthStatusHandler,
@@ -1076,6 +1131,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost/account/orders.data'),
         waitUntil: vi.fn(),
       });
@@ -1096,6 +1152,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost/account/_root.data'),
         waitUntil: vi.fn(),
       });
@@ -1116,6 +1173,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost/_root.data'),
         waitUntil: vi.fn(),
       });
@@ -1138,6 +1196,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });
@@ -1162,6 +1221,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost/account/orders/123'),
         waitUntil: vi.fn(),
       });
@@ -1183,6 +1243,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost/account/orders'),
         waitUntil: vi.fn(),
         customAuthStatusHandler,
@@ -1203,6 +1264,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });
@@ -1222,6 +1284,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });
@@ -1241,6 +1304,7 @@ describe('customer', () => {
         session,
         customerAccountId: 'customerAccountId',
         shopId: '1',
+        storefrontDomain: 'test-shop.myshopify.com',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
       });

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -909,6 +909,7 @@ describe('customer', () => {
         shopId: '1',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
+        useDiscovery: false,
       });
 
       (session.get as any).mockImplementation(() => ({
@@ -981,6 +982,7 @@ describe('customer', () => {
         shopId: '1',
         request: new Request('https://localhost'),
         waitUntil: vi.fn(),
+        useDiscovery: false,
       });
 
       (session.get as any).mockImplementation(() => ({

--- a/packages/hydrogen/src/customer/discovery.test.ts
+++ b/packages/hydrogen/src/customer/discovery.test.ts
@@ -1,0 +1,368 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {
+  discoverOpenIdConfiguration,
+  discoverCustomerAccountApi,
+  discoverCustomerAccountEndpoints,
+  clearDiscoveryCache,
+} from './discovery';
+import {USER_AGENT} from './constants';
+
+// Mock fetch
+global.fetch = vi.fn();
+
+describe('discovery utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearDiscoveryCache();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('discoverOpenIdConfiguration', () => {
+    it('successfully discovers OpenID configuration', async () => {
+      const mockConfig = {
+        issuer: 'https://test-shop.account.myshopify.com',
+        authorization_endpoint:
+          'https://test-shop.account.myshopify.com/oauth/authorize',
+        token_endpoint: 'https://test-shop.account.myshopify.com/oauth/token',
+        jwks_uri:
+          'https://test-shop.account.myshopify.com/.well-known/jwks.json',
+        end_session_endpoint: 'https://test-shop.account.myshopify.com/logout',
+      };
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockConfig),
+      } as Response);
+
+      const result = await discoverOpenIdConfiguration(
+        'test-shop.myshopify.com',
+      );
+      expect(result).toEqual(mockConfig);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://test-shop.myshopify.com/.well-known/openid-configuration',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Accept: 'application/json',
+            'User-Agent': USER_AGENT,
+          }),
+          signal: expect.any(Object),
+        }),
+      );
+    });
+
+    it('returns null when endpoint is not found', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      const result = await discoverOpenIdConfiguration(
+        'test-shop.myshopify.com',
+      );
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('OpenID configuration discovery failed'),
+      );
+    });
+
+    it('returns null when configuration is invalid', async () => {
+      const invalidConfig = {
+        issuer: 'https://test-shop.account.myshopify.com',
+        // missing required endpoints
+      };
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(invalidConfig),
+      } as Response);
+
+      const result = await discoverOpenIdConfiguration(
+        'test-shop.myshopify.com',
+      );
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid OpenID configuration'),
+      );
+    });
+
+    it('handles network errors gracefully', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await discoverOpenIdConfiguration(
+        'test-shop.myshopify.com',
+      );
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('OpenID configuration discovery failed'),
+        expect.any(Error),
+      );
+    });
+
+    it('caches successful results', async () => {
+      const mockConfig = {
+        issuer: 'https://test-shop.account.myshopify.com',
+        authorization_endpoint:
+          'https://test-shop.account.myshopify.com/oauth/authorize',
+        token_endpoint: 'https://test-shop.account.myshopify.com/oauth/token',
+        jwks_uri:
+          'https://test-shop.account.myshopify.com/.well-known/jwks.json',
+        end_session_endpoint: 'https://test-shop.account.myshopify.com/logout',
+      };
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockConfig),
+      } as Response);
+
+      // First call
+      const result1 = await discoverOpenIdConfiguration(
+        'test-shop.myshopify.com',
+      );
+      expect(result1).toEqual(mockConfig);
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      // Second call should use cache
+      const result2 = await discoverOpenIdConfiguration(
+        'test-shop.myshopify.com',
+      );
+      expect(result2).toEqual(mockConfig);
+      expect(fetch).toHaveBeenCalledTimes(1); // Still only called once
+    });
+  });
+
+  describe('discoverCustomerAccountApi', () => {
+    it('successfully discovers Customer Account API configuration', async () => {
+      const mockConfig = {
+        graphql_api:
+          'https://test-shop.account.myshopify.com/customer/api/graphql',
+        mcp_api: 'https://test-shop.account.myshopify.com/customer/api/mcp',
+      };
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockConfig),
+      } as Response);
+
+      const result = await discoverCustomerAccountApi(
+        'test-shop.myshopify.com',
+      );
+      expect(result).toEqual(mockConfig);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://test-shop.myshopify.com/.well-known/customer-account-api',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Accept: 'application/json',
+            'User-Agent': USER_AGENT,
+          }),
+          signal: expect.any(Object),
+        }),
+      );
+    });
+
+    it('returns null when endpoint is not found', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      const result = await discoverCustomerAccountApi(
+        'test-shop.myshopify.com',
+      );
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Customer Account API discovery failed'),
+      );
+    });
+
+    it('returns null when configuration is invalid', async () => {
+      const invalidConfig = {
+        graphql_api:
+          'https://test-shop.account.myshopify.com/customer/api/graphql',
+        // missing mcp_api
+      };
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(invalidConfig),
+      } as Response);
+
+      const result = await discoverCustomerAccountApi(
+        'test-shop.myshopify.com',
+      );
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid Customer Account API configuration'),
+      );
+    });
+  });
+
+  describe('discoverCustomerAccountEndpoints', () => {
+    it('successfully discovers all endpoints', async () => {
+      const mockOpenIdConfig = {
+        issuer: 'https://test-shop.account.myshopify.com',
+        authorization_endpoint:
+          'https://test-shop.account.myshopify.com/oauth/authorize',
+        token_endpoint: 'https://test-shop.account.myshopify.com/oauth/token',
+        jwks_uri:
+          'https://test-shop.account.myshopify.com/.well-known/jwks.json',
+        end_session_endpoint: 'https://test-shop.account.myshopify.com/logout',
+      };
+
+      const mockApiConfig = {
+        graphql_api:
+          'https://test-shop.account.myshopify.com/customer/api/graphql',
+        mcp_api: 'https://test-shop.account.myshopify.com/customer/api/mcp',
+      };
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockOpenIdConfig),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockApiConfig),
+        } as Response);
+
+      const result = await discoverCustomerAccountEndpoints(
+        'test-shop.myshopify.com',
+      );
+      expect(result).toEqual({
+        graphqlApiUrl: mockApiConfig.graphql_api,
+        authorizationUrl: mockOpenIdConfig.authorization_endpoint,
+        tokenUrl: mockOpenIdConfig.token_endpoint,
+        logoutUrl: mockOpenIdConfig.end_session_endpoint,
+      });
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Successfully discovered Customer Account endpoints',
+        ),
+      );
+    });
+
+    it('handles partial discovery gracefully', async () => {
+      const mockOpenIdConfig = {
+        issuer: 'https://test-shop.account.myshopify.com',
+        authorization_endpoint:
+          'https://test-shop.account.myshopify.com/oauth/authorize',
+        token_endpoint: 'https://test-shop.account.myshopify.com/oauth/token',
+        jwks_uri:
+          'https://test-shop.account.myshopify.com/.well-known/jwks.json',
+        end_session_endpoint: 'https://test-shop.account.myshopify.com/logout',
+      };
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockOpenIdConfig),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+        } as Response);
+
+      const result = await discoverCustomerAccountEndpoints(
+        'test-shop.myshopify.com',
+      );
+      // With all-or-nothing approach, partial discovery returns null
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Incomplete discovery'),
+      );
+    });
+
+    it('returns null when no domain is provided', async () => {
+      const result = await discoverCustomerAccountEndpoints('');
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('No storefront domain provided'),
+      );
+    });
+
+    it('returns null when all discovery fails', async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+        } as Response);
+
+      const result = await discoverCustomerAccountEndpoints(
+        'test-shop.myshopify.com',
+      );
+      // With all-or-nothing approach, complete failure returns null
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Incomplete discovery'),
+      );
+    });
+  });
+
+  describe('clearDiscoveryCache', () => {
+    it('clears cache for specific domain', async () => {
+      const mockConfig = {
+        issuer: 'https://test-shop.account.myshopify.com',
+        authorization_endpoint:
+          'https://test-shop.account.myshopify.com/oauth/authorize',
+        token_endpoint: 'https://test-shop.account.myshopify.com/oauth/token',
+        jwks_uri:
+          'https://test-shop.account.myshopify.com/.well-known/jwks.json',
+        end_session_endpoint: 'https://test-shop.account.myshopify.com/logout',
+      };
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockConfig),
+      } as Response);
+
+      // Cache a result
+      await discoverOpenIdConfiguration('test-shop.myshopify.com');
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      // Clear cache for this domain
+      clearDiscoveryCache('test-shop.myshopify.com');
+
+      // Should fetch again
+      await discoverOpenIdConfiguration('test-shop.myshopify.com');
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears all cache when no domain specified', async () => {
+      const mockConfig = {
+        issuer: 'https://test-shop.account.myshopify.com',
+        authorization_endpoint:
+          'https://test-shop.account.myshopify.com/oauth/authorize',
+        token_endpoint: 'https://test-shop.account.myshopify.com/oauth/token',
+        jwks_uri:
+          'https://test-shop.account.myshopify.com/.well-known/jwks.json',
+        end_session_endpoint: 'https://test-shop.account.myshopify.com/logout',
+      };
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockConfig),
+      } as Response);
+
+      // Cache results for multiple domains
+      await discoverOpenIdConfiguration('test-shop1.myshopify.com');
+      await discoverOpenIdConfiguration('test-shop2.myshopify.com');
+      expect(fetch).toHaveBeenCalledTimes(2);
+
+      // Clear all cache
+      clearDiscoveryCache();
+
+      // Should fetch again for both
+      await discoverOpenIdConfiguration('test-shop1.myshopify.com');
+      await discoverOpenIdConfiguration('test-shop2.myshopify.com');
+      expect(fetch).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/packages/hydrogen/src/customer/discovery.ts
+++ b/packages/hydrogen/src/customer/discovery.ts
@@ -1,0 +1,235 @@
+import {USER_AGENT} from './constants';
+
+interface OpenIdConfiguration {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  jwks_uri: string;
+  end_session_endpoint: string;
+  [key: string]: any;
+}
+
+interface CustomerAccountApiConfiguration {
+  graphql_api: string;
+  mcp_api: string;
+}
+
+export interface DiscoveredEndpoints {
+  graphqlApiUrl: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  logoutUrl: string;
+}
+
+interface DiscoveryCache {
+  openid?: {
+    config: OpenIdConfiguration;
+    timestamp: number;
+  };
+  customerApi?: {
+    config: CustomerAccountApiConfiguration;
+    timestamp: number;
+  };
+}
+
+const DISCOVERY_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+const DISCOVERY_TIMEOUT = 5000; // 5 seconds
+const discoveryCache = new Map<string, DiscoveryCache>();
+
+function getCacheKey(domain: string): string {
+  return domain.toLowerCase();
+}
+
+function isValidCache(cacheEntry: {timestamp: number} | undefined): boolean {
+  return Boolean(
+    cacheEntry && Date.now() - cacheEntry.timestamp < DISCOVERY_CACHE_TTL,
+  );
+}
+
+async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number = DISCOVERY_TIMEOUT,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+    });
+    clearTimeout(timeoutId);
+
+    return response;
+  } catch (error) {
+    console.warn(`[h2:warn:discovery] fetchWithTimeout failed: ${error}`);
+    clearTimeout(timeoutId);
+    throw error;
+  }
+}
+
+export async function discoverOpenIdConfiguration(
+  storefrontDomain: string,
+): Promise<OpenIdConfiguration | null> {
+  const cacheKey = getCacheKey(storefrontDomain);
+  const cached = discoveryCache.get(cacheKey)?.openid;
+
+  if (isValidCache(cached)) {
+    return cached!.config;
+  }
+
+  const discoveryUrl = `https://${storefrontDomain}/.well-known/openid-configuration`;
+
+  try {
+    const response = await fetchWithTimeout(discoveryUrl);
+
+    if (!response.ok) {
+      console.warn(
+        `[h2:warn:discovery] OpenID configuration discovery failed for ${discoveryUrl}: ${response.status}`,
+      );
+      return null;
+    }
+
+    const config = (await response.json()) as OpenIdConfiguration;
+
+    // Validate required fields
+    if (
+      !config.authorization_endpoint ||
+      !config.token_endpoint ||
+      !config.end_session_endpoint
+    ) {
+      console.warn(
+        `[h2:warn:discovery] Invalid OpenID configuration for ${discoveryUrl}: missing required endpoints`,
+      );
+      return null;
+    }
+
+    // Update cache
+    const existingCache = discoveryCache.get(cacheKey) || {};
+    discoveryCache.set(cacheKey, {
+      ...existingCache,
+      openid: {
+        config,
+        timestamp: Date.now(),
+      },
+    });
+
+    return config;
+  } catch (error) {
+    console.warn(
+      `[h2:warn:discovery] OpenID configuration discovery failed for ${discoveryUrl}:`,
+      error,
+    );
+    return null;
+  }
+}
+
+export async function discoverCustomerAccountApi(
+  storefrontDomain: string,
+): Promise<CustomerAccountApiConfiguration | null> {
+  const cacheKey = getCacheKey(storefrontDomain);
+  const cached = discoveryCache.get(cacheKey)?.customerApi;
+
+  if (isValidCache(cached)) {
+    return cached!.config;
+  }
+  const discoveryUrl = `https://${storefrontDomain}/.well-known/customer-account-api`;
+
+  try {
+    const response = await fetchWithTimeout(discoveryUrl);
+
+    if (!response.ok) {
+      console.warn(
+        `[h2:warn:discovery] Customer Account API discovery failed for ${discoveryUrl}: ${response.status}`,
+      );
+      return null;
+    }
+
+    const config = (await response.json()) as CustomerAccountApiConfiguration;
+
+    // Validate required fields
+    if (!config.graphql_api || !config.mcp_api) {
+      console.warn(
+        `[h2:warn:discovery] Invalid Customer Account API configuration for ${discoveryUrl}: missing required endpoints`,
+      );
+      return null;
+    }
+
+    // Update cache
+    const existingCache = discoveryCache.get(cacheKey) || {};
+    discoveryCache.set(cacheKey, {
+      ...existingCache,
+      customerApi: {
+        config,
+        timestamp: Date.now(),
+      },
+    });
+
+    return config;
+  } catch (error) {
+    console.warn(
+      `[h2:warn:discovery] Customer Account API discovery failed for ${discoveryUrl}:`,
+      error,
+    );
+    return null;
+  }
+}
+
+export function clearDiscoveryCache(storefrontDomain?: string): void {
+  if (storefrontDomain) {
+    discoveryCache.delete(getCacheKey(storefrontDomain));
+  } else {
+    discoveryCache.clear();
+  }
+}
+
+export async function discoverCustomerAccountEndpoints(
+  storefrontDomain: string,
+): Promise<DiscoveredEndpoints | null> {
+  if (!storefrontDomain) {
+    console.warn(
+      '[h2:warn:discovery] No storefront domain provided for endpoint discovery',
+    );
+    return null;
+  }
+
+  try {
+    const [openidConfig, customerApiConfig] = await Promise.all([
+      discoverOpenIdConfiguration(storefrontDomain),
+      discoverCustomerAccountApi(storefrontDomain),
+    ]);
+
+    // All-or-nothing validation: if either discovery fails, return null
+    if (!openidConfig || !customerApiConfig) {
+      console.warn(
+        `[h2:warn:discovery] Incomplete discovery for ${storefrontDomain}. ` +
+          `OpenID: ${!!openidConfig}, CustomerAPI: ${!!customerApiConfig}. ` +
+          `Falling back to legacy URLs.`,
+      );
+      return null;
+    }
+
+    // Now safe - both configs are guaranteed to exist
+    const endpoints = {
+      graphqlApiUrl: customerApiConfig.graphql_api,
+      authorizationUrl: openidConfig.authorization_endpoint,
+      tokenUrl: openidConfig.token_endpoint,
+      logoutUrl: openidConfig.end_session_endpoint,
+    };
+
+    console.log(
+      `[h2:info:discovery] Successfully discovered Customer Account endpoints for ${storefrontDomain}`,
+    );
+
+    return endpoints;
+  } catch (error) {
+    console.warn(
+      `[h2:warn:discovery] Failed to discover Customer Account endpoints for ${storefrontDomain}:`,
+      error,
+    );
+    return null;
+  }
+}

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -169,10 +169,8 @@ export type CustomerAccountOptions = {
   unstableB2b?: boolean;
   /** Localization data. */
   language?: LanguageCode;
-  /** Enable dynamic discovery of Customer Account endpoints using .well-known endpoints on the storefront domain. When enabled, Customer Account API endpoints will be discovered dynamically instead of using hardcoded shopify.com URLs. Defaults to true. */
-  useDiscovery?: boolean;
-  /** The storefront domain to use for endpoint discovery. If not provided, it will be extracted from the request URL. This should be the domain where your Shopify store is hosted (e.g., 'mystore.myshopify.com' or 'shop.example.com'). */
-  storefrontDomain?: string;
+  /** The storefront domain to use for endpoint discovery. Customer Account API endpoints are dynamically discovered using .well-known endpoints. If not provided, the domain will be extracted from the request URL. This should be the domain where your Shopify store is hosted (e.g., 'mystore.myshopify.com' or 'shop.example.com'). */
+  storefrontDomain: string;
 };
 
 /** Below are types meant for documentation only. Ensure it stay in sync with the type above. */

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -169,6 +169,10 @@ export type CustomerAccountOptions = {
   unstableB2b?: boolean;
   /** Localization data. */
   language?: LanguageCode;
+  /** Enable dynamic discovery of Customer Account endpoints using .well-known endpoints on the storefront domain. When enabled, Customer Account API endpoints will be discovered dynamically instead of using hardcoded shopify.com URLs. Defaults to true. */
+  useDiscovery?: boolean;
+  /** The storefront domain to use for endpoint discovery. If not provided, it will be extracted from the request URL. This should be the domain where your Shopify store is hosted (e.g., 'mystore.myshopify.com' or 'shop.example.com'). */
+  storefrontDomain?: string;
 };
 
 /** Below are types meant for documentation only. Ensure it stay in sync with the type above. */


### PR DESCRIPTION
### WHY are these changes introduced?

The current Hydrogen SDK hardcodes `shopify.com` domain dependencies for Customer Account API interactions, creating maintenance burden as we must support legacy authentication paths from Identity (`/[shop_id]/auth/oauth/…`) alongside new paths used by Core IdP (`/authentication/[shop_id]/oauth/…`).

This PR implements dynamic discovery of Customer Account endpoints via `.well-known` endpoints on the storefront domain, eliminating hardcoded URL dependencies and enabling authentication path changes without backwards compatibility concerns.

### WHAT is this pull request doing?

This PR introduces automatic endpoint discovery for the Customer Account API through two new discovery endpoints:

**New Discovery Module** (`packages/hydrogen/src/customer/discovery.ts`):
- Implements `discoverOpenIdConfiguration()` to fetch OAuth endpoints from `/.well-known/openid-configuration`
- Implements `discoverCustomerAccountApi()` to fetch API URLs from `/.well-known/customer-account-api`
- Provides in-memory caching with 1-hour TTL to minimize network requests
- Handles discovery failures gracefully with automatic fallback to legacy URLs

**Updated Customer Account Helper** (`packages/hydrogen/src/customer/customer-account-helper.ts`):
- Adds `createCustomerAccountHelperWithDiscovery()` function for async endpoint resolution
- Maintains backward compatibility with existing synchronous helper
- Supports both discovered and legacy URL generation

**Enhanced Customer Account Client** (`packages/hydrogen/src/customer/customer.ts`):
- Adds `useDiscovery` option (default: `true`) to enable/disable discovery
- Adds `storefrontDomain` option for explicit domain specification
- Automatically extracts storefront domain from request URL if not provided
- Uses discovered endpoints for all Customer Account API operations (GraphQL, auth, token exchange, logout)
- Gracefully falls back to legacy `shopify.com` URLs when discovery fails

**Developer Experience**:
- Discovery is **enabled by default** with automatic fallback, requiring no code changes
- Developers can opt-out by setting `useDiscovery: false` in `createCustomerAccountClient()`
- All existing authentication flows continue to work without modification

**Key Implementation Details**:
- Discovery requests include proper User-Agent headers and 5-second timeouts
- All discovery endpoints validate required fields before returning results
- "All-or-nothing" validation ensures consistent behavior (if one discovery fails, fall back completely)
- Comprehensive test coverage for discovery, fallback scenarios, and integration

### HOW to test your changes?

#### Unit Tests
```bash
npm test -- packages/hydrogen/src/customer/discovery.test.ts
npm test -- packages/hydrogen/src/customer/customer-account-helper.test.ts
npm test -- packages/hydrogen/src/customer/customer.test.ts
```

Integration Testing

1. Test with Discovery Enabled (Default)
```typescript
// In your Hydrogen app (e.g., skeleton template)

const customerAccount = createCustomerAccountClient({
  // ... other options,
  // useDiscovery: true is the default
});
```
2. Test OAuth Flow
  - Navigate to /account/login
  - Verify successful redirect to authentication endpoint
  - Complete login and verify redirect back to your app
  - Check that GraphQL queries work correctly
3. Test Fallback Behavior
  - Temporarily block /.well-known/ endpoints (via hosts file or firewall)
  - Verify that authentication still works using legacy URLs
  - Check console for discovery warning messages
4. Test Opt-Out
```typescript
const customerAccount = createCustomerAccountClient({
  // ... other options
  useDiscovery: false, // Explicitly disable discovery
});
```
- Verify authentication flow uses legacy shopify.com URLs

Manual Testing Checklist

- Login flow works with discovered endpoints
- Logout flow works with discovered endpoints
- GraphQL queries execute successfully
- Token refresh works correctly
- Discovery failures fall back to legacy URLs gracefully
- Opt-out (useDiscovery: false) uses legacy URLs

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
