### PR TITLE
Update skeleton, create-hydrogen and cli-hydrogen for @shopify/cli@3.85.4

### DIFF
--- a/.changeset/tiny-donuts-attend.md
+++ b/.changeset/tiny-donuts-attend.md
@@ -1,0 +1,6 @@
+---
+'skeleton': patch
+'@shopify/create-hydrogen': patch
+---
+
+Update skeleton and create-hydrogen for @shopify/cli@3.85.4 incl @shopify/cli-hydrogen@11.1.4

--- a/.changeset/tiny-donuts-attend.md
+++ b/.changeset/tiny-donuts-attend.md
@@ -1,6 +1,7 @@
 ---
 'skeleton': patch
 '@shopify/create-hydrogen': patch
+'@shopify/cli-hydrogen': patch
 ---
 
 Update skeleton and create-hydrogen for @shopify/cli@3.85.4 incl @shopify/cli-hydrogen@11.1.4

--- a/cookbook/recipes/express/patches/package.json.47be7b.patch
+++ b/cookbook/recipes/express/patches/package.json.47be7b.patch
@@ -41,7 +41,7 @@ index 69150ea03..d3c3594dc 100644
      "@graphql-codegen/cli": "5.0.2",
      "@react-router/dev": "7.9.2",
      "@react-router/fs-routes": "7.9.2",
-     "@shopify/cli": "3.84.1",
+     "@shopify/cli": "3.85.4",
      "@shopify/hydrogen-codegen": "^0.3.3",
 -    "@shopify/mini-oxygen": "^4.0.0",
 -    "@shopify/oxygen-workers-types": "^4.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31658,7 +31658,7 @@
     },
     "packages/cli": {
       "name": "@shopify/cli-hydrogen",
-      "version": "12.0.0",
+      "version": "11.1.4",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "0.34.1",
@@ -35046,7 +35046,7 @@
         "@graphql-codegen/cli": "5.0.2",
         "@react-router/dev": "7.9.2",
         "@react-router/fs-routes": "7.9.2",
-        "@shopify/cli": "3.84.1",
+        "@shopify/cli": "3.85.4",
         "@shopify/hydrogen-codegen": "^0.3.3",
         "@shopify/mini-oxygen": "^4.0.0",
         "@shopify/oxygen-workers-types": "^4.1.6",
@@ -35449,7 +35449,9 @@
       }
     },
     "templates/skeleton/node_modules/@shopify/cli": {
-      "version": "3.84.1",
+      "version": "3.85.4",
+      "resolved": "https://registry.npmjs.org/@shopify/cli/-/cli-3.85.4.tgz",
+      "integrity": "sha512-DuOLU3HMkc2GNXlZrgoR/Pg7ELeiuXadsvDiC3ZqSzvZoy+wisH+LSVrM+jLk4YNC1SKjc8iZc09l6+RAb/wXw==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -30,7 +30,7 @@
     "@graphql-codegen/cli": "5.0.2",
     "@react-router/dev": "7.9.2",
     "@react-router/fs-routes": "7.9.2",
-    "@shopify/cli": "3.84.1",
+    "@shopify/cli": "3.85.4",
     "@shopify/hydrogen-codegen": "^0.3.3",
     "@shopify/mini-oxygen": "^4.0.0",
     "@shopify/oxygen-workers-types": "^4.1.6",


### PR DESCRIPTION
### WHY are these changes introduced?

This PR updates the skeleton template's dependency on `@shopify/cli` from version 3.84.1 to 3.85.4, which includes `@shopify/cli-hydrogen@11.1.4`. This ensures that newly scaffolded Hydrogen projects use the latest Shopify CLI with the most recent hydrogen plugin.

Per the Hydrogen release process, skeleton template changes require a version bump to `@shopify/cli-hydrogen` to ensure the CLI bundles the latest skeleton snapshot in its distribution.

### WHAT is this pull request doing?

This PR makes coordinated changes across the release system:

| Component | Change | Impact |
|-----------|--------|--------|
| `templates/skeleton/package.json` | `@shopify/cli`: `3.84.1` → `3.85.4` | Source template updated |
| `package-lock.json` | Updated lockfile entries | Ensures consistent dependency resolution |
| Changeset | Added for `skeleton`, `@shopify/create-hydrogen`, and `@shopify/cli-hydrogen` | Triggers patch releases to bundle updated template |

<details>
<summary>How the Bundling Works</summary>

When `@shopify/cli-hydrogen` is built (via `tsup.config.ts`), it copies the skeleton template from `templates/skeleton/` into `dist/assets/hydrogen/starter/` and publishes it as part of the npm package.

Current published `@shopify/cli-hydrogen@11.1.4` bundles:
```json
"@shopify/cli": "3.84.1"
```

After this release, the new `@shopify/cli-hydrogen` will bundle:
```json
"@shopify/cli": "3.85.4"
```

This is why the changeset **must** include `@shopify/cli-hydrogen` - without a version bump, the CLI would continue distributing the old bundled skeleton.

</details>

<details>
<summary>Dependency Version Details</summary>

```diff
// templates/skeleton/package.json
  "devDependencies": {
-   "@shopify/cli": "3.84.1",
+   "@shopify/cli": "3.85.4",
  }
```

The changeset specifies:
- `skeleton`: patch version bump
- `@shopify/create-hydrogen`: patch version bump
- `@shopify/cli-hydrogen`: patch version bump (ensures bundled skeleton is updated)

</details>

### HOW to test your changes?

#### Validation Checklist

Pre-Release:
- [ ] Source skeleton contains `@shopify/cli@3.85.4`
- [ ] Built CLI bundles skeleton with `@shopify/cli@3.85.4`
- [ ] Changeset includes `skeleton`, `@shopify/create-hydrogen`, and `@shopify/cli-hydrogen`

Post-Release:
- [ ] Published `@shopify/cli-hydrogen` package bundles `@shopify/cli@3.85.4`
- [ ] Scaffolded project contains `@shopify/cli@3.85.4`
- [ ] `npm install` completes without peer dependency warnings
- [ ] `npm run dev` starts dev server successfully
- [ ] `npm run build` completes without errors
- [ ] No regression in CLI command functionality

#### Post-merge steps

After this PR is merged and released:

1. **Monitor the Version PR**: The automated changeset workflow will create/update the CI release PR with entries for:
   - `skeleton` (patch)
   - `@shopify/create-hydrogen` (patch)
   - `@shopify/cli-hydrogen` (patch)

2. **Verify npm publication**: Once the Version PR is merged, confirm all three packages publish successfully

3. **Validate bundled skeleton**: Download the published `@shopify/cli-hydrogen` and verify it bundles the correct skeleton version (see Post-Release Testing above)

4. **Test end-to-end scaffolding**: Create a new project and confirm it has `@shopify/cli@3.85.4`

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes *(N/A - dependency version update)*
- [ ] I've added or updated the documentation *(N/A - no user-facing docs needed)*

---

**Note**: This PR follows the Hydrogen release circular dependency pattern documented in `CLAUDE.md`. The skeleton template is bundled within `@shopify/cli-hydrogen` during its build process (via `tsup.config.ts`), which is why the changeset must include `@shopify/cli-hydrogen` to ensure the updated skeleton is distributed to users.
