### PR TITLE
whitespace-only changes to an existing changeset

### DIFF
--- a/.changeset/hydrogen-react-router-context.md
+++ b/.changeset/hydrogen-react-router-context.md
@@ -15,7 +15,6 @@ Hydrogen now provides its own `createRequestHandler` that wraps React Router's i
 ```
 
 This new handler:
-
 - Uses React Router's `createRequestHandler` internally
 - Adds Hydrogen-specific request validation
 - Includes powered-by headers
@@ -36,7 +35,6 @@ export default {
 ```
 
 The preset provides:
-
 - Optimized build settings for Oxygen deployment
 - Proper server/client module resolution
 - Performance-tuned bundling configuration
@@ -94,7 +92,6 @@ The `HydrogenRouterContextProvider` type provides better type safety and Intelli
 ## New Context Access Patterns
 
 ### Pattern 1: Direct Context Access (Existing)
-
 Continue using direct destructuring from context - no changes needed:
 
 ```ts
@@ -102,16 +99,15 @@ Continue using direct destructuring from context - no changes needed:
 export async function loader({context}: Route.LoaderArgs) {
   // Direct access - works as before
   const {storefront, cart, env} = context;
-
+  
   const data = await storefront.query(QUERY);
   const cartData = await cart.get();
-
+  
   return {data, cart: cartData};
 }
 ```
 
 ### Pattern 2: Context Registry Pattern (New)
-
 Use the new `hydrogenContext` registry with React Router 7.8's `context.get()`:
 
 ```diff
@@ -126,7 +122,7 @@ export async function loader({context}: Route.LoaderArgs) {
 + const cart = context.get(hydrogenContext.cart);
 + const session = context.get(hydrogenContext.session);
 + const env = context.get(hydrogenContext.env);
-
+  
   const product = await storefront.query(PRODUCT_QUERY);
   return {product};
 }
@@ -139,9 +135,8 @@ export async function action({context}: Route.ActionArgs) {
 ```
 
 Available context keys in `hydrogenContext`:
-
 - `hydrogenContext.storefront` - Storefront API client
-- `hydrogenContext.customerAccount` - Customer Account API client
+- `hydrogenContext.customerAccount` - Customer Account API client  
 - `hydrogenContext.cart` - Cart handler instance
 - `hydrogenContext.env` - Environment variables
 - `hydrogenContext.waitUntil` - Oxygen waitUntil for background tasks
@@ -239,3 +234,4 @@ export default {
 ```
 
 The new `createRequestHandler` from `@shopify/hydrogen/oxygen` wraps React Router's handler with additional Hydrogen-specific functionality like powered-by headers and request validation.
+


### PR DESCRIPTION
### WHY are these changes introduced?

This Graphite stack of PR consists of the changes in https://github.com/Shopify/hydrogen/pull/3169, but easier to review and split up into multiple PRs.

I created this by:
1. Resetting (hard) all commits on main since [this PR was merged](https://github.com/Shopify/hydrogen/commit/461e5a5b693894a26fd646ea1ae54698dec2f0df)
2. Resetting (soft) [this PR's merge commit](https://github.com/Shopify/hydrogen/commit/461e5a5b693894a26fd646ea1ae54698dec2f0df)
3. Ran `npm run review-recipe-diffs` introduced in [this PR](https://github.com/Shopify/hydrogen/pull/3201) 
    - I cherry-picked the commit, ran the scripts, then deleted the changes from that commit (ie: the changes from that commit/PR aren't present in this Graphite stack)


<details>

<summary>Examples -> recipes migration summary. table + info</summary>

# Recipe Conversion Summary

This table shows all recipes after applying the changes on the current branch.

| Recipe Name | Pre-existing | Original Example Name | Notes |
|-------------|--------------|----------------------|--------|
| b2b | No | b2b | Converted from example |
| bundles | Yes | - | Pre-existing recipe |
| combined-listings | Yes | - | Pre-existing recipe |
| custom-cart-method | No | custom-cart-method | Converted from example |
| express | No | express | Converted from example |
| gtm | No | gtm | Converted from example |
| infinite-scroll | No | infinite-scroll | Converted from example |
| legacy-customer-account-flow | No | legacy-customer-account-flow | Converted from example |
| markets | Yes | - | Pre-existing recipe |
| metaobjects | No | metaobjects | Converted from example |
| multipass | No | multipass | Converted from example |
| partytown | No | partytown | Converted from example |
| subscriptions | Yes | - | Pre-existing recipe (but also had an example with same name) |
| third-party-api | No | third-party-queries-caching | Renamed during conversion |

## Summary
- **Total recipes**: 14
- **Pre-existing recipes**: 4 (bundles, combined-listings, markets, subscriptions)
- **New recipes from examples**: 10
- **Renamed during conversion**: 1 (third-party-queries-caching → third-party-api)

## Notes
- The `subscriptions` recipe was pre-existing, but there was also an example with the same name that was deleted
- The `third-party-queries-caching` example was renamed to `third-party-api` when converted to a recipe
- All other converted examples retained their original names as recipes

</details>