### PR TITLE
Remove regulation-specific privacy fields from public API

### DIFF
--- a/.changeset/remove-regulation-specific-fields.md
+++ b/.changeset/remove-regulation-specific-fields.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen-react': patch
+'@shopify/hydrogen': patch
+---
+
+Remove regulation-specific privacy fields from public API documentation. The generalized privacy fields (analyticsAllowed, marketingAllowed, saleOfDataAllowed) remain available.

--- a/packages/hydrogen-react/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen-react/docs/generated/generated_docs_data.json
@@ -1566,7 +1566,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-autocomplete",
-                "value": "'none' | 'inline' | 'list' | 'both' | undefined",
+                "value": "\"none\" | \"inline\" | \"list\" | \"both\" | undefined",
                 "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.",
                 "isOptional": true
               },
@@ -1598,7 +1598,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-checked",
-                "value": "boolean | 'false' | 'mixed' | 'true' | undefined",
+                "value": "boolean | \"false\" | \"mixed\" | \"true\" | undefined",
                 "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets.",
                 "isOptional": true
               },
@@ -1646,7 +1646,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-current",
-                "value": "boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time' | undefined",
+                "value": "boolean | \"false\" | \"true\" | \"page\" | \"step\" | \"location\" | \"date\" | \"time\" | undefined",
                 "description": "Indicates the element that represents the current item within a container or set of related elements.",
                 "isOptional": true
               },
@@ -1686,7 +1686,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-dropeffect",
-                "value": "'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined",
+                "value": "\"none\" | \"copy\" | \"execute\" | \"link\" | \"move\" | \"popup\" | undefined",
                 "description": "Indicates what functions can be performed when a dragged object is released on the drop target.",
                 "isOptional": true,
                 "deprecationMessage": "in ARIA 1.1"
@@ -1728,7 +1728,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-haspopup",
-                "value": "boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | undefined",
+                "value": "boolean | \"false\" | \"true\" | \"menu\" | \"listbox\" | \"tree\" | \"grid\" | \"dialog\" | undefined",
                 "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
                 "isOptional": true
               },
@@ -1744,7 +1744,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-invalid",
-                "value": "boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined",
+                "value": "boolean | \"false\" | \"true\" | \"grammar\" | \"spelling\" | undefined",
                 "description": "Indicates the entered value does not conform to the format expected by the application.",
                 "isOptional": true
               },
@@ -1784,7 +1784,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-live",
-                "value": "'off' | 'assertive' | 'polite' | undefined",
+                "value": "\"off\" | \"assertive\" | \"polite\" | undefined",
                 "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
                 "isOptional": true
               },
@@ -1816,7 +1816,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-orientation",
-                "value": "'horizontal' | 'vertical' | undefined",
+                "value": "\"horizontal\" | \"vertical\" | undefined",
                 "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
                 "isOptional": true
               },
@@ -1848,7 +1848,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-pressed",
-                "value": "boolean | 'false' | 'mixed' | 'true' | undefined",
+                "value": "boolean | \"false\" | \"mixed\" | \"true\" | undefined",
                 "description": "Indicates the current \"pressed\" state of toggle buttons.",
                 "isOptional": true
               },
@@ -1864,7 +1864,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-relevant",
-                "value": "'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' | undefined",
+                "value": "| \"additions\"\n            | \"additions removals\"\n            | \"additions text\"\n            | \"all\"\n            | \"removals\"\n            | \"removals additions\"\n            | \"removals text\"\n            | \"text\"\n            | \"text additions\"\n            | \"text removals\"\n            | undefined",
                 "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
                 "isOptional": true
               },
@@ -1936,7 +1936,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-sort",
-                "value": "'none' | 'ascending' | 'descending' | 'other' | undefined",
+                "value": "\"none\" | \"ascending\" | \"descending\" | \"other\" | undefined",
                 "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
                 "isOptional": true
               },
@@ -1976,7 +1976,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "autoCapitalize",
-                "value": "string | undefined",
+                "value": "\"off\" | \"none\" | \"on\" | \"sentences\" | \"words\" | \"characters\" | undefined | (string & {})",
                 "description": "",
                 "isOptional": true
               },
@@ -2040,7 +2040,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "contentEditable",
-                "value": "Booleanish | \"inherit\" | undefined",
+                "value": "Booleanish | \"inherit\" | \"plaintext-only\" | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -2087,7 +2087,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "defaultValue",
-                "value": "string | number | ReadonlyArray<string> | undefined",
+                "value": "string | number | readonly string[] | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -2104,6 +2104,22 @@
                 "syntaxKind": "PropertySignature",
                 "name": "draggable",
                 "value": "Booleanish | undefined",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/MediaFile.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "enterKeyHint",
+                "value": "\"enter\" | \"done\" | \"go\" | \"next\" | \"previous\" | \"search\" | \"send\" | undefined",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/MediaFile.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "exportparts",
+                "value": "string | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -2135,7 +2151,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "inputMode",
-                "value": "'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search' | undefined",
+                "value": "\"none\" | \"text\" | \"tel\" | \"url\" | \"email\" | \"numeric\" | \"decimal\" | \"search\" | undefined",
                 "description": "Hints at the type of data that might be entered by the user while editing the element or its contents",
                 "isOptional": true
               },
@@ -2295,7 +2311,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "onBeforeInput",
-                "value": "FormEventHandler<T> | undefined",
+                "value": "InputEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -2794,7 +2810,7 @@
                 "value": "KeyboardEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true,
-                "deprecationMessage": "Deprecated"
+                "deprecationMessage": "Use `onKeyUp` or `onKeyDown` instead"
               },
               {
                 "filePath": "src/MediaFile.tsx",
@@ -2803,7 +2819,7 @@
                 "value": "KeyboardEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true,
-                "deprecationMessage": "Deprecated"
+                "deprecationMessage": "Use `onKeyUpCapture` or `onKeyDownCapture` instead"
               },
               {
                 "filePath": "src/MediaFile.tsx",
@@ -3104,23 +3120,7 @@
               {
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
-                "name": "onPointerEnterCapture",
-                "value": "PointerEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/MediaFile.tsx",
-                "syntaxKind": "PropertySignature",
                 "name": "onPointerLeave",
-                "value": "PointerEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/MediaFile.tsx",
-                "syntaxKind": "PropertySignature",
-                "name": "onPointerLeaveCapture",
                 "value": "PointerEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true
@@ -3234,22 +3234,6 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onResetCapture",
                 "value": "FormEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/MediaFile.tsx",
-                "syntaxKind": "PropertySignature",
-                "name": "onResize",
-                "value": "ReactEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/MediaFile.tsx",
-                "syntaxKind": "PropertySignature",
-                "name": "onResizeCapture",
-                "value": "ReactEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -3512,7 +3496,7 @@
               {
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
-                "name": "placeholder",
+                "name": "part",
                 "value": "string | undefined",
                 "description": "",
                 "isOptional": true
@@ -3649,7 +3633,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "translate",
-                "value": "'yes' | 'no' | undefined",
+                "value": "\"yes\" | \"no\" | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -3665,7 +3649,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "unselectable",
-                "value": "'on' | 'off' | undefined",
+                "value": "\"on\" | \"off\" | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -4131,8 +4115,8 @@
                 "filePath": "src/Money.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "data",
-                "value": "PartialDeep<AnyMoneyV2, {recurseIntoArrays: true}>",
-                "description": "An object with fields that correspond to the Storefront API's [MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) or Customer Account API's MoneyV2 object."
+                "value": "PartialDeep<MoneyV2, {recurseIntoArrays: true}>",
+                "description": "An object with fields that correspond to the [Storefront API's MoneyV2 object](https://shopify.dev/docs/api/storefront/2025-07/objects/MoneyV2) or [Customer Account API's MoneyV2 object](https://shopify.dev/docs/api/customer/2025-07/objects/moneyv2)."
               },
               {
                 "filePath": "src/Money.tsx",
@@ -4167,14 +4151,14 @@
                 "isOptional": true
               }
             ],
-            "value": "export interface MoneyPropsBase<ComponentGeneric extends React.ElementType> {\n  /** An HTML tag or React Component to be rendered as the base element wrapper. The default is `div`. */\n  as?: ComponentGeneric;\n  /** An object with fields that correspond to the Storefront API's [MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) or Customer Account API's MoneyV2 object. */\n  data: PartialDeep<AnyMoneyV2, {recurseIntoArrays: true}>;\n  /** Whether to remove the currency symbol from the output. */\n  withoutCurrency?: boolean;\n  /** Whether to remove trailing zeros (fractional money) from the output. */\n  withoutTrailingZeros?: boolean;\n  /** A [UnitPriceMeasurement object](https://shopify.dev/api/storefront/2025-07/objects/unitpricemeasurement). */\n  measurement?: PartialDeep<UnitPriceMeasurement, {recurseIntoArrays: true}>;\n  /** Customizes the separator between the money output and the measurement output. Used with the `measurement` prop. Defaults to `'/'`. */\n  measurementSeparator?: ReactNode;\n}"
+            "value": "export interface MoneyPropsBase<ComponentGeneric extends React.ElementType> {\n  /** An HTML tag or React Component to be rendered as the base element wrapper. The default is `div`. */\n  as?: ComponentGeneric;\n  /** An object with fields that correspond to the [Storefront API's MoneyV2 object](https://shopify.dev/docs/api/storefront/2025-07/objects/MoneyV2) or [Customer Account API's MoneyV2 object](https://shopify.dev/docs/api/customer/2025-07/objects/moneyv2). */\n  data: PartialDeep<MoneyV2, {recurseIntoArrays: true}>;\n  /** Whether to remove the currency symbol from the output. */\n  withoutCurrency?: boolean;\n  /** Whether to remove trailing zeros (fractional money) from the output. */\n  withoutTrailingZeros?: boolean;\n  /** A [UnitPriceMeasurement object](https://shopify.dev/api/storefront/2025-07/objects/unitpricemeasurement). */\n  measurement?: PartialDeep<UnitPriceMeasurement, {recurseIntoArrays: true}>;\n  /** Customizes the separator between the money output and the measurement output. Used with the `measurement` prop. Defaults to `'/'`. */\n  measurementSeparator?: ReactNode;\n}"
           },
-          "AnyMoneyV2": {
+          "MoneyV2": {
             "filePath": "src/Money.tsx",
             "syntaxKind": "TypeAliasDeclaration",
-            "name": "AnyMoneyV2",
-            "value": "MoneyV2 | CustomerMoneyV2",
-            "description": ""
+            "name": "MoneyV2",
+            "value": "StorefrontApiMoneyV2 | CustomerAccountApiMoneyV2",
+            "description": "Supports MoneyV2 from both Storefront API and Customer Account API. The APIs may have different CurrencyCode enums (e.g., Customer Account API added USDC in 2025-07, but Storefront API doesn't support USDC in 2025-07). This union type ensures Money component works with data from either API."
           }
         }
       }
@@ -5059,14 +5043,6 @@
               {
                 "filePath": "src/analytics-types.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "ccpaEnforced",
-                "value": "boolean",
-                "description": "Result of `!customerPrivacyApi.saleOfDataAllowed()`",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/analytics-types.ts",
-                "syntaxKind": "PropertySignature",
                 "name": "collectionHandle",
                 "value": "string",
                 "description": "Shopify collection handle.",
@@ -5093,14 +5069,6 @@
                 "name": "customerId",
                 "value": "string",
                 "description": "Shopify customer id in the form of `gid://shopify/Customer/<id>`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/analytics-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "gdprEnforced",
-                "value": "boolean",
-                "description": "Result of `!(customerPrivacyApi.marketingAllowed() && customerPrivacy.analyticsProcessingAllowed())`",
                 "isOptional": true
               },
               {
@@ -5270,6 +5238,13 @@
             ],
             "value": "export interface ShopifyPageViewPayload\n  extends ShopifyAnalyticsBase,\n    ClientBrowserParameters {\n  /** Canonical url. */\n  canonicalUrl?: string;\n  /** Shopify page type. */\n  pageType?: string;\n  /** Shopify resource id in the form of `gid://shopify/<type>/<id>`. */\n  resourceId?: string;\n  /** Shopify collection handle. */\n  collectionHandle?: string;\n  /** Shopify collection id. */\n  collectionId?: string;\n  /** Search term used on a search results page. */\n  searchString?: string;\n}"
           },
+          "CurrencyCode": {
+            "filePath": "src/useMoney.tsx",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CurrencyCode",
+            "value": "StorefrontApiCurrencyCode | CustomerAccountApiCurrencyCode",
+            "description": "Supports CurrencyCode from both Storefront API and Customer Account API. The APIs may have different CurrencyCode enums (e.g., Customer Account API added USDC in 2025-07, but Storefront API doesn't support USDC in 2025-07). This union type ensures useMoney works with data from either API."
+          },
           "ShopifyAnalyticsProduct": {
             "filePath": "src/analytics-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
@@ -5438,14 +5413,6 @@
               {
                 "filePath": "src/analytics-types.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "ccpaEnforced",
-                "value": "boolean",
-                "description": "Result of `!customerPrivacyApi.saleOfDataAllowed()`",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/analytics-types.ts",
-                "syntaxKind": "PropertySignature",
                 "name": "currency",
                 "value": "CurrencyCode",
                 "description": "Currency code."
@@ -5456,14 +5423,6 @@
                 "name": "customerId",
                 "value": "string",
                 "description": "Shopify customer id in the form of `gid://shopify/Customer/<id>`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/analytics-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "gdprEnforced",
-                "value": "boolean",
-                "description": "Result of `!(customerPrivacyApi.marketingAllowed() && customerPrivacy.analyticsProcessingAllowed())`",
                 "isOptional": true
               },
               {
@@ -6662,7 +6621,7 @@
               "name": "ReturnGeneric",
               "value": "ReturnGeneric"
             },
-            "value": "export function parseMetafield<ReturnGeneric>(\n  metafield: PartialDeep<MetafieldBaseType, {recurseIntoArrays: true}>,\n): ReturnGeneric {\n  if (!metafield.type) {\n    const noTypeError = `parseMetafield(): The 'type' field is required in order to parse the Metafield.`;\n    if (__HYDROGEN_DEV__) {\n      throw new Error(noTypeError);\n    } else {\n      console.error(`${noTypeError} Returning 'parsedValue' of 'null'`);\n      return {\n        ...metafield,\n        parsedValue: null,\n      } as ReturnGeneric;\n    }\n  }\n\n  switch (metafield.type) {\n    case 'boolean':\n      return {\n        ...metafield,\n        parsedValue: metafield.value === 'true',\n      } as ReturnGeneric;\n\n    case 'collection_reference':\n    case 'file_reference':\n    case 'page_reference':\n    case 'product_reference':\n    case 'variant_reference':\n      return {\n        ...metafield,\n        parsedValue: metafield.reference,\n      } as ReturnGeneric;\n\n    case 'color':\n    case 'multi_line_text_field':\n    case 'single_line_text_field':\n    case 'url':\n      return {\n        ...metafield,\n        parsedValue: metafield.value,\n      } as ReturnGeneric;\n\n    // TODO: 'money' should probably be parsed even further to like `useMoney()`, but that logic needs to be extracted first so it's not a hook\n    case 'dimension':\n    case 'money':\n    case 'json':\n    case 'rating':\n    case 'volume':\n    case 'weight':\n    case 'rich_text_field':\n    case 'list.color':\n    case 'list.dimension':\n    case 'list.number_integer':\n    case 'list.number_decimal':\n    case 'list.rating':\n    case 'list.single_line_text_field':\n    case 'list.url':\n    case 'list.volume':\n    case 'list.weight': {\n      let parsedValue = null;\n      try {\n        parsedValue = parseJSON(metafield.value ?? '');\n      } catch (err) {\n        const parseError = `parseMetafield(): attempted to JSON.parse the 'metafield.value' property, but failed.`;\n        if (__HYDROGEN_DEV__) {\n          throw new Error(parseError);\n        } else {\n          console.error(`${parseError} Returning 'null' for 'parsedValue'`);\n        }\n        parsedValue = null;\n      }\n      return {\n        ...metafield,\n        parsedValue,\n      } as ReturnGeneric;\n    }\n\n    case 'date':\n    case 'date_time':\n      return {\n        ...metafield,\n        parsedValue: new Date(metafield.value ?? ''),\n      } as ReturnGeneric;\n\n    case 'list.date':\n    case 'list.date_time': {\n      const jsonParseValue = parseJSON(metafield?.value ?? '') as string[];\n      return {\n        ...metafield,\n        parsedValue: jsonParseValue.map((dateString) => new Date(dateString)),\n      } as ReturnGeneric;\n    }\n\n    case 'number_decimal':\n    case 'number_integer':\n      return {\n        ...metafield,\n        parsedValue: Number(metafield.value),\n      } as ReturnGeneric;\n\n    case 'list.collection_reference':\n    case 'list.file_reference':\n    case 'list.page_reference':\n    case 'list.product_reference':\n    case 'list.variant_reference':\n      return {\n        ...metafield,\n        parsedValue: flattenConnection(metafield.references ?? undefined),\n      } as ReturnGeneric;\n\n    default: {\n      const typeNotFoundError = `parseMetafield(): the 'metafield.type' you passed in is not supported. Your type: \"${metafield.type}\". If you believe this is an error, please open an issue on GitHub.`;\n      if (__HYDROGEN_DEV__) {\n        throw new Error(typeNotFoundError);\n      } else {\n        console.error(\n          `${typeNotFoundError}  Returning 'parsedValue' of 'null'`,\n        );\n        return {\n          ...metafield,\n          parsedValue: null,\n        } as ReturnGeneric;\n      }\n    }\n  }\n}"
+            "value": "export function parseMetafield<ReturnGeneric>(\n  metafield: PartialDeep<MetafieldBaseType, {recurseIntoArrays: true}>,\n): ReturnGeneric {\n  if (!metafield.type) {\n    const noTypeError = `parseMetafield(): The 'type' field is required in order to parse the Metafield.`;\n    if (__HYDROGEN_DEV__) {\n      throw new Error(noTypeError);\n    } else {\n      console.error(`${noTypeError} Returning 'parsedValue' of 'null'`);\n      return {\n        ...metafield,\n        parsedValue: null,\n      } as ReturnGeneric;\n    }\n  }\n\n  switch (metafield.type) {\n    case 'boolean':\n      return {\n        ...metafield,\n        parsedValue: metafield.value === 'true',\n      } as ReturnGeneric;\n\n    case 'collection_reference':\n    case 'file_reference':\n    case 'page_reference':\n    case 'product_reference':\n    case 'variant_reference':\n      return {\n        ...metafield,\n        parsedValue: metafield.reference,\n      } as ReturnGeneric;\n\n    case 'color':\n    case 'multi_line_text_field':\n    case 'single_line_text_field':\n    case 'url':\n      return {\n        ...metafield,\n        parsedValue: metafield.value,\n      } as ReturnGeneric;\n\n    // TODO: 'money' should probably be parsed even further to like `useMoney()`, but that logic needs to be extracted first so it's not a hook\n    case 'money': {\n      let parsedValue: MoneyV2 | null = null;\n      try {\n        const parsed = parseJSON(metafield.value ?? '');\n        // Transform currency_code from Storefront API to currencyCode to match MoneyV2 type\n        if (parsed && typeof parsed === 'object' && 'currency_code' in parsed) {\n          const moneyData = parsed as {amount: string; currency_code: string};\n          parsedValue = {\n            amount: moneyData.amount,\n            currencyCode: moneyData.currency_code as CurrencyCode,\n          };\n        } else if (\n          parsed &&\n          typeof parsed === 'object' &&\n          'currencyCode' in parsed\n        ) {\n          // Already in correct format (for backward compatibility)\n          parsedValue = parsed as MoneyV2;\n        } else {\n          parsedValue = parsed as MoneyV2 | null;\n        }\n      } catch (err) {\n        const parseError = `parseMetafield(): attempted to JSON.parse the 'metafield.value' property, but failed.`;\n        if (__HYDROGEN_DEV__) {\n          throw new Error(parseError);\n        } else {\n          console.error(`${parseError} Returning 'null' for 'parsedValue'`);\n        }\n        parsedValue = null;\n      }\n      return {\n        ...metafield,\n        parsedValue,\n      } as ReturnGeneric;\n    }\n\n    case 'dimension':\n    case 'json':\n    case 'rating':\n    case 'volume':\n    case 'weight':\n    case 'rich_text_field':\n    case 'list.color':\n    case 'list.dimension':\n    case 'list.number_integer':\n    case 'list.number_decimal':\n    case 'list.rating':\n    case 'list.single_line_text_field':\n    case 'list.url':\n    case 'list.volume':\n    case 'list.weight': {\n      let parsedValue = null;\n      try {\n        parsedValue = parseJSON(metafield.value ?? '');\n      } catch (err) {\n        const parseError = `parseMetafield(): attempted to JSON.parse the 'metafield.value' property, but failed.`;\n        if (__HYDROGEN_DEV__) {\n          throw new Error(parseError);\n        } else {\n          console.error(`${parseError} Returning 'null' for 'parsedValue'`);\n        }\n        parsedValue = null;\n      }\n      return {\n        ...metafield,\n        parsedValue,\n      } as ReturnGeneric;\n    }\n\n    case 'date':\n    case 'date_time':\n      return {\n        ...metafield,\n        parsedValue: new Date(metafield.value ?? ''),\n      } as ReturnGeneric;\n\n    case 'list.date':\n    case 'list.date_time': {\n      const jsonParseValue = parseJSON(metafield?.value ?? '') as string[];\n      return {\n        ...metafield,\n        parsedValue: jsonParseValue.map((dateString) => new Date(dateString)),\n      } as ReturnGeneric;\n    }\n\n    case 'number_decimal':\n    case 'number_integer':\n      return {\n        ...metafield,\n        parsedValue: Number(metafield.value),\n      } as ReturnGeneric;\n\n    case 'list.collection_reference':\n    case 'list.file_reference':\n    case 'list.page_reference':\n    case 'list.product_reference':\n    case 'list.variant_reference':\n      return {\n        ...metafield,\n        parsedValue: flattenConnection(metafield.references ?? undefined),\n      } as ReturnGeneric;\n\n    default: {\n      const typeNotFoundError = `parseMetafield(): the 'metafield.type' you passed in is not supported. Your type: \"${metafield.type}\". If you believe this is an error, please open an issue on GitHub.`;\n      if (__HYDROGEN_DEV__) {\n        throw new Error(typeNotFoundError);\n      } else {\n        console.error(\n          `${typeNotFoundError}  Returning 'parsedValue' of 'null'`,\n        );\n        return {\n          ...metafield,\n          parsedValue: null,\n        } as ReturnGeneric;\n      }\n    }\n  }\n}"
           }
         }
       }
@@ -7217,12 +7176,12 @@
           "UseMoneyGeneratedType": {
             "filePath": "src/useMoney.tsx",
             "name": "UseMoneyGeneratedType",
-            "description": "The `useMoney` hook takes a [MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) and returns a default-formatted string of the amount with the correct currency indicator, along with some of the parts provided by [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). Uses `locale` from `ShopifyProvider` &nbsp;",
+            "description": "The `useMoney` hook takes a [MoneyV2 object from the Storefront API](https://shopify.dev/docs/api/storefront/2025-07/objects/MoneyV2) or a [MoneyV2 object from the Customer Account API](https://shopify.dev/docs/api/customer/2025-07/objects/moneyv2) and returns a default-formatted string of the amount with the correct currency indicator, along with some of the parts provided by [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). Uses `locale` from `ShopifyProvider` &nbsp;",
             "params": [
               {
                 "name": "money",
                 "description": "",
-                "value": "AnyMoneyV2",
+                "value": "MoneyV2",
                 "filePath": "src/useMoney.tsx"
               }
             ],
@@ -7232,7 +7191,7 @@
               "name": "UseMoneyValue",
               "value": "UseMoneyValue"
             },
-            "value": "export function useMoney(money: AnyMoneyV2): UseMoneyValue {\n  const {countryIsoCode, languageIsoCode} = useShop();\n  const locale = languageIsoCode.includes('_')\n    ? languageIsoCode.replace('_', '-')\n    : `${languageIsoCode}-${countryIsoCode}`;\n\n  if (!locale) {\n    throw new Error(\n      `useMoney(): Unable to get 'locale' from 'useShop()', which means that 'locale' was not passed to '<ShopifyProvider/>'. 'locale' is required for 'useMoney()' to work`,\n    );\n  }\n\n  const amount = parseFloat(money.amount);\n\n  // Check if the currency code is supported by Intl.NumberFormat\n  let isCurrencySupported = true;\n  try {\n    new Intl.NumberFormat(locale, {style: 'currency', currency: money.currencyCode});\n  } catch (e) {\n    if (e instanceof RangeError && e.message.includes('currency')) {\n      isCurrencySupported = false;\n    }\n  }\n\n  const {\n    defaultFormatter,\n    nameFormatter,\n    narrowSymbolFormatter,\n    withoutTrailingZerosFormatter,\n    withoutCurrencyFormatter,\n    withoutTrailingZerosOrCurrencyFormatter,\n  } = useMemo(() => {\n    // For unsupported currencies (like USDC cryptocurrency), use decimal formatting with 2 decimal places\n    // We default to 2 decimal places based on research showing USDC displays like USD to reinforce its 1:1 peg\n    const options = isCurrencySupported \n      ? {\n          style: 'currency' as const,\n          currency: money.currencyCode,\n        }\n      : {\n          style: 'decimal' as const,\n          minimumFractionDigits: 2,\n          maximumFractionDigits: 2,\n        };\n\n    return {\n      defaultFormatter: getLazyFormatter(locale, options),\n      nameFormatter: getLazyFormatter(locale, {\n        ...options,\n        currencyDisplay: 'name',\n      }),\n      narrowSymbolFormatter: getLazyFormatter(locale, {\n        ...options,\n        currencyDisplay: 'narrowSymbol',\n      }),\n      withoutTrailingZerosFormatter: getLazyFormatter(locale, {\n        ...options,\n        minimumFractionDigits: 0,\n        maximumFractionDigits: 0,\n      }),\n      withoutCurrencyFormatter: getLazyFormatter(locale, {\n        minimumFractionDigits: 2,\n        maximumFractionDigits: 2,\n      }),\n      withoutTrailingZerosOrCurrencyFormatter: getLazyFormatter(locale, {\n        minimumFractionDigits: 0,\n        maximumFractionDigits: 0,\n      }),\n    };\n  }, [money.currencyCode, locale, isCurrencySupported]);\n\n  const isPartCurrency = (part: Intl.NumberFormatPart): boolean =>\n    part.type === 'currency';\n\n  // By wrapping these properties in functions, we only\n  // create formatters if they are going to be used.\n  const lazyFormatters = useMemo(\n    () => ({\n      original: (): AnyMoneyV2 => money,\n      currencyCode: (): AnyCurrencyCode => money.currencyCode,\n\n      localizedString: (): string => {\n        const formatted = defaultFormatter().format(amount);\n        // For unsupported currencies, append the currency code\n        return isCurrencySupported ? formatted : `${formatted} ${money.currencyCode}`;\n      },\n\n      parts: (): Intl.NumberFormatPart[] => {\n        const parts = defaultFormatter().formatToParts(amount);\n        // For unsupported currencies, add currency code as a currency part\n        if (!isCurrencySupported) {\n          parts.push(\n            {type: 'literal', value: ' '},\n            {type: 'currency', value: money.currencyCode}\n          );\n        }\n        return parts;\n      },\n\n      withoutTrailingZeros: (): string => {\n        const formatted = amount % 1 === 0\n          ? withoutTrailingZerosFormatter().format(amount)\n          : defaultFormatter().format(amount);\n        // For unsupported currencies, append the currency code\n        return isCurrencySupported ? formatted : `${formatted} ${money.currencyCode}`;\n      },\n\n      withoutTrailingZerosAndCurrency: (): string =>\n        amount % 1 === 0\n          ? withoutTrailingZerosOrCurrencyFormatter().format(amount)\n          : withoutCurrencyFormatter().format(amount),\n\n      currencyName: (): string =>\n        nameFormatter().formatToParts(amount).find(isPartCurrency)?.value ??\n        money.currencyCode, // e.g. \"US dollars\"\n\n      currencySymbol: (): string =>\n        defaultFormatter().formatToParts(amount).find(isPartCurrency)?.value ??\n        money.currencyCode, // e.g. \"USD\"\n\n      currencyNarrowSymbol: (): string =>\n        narrowSymbolFormatter().formatToParts(amount).find(isPartCurrency)\n          ?.value ?? '', // e.g. \"$\"\n\n      amount: (): string =>\n        defaultFormatter()\n          .formatToParts(amount)\n          .filter((part) =>\n            ['decimal', 'fraction', 'group', 'integer', 'literal'].includes(\n              part.type,\n            ),\n          )\n          .map((part) => part.value)\n          .join(''),\n    }),\n    [\n      money,\n      amount,\n      isCurrencySupported,\n      nameFormatter,\n      defaultFormatter,\n      narrowSymbolFormatter,\n      withoutCurrencyFormatter,\n      withoutTrailingZerosFormatter,\n      withoutTrailingZerosOrCurrencyFormatter,\n    ],\n  );\n\n  // Call functions automatically when the properties are accessed\n  // to keep these functions as an implementation detail.\n  return useMemo(\n    () =>\n      new Proxy(lazyFormatters as unknown as UseMoneyValue, {\n        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call\n        get: (target, key) => Reflect.get(target, key)?.call(null),\n      }),\n    [lazyFormatters],\n  );\n}",
+            "value": "export function useMoney(money: MoneyV2): UseMoneyValue {\n  const {countryIsoCode, languageIsoCode} = useShop();\n  const locale = languageIsoCode.includes('_')\n    ? languageIsoCode.replace('_', '-')\n    : `${languageIsoCode}-${countryIsoCode}`;\n\n  if (!locale) {\n    throw new Error(\n      `useMoney(): Unable to get 'locale' from 'useShop()', which means that 'locale' was not passed to '<ShopifyProvider/>'. 'locale' is required for 'useMoney()' to work`,\n    );\n  }\n\n  const amount = parseFloat(money.amount);\n\n  // Check if the currency code is supported by Intl.NumberFormat\n  let isCurrencySupported = true;\n  try {\n    new Intl.NumberFormat(locale, {\n      style: 'currency',\n      currency: money.currencyCode,\n    });\n  } catch (e) {\n    if (e instanceof RangeError && e.message.includes('currency')) {\n      isCurrencySupported = false;\n    }\n  }\n\n  const {\n    defaultFormatter,\n    nameFormatter,\n    narrowSymbolFormatter,\n    withoutTrailingZerosFormatter,\n    withoutCurrencyFormatter,\n    withoutTrailingZerosOrCurrencyFormatter,\n  } = useMemo(() => {\n    // For unsupported currencies (like USDC cryptocurrency), use decimal formatting with 2 decimal places\n    // We default to 2 decimal places based on research showing USDC displays like USD to reinforce its 1:1 peg\n    const options = isCurrencySupported\n      ? {\n          style: 'currency' as const,\n          currency: money.currencyCode,\n        }\n      : {\n          style: 'decimal' as const,\n          minimumFractionDigits: 2,\n          maximumFractionDigits: 2,\n        };\n\n    return {\n      defaultFormatter: getLazyFormatter(locale, options),\n      nameFormatter: getLazyFormatter(locale, {\n        ...options,\n        currencyDisplay: 'name',\n      }),\n      narrowSymbolFormatter: getLazyFormatter(locale, {\n        ...options,\n        currencyDisplay: 'narrowSymbol',\n      }),\n      withoutTrailingZerosFormatter: getLazyFormatter(locale, {\n        ...options,\n        minimumFractionDigits: 0,\n        maximumFractionDigits: 0,\n      }),\n      withoutCurrencyFormatter: getLazyFormatter(locale, {\n        minimumFractionDigits: 2,\n        maximumFractionDigits: 2,\n      }),\n      withoutTrailingZerosOrCurrencyFormatter: getLazyFormatter(locale, {\n        minimumFractionDigits: 0,\n        maximumFractionDigits: 0,\n      }),\n    };\n  }, [money.currencyCode, locale, isCurrencySupported]);\n\n  const isPartCurrency = (part: Intl.NumberFormatPart): boolean =>\n    part.type === 'currency';\n\n  // By wrapping these properties in functions, we only\n  // create formatters if they are going to be used.\n  const lazyFormatters = useMemo(\n    () => ({\n      original: (): MoneyV2 => money,\n      currencyCode: (): CurrencyCode => money.currencyCode,\n\n      localizedString: (): string => {\n        const formatted = defaultFormatter().format(amount);\n        // For unsupported currencies, append the currency code\n        return isCurrencySupported\n          ? formatted\n          : `${formatted} ${money.currencyCode}`;\n      },\n\n      parts: (): Intl.NumberFormatPart[] => {\n        const parts = defaultFormatter().formatToParts(amount);\n        // For unsupported currencies, add currency code as a currency part\n        if (!isCurrencySupported) {\n          parts.push(\n            {type: 'literal', value: ' '},\n            {type: 'currency', value: money.currencyCode},\n          );\n        }\n        return parts;\n      },\n\n      withoutTrailingZeros: (): string => {\n        const formatted =\n          amount % 1 === 0\n            ? withoutTrailingZerosFormatter().format(amount)\n            : defaultFormatter().format(amount);\n        // For unsupported currencies, append the currency code\n        return isCurrencySupported\n          ? formatted\n          : `${formatted} ${money.currencyCode}`;\n      },\n\n      withoutTrailingZerosAndCurrency: (): string =>\n        amount % 1 === 0\n          ? withoutTrailingZerosOrCurrencyFormatter().format(amount)\n          : withoutCurrencyFormatter().format(amount),\n\n      currencyName: (): string =>\n        nameFormatter().formatToParts(amount).find(isPartCurrency)?.value ??\n        money.currencyCode, // e.g. \"US dollars\"\n\n      currencySymbol: (): string =>\n        defaultFormatter().formatToParts(amount).find(isPartCurrency)?.value ??\n        money.currencyCode, // e.g. \"USD\"\n\n      currencyNarrowSymbol: (): string =>\n        narrowSymbolFormatter().formatToParts(amount).find(isPartCurrency)\n          ?.value ?? '', // e.g. \"$\"\n\n      amount: (): string =>\n        defaultFormatter()\n          .formatToParts(amount)\n          .filter((part) =>\n            ['decimal', 'fraction', 'group', 'integer', 'literal'].includes(\n              part.type,\n            ),\n          )\n          .map((part) => part.value)\n          .join(''),\n    }),\n    [\n      money,\n      amount,\n      isCurrencySupported,\n      nameFormatter,\n      defaultFormatter,\n      narrowSymbolFormatter,\n      withoutCurrencyFormatter,\n      withoutTrailingZerosFormatter,\n      withoutTrailingZerosOrCurrencyFormatter,\n    ],\n  );\n\n  // Call functions automatically when the properties are accessed\n  // to keep these functions as an implementation detail.\n  return useMemo(\n    () =>\n      new Proxy(lazyFormatters as unknown as UseMoneyValue, {\n        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call\n        get: (target, key) => Reflect.get(target, key)?.call(null),\n      }),\n    [lazyFormatters],\n  );\n}",
             "examples": [
               {
                 "title": "Example",
@@ -7358,18 +7317,18 @@
               }
             ]
           },
-          "AnyMoneyV2": {
+          "MoneyV2": {
             "filePath": "src/useMoney.tsx",
             "syntaxKind": "TypeAliasDeclaration",
-            "name": "AnyMoneyV2",
-            "value": "MoneyV2 | CustomerMoneyV2",
-            "description": ""
+            "name": "MoneyV2",
+            "value": "StorefrontApiMoneyV2 | CustomerAccountApiMoneyV2",
+            "description": "Supports MoneyV2 from both Storefront API and Customer Account API. The APIs may have different CurrencyCode enums (e.g., Customer Account API added USDC in 2025-07, but Storefront API doesn't support USDC in 2025-07). This union type ensures useMoney works with data from either API."
           },
           "UseMoneyValue": {
             "filePath": "src/useMoney.tsx",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "UseMoneyValue",
-            "value": "{\n  /**\n   * The currency code from the `MoneyV2` object.\n   */\n  currencyCode: AnyCurrencyCode;\n  /**\n   * The name for the currency code, returned by `Intl.NumberFormat`.\n   */\n  currencyName?: string;\n  /**\n   * The currency symbol returned by `Intl.NumberFormat`.\n   */\n  currencySymbol?: string;\n  /**\n   * The currency narrow symbol returned by `Intl.NumberFormat`.\n   */\n  currencyNarrowSymbol?: string;\n  /**\n   * The localized amount, without any currency symbols or non-number types from the `Intl.NumberFormat.formatToParts` parts.\n   */\n  amount: string;\n  /**\n   * All parts returned by `Intl.NumberFormat.formatToParts`.\n   */\n  parts: Intl.NumberFormatPart[];\n  /**\n   * A string returned by `new Intl.NumberFormat` for the amount and currency code,\n   * using the `locale` value in the [`LocalizationProvider` component](https://shopify.dev/api/hydrogen/components/localization/localizationprovider).\n   */\n  localizedString: string;\n  /**\n   * The `MoneyV2` object provided as an argument to the hook.\n   */\n  original: AnyMoneyV2;\n  /**\n   * A string with trailing zeros removed from the fractional part, if any exist. If there are no trailing zeros, then the fractional part remains.\n   * For example, `$640.00` turns into `$640`.\n   * `$640.42` remains `$640.42`.\n   */\n  withoutTrailingZeros: string;\n  /**\n   * A string without currency and without trailing zeros removed from the fractional part, if any exist. If there are no trailing zeros, then the fractional part remains.\n   * For example, `$640.00` turns into `640`.\n   * `$640.42` turns into `640.42`.\n   */\n  withoutTrailingZerosAndCurrency: string;\n}",
+            "value": "{\n  /**\n   * The currency code from the `MoneyV2` object.\n   */\n  currencyCode: CurrencyCode;\n  /**\n   * The name for the currency code, returned by `Intl.NumberFormat`.\n   */\n  currencyName?: string;\n  /**\n   * The currency symbol returned by `Intl.NumberFormat`.\n   */\n  currencySymbol?: string;\n  /**\n   * The currency narrow symbol returned by `Intl.NumberFormat`.\n   */\n  currencyNarrowSymbol?: string;\n  /**\n   * The localized amount, without any currency symbols or non-number types from the `Intl.NumberFormat.formatToParts` parts.\n   */\n  amount: string;\n  /**\n   * All parts returned by `Intl.NumberFormat.formatToParts`.\n   */\n  parts: Intl.NumberFormatPart[];\n  /**\n   * A string returned by `new Intl.NumberFormat` for the amount and currency code,\n   * using the `locale` value in the [`LocalizationProvider` component](https://shopify.dev/api/hydrogen/components/localization/localizationprovider).\n   */\n  localizedString: string;\n  /**\n   * The `MoneyV2` object provided as an argument to the hook.\n   */\n  original: MoneyV2;\n  /**\n   * A string with trailing zeros removed from the fractional part, if any exist. If there are no trailing zeros, then the fractional part remains.\n   * For example, `$640.00` turns into `$640`.\n   * `$640.42` remains `$640.42`.\n   */\n  withoutTrailingZeros: string;\n  /**\n   * A string without currency and without trailing zeros removed from the fractional part, if any exist. If there are no trailing zeros, then the fractional part remains.\n   * For example, `$640.00` turns into `640`.\n   * `$640.42` turns into `640.42`.\n   */\n  withoutTrailingZerosAndCurrency: string;\n}",
             "description": "",
             "members": [
               {
@@ -7383,7 +7342,7 @@
                 "filePath": "src/useMoney.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "currencyCode",
-                "value": "AnyCurrencyCode",
+                "value": "CurrencyCode",
                 "description": "The currency code from the `MoneyV2` object."
               },
               {
@@ -7421,7 +7380,7 @@
                 "filePath": "src/useMoney.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "original",
-                "value": "AnyMoneyV2",
+                "value": "MoneyV2",
                 "description": "The `MoneyV2` object provided as an argument to the hook."
               },
               {
@@ -7447,12 +7406,12 @@
               }
             ]
           },
-          "AnyCurrencyCode": {
+          "CurrencyCode": {
             "filePath": "src/useMoney.tsx",
             "syntaxKind": "TypeAliasDeclaration",
-            "name": "AnyCurrencyCode",
-            "value": "CurrencyCode | CustomerCurrencyCode",
-            "description": ""
+            "name": "CurrencyCode",
+            "value": "StorefrontApiCurrencyCode | CustomerAccountApiCurrencyCode",
+            "description": "Supports CurrencyCode from both Storefront API and Customer Account API. The APIs may have different CurrencyCode enums (e.g., Customer Account API added USDC in 2025-07, but Storefront API doesn't support USDC in 2025-07). This union type ensures useMoney works with data from either API."
           }
         }
       }

--- a/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.test.ts
+++ b/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.test.ts
@@ -13,6 +13,7 @@ import type {
   ShopifyAnalyticsPayload,
   ShopifyMonorailPayload,
   ShopifyPageViewPayload,
+  ShopifyPageViewPayloadWithPrivacyFields,
 } from './analytics-types.js';
 import {version} from '../package.json';
 
@@ -64,7 +65,7 @@ describe(`analytics schema - custom storefront customer tracking`, () => {
     });
 
     it(`base payload with non-default values using hydrogenSubchannelId`, () => {
-      const pageViewPayload: ShopifyPageViewPayload = {
+      const pageViewPayload: ShopifyPageViewPayloadWithPrivacyFields = {
         ...BASE_PAYLOAD,
         shopId: 'gid://shopify/Shop/2',
         hasUserConsent: false,

--- a/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.ts
+++ b/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.ts
@@ -1,7 +1,10 @@
 import {
   ShopifyAnalyticsPayload,
+  ShopifyAnalyticsPayloadWithPrivacyFields,
   ShopifyPageViewPayload,
+  ShopifyPageViewPayloadWithPrivacyFields,
   ShopifyAddToCartPayload,
+  ShopifyAddToCartPayloadWithPrivacyFields,
   ShopifyMonorailPayload,
   ShopifyAnalyticsProduct,
   ShopifyMonorailEvent,
@@ -19,7 +22,7 @@ const PRODUCT_ADDED_TO_CART_EVENT_NAME = 'product_added_to_cart';
 const SEARCH_SUBMITTED_EVENT_NAME = 'search_submitted';
 
 function prepareAdditionalPayload(
-  payload: ShopifyPageViewPayload,
+  payload: ShopifyPageViewPayload | ShopifyPageViewPayloadWithPrivacyFields,
 ): Pick<ShopifyMonorailPayload, 'canonical_url' | 'customer_id'> {
   return {
     canonical_url: payload.canonicalUrl || payload.url,
@@ -30,7 +33,7 @@ function prepareAdditionalPayload(
 // Send the page view event to the Monorail server.
 // It also sends additional page view events based on the page type.
 export function pageView(
-  payload: ShopifyPageViewPayload,
+  payload: ShopifyPageViewPayload | ShopifyPageViewPayloadWithPrivacyFields,
 ): ShopifyMonorailEvent[] {
   const pageViewPayload = payload;
   const additionalPayload = prepareAdditionalPayload(pageViewPayload);
@@ -196,7 +199,7 @@ export function searchView(
 }
 
 export function addToCart(
-  payload: ShopifyAddToCartPayload,
+  payload: ShopifyAddToCartPayload | ShopifyAddToCartPayloadWithPrivacyFields,
 ): ShopifyMonorailEvent[] {
   const addToCartPayload = payload;
   const cartToken = parseGid(addToCartPayload.cartId);
@@ -221,8 +224,11 @@ export function addToCart(
 }
 
 function formatPayload(
-  payload: ShopifyAnalyticsPayload,
+  payload: ShopifyAnalyticsPayload | ShopifyAnalyticsPayloadWithPrivacyFields,
 ): ShopifyMonorailPayload {
+  const payloadWithPrivacy =
+    payload as ShopifyAnalyticsPayloadWithPrivacyFields;
+
   return {
     source: payload.shopifySalesChannel || ShopifySalesChannel.headless,
     asset_version_id: payload.assetVersionId || version,
@@ -244,9 +250,9 @@ function formatPayload(
     shop_id: parseInt(parseGid(payload.shopId).id),
     currency: payload.currency,
 
-    ccpa_enforced: payload.ccpaEnforced || false,
-    gdpr_enforced: payload.gdprEnforced || false,
-    gdpr_enforced_as_string: payload.gdprEnforced ? 'true' : 'false',
+    ccpa_enforced: payloadWithPrivacy.ccpaEnforced || false,
+    gdpr_enforced: payloadWithPrivacy.gdprEnforced || false,
+    gdpr_enforced_as_string: payloadWithPrivacy.gdprEnforced ? 'true' : 'false',
     analytics_allowed: payload.analyticsAllowed || false,
     marketing_allowed: payload.marketingAllowed || false,
     sale_of_data_allowed: payload.saleOfDataAllowed || false,

--- a/packages/hydrogen-react/src/analytics-types.ts
+++ b/packages/hydrogen-react/src/analytics-types.ts
@@ -117,16 +117,22 @@ type ShopifyAnalyticsBase = {
   totalValue?: number;
   /** Product list. */
   products?: ShopifyAnalyticsProduct[];
-  /** Result of `!customerPrivacyApi.saleOfDataAllowed()` */
-  ccpaEnforced?: boolean;
-  /** Result of `!(customerPrivacyApi.marketingAllowed() && customerPrivacy.analyticsProcessingAllowed())`*/
-  gdprEnforced?: boolean;
   /** Result of `customerPrivacyApi.analyticsProcessingAllowed()` */
   analyticsAllowed?: boolean;
   /** Result of `customerPrivacyApi.marketingAllowed()` */
   marketingAllowed?: boolean;
   /** Result of `customerPrivacyApi.saleOfDataAllowed()` */
   saleOfDataAllowed?: boolean;
+};
+
+/**
+ * @internal
+ * Internal type that includes computed regulation-specific fields.
+ * These fields are computed by Hydrogen and sent to analytics backend.
+ */
+type ShopifyAnalyticsBaseWithPrivacyFields = ShopifyAnalyticsBase & {
+  ccpaEnforced?: boolean;
+  gdprEnforced?: boolean;
 };
 
 export type ShopifySalesChannels = keyof typeof ShopifySalesChannel;
@@ -149,6 +155,17 @@ export interface ShopifyPageViewPayload
   searchString?: string;
 }
 
+/**
+ * @internal
+ * Internal payload type with privacy fields for analytics backend.
+ */
+export type ShopifyPageViewPayloadWithPrivacyFields = Omit<
+  ShopifyPageViewPayload,
+  keyof ShopifyAnalyticsBase
+> &
+  ShopifyAnalyticsBaseWithPrivacyFields &
+  ClientBrowserParameters;
+
 export type ShopifyPageView = {
   /** Use `AnalyticsEventName.PAGE_VIEW` constant. */
   eventName: string;
@@ -161,6 +178,17 @@ export interface ShopifyAddToCartPayload
   /** Shopify cart id in the form of `gid://shopify/Cart/<id>`. */
   cartId: string;
 }
+
+/**
+ * @internal
+ * Internal payload type with privacy fields for analytics backend.
+ */
+export type ShopifyAddToCartPayloadWithPrivacyFields = Omit<
+  ShopifyAddToCartPayload,
+  keyof ShopifyAnalyticsBase
+> &
+  ShopifyAnalyticsBaseWithPrivacyFields &
+  ClientBrowserParameters;
 
 export type ShopifyAddToCart = {
   /** Use `AnalyticsEventName.ADD_TO_CART` constant. */
@@ -184,6 +212,15 @@ export type ShopifyMonorailEvent = {
 export type ShopifyAnalyticsPayload =
   | ShopifyPageViewPayload
   | ShopifyAddToCartPayload;
+
+/**
+ * @internal
+ * Internal analytics payload type with privacy fields for analytics backend.
+ */
+export type ShopifyAnalyticsPayloadWithPrivacyFields =
+  | ShopifyPageViewPayloadWithPrivacyFields
+  | ShopifyAddToCartPayloadWithPrivacyFields;
+
 export type ShopifyAnalytics = ShopifyPageView | ShopifyAddToCart;
 
 export type ShopifyCookies = {

--- a/packages/hydrogen/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen/docs/generated/generated_docs_data.json
@@ -3312,7 +3312,7 @@
             "filePath": "src/cart/CartForm.tsx",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CartActionInputProps",
-            "value": "CartAttributesUpdateProps | CartBuyerIdentityUpdateProps | CartCreateProps | CartDiscountCodesUpdateProps | CartGiftCardCodesUpdateProps | CartLinesAddProps | CartLinesUpdateProps | CartLinesRemoveProps | CartNoteUpdateProps | CartSelectedDeliveryOptionsUpdateProps | CartMetafieldsSetProps | CartMetafieldDeleteProps | CartDeliveryAddressesAddProps | CartDeliveryAddressesRemoveProps | CartDeliveryAddressesUpdateProps | CartCustomProps",
+            "value": "CartAttributesUpdateProps | CartBuyerIdentityUpdateProps | CartCreateProps | CartDiscountCodesUpdateProps | CartGiftCardCodesUpdateProps | CartGiftCardCodesRemoveProps | CartLinesAddProps | CartLinesUpdateProps | CartLinesRemoveProps | CartNoteUpdateProps | CartSelectedDeliveryOptionsUpdateProps | CartMetafieldsSetProps | CartMetafieldDeleteProps | CartDeliveryAddressesAddProps | CartDeliveryAddressesRemoveProps | CartDeliveryAddressesUpdateProps | CartCustomProps",
             "description": ""
           },
           "CartAttributesUpdateProps": {
@@ -3451,6 +3451,30 @@
                 "syntaxKind": "PropertySignature",
                 "name": "action",
                 "value": "\"GiftCardCodesUpdate\"",
+                "description": ""
+              },
+              {
+                "filePath": "src/cart/CartForm.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "inputs",
+                "value": "{ giftCardCodes: string[]; } & OtherFormData",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "CartGiftCardCodesRemoveProps": {
+            "filePath": "src/cart/CartForm.tsx",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartGiftCardCodesRemoveProps",
+            "value": "{\n  action: 'GiftCardCodesRemove';\n  inputs?: {\n    giftCardCodes: string[];\n  } & OtherFormData;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/cart/CartForm.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "action",
+                "value": "\"GiftCardCodesRemove\"",
                 "description": ""
               },
               {
@@ -4466,7 +4490,7 @@
             "filePath": "src/cart/createCartHandler.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "HydrogenCartForDocs",
-            "value": "{\n  /**\n   * Adds items to the cart.\n   * If the cart doesn't exist, a new one will be created.\n   */\n  addLines?: CartLinesAddFunction;\n  /**\n   * Adds a delivery address to the cart.\n   */\n  addDeliveryAddresses?: CartDeliveryAddressesAddFunction;\n  /**\n   * Creates a new cart.\n   */\n  create?: CartCreateFunction;\n  /**\n   * Removes a custom field (metafield) from the cart.\n   */\n  deleteMetafield?: CartMetafieldDeleteFunction;\n  /**\n   * Retrieves the cart information.\n   */\n  get?: CartGetFunction;\n  /**\n   * Retrieves the unique identifier of the cart.\n   * By default, it gets the ID from the request cookie.\n   */\n  getCartId?: () => string | undefined;\n  /**\n   * Removes a delivery address from the cart\n   */\n  removeDeliveryAddresses?: CartDeliveryAddressesRemoveFunction;\n  /**\n   * Removes items from the cart.\n   */\n  removeLines?: CartLinesRemoveFunction;\n  /**\n   * Sets the unique identifier of the cart.\n   * By default, it sets the ID in the header cookie.\n   */\n  setCartId?: (cartId: string) => Headers;\n  /**\n   * Adds extra information (metafields) to the cart.\n   * If the cart doesn't exist, a new one will be created.\n   */\n  setMetafields?: CartMetafieldsSetFunction;\n  /**\n   * Update cart delivery addresses.\n   */\n  updateDeliveryAddresses?: CartDeliveryAddressesUpdateFunction;\n  /**\n   * Updates additional information (attributes) in the cart.\n   */\n  updateAttributes?: CartAttributesUpdateFunction;\n  /**\n   * Updates the buyer's information in the cart.\n   * If the cart doesn't exist, a new one will be created.\n   */\n  updateBuyerIdentity?: CartBuyerIdentityUpdateFunction;\n  /**\n   * Updates discount codes in the cart.\n   */\n  updateDiscountCodes?: CartDiscountCodesUpdateFunction;\n  /**\n   * Updates gift card codes in the cart.\n   */\n  updateGiftCardCodes?: CartGiftCardCodesUpdateFunction;\n  /**\n   * Updates items in the cart.\n   */\n  updateLines?: CartLinesUpdateFunction;\n  /**\n   * Updates the note in the cart.\n   * If the cart doesn't exist, a new one will be created.\n   */\n  updateNote?: CartNoteUpdateFunction;\n  /**\n   * Updates the selected delivery options in the cart.\n   * Only available for carts associated with a customer access token.\n   */\n  updateSelectedDeliveryOption?: CartSelectedDeliveryOptionsUpdateFunction;\n}",
+            "value": "{\n  /**\n   * Adds items to the cart.\n   * If the cart doesn't exist, a new one will be created.\n   */\n  addLines?: CartLinesAddFunction;\n  /**\n   * Adds a delivery address to the cart.\n   */\n  addDeliveryAddresses?: CartDeliveryAddressesAddFunction;\n  /**\n   * Creates a new cart.\n   */\n  create?: CartCreateFunction;\n  /**\n   * Removes a custom field (metafield) from the cart.\n   */\n  deleteMetafield?: CartMetafieldDeleteFunction;\n  /**\n   * Retrieves the cart information.\n   */\n  get?: CartGetFunction;\n  /**\n   * Retrieves the unique identifier of the cart.\n   * By default, it gets the ID from the request cookie.\n   */\n  getCartId?: () => string | undefined;\n  /**\n   * Removes a delivery address from the cart\n   */\n  removeDeliveryAddresses?: CartDeliveryAddressesRemoveFunction;\n  /**\n   * Removes items from the cart.\n   */\n  removeLines?: CartLinesRemoveFunction;\n  /**\n   * Sets the unique identifier of the cart.\n   * By default, it sets the ID in the header cookie.\n   */\n  setCartId?: (cartId: string) => Headers;\n  /**\n   * Adds extra information (metafields) to the cart.\n   * If the cart doesn't exist, a new one will be created.\n   */\n  setMetafields?: CartMetafieldsSetFunction;\n  /**\n   * Update cart delivery addresses.\n   */\n  updateDeliveryAddresses?: CartDeliveryAddressesUpdateFunction;\n  /**\n   * Updates additional information (attributes) in the cart.\n   */\n  updateAttributes?: CartAttributesUpdateFunction;\n  /**\n   * Updates the buyer's information in the cart.\n   * If the cart doesn't exist, a new one will be created.\n   */\n  updateBuyerIdentity?: CartBuyerIdentityUpdateFunction;\n  /**\n   * Updates discount codes in the cart.\n   */\n  updateDiscountCodes?: CartDiscountCodesUpdateFunction;\n  /**\n   * Updates gift card codes in the cart.\n   */\n  updateGiftCardCodes?: CartGiftCardCodesUpdateFunction;\n  /**\n   * Removes gift card codes from the cart.\n   */\n  removeGiftCardCodes?: CartGiftCardCodesRemoveFunction;\n  /**\n   * Updates items in the cart.\n   */\n  updateLines?: CartLinesUpdateFunction;\n  /**\n   * Updates the note in the cart.\n   * If the cart doesn't exist, a new one will be created.\n   */\n  updateNote?: CartNoteUpdateFunction;\n  /**\n   * Updates the selected delivery options in the cart.\n   * Only available for carts associated with a customer access token.\n   */\n  updateSelectedDeliveryOption?: CartSelectedDeliveryOptionsUpdateFunction;\n}",
             "description": "",
             "members": [
               {
@@ -4523,6 +4547,14 @@
                 "name": "removeDeliveryAddresses",
                 "value": "CartDeliveryAddressesRemoveFunction",
                 "description": "Removes a delivery address from the cart",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cart/createCartHandler.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "removeGiftCardCodes",
+                "value": "CartGiftCardCodesRemoveFunction",
+                "description": "Removes gift card codes from the cart.",
                 "isOptional": true
               },
               {
@@ -4961,6 +4993,33 @@
               "value": "Promise<CartQueryDataReturn>"
             },
             "value": "export type CartDeliveryAddressesRemoveFunction = (\n  addressIds: Array<Scalars['ID']['input']> | Array<string>,\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+          },
+          "CartGiftCardCodesRemoveFunction": {
+            "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts",
+            "name": "CartGiftCardCodesRemoveFunction",
+            "description": "",
+            "params": [
+              {
+                "name": "appliedGiftCardIds",
+                "description": "",
+                "value": "string[]",
+                "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts"
+              },
+              {
+                "name": "optionalParams",
+                "description": "",
+                "value": "CartOptionalInput",
+                "isOptional": true,
+                "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts",
+              "description": "",
+              "name": "Promise<CartQueryDataReturn>",
+              "value": "Promise<CartQueryDataReturn>"
+            },
+            "value": "export type CartGiftCardCodesRemoveFunction = (\n  appliedGiftCardIds: string[],\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
           },
           "CartLinesRemoveFunction": {
             "filePath": "src/cart/queries/cartLinesRemoveDefault.ts",
@@ -5653,7 +5712,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an array of [AttributeInput](/docs/api/storefront/2025-04/input-objects/AttributeInput) and updates attributes to a cart",
+    "description": "Creates a function that accepts an array of [AttributeInput](/docs/api/storefront/2025-07/input-objects/AttributeInput) and updates attributes to a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -5737,7 +5796,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -5774,6 +5833,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -5844,9 +5910,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -5970,7 +6044,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -6467,7 +6541,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an object of [CartBuyerIdentityInput](/docs/api/storefront/2025-04/input-objects/CartBuyerIdentityInput) and updates the buyer identity of a cart",
+    "description": "Creates a function that accepts an object of [CartBuyerIdentityInput](/docs/api/storefront/2025-07/input-objects/CartBuyerIdentityInput) and updates the buyer identity of a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -6551,7 +6625,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -6588,6 +6662,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -6658,9 +6739,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -6784,7 +6873,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -7281,7 +7370,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an object of [CartInput](/docs/api/storefront/2025-04/input-objects/CartInput) and returns a new cart",
+    "description": "Creates a function that accepts an object of [CartInput](/docs/api/storefront/2025-07/input-objects/CartInput) and returns a new cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -7365,7 +7454,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -7402,6 +7491,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -7472,9 +7568,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -7598,7 +7702,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -8095,7 +8199,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an array of [CartSelectableAddressInput](/docs/api/storefront/2025-04/input-objects/CartSelectableAddressInput) to add to a cart",
+    "description": "Creates a function that accepts an array of [CartSelectableAddressInput](/docs/api/storefront/2025-07/input-objects/CartSelectableAddressInput) to add to a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -8191,7 +8295,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -8228,6 +8332,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -8298,9 +8409,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -8424,7 +8543,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -8914,7 +9033,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an array of delivery address IDs [ID](/docs/api/storefront/2025-04/scalars/ID) to remove from a cart",
+    "description": "Creates a function that accepts an array of delivery address IDs [ID](/docs/api/storefront/2025-07/scalars/ID) to remove from a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -9010,7 +9129,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -9047,6 +9166,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -9117,9 +9243,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -9243,7 +9377,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -9733,7 +9867,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an array of selectable delivery addresses [CartSelectableAddressUpdateInput](/docs/api/storefront/2025-04/input-objects/CartSelectableAddressUpdateInput) to update in a cart",
+    "description": "Creates a function that accepts an array of selectable delivery addresses [CartSelectableAddressUpdateInput](/docs/api/storefront/2025-07/input-objects/CartSelectableAddressUpdateInput) to update in a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -9829,7 +9963,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -9866,6 +10000,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -9936,9 +10077,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -10062,7 +10211,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -10636,7 +10785,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -10673,6 +10822,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -10743,9 +10899,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -10869,7 +11033,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -11450,7 +11614,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -11487,6 +11651,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -11557,9 +11728,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -11683,7 +11862,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -12111,12 +12290,23 @@
     ]
   },
   {
-    "name": "cartGiftCardCodesUpdateDefault",
+    "name": "cartGiftCardCodesRemoveDefault",
     "category": "utilities",
     "subCategory": "cart",
     "isVisualComponent": false,
-    "related": [],
-    "description": "Creates a function that accepts an array of strings and adds the gift card codes to a cart",
+    "related": [
+      {
+        "name": "cartGiftCardCodesUpdateDefault",
+        "type": "utilities",
+        "url": "/docs/api/hydrogen/utilities/cartgiftcardcodesupdatedefault"
+      },
+      {
+        "name": "createCartHandler",
+        "type": "utilities",
+        "url": "/docs/api/hydrogen/utilities/createcarthandler"
+      }
+    ],
+    "description": "Creates a function that accepts an array of gift card codes to remove from a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -12124,8 +12314,13 @@
         "tabs": [
           {
             "title": "JavaScript",
-            "code": "import {cartGiftCardCodesUpdateDefault} from '@shopify/hydrogen';\n\nconst cartGiftCardCodes = cartGiftCardCodesUpdateDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartGiftCardCodes(['GIFT_CARD_CODE_123']);\n",
+            "code": "import {cartGiftCardCodesRemoveDefault} from '@shopify/hydrogen';\n\nexport async function action({context}) {\n  const cartRemoveGiftCardCodes = cartGiftCardCodesRemoveDefault({\n    storefront: context.storefront,\n    getCartId: () =&gt; context.cart.getCartId(),\n  });\n\n  const result = await cartRemoveGiftCardCodes([\n    'GIFT_CARD_CODE_1',\n    'GIFT_CARD_CODE_2',\n  ]);\n  return result;\n}\n",
             "language": "js"
+          },
+          {
+            "title": "TypeScript",
+            "code": "import {\n  cartGiftCardCodesRemoveDefault,\n  type HydrogenCart,\n  type CartQueryOptions,\n} from '@shopify/hydrogen';\n\nexport async function action({context}: {context: CartQueryOptions}) {\n  const cartRemoveGiftCardCodes: HydrogenCart['removeGiftCardCodes'] =\n    cartGiftCardCodesRemoveDefault({\n      storefront: context.storefront,\n      getCartId: context.getCartId,\n    });\n\n  const result = await cartRemoveGiftCardCodes([\n    'GIFT_CARD_CODE_1',\n    'GIFT_CARD_CODE_2',\n  ]);\n  return result;\n}\n",
+            "language": "ts"
           }
         ],
         "title": "example"
@@ -12133,29 +12328,29 @@
     },
     "definitions": [
       {
-        "title": "cartGiftCardCodesUpdateDefault",
+        "title": "cartGiftCardCodesRemoveDefault",
         "description": "",
-        "type": "CartGiftCardCodesUpdateDefaultGeneratedType",
+        "type": "CartGiftCardCodesRemoveDefaultGeneratedType",
         "typeDefinitions": {
-          "CartGiftCardCodesUpdateDefaultGeneratedType": {
-            "filePath": "src/cart/queries/cartGiftCardCodeUpdateDefault.ts",
-            "name": "CartGiftCardCodesUpdateDefaultGeneratedType",
+          "CartGiftCardCodesRemoveDefaultGeneratedType": {
+            "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts",
+            "name": "CartGiftCardCodesRemoveDefaultGeneratedType",
             "description": "",
             "params": [
               {
                 "name": "options",
                 "description": "",
                 "value": "CartQueryOptions",
-                "filePath": "src/cart/queries/cartGiftCardCodeUpdateDefault.ts"
+                "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts"
               }
             ],
             "returns": {
-              "filePath": "src/cart/queries/cartGiftCardCodeUpdateDefault.ts",
+              "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts",
               "description": "",
-              "name": "CartGiftCardCodesUpdateFunction",
-              "value": "CartGiftCardCodesUpdateFunction"
+              "name": "CartGiftCardCodesRemoveFunction",
+              "value": "CartGiftCardCodesRemoveFunction"
             },
-            "value": "export function cartGiftCardCodesUpdateDefault(\n  options: CartQueryOptions,\n): CartGiftCardCodesUpdateFunction {\n  return async (giftCardCodes, optionalParams) => {\n    // Ensure the gift card codes are unique\n    const uniqueCodes = giftCardCodes.filter((value, index, array) => {\n      return array.indexOf(value) === index;\n    });\n\n    const {cartGiftCardCodesUpdate, errors} = await options.storefront.mutate<{\n      cartGiftCardCodesUpdate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_GIFT_CARD_CODE_UPDATE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        giftCardCodes: uniqueCodes,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartGiftCardCodesUpdate, errors);\n  };\n}"
+            "value": "export function cartGiftCardCodesRemoveDefault(\n  options: CartQueryOptions,\n): CartGiftCardCodesRemoveFunction {\n  return async (appliedGiftCardIds, optionalParams) => {\n    const {cartGiftCardCodesRemove, errors} = await options.storefront.mutate<{\n      cartGiftCardCodesRemove: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_GIFT_CARD_CODES_REMOVE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        appliedGiftCardIds,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartGiftCardCodesRemove, errors);\n  };\n}"
           },
           "CartQueryOptions": {
             "filePath": "src/cart/queries/cart-types.ts",
@@ -12200,7 +12395,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -12237,6 +12432,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -12307,9 +12509,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -12433,7 +12643,829 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "src/utils/graphql.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "name",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "src/utils/graphql.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "message",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "src/utils/graphql.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "stack",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export class GraphQLError extends Error {\n  /**\n   * If an error can be associated to a particular point in the requested\n   * GraphQL document, it should contain a list of locations.\n   */\n  locations?: Array<{line: number; column: number}>;\n  /**\n   * If an error can be associated to a particular field in the GraphQL result,\n   * it _must_ contain an entry with the key `path` that details the path of\n   * the response field which experienced the error. This allows clients to\n   * identify whether a null result is intentional or caused by a runtime error.\n   */\n  path?: Array<string | number>;\n  /**\n   * Reserved for implementors to extend the protocol however they see fit,\n   * and hence there are no additional restrictions on its contents.\n   */\n  extensions?: {[key: string]: unknown};\n\n  constructor(\n    message?: string,\n    options: Pick<\n      GraphQLError,\n      'locations' | 'path' | 'extensions' | 'stack' | 'cause'\n    > & {\n      query?: string;\n      queryVariables?: GenericVariables;\n      requestId?: string | null;\n      clientOperation?: string;\n    } = {},\n  ) {\n    const h2Prefix = options.clientOperation\n      ? `[h2:error:${options.clientOperation}] `\n      : '';\n\n    const enhancedMessage =\n      h2Prefix +\n      message +\n      (options.requestId ? ` - Request ID: ${options.requestId}` : '');\n\n    super(enhancedMessage);\n    this.name = 'GraphQLError';\n    this.extensions = options.extensions;\n    this.locations = options.locations;\n    this.path = options.path;\n    this.stack = options.stack || undefined;\n\n    try {\n      this.cause = JSON.stringify({\n        ...(typeof options.cause === 'object' ? options.cause : {}),\n        requestId: options.requestId,\n        ...(process.env.NODE_ENV === 'development' && {\n          path: options.path,\n          extensions: options.extensions,\n          graphql: h2Prefix &&\n            options.query && {\n              query: options.query,\n              variables: JSON.stringify(options.queryVariables),\n            },\n        }),\n      });\n    } catch {\n      if (options.cause) this.cause = options.cause;\n    }\n  }\n\n  get [Symbol.toStringTag]() {\n    return this.name;\n  }\n\n  /**\n   * Note: `toString()` is internally used by `console.log(...)` / `console.error(...)`\n   * when ingesting logs in Oxygen production. Therefore, we want to make sure that\n   * the error message is as informative as possible instead of `[object Object]`.\n   */\n  override toString() {\n    let result = `${this.name}: ${this.message}`;\n\n    if (this.path) {\n      try {\n        result += ` | path: ${JSON.stringify(this.path)}`;\n      } catch {}\n    }\n\n    if (this.extensions) {\n      try {\n        result += ` | extensions: ${JSON.stringify(this.extensions)}`;\n      } catch {}\n    }\n\n    result += '\\n';\n\n    if (this.stack) {\n      // Remove the message line from the stack.\n      result += `${this.stack.slice(this.stack.indexOf('\\n') + 1)}\\n`;\n    }\n\n    return result;\n  }\n\n  /**\n   * Note: toJSON` is internally used by `JSON.stringify(...)`.\n   * The most common scenario when this error instance is going to be stringified is\n   * when it's passed to Remix' `json` and `defer` functions: e.g. `{promise: storefront.query(...)}`.\n   * In this situation, we don't want to expose private error information to the browser so we only\n   * do it in development.\n   */\n  toJSON() {\n    const formatted: Pick<\n      GraphQLError,\n      'name' | 'message' | 'path' | 'extensions' | 'locations' | 'stack'\n    > = {name: 'Error', message: ''};\n\n    if (process.env.NODE_ENV === 'development') {\n      formatted.name = this.name;\n      formatted.message = 'Development: ' + this.message;\n      if (this.path) formatted.path = this.path;\n      if (this.locations) formatted.locations = this.locations;\n      if (this.extensions) formatted.extensions = this.extensions;\n      // Skip stack on purpose because we don't want to expose it to the browser.\n    }\n\n    return formatted;\n  }\n}"
+          },
+          "CustomerAccountQueries": {
+            "filePath": "src/customer/types.ts",
+            "name": "CustomerAccountQueries",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "Storefront": {
+            "filePath": "src/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "Storefront",
+            "value": "{\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontQueries,\n      RawGqlString,\n      StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, 'cache'>,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      StorefrontMutations,\n      RawGqlString,\n      StorefrontCommonExtraParams,\n      AutoAddedVariableNames\n    >\n  ) => Promise<\n    ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> &\n      StorefrontError\n  >;\n  cache?: Cache;\n  CacheNone: typeof CacheNone;\n  CacheLong: typeof CacheLong;\n  CacheShort: typeof CacheShort;\n  CacheCustom: typeof CacheCustom;\n  generateCacheControlHeader: typeof generateCacheControlHeader;\n  getPublicTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  getPrivateTokenHeaders: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  getShopifyDomain: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  getApiUrl: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  i18n: TI18n;\n}",
+            "description": "Interface to interact with the Storefront API.",
+            "members": [
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cache",
+                "value": "Cache",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheCustom",
+                "value": "(overrideOptions: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheLong",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheNone",
+                "value": "() => NoStoreStrategy",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "CacheShort",
+                "value": "(overrideOptions?: AllCacheOptions) => AllCacheOptions",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "generateCacheControlHeader",
+                "value": "(cacheOptions: AllCacheOptions) => string",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPrivateTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getPublicTokenHeaders",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getShopifyDomain",
+                "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "TI18n",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? SetOptional<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? SetOptional<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & ClientVariables<StorefrontMutations, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? SetOptional<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? SetOptional<StorefrontMutations[RawGqlString][\"variables\"], Extract<keyof StorefrontMutations[RawGqlString][\"variables\"], AutoAddedVariableNames>> : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontMutations, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames, Omit<StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> extends true ? [(StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? SetOptional<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? SetOptional<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> : { readonly [variable: string]: unknown; }>>)?] : [StorefrontCommonExtraParams & Pick<StorefrontQueryOptions, \"cache\"> & ClientVariables<StorefrontQueries, RawGqlString, AutoAddedVariableNames, \"variables\", RawGqlString extends never ? SetOptional<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? SetOptional<StorefrontQueries[RawGqlString][\"variables\"], Extract<keyof StorefrontQueries[RawGqlString][\"variables\"], AutoAddedVariableNames>> : { readonly [variable: string]: unknown; }>>]) => Promise<ClientReturn<StorefrontQueries, RawGqlString, OverrideReturnType> & StorefrontError>",
+                "description": ""
+              }
+            ]
+          },
+          "AllCacheOptions": {
+            "filePath": "src/cache/strategies.ts",
+            "name": "AllCacheOptions",
+            "description": "Override options for a cache strategy.",
+            "members": [
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface AllCacheOptions {\n  /**\n   * The caching mode, generally `public`, `private`, or `no-store`.\n   */\n  mode?: string;\n  /**\n   * The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).\n   */\n  maxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).\n   */\n  staleWhileRevalidate?: number;\n  /**\n   * Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).\n   */\n  sMaxAge?: number;\n  /**\n   * Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).\n   */\n  staleIfError?: number;\n}"
+          },
+          "NoStoreStrategy": {
+            "filePath": "src/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "NoStoreStrategy",
+            "value": "{\n  mode: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": ""
+              }
+            ]
+          },
+          "StorefrontMutations": {
+            "filePath": "src/storefront.ts",
+            "name": "StorefrontMutations",
+            "description": "Maps all the mutations found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "AutoAddedVariableNames": {
+            "filePath": "src/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AutoAddedVariableNames",
+            "value": "'country' | 'language'",
+            "description": ""
+          },
+          "StorefrontCommonExtraParams": {
+            "filePath": "src/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontCommonExtraParams",
+            "value": "{\n  headers?: HeadersInit;\n  storefrontApiVersion?: string;\n  displayName?: string;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "displayName",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "HeadersInit",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefrontApiVersion",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontError": {
+            "filePath": "src/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontError",
+            "value": "{\n  errors?: StorefrontApiErrors;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/storefront.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "errors",
+                "value": "StorefrontApiErrors",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "StorefrontApiErrors": {
+            "filePath": "src/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontApiErrors",
+            "value": "JsonGraphQLError[] | undefined",
+            "description": ""
+          },
+          "JsonGraphQLError": {
+            "filePath": "src/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "JsonGraphQLError",
+            "value": "ReturnType<GraphQLError['toJSON']>",
+            "description": "",
+            "members": []
+          },
+          "StorefrontQueries": {
+            "filePath": "src/storefront.ts",
+            "name": "StorefrontQueries",
+            "description": "Maps all the queries found in the project to variables and return types.",
+            "members": [],
+            "value": "export interface StorefrontQueries {\n  // Example of how a generated query type looks like:\n  // '#graphql query q1 {...}': {return: Q1Query; variables: Q1QueryVariables};\n}"
+          },
+          "StorefrontQueryOptions": {
+            "filePath": "src/storefront.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StorefrontQueryOptions",
+            "value": "StorefrontCommonExtraParams & {\n  query: string;\n  mutation?: never;\n  cache?: CachingStrategy;\n}",
+            "description": ""
+          },
+          "CachingStrategy": {
+            "filePath": "src/cache/strategies.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CachingStrategy",
+            "value": "AllCacheOptions",
+            "description": "Use the `CachingStrategy` to define a custom caching mechanism for your data. Or use one of the pre-defined caching strategies: CacheNone, CacheShort, CacheLong.",
+            "members": [
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "maxAge",
+                "value": "number",
+                "description": "The maximum amount of time in seconds that a resource will be considered fresh. See `max-age` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=Response%20Directives-,max%2Dage,-The%20max%2Dage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mode",
+                "value": "string",
+                "description": "The caching mode, generally `public`, `private`, or `no-store`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sMaxAge",
+                "value": "number",
+                "description": "Similar to `maxAge` but specific to shared caches. See `s-maxage` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage).",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleIfError",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response if an error occurs while revalidating the cache. See `stale-if-error` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error).",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cache/strategies.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "staleWhileRevalidate",
+                "value": "number",
+                "description": "Indicate that the cache should serve the stale response in the background while revalidating the cache. See `stale-while-revalidate` in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate).",
+                "isOptional": true
+              }
+            ]
+          },
+          "CartGiftCardCodesRemoveFunction": {
+            "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts",
+            "name": "CartGiftCardCodesRemoveFunction",
+            "description": "",
+            "params": [
+              {
+                "name": "appliedGiftCardIds",
+                "description": "",
+                "value": "string[]",
+                "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts"
+              },
+              {
+                "name": "optionalParams",
+                "description": "",
+                "value": "CartOptionalInput",
+                "isOptional": true,
+                "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "src/cart/queries/cartGiftCardCodesRemoveDefault.ts",
+              "description": "",
+              "name": "Promise<CartQueryDataReturn>",
+              "value": "Promise<CartQueryDataReturn>"
+            },
+            "value": "export type CartGiftCardCodesRemoveFunction = (\n  appliedGiftCardIds: string[],\n  optionalParams?: CartOptionalInput,\n) => Promise<CartQueryDataReturn>;"
+          },
+          "CartOptionalInput": {
+            "filePath": "src/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartOptionalInput",
+            "value": "{\n  /**\n   * The cart id.\n   * @default cart.getCartId();\n   */\n  cartId?: Scalars['ID']['input'];\n  /**\n   * The country code.\n   * @default storefront.i18n.country\n   */\n  country?: CountryCode;\n  /**\n   * The language code.\n   * @default storefront.i18n.language\n   */\n  language?: LanguageCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartId",
+                "value": "string",
+                "description": "The cart id.",
+                "isOptional": true,
+                "defaultValue": "cart.getCartId();"
+              },
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "country",
+                "value": "CountryCode",
+                "description": "The country code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.country"
+              },
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "language",
+                "value": "LanguageCode",
+                "description": "The language code.",
+                "isOptional": true,
+                "defaultValue": "storefront.i18n.language"
+              }
+            ]
+          },
+          "CartQueryDataReturn": {
+            "filePath": "src/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryDataReturn",
+            "value": "CartQueryData & {\n  errors?: StorefrontApiErrors;\n}",
+            "description": ""
+          },
+          "CartQueryData": {
+            "filePath": "src/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryData",
+            "value": "{\n  cart: Cart;\n  userErrors?:\n    | CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[];\n  warnings?: CartWarning[];\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cart",
+                "value": "Cart",
+                "description": ""
+              },
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "userErrors",
+                "value": "| CartUserError[]\n    | MetafieldsSetUserError[]\n    | MetafieldDeleteUserError[]",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "warnings",
+                "value": "CartWarning[]",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "Cart": {
+            "description": "",
+            "name": "Cart",
+            "value": "Cart",
+            "members": [],
+            "override": "[Cart](/docs/api/storefront/2025-04/objects/Cart) - Storefront API type"
+          },
+          "CartUserError": {
+            "description": "",
+            "name": "CartUserError",
+            "value": "CartUserError",
+            "members": [],
+            "override": "[CartUserError](/docs/api/storefront/2025-04/objects/CartUserError) - Storefront API type"
+          },
+          "MetafieldsSetUserError": {
+            "description": "",
+            "name": "MetafieldsSetUserError",
+            "value": "MetafieldsSetUserError",
+            "members": [],
+            "override": "[MetafieldsSetUserError](/docs/api/storefront/2025-04/objects/MetafieldsSetUserError) - Storefront API type"
+          },
+          "MetafieldDeleteUserError": {
+            "description": "",
+            "name": "MetafieldDeleteUserError",
+            "value": "MetafieldDeleteUserError",
+            "members": [],
+            "override": "[MetafieldDeleteUserError](/docs/api/storefront/2025-04/objects/MetafieldDeleteUserError) - Storefront API type"
+          },
+          "CartWarning": {
+            "description": "",
+            "name": "CartWarning",
+            "value": "CartWarning",
+            "members": [],
+            "override": "[CartWarning](/docs/api/storefront/2025-04/objects/CartWarning) - Storefront API type"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "name": "cartGiftCardCodesUpdateDefault",
+    "category": "utilities",
+    "subCategory": "cart",
+    "isVisualComponent": false,
+    "related": [],
+    "description": "Creates a function that accepts an array of strings and adds the gift card codes to a cart",
+    "type": "utility",
+    "defaultExample": {
+      "description": "This is the default example",
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "JavaScript",
+            "code": "import {cartGiftCardCodesUpdateDefault} from '@shopify/hydrogen';\n\nconst cartGiftCardCodes = cartGiftCardCodesUpdateDefault({\n  storefront,\n  getCartId,\n});\n\nconst result = await cartGiftCardCodes(['GIFT_CARD_CODE_123']);\n",
+            "language": "js"
+          }
+        ],
+        "title": "example"
+      }
+    },
+    "definitions": [
+      {
+        "title": "cartGiftCardCodesUpdateDefault",
+        "description": "",
+        "type": "CartGiftCardCodesUpdateDefaultGeneratedType",
+        "typeDefinitions": {
+          "CartGiftCardCodesUpdateDefaultGeneratedType": {
+            "filePath": "src/cart/queries/cartGiftCardCodeUpdateDefault.ts",
+            "name": "CartGiftCardCodesUpdateDefaultGeneratedType",
+            "description": "",
+            "params": [
+              {
+                "name": "options",
+                "description": "",
+                "value": "CartQueryOptions",
+                "filePath": "src/cart/queries/cartGiftCardCodeUpdateDefault.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "src/cart/queries/cartGiftCardCodeUpdateDefault.ts",
+              "description": "",
+              "name": "CartGiftCardCodesUpdateFunction",
+              "value": "CartGiftCardCodesUpdateFunction"
+            },
+            "value": "export function cartGiftCardCodesUpdateDefault(\n  options: CartQueryOptions,\n): CartGiftCardCodesUpdateFunction {\n  return async (giftCardCodes, optionalParams) => {\n    // Ensure the gift card codes are unique\n    const uniqueCodes = giftCardCodes.filter((value, index, array) => {\n      return array.indexOf(value) === index;\n    });\n\n    const {cartGiftCardCodesUpdate, errors} = await options.storefront.mutate<{\n      cartGiftCardCodesUpdate: CartQueryData;\n      errors: StorefrontApiErrors;\n    }>(CART_GIFT_CARD_CODE_UPDATE_MUTATION(options.cartFragment), {\n      variables: {\n        cartId: options.getCartId(),\n        giftCardCodes: uniqueCodes,\n        ...optionalParams,\n      },\n    });\n    return formatAPIResult(cartGiftCardCodesUpdate, errors);\n  };\n}"
+          },
+          "CartQueryOptions": {
+            "filePath": "src/cart/queries/cart-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CartQueryOptions",
+            "value": "{\n  /**\n   * The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient).\n   */\n  storefront: Storefront;\n  /**\n   * A function that returns the cart ID.\n   */\n  getCartId: () => string | undefined;\n  /**\n   * The cart fragment to override the one used in this query.\n   */\n  cartFragment?: string;\n  /**\n   * The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).\n   */\n  customerAccount?: CustomerAccount;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cartFragment",
+                "value": "string",
+                "description": "The cart fragment to override the one used in this query.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAccount",
+                "value": "CustomerAccount",
+                "description": "The customer account instance created by [`createCustomerAccount`](docs/api/hydrogen/latest/customer/createcustomeraccount).",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getCartId",
+                "value": "() => string",
+                "description": "A function that returns the cart ID."
+              },
+              {
+                "filePath": "src/cart/queries/cart-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "storefront",
+                "value": "Storefront",
+                "description": "The storefront client instance created by [`createStorefrontClient`](docs/api/hydrogen/latest/utilities/createstorefrontclient)."
+              }
+            ]
+          },
+          "CustomerAccount": {
+            "filePath": "src/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAccount",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "authorize",
+                "value": "() => Promise<Response>",
+                "description": "On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getAccessToken",
+                "value": "() => Promise<string>",
+                "description": "Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getApiUrl",
+                "value": "() => string",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "Get buyer token and company location id from session."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "handleAuthStatus",
+                "value": "() => void | DataFunctionValue",
+                "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoggedIn",
+                "value": "() => Promise<boolean>",
+                "description": "Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "login",
+                "value": "(options?: LoginOptions) => Promise<Response>",
+                "description": "Start the OAuth login flow. This function should be called and returned from a Remix loader. It redirects the customer to a Shopify login domain. It also defined the final path the customer lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is automatically setup unless `customAuthStatusHandler` option is in use)"
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logout",
+                "value": "(options?: LogoutOptions) => Promise<Response>",
+                "description": "Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "mutate",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(mutation: RawGqlString, ...options: IsOptionalVariables<CustomerAccountMutations[RawGqlString][\"variables\"], never, Omit<CustomerAccountMutations[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? SetOptional<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>> : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? SetOptional<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>> : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountMutations, RawGqlString, never, \"variables\", RawGqlString extends never ? SetOptional<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>> : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? SetOptional<CustomerAccountMutations[RawGqlString][\"variables\"], Extract<keyof CustomerAccountMutations[RawGqlString][\"variables\"], never>> : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"path\" | \"name\" | \"message\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "<OverrideReturnType extends unknown = never, RawGqlString extends string = string>(query: RawGqlString, ...options: IsOptionalVariables<CustomerAccountQueries[RawGqlString][\"variables\"], never, Omit<CustomerAccountQueries[RawGqlString][\"variables\"], never>> extends true ? [({} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? SetOptional<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>> : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? SetOptional<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>> : { readonly [variable: string]: unknown; }>>)?] : [{} & ClientVariables<CustomerAccountQueries, RawGqlString, never, \"variables\", RawGqlString extends never ? SetOptional<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>> : { readonly [variable: string]: unknown; }, Record<\"variables\", RawGqlString extends never ? SetOptional<CustomerAccountQueries[RawGqlString][\"variables\"], Extract<keyof CustomerAccountQueries[RawGqlString][\"variables\"], never>> : { readonly [variable: string]: unknown; }>>]) => Promise<Omit<CustomerAPIResponse<ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>>, \"errors\"> & { errors?: Pick<GraphQLError, \"path\" | \"name\" | \"message\" | \"extensions\" | \"locations\" | \"stack\">[]; }>",
+                "description": "Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "Set buyer information into session."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_getBuyer",
+                "value": "() => Promise<Partial<BuyerInput>>",
+                "description": "Deprecated. Please use getBuyer. Get buyer token and company location id from session."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "UNSTABLE_setBuyer",
+                "value": "(buyer: Partial<BuyerInput>) => void",
+                "description": "Deprecated. Please use setBuyer. Set buyer information into session."
+              }
+            ]
+          },
+          "DataFunctionValue": {
+            "filePath": "src/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataFunctionValue",
+            "value": "Response | NonNullable<unknown> | null",
+            "description": ""
+          },
+          "LoginOptions": {
+            "filePath": "src/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoginOptions",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "uiLocales",
+                "value": "LanguageCode",
+                "description": "",
+                "isOptional": true
+              }
+            ]
+          },
+          "LogoutOptions": {
+            "filePath": "src/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogoutOptions",
+            "value": "{\n  /** The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev. */\n  postLogoutRedirectUri?: string;\n  /** Add custom headers to the logout redirect. */\n  headers?: HeadersInit;\n  /** If true, custom data in the session will not be cleared on logout. */\n  keepSession?: boolean;\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "HeadersInit",
+                "description": "Add custom headers to the logout redirect.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "keepSession",
+                "value": "boolean",
+                "description": "If true, custom data in the session will not be cleared on logout.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "postLogoutRedirectUri",
+                "value": "string",
+                "description": "The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.",
+                "isOptional": true
+              }
+            ]
+          },
+          "CustomerAccountMutations": {
+            "filePath": "src/customer/types.ts",
+            "name": "CustomerAccountMutations",
+            "description": "",
+            "members": [],
+            "value": "export interface CustomerAccountMutations {\n  // Example of how a generated mutation type looks like:\n  // '#graphql mutation m1 {...}': {return: M1Mutation; variables: M1MutationVariables};\n}"
+          },
+          "CustomerAPIResponse": {
+            "filePath": "src/customer/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CustomerAPIResponse",
+            "value": "{\n  data: ReturnType;\n  errors: Array<{\n    message: string;\n    locations?: Array<{line: number; column: number}>;\n    path?: Array<string>;\n    extensions: {code: string};\n  }>;\n  extensions: {\n    cost: {\n      requestQueryCost: number;\n      actualQueryCakes: number;\n      throttleStatus: {\n        maximumAvailable: number;\n        currentAvailable: number;\n        restoreRate: number;\n      };\n    };\n  };\n}",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "data",
+                "value": "ReturnType",
+                "description": ""
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "errors",
+                "value": "Array<{\n    message: string;\n    locations?: Array<{line: number; column: number}>;\n    path?: Array<string>;\n    extensions: {code: string};\n  }>",
+                "description": ""
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "extensions",
+                "value": "{ cost: { requestQueryCost: number; actualQueryCakes: number; throttleStatus: { maximumAvailable: number; currentAvailable: number; restoreRate: number; }; }; }",
+                "description": ""
+              }
+            ]
+          },
+          "GraphQLError": {
+            "filePath": "src/utils/graphql.ts",
+            "name": "GraphQLError",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/utils/graphql.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "locations",
+                "value": "{ line: number; column: number; }[]",
+                "description": "If an error can be associated to a particular point in the requested GraphQL document, it should contain a list of locations."
+              },
+              {
+                "filePath": "src/utils/graphql.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "path",
+                "value": "(string | number)[]",
+                "description": "If an error can be associated to a particular field in the GraphQL result, it _must_ contain an entry with the key `path` that details the path of the response field which experienced the error. This allows clients to identify whether a null result is intentional or caused by a runtime error."
+              },
+              {
+                "filePath": "src/utils/graphql.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "extensions",
+                "value": "{ [key: string]: unknown; }",
+                "description": "Reserved for implementors to extend the protocol however they see fit, and hence there are no additional restrictions on its contents."
+              },
+              {
+                "filePath": "src/utils/graphql.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toString",
+                "value": "() => string",
+                "description": "Note: `toString()` is internally used by `console.log(...)` / `console.error(...)` when ingesting logs in Oxygen production. Therefore, we want to make sure that the error message is as informative as possible instead of `[object Object]`."
+              },
+              {
+                "filePath": "src/utils/graphql.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toJSON",
+                "value": "() => Pick<GraphQLError, \"path\" | \"name\" | \"message\" | \"extensions\" | \"locations\" | \"stack\">",
+                "description": "Note: toJSON` is internally used by `JSON.stringify(...)`. The most common scenario when this error instance is going to be stringified is when it's passed to Remix' `json` and `defer` functions: e.g. `{promise: storefront.query(...)}`. In this situation, we don't want to expose private error information to the browser so we only do it in development."
+              },
+              {
+                "filePath": "src/utils/graphql.ts",
+                "syntaxKind": "GetAccessor",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -12923,7 +13955,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an array of [CartLineInput](/docs/api/storefront/2025-04/input-objects/CartLineInput) and adds the line items to a cart",
+    "description": "Creates a function that accepts an array of [CartLineInput](/docs/api/storefront/2025-07/input-objects/CartLineInput) and adds the line items to a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -13007,7 +14039,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -13044,6 +14076,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -13114,9 +14153,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -13240,7 +14287,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -13821,7 +14868,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -13858,6 +14905,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -13928,9 +14982,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -14054,7 +15116,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -14544,7 +15606,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an array of [CartLineUpdateInput](/docs/api/storefront/2025-04/input-objects/CartLineUpdateInput) and updates the line items in a cart",
+    "description": "Creates a function that accepts an array of [CartLineUpdateInput](/docs/api/storefront/2025-07/input-objects/CartLineUpdateInput) and updates the line items in a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -14628,7 +15690,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -14665,6 +15727,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -14735,9 +15804,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -14861,7 +15938,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -15442,7 +16519,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -15479,6 +16556,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -15549,9 +16633,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -15675,7 +16767,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -16165,7 +17257,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an array of [CartMetafieldsSetInput](https://shopify.dev/docs/api/storefront/2025-04/input-objects/CartMetafieldsSetInput) without `ownerId` and set the metafields to a cart",
+    "description": "Creates a function that accepts an array of [CartMetafieldsSetInput](https://shopify.dev/docs/api/storefront/2025-07/input-objects/CartMetafieldsSetInput) without `ownerId` and set the metafields to a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -16249,7 +17341,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -16286,6 +17378,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -16356,9 +17455,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -16482,7 +17589,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -17063,7 +18170,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -17100,6 +18207,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -17170,9 +18284,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -17296,7 +18418,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -17786,7 +18908,7 @@
     "subCategory": "cart",
     "isVisualComponent": false,
     "related": [],
-    "description": "Creates a function that accepts an object of [CartSelectedDeliveryOptionInput](/docs/api/storefront/2025-04/input-objects/CartSelectedDeliveryOptionInput) and updates the selected delivery option of a cart",
+    "description": "Creates a function that accepts an object of [CartSelectedDeliveryOptionInput](/docs/api/storefront/2025-07/input-objects/CartSelectedDeliveryOptionInput) and updates the selected delivery option of a cart",
     "type": "utility",
     "defaultExample": {
       "description": "This is the default example",
@@ -17870,7 +18992,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -17907,6 +19029,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -17977,9 +19106,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -18103,7 +19240,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -18881,7 +20018,7 @@
             "filePath": "src/cart/createCartHandler.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "HydrogenCart",
-            "value": "{\n  get: ReturnType<typeof cartGetDefault>;\n  getCartId: () => string | undefined;\n  setCartId: (cartId: string) => Headers;\n  create: ReturnType<typeof cartCreateDefault>;\n  addLines: ReturnType<typeof cartLinesAddDefault>;\n  updateLines: ReturnType<typeof cartLinesUpdateDefault>;\n  removeLines: ReturnType<typeof cartLinesRemoveDefault>;\n  updateDiscountCodes: ReturnType<typeof cartDiscountCodesUpdateDefault>;\n  updateGiftCardCodes: ReturnType<typeof cartGiftCardCodesUpdateDefault>;\n  updateBuyerIdentity: ReturnType<typeof cartBuyerIdentityUpdateDefault>;\n  updateNote: ReturnType<typeof cartNoteUpdateDefault>;\n  updateSelectedDeliveryOption: ReturnType<\n    typeof cartSelectedDeliveryOptionsUpdateDefault\n  >;\n  updateAttributes: ReturnType<typeof cartAttributesUpdateDefault>;\n  setMetafields: ReturnType<typeof cartMetafieldsSetDefault>;\n  deleteMetafield: ReturnType<typeof cartMetafieldDeleteDefault>;\n  /**\n   * Adds delivery addresses to the cart.\n   *\n   * This function sends a mutation to the storefront API to add one or more delivery addresses to the cart.\n   * It returns the result of the mutation, including any errors that occurred.\n   *\n   * @param {CartQueryOptions} options - The options for the cart query, including the storefront API client and cart fragment.\n   * @returns {ReturnType<typeof cartDeliveryAddressesAddDefault>} - A function that takes an array of addresses and optional parameters, and returns the result of the API call.\n   *\n   * @example\n   * const result = await cart.addDeliveryAddresses(\n   *   [\n   *     {\n   *       address1: '123 Main St',\n   *       city: 'Anytown',\n   *       countryCode: 'US'\n   *     }\n   *   ],\n   *   { someOptionalParam: 'value' }\n   * );\n   */\n  addDeliveryAddresses: ReturnType<typeof cartDeliveryAddressesAddDefault>;\n  /**\n   * Removes delivery addresses from the cart.\n   *\n   * This function sends a mutation to the storefront API to remove one or more delivery addresses from the cart.\n   * It returns the result of the mutation, including any errors that occurred.\n   *\n   * @param {CartQueryOptions} options - The options for the cart query, including the storefront API client and cart fragment.\n   * @returns {CartDeliveryAddressRemoveFunction} - A function that takes an array of address IDs and optional parameters, and returns the result of the API call.\n   *\n   * @example\n   * const result = await cart.removeDeliveryAddresses([\n   *   \"gid://shopify/<objectName>/10079785100\"\n   * ],\n   * { someOptionalParam: 'value' });\n   */\n\n  removeDeliveryAddresses: ReturnType<\n    typeof cartDeliveryAddressesRemoveDefault\n  >;\n  /**\n  * Updates delivery addresses in the cart.\n  *\n  * This function sends a mutation to the storefront API to update one or more delivery addresses in the cart.\n  * It returns the result of the mutation, including any errors that occurred.\n  *\n  * @param {CartQueryOptions} options - The options for the cart query, including the storefront API client and cart fragment.\n  * @returns {CartDeliveryAddressUpdateFunction} - A function that takes an array of addresses and optional parameters, and returns the result of the API call.\n  *\n  * const result = await cart.updateDeliveryAddresses([\n      {\n        \"address\": {\n          \"copyFromCustomerAddressId\": \"gid://shopify/<objectName>/10079785100\",\n          \"deliveryAddress\": {\n            \"address1\": \"<your-address1>\",\n            \"address2\": \"<your-address2>\",\n            \"city\": \"<your-city>\",\n            \"company\": \"<your-company>\",\n            \"countryCode\": \"AC\",\n            \"firstName\": \"<your-firstName>\",\n            \"lastName\": \"<your-lastName>\",\n            \"phone\": \"<your-phone>\",\n            \"provinceCode\": \"<your-provinceCode>\",\n            \"zip\": \"<your-zip>\"\n          }\n        },\n        \"id\": \"gid://shopify/<objectName>/10079785100\",\n        \"oneTimeUse\": true,\n        \"selected\": true,\n        \"validationStrategy\": \"COUNTRY_CODE_ONLY\"\n      }\n    ],{ someOptionalParam: 'value' });\n  */\n  updateDeliveryAddresses: ReturnType<\n    typeof cartDeliveryAddressesUpdateDefault\n  >;\n}",
+            "value": "{\n  get: ReturnType<typeof cartGetDefault>;\n  getCartId: () => string | undefined;\n  setCartId: (cartId: string) => Headers;\n  create: ReturnType<typeof cartCreateDefault>;\n  addLines: ReturnType<typeof cartLinesAddDefault>;\n  updateLines: ReturnType<typeof cartLinesUpdateDefault>;\n  removeLines: ReturnType<typeof cartLinesRemoveDefault>;\n  updateDiscountCodes: ReturnType<typeof cartDiscountCodesUpdateDefault>;\n  updateGiftCardCodes: ReturnType<typeof cartGiftCardCodesUpdateDefault>;\n  removeGiftCardCodes: ReturnType<typeof cartGiftCardCodesRemoveDefault>;\n  updateBuyerIdentity: ReturnType<typeof cartBuyerIdentityUpdateDefault>;\n  updateNote: ReturnType<typeof cartNoteUpdateDefault>;\n  updateSelectedDeliveryOption: ReturnType<\n    typeof cartSelectedDeliveryOptionsUpdateDefault\n  >;\n  updateAttributes: ReturnType<typeof cartAttributesUpdateDefault>;\n  setMetafields: ReturnType<typeof cartMetafieldsSetDefault>;\n  deleteMetafield: ReturnType<typeof cartMetafieldDeleteDefault>;\n  /**\n   * Adds delivery addresses to the cart.\n   *\n   * This function sends a mutation to the storefront API to add one or more delivery addresses to the cart.\n   * It returns the result of the mutation, including any errors that occurred.\n   *\n   * @param {CartQueryOptions} options - The options for the cart query, including the storefront API client and cart fragment.\n   * @returns {ReturnType<typeof cartDeliveryAddressesAddDefault>} - A function that takes an array of addresses and optional parameters, and returns the result of the API call.\n   *\n   * @example\n   * const result = await cart.addDeliveryAddresses(\n   *   [\n   *     {\n   *       address1: '123 Main St',\n   *       city: 'Anytown',\n   *       countryCode: 'US'\n   *     }\n   *   ],\n   *   { someOptionalParam: 'value' }\n   * );\n   */\n  addDeliveryAddresses: ReturnType<typeof cartDeliveryAddressesAddDefault>;\n  /**\n   * Removes delivery addresses from the cart.\n   *\n   * This function sends a mutation to the storefront API to remove one or more delivery addresses from the cart.\n   * It returns the result of the mutation, including any errors that occurred.\n   *\n   * @param {CartQueryOptions} options - The options for the cart query, including the storefront API client and cart fragment.\n   * @returns {CartDeliveryAddressRemoveFunction} - A function that takes an array of address IDs and optional parameters, and returns the result of the API call.\n   *\n   * @example\n   * const result = await cart.removeDeliveryAddresses([\n   *   \"gid://shopify/<objectName>/10079785100\"\n   * ],\n   * { someOptionalParam: 'value' });\n   */\n\n  removeDeliveryAddresses: ReturnType<\n    typeof cartDeliveryAddressesRemoveDefault\n  >;\n  /**\n  * Updates delivery addresses in the cart.\n  *\n  * This function sends a mutation to the storefront API to update one or more delivery addresses in the cart.\n  * It returns the result of the mutation, including any errors that occurred.\n  *\n  * @param {CartQueryOptions} options - The options for the cart query, including the storefront API client and cart fragment.\n  * @returns {CartDeliveryAddressUpdateFunction} - A function that takes an array of addresses and optional parameters, and returns the result of the API call.\n  *\n  * const result = await cart.updateDeliveryAddresses([\n      {\n        \"address\": {\n          \"copyFromCustomerAddressId\": \"gid://shopify/<objectName>/10079785100\",\n          \"deliveryAddress\": {\n            \"address1\": \"<your-address1>\",\n            \"address2\": \"<your-address2>\",\n            \"city\": \"<your-city>\",\n            \"company\": \"<your-company>\",\n            \"countryCode\": \"AC\",\n            \"firstName\": \"<your-firstName>\",\n            \"lastName\": \"<your-lastName>\",\n            \"phone\": \"<your-phone>\",\n            \"provinceCode\": \"<your-provinceCode>\",\n            \"zip\": \"<your-zip>\"\n          }\n        },\n        \"id\": \"gid://shopify/<objectName>/10079785100\",\n        \"oneTimeUse\": true,\n        \"selected\": true,\n        \"validationStrategy\": \"COUNTRY_CODE_ONLY\"\n      }\n    ],{ someOptionalParam: 'value' });\n  */\n  updateDeliveryAddresses: ReturnType<\n    typeof cartDeliveryAddressesUpdateDefault\n  >;\n}",
             "description": "",
             "members": [
               {
@@ -18956,6 +20093,13 @@
                     ]
                   }
                 ]
+              },
+              {
+                "filePath": "src/cart/createCartHandler.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "removeGiftCardCodes",
+                "value": "ReturnType<typeof cartGiftCardCodesRemoveDefault>",
+                "description": ""
               },
               {
                 "filePath": "src/cart/createCartHandler.ts",
@@ -19047,7 +20191,7 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "CustomerAccount",
-            "value": "{\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
+            "value": "{\n  /** The i18n configuration for Customer Account API */\n  i18n: {language: LanguageCode};\n  /** Start the OAuth login flow. This function should be called and returned from a Remix loader.\n   * It redirects the customer to a Shopify login domain. It also defined the final path the customer\n   * lands on at the end of the oAuth flow with the value of the `return_to` query param. (This is\n   * automatically setup unless `customAuthStatusHandler` option is in use)\n   *\n   * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:\n   * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,\n   * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.\n   * */\n  login: (options?: LoginOptions) => Promise<Response>;\n  /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */\n  authorize: () => Promise<Response>;\n  /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */\n  isLoggedIn: () => Promise<boolean>;\n  /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */\n  handleAuthStatus: () => void | DataFunctionValue;\n  /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */\n  getAccessToken: () => Promise<string | undefined>;\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/\n  getApiUrl: () => string;\n  /** Logout the customer by clearing the session and redirecting to the login domain. It should be called and returned from a Remix action. The path app should redirect to after logout can be setup in Customer Account API settings in admin.\n   *\n   * @param options.postLogoutRedirectUri - The url to redirect customer to after logout, should be a relative URL. This url will need to included in Customer Account API's application setup for logout URI. The default value is current app origin, which is automatically setup in admin when using `--customer-account-push` flag with dev.\n   * @param options.headers - These will be passed along to the logout redirect. You can use these to set/clear cookies on logout, like the cart.\n   * @param options.keepSession - If true, custom data in the session will not be cleared on logout.\n   * */\n  logout: (options?: LogoutOptions) => Promise<Response>;\n  /** Execute a GraphQL query against the Customer Account API. This method execute `handleAuthStatus()` ahead of query. */\n  query: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    query: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountQueries,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountQueries, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Execute a GraphQL mutation against the Customer Account API. This method execute `handleAuthStatus()` ahead of mutation. */\n  mutate: <\n    OverrideReturnType extends any = never,\n    RawGqlString extends string = string,\n  >(\n    mutation: RawGqlString,\n    ...options: ClientVariablesInRestParams<\n      CustomerAccountMutations,\n      RawGqlString\n    >\n  ) => Promise<\n    Omit<\n      CustomerAPIResponse<\n        ClientReturn<CustomerAccountMutations, RawGqlString, OverrideReturnType>\n      >,\n      'errors'\n    > & {errors?: JsonGraphQLError[]}\n  >;\n  /** Set buyer information into session.*/\n  setBuyer: (buyer: Buyer) => void;\n  /** Get buyer token and company location id from session.*/\n  getBuyer: () => Promise<Buyer>;\n  /** Deprecated. Please use setBuyer. Set buyer information into session.*/\n  UNSTABLE_setBuyer: (buyer: Buyer) => void;\n  /** Deprecated. Please use getBuyer. Get buyer token and company location id from session.*/\n  UNSTABLE_getBuyer: () => Promise<Buyer>;\n}",
             "description": "",
             "members": [
               {
@@ -19084,6 +20228,13 @@
                 "name": "handleAuthStatus",
                 "value": "() => void | DataFunctionValue",
                 "description": "Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option."
+              },
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "i18n",
+                "value": "{ language: LanguageCode; }",
+                "description": "The i18n configuration for Customer Account API"
               },
               {
                 "filePath": "src/customer/types.ts",
@@ -19154,9 +20305,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -19280,7 +20439,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@676",
+                "name": "__@toStringTag@684",
                 "value": "string",
                 "description": ""
               },
@@ -19658,7 +20817,7 @@
         "url": "/docs/api/hydrogen/utilities/inmemorycache"
       }
     ],
-    "description": "This function extends `createStorefrontClient` from [Hydrogen React](/docs/api/hydrogen-react/2025-04/utilities/createstorefrontclient).\nThe additional arguments enable internationalization (i18n), caching, and other features particular to Remix and Oxygen.\n\nLearn more about [data fetching in Hydrogen](/docs/custom-storefronts/hydrogen/data-fetching/fetch-data).",
+    "description": "This function extends `createStorefrontClient` from [Hydrogen React](/docs/api/hydrogen-react/2025-07/utilities/createstorefrontclient).\nThe additional arguments enable internationalization (i18n), caching, and other features particular to Remix and Oxygen.\n\nLearn more about [data fetching in Hydrogen](/docs/custom-storefronts/hydrogen/data-fetching/fetch-data).",
     "type": "utility",
     "defaultExample": {
       "description": "I am the default example",
@@ -19776,7 +20935,7 @@
             "filePath": "src/storefront.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "StorefrontForDoc",
-            "value": "{\n  /** The function to run a query on Storefront API. */\n  query?: <TData = any>(\n    query: string,\n    options: StorefrontQueryOptionsForDocs,\n  ) => Promise<TData & StorefrontError>;\n  /** The function to run a mutation on Storefront API. */\n  mutate?: <TData = any>(\n    mutation: string,\n    options: StorefrontMutationOptionsForDocs,\n  ) => Promise<TData & StorefrontError>;\n  /** The cache instance passed in from the `createStorefrontClient` argument. */\n  cache?: Cache;\n  /** Re-export of [`CacheNone`](/docs/api/hydrogen/utilities/cachenone). */\n  CacheNone?: typeof CacheNone;\n  /** Re-export of [`CacheLong`](/docs/api/hydrogen/utilities/cachelong). */\n  CacheLong?: typeof CacheLong;\n  /** Re-export of [`CacheShort`](/docs/api/hydrogen/utilities/cacheshort). */\n  CacheShort?: typeof CacheShort;\n  /** Re-export of [`CacheCustom`](/docs/api/hydrogen/utilities/cachecustom). */\n  CacheCustom?: typeof CacheCustom;\n  /** Re-export of [`generateCacheControlHeader`](/docs/api/hydrogen/utilities/generatecachecontrolheader). */\n  generateCacheControlHeader?: typeof generateCacheControlHeader;\n  /** Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint. See [`getPublicTokenHeaders` in Hydrogen React](/docs/api/hydrogen-react/2025-04/utilities/createstorefrontclient#:~:text=%27graphql%27.-,getPublicTokenHeaders,-(props%3F%3A) for more details. */\n  getPublicTokenHeaders?: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  /** Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint for API calls made from a server. See [`getPrivateTokenHeaders` in  Hydrogen React](/docs/api/hydrogen-react/2025-04/utilities/createstorefrontclient#:~:text=storefrontApiVersion-,getPrivateTokenHeaders,-(props%3F%3A) for more details.*/\n  getPrivateTokenHeaders?: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  /** Creates the fully-qualified URL to your myshopify.com domain. See [`getShopifyDomain` in  Hydrogen React](/docs/api/hydrogen-react/2025-04/utilities/createstorefrontclient#:~:text=StorefrontClientReturn-,getShopifyDomain,-(props%3F%3A) for more details. */\n  getShopifyDomain?: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint. See [`getStorefrontApiUrl` in  Hydrogen React](/docs/api/hydrogen-react/2025-04/utilities/createstorefrontclient#:~:text=storeDomain-,getStorefrontApiUrl,-(props%3F%3A) for more details.*/\n  getApiUrl?: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  /** The `i18n` object passed in from the `createStorefrontClient` argument. */\n  i18n?: TI18n;\n}",
+            "value": "{\n  /** The function to run a query on Storefront API. */\n  query?: <TData = any>(\n    query: string,\n    options: StorefrontQueryOptionsForDocs,\n  ) => Promise<TData & StorefrontError>;\n  /** The function to run a mutation on Storefront API. */\n  mutate?: <TData = any>(\n    mutation: string,\n    options: StorefrontMutationOptionsForDocs,\n  ) => Promise<TData & StorefrontError>;\n  /** The cache instance passed in from the `createStorefrontClient` argument. */\n  cache?: Cache;\n  /** Re-export of [`CacheNone`](/docs/api/hydrogen/utilities/cachenone). */\n  CacheNone?: typeof CacheNone;\n  /** Re-export of [`CacheLong`](/docs/api/hydrogen/utilities/cachelong). */\n  CacheLong?: typeof CacheLong;\n  /** Re-export of [`CacheShort`](/docs/api/hydrogen/utilities/cacheshort). */\n  CacheShort?: typeof CacheShort;\n  /** Re-export of [`CacheCustom`](/docs/api/hydrogen/utilities/cachecustom). */\n  CacheCustom?: typeof CacheCustom;\n  /** Re-export of [`generateCacheControlHeader`](/docs/api/hydrogen/utilities/generatecachecontrolheader). */\n  generateCacheControlHeader?: typeof generateCacheControlHeader;\n  /** Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint. See [`getPublicTokenHeaders` in Hydrogen React](/docs/api/hydrogen-react/2025-07/utilities/createstorefrontclient#:~:text=%27graphql%27.-,getPublicTokenHeaders,-(props%3F%3A) for more details. */\n  getPublicTokenHeaders?: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPublicTokenHeaders'];\n  /** Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint for API calls made from a server. See [`getPrivateTokenHeaders` in  Hydrogen React](/docs/api/hydrogen-react/2025-07/utilities/createstorefrontclient#:~:text=storefrontApiVersion-,getPrivateTokenHeaders,-(props%3F%3A) for more details.*/\n  getPrivateTokenHeaders?: ReturnType<\n    typeof createStorefrontUtilities\n  >['getPrivateTokenHeaders'];\n  /** Creates the fully-qualified URL to your myshopify.com domain. See [`getShopifyDomain` in  Hydrogen React](/docs/api/hydrogen-react/2025-07/utilities/createstorefrontclient#:~:text=StorefrontClientReturn-,getShopifyDomain,-(props%3F%3A) for more details. */\n  getShopifyDomain?: ReturnType<\n    typeof createStorefrontUtilities\n  >['getShopifyDomain'];\n  /** Creates the fully-qualified URL to your store's GraphQL endpoint. See [`getStorefrontApiUrl` in  Hydrogen React](/docs/api/hydrogen-react/2025-07/utilities/createstorefrontclient#:~:text=storeDomain-,getStorefrontApiUrl,-(props%3F%3A) for more details.*/\n  getApiUrl?: ReturnType<\n    typeof createStorefrontUtilities\n  >['getStorefrontApiUrl'];\n  /** The `i18n` object passed in from the `createStorefrontClient` argument. */\n  i18n?: TI18n;\n}",
             "description": "",
             "members": [
               {
@@ -19832,7 +20991,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "getApiUrl",
                 "value": "(props?: Partial<Pick<StorefrontClientProps, \"storefrontApiVersion\" | \"storeDomain\">>) => string",
-                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint. See [`getStorefrontApiUrl` in  Hydrogen React](/docs/api/hydrogen-react/2025-04/utilities/createstorefrontclient#:~:text=storeDomain-,getStorefrontApiUrl,-(props%3F%3A) for more details.",
+                "description": "Creates the fully-qualified URL to your store's GraphQL endpoint. See [`getStorefrontApiUrl` in  Hydrogen React](/docs/api/hydrogen-react/2025-07/utilities/createstorefrontclient#:~:text=storeDomain-,getStorefrontApiUrl,-(props%3F%3A) for more details.",
                 "isOptional": true
               },
               {
@@ -19840,7 +20999,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "getPrivateTokenHeaders",
                 "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"privateStorefrontToken\"> & { buyerIp?: string; }) => Record<string, string>",
-                "description": "Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint for API calls made from a server. See [`getPrivateTokenHeaders` in  Hydrogen React](/docs/api/hydrogen-react/2025-04/utilities/createstorefrontclient#:~:text=storefrontApiVersion-,getPrivateTokenHeaders,-(props%3F%3A) for more details.",
+                "description": "Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint for API calls made from a server. See [`getPrivateTokenHeaders` in  Hydrogen React](/docs/api/hydrogen-react/2025-07/utilities/createstorefrontclient#:~:text=storefrontApiVersion-,getPrivateTokenHeaders,-(props%3F%3A) for more details.",
                 "isOptional": true
               },
               {
@@ -19848,7 +21007,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "getPublicTokenHeaders",
                 "value": "(props?: Partial<Pick<StorefrontClientProps, \"contentType\">> & Pick<StorefrontClientProps, \"publicStorefrontToken\">) => Record<string, string>",
-                "description": "Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint. See [`getPublicTokenHeaders` in Hydrogen React](/docs/api/hydrogen-react/2025-04/utilities/createstorefrontclient#:~:text=%27graphql%27.-,getPublicTokenHeaders,-(props%3F%3A) for more details.",
+                "description": "Returns an object that contains headers that are needed for each query to Storefront API GraphQL endpoint. See [`getPublicTokenHeaders` in Hydrogen React](/docs/api/hydrogen-react/2025-07/utilities/createstorefrontclient#:~:text=%27graphql%27.-,getPublicTokenHeaders,-(props%3F%3A) for more details.",
                 "isOptional": true
               },
               {
@@ -19856,7 +21015,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "getShopifyDomain",
                 "value": "(props?: Partial<Pick<StorefrontClientProps, \"storeDomain\">>) => string",
-                "description": "Creates the fully-qualified URL to your myshopify.com domain. See [`getShopifyDomain` in  Hydrogen React](/docs/api/hydrogen-react/2025-04/utilities/createstorefrontclient#:~:text=StorefrontClientReturn-,getShopifyDomain,-(props%3F%3A) for more details.",
+                "description": "Creates the fully-qualified URL to your myshopify.com domain. See [`getShopifyDomain` in  Hydrogen React](/docs/api/hydrogen-react/2025-07/utilities/createstorefrontclient#:~:text=StorefrontClientReturn-,getShopifyDomain,-(props%3F%3A) for more details.",
                 "isOptional": true
               },
               {
@@ -20230,7 +21389,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-autocomplete",
-                "value": "'none' | 'inline' | 'list' | 'both' | undefined",
+                "value": "\"none\" | \"inline\" | \"list\" | \"both\" | undefined",
                 "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.",
                 "isOptional": true
               },
@@ -20262,7 +21421,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-checked",
-                "value": "boolean | 'false' | 'mixed' | 'true' | undefined",
+                "value": "boolean | \"false\" | \"mixed\" | \"true\" | undefined",
                 "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets.",
                 "isOptional": true
               },
@@ -20310,7 +21469,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-current",
-                "value": "boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time' | undefined",
+                "value": "boolean | \"false\" | \"true\" | \"page\" | \"step\" | \"location\" | \"date\" | \"time\" | undefined",
                 "description": "Indicates the element that represents the current item within a container or set of related elements.",
                 "isOptional": true
               },
@@ -20350,7 +21509,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-dropeffect",
-                "value": "'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined",
+                "value": "\"none\" | \"copy\" | \"execute\" | \"link\" | \"move\" | \"popup\" | undefined",
                 "description": "Indicates what functions can be performed when a dragged object is released on the drop target.",
                 "isOptional": true,
                 "deprecationMessage": "in ARIA 1.1"
@@ -20392,7 +21551,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-haspopup",
-                "value": "boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | undefined",
+                "value": "boolean | \"false\" | \"true\" | \"menu\" | \"listbox\" | \"tree\" | \"grid\" | \"dialog\" | undefined",
                 "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
                 "isOptional": true
               },
@@ -20408,7 +21567,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-invalid",
-                "value": "boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined",
+                "value": "boolean | \"false\" | \"true\" | \"grammar\" | \"spelling\" | undefined",
                 "description": "Indicates the entered value does not conform to the format expected by the application.",
                 "isOptional": true
               },
@@ -20448,7 +21607,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-live",
-                "value": "'off' | 'assertive' | 'polite' | undefined",
+                "value": "\"off\" | \"assertive\" | \"polite\" | undefined",
                 "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
                 "isOptional": true
               },
@@ -20480,7 +21639,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-orientation",
-                "value": "'horizontal' | 'vertical' | undefined",
+                "value": "\"horizontal\" | \"vertical\" | undefined",
                 "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
                 "isOptional": true
               },
@@ -20512,7 +21671,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-pressed",
-                "value": "boolean | 'false' | 'mixed' | 'true' | undefined",
+                "value": "boolean | \"false\" | \"mixed\" | \"true\" | undefined",
                 "description": "Indicates the current \"pressed\" state of toggle buttons.",
                 "isOptional": true
               },
@@ -20528,7 +21687,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-relevant",
-                "value": "'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' | undefined",
+                "value": "| \"additions\"\n            | \"additions removals\"\n            | \"additions text\"\n            | \"all\"\n            | \"removals\"\n            | \"removals additions\"\n            | \"removals text\"\n            | \"text\"\n            | \"text additions\"\n            | \"text removals\"\n            | undefined",
                 "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
                 "isOptional": true
               },
@@ -20600,7 +21759,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-sort",
-                "value": "'none' | 'ascending' | 'descending' | 'other' | undefined",
+                "value": "\"none\" | \"ascending\" | \"descending\" | \"other\" | undefined",
                 "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
                 "isOptional": true
               },
@@ -20648,7 +21807,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "autoCapitalize",
-                "value": "string | undefined",
+                "value": "\"off\" | \"none\" | \"on\" | \"sentences\" | \"words\" | \"characters\" | undefined | (string & {})",
                 "description": "",
                 "isOptional": true
               },
@@ -20673,6 +21832,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "autoSave",
                 "value": "string | undefined",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/csp/Script.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "blocking",
+                "value": "\"render\" | (string & {}) | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -20721,7 +21888,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "contentEditable",
-                "value": "Booleanish | \"inherit\" | undefined",
+                "value": "Booleanish | \"inherit\" | \"plaintext-only\" | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -20769,7 +21936,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "defaultValue",
-                "value": "string | number | ReadonlyArray<string> | undefined",
+                "value": "string | number | readonly string[] | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -20794,6 +21961,22 @@
                 "syntaxKind": "PropertySignature",
                 "name": "draggable",
                 "value": "Booleanish | undefined",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/csp/Script.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "enterKeyHint",
+                "value": "\"enter\" | \"done\" | \"go\" | \"next\" | \"previous\" | \"search\" | \"send\" | undefined",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/csp/Script.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "exportparts",
+                "value": "string | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -20825,7 +22008,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "inputMode",
-                "value": "'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search' | undefined",
+                "value": "\"none\" | \"text\" | \"tel\" | \"url\" | \"email\" | \"numeric\" | \"decimal\" | \"search\" | undefined",
                 "description": "Hints at the type of data that might be entered by the user while editing the element or its contents",
                 "isOptional": true
               },
@@ -20993,7 +22176,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "onBeforeInput",
-                "value": "FormEventHandler<T> | undefined",
+                "value": "InputEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -21492,7 +22675,7 @@
                 "value": "KeyboardEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true,
-                "deprecationMessage": "Deprecated"
+                "deprecationMessage": "Use `onKeyUp` or `onKeyDown` instead"
               },
               {
                 "filePath": "src/csp/Script.tsx",
@@ -21501,7 +22684,7 @@
                 "value": "KeyboardEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true,
-                "deprecationMessage": "Deprecated"
+                "deprecationMessage": "Use `onKeyUpCapture` or `onKeyDownCapture` instead"
               },
               {
                 "filePath": "src/csp/Script.tsx",
@@ -21802,23 +22985,7 @@
               {
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
-                "name": "onPointerEnterCapture",
-                "value": "PointerEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/csp/Script.tsx",
-                "syntaxKind": "PropertySignature",
                 "name": "onPointerLeave",
-                "value": "PointerEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/csp/Script.tsx",
-                "syntaxKind": "PropertySignature",
-                "name": "onPointerLeaveCapture",
                 "value": "PointerEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true
@@ -21932,22 +23099,6 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onResetCapture",
                 "value": "FormEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/csp/Script.tsx",
-                "syntaxKind": "PropertySignature",
-                "name": "onResize",
-                "value": "ReactEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/csp/Script.tsx",
-                "syntaxKind": "PropertySignature",
-                "name": "onResizeCapture",
-                "value": "ReactEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -22210,7 +23361,7 @@
               {
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
-                "name": "placeholder",
+                "name": "part",
                 "value": "string | undefined",
                 "description": "",
                 "isOptional": true
@@ -22363,7 +23514,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "translate",
-                "value": "'yes' | 'no' | undefined",
+                "value": "\"yes\" | \"no\" | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -22387,7 +23538,7 @@
                 "filePath": "src/csp/Script.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "unselectable",
-                "value": "'on' | 'off' | undefined",
+                "value": "\"on\" | \"off\" | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -23296,9 +24447,17 @@
             "filePath": "src/customer/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoginOptions",
-            "value": "{\n  uiLocales?: LanguageCode;\n}",
+            "value": "{\n  uiLocales?: LanguageCode;\n  countryCode?: CountryCode;\n}",
             "description": "",
             "members": [
+              {
+                "filePath": "src/customer/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "countryCode",
+                "value": "CountryCode",
+                "description": "",
+                "isOptional": true
+              },
               {
                 "filePath": "src/customer/types.ts",
                 "syntaxKind": "PropertySignature",
@@ -23608,30 +24767,56 @@
                 "name": "contextTypes",
                 "value": "ValidationMap<any> | undefined",
                 "description": "",
-                "isOptional": true
+                "isOptional": true,
+                "deprecationMessage": "Lets you specify which legacy context is consumed by\nthis component."
               },
               {
                 "filePath": "src/pagination/Pagination.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "defaultProps",
                 "value": "Partial<P> | undefined",
-                "description": "",
-                "isOptional": true
+                "description": "Used to define default values for the props accepted by the component.",
+                "isOptional": true,
+                "deprecationMessage": "Use {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value default values for destructuring assignments instead}.",
+                "examples": [
+                  {
+                    "title": "Example",
+                    "description": "",
+                    "tabs": [
+                      {
+                        "code": "type Props = { name?: string }\n\nconst MyComponent: FC<Props> = (props) => {\n  return <div>{props.name}</div>\n}\n\nMyComponent.defaultProps = {\n  name: 'John Doe'\n}",
+                        "title": "Example"
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "filePath": "src/pagination/Pagination.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "displayName",
                 "value": "string | undefined",
-                "description": "",
-                "isOptional": true
+                "description": "Used in debugging messages. You might want to set it explicitly if you want to display a different name for debugging purposes.",
+                "isOptional": true,
+                "examples": [
+                  {
+                    "title": "Example",
+                    "description": "",
+                    "tabs": [
+                      {
+                        "code": "const MyComponent: FC = () => {\n  return <div>Hello!</div>\n}\n\nMyComponent.displayName = 'MyAwesomeComponent'",
+                        "title": "Example"
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "filePath": "src/pagination/Pagination.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "propTypes",
                 "value": "WeakValidationMap<P> | undefined",
-                "description": "",
+                "description": "Used to declare the types of the props accepted by the component. These types will be checked during rendering and in development only.\n\nWe recommend using TypeScript instead of checking prop types at runtime.",
                 "isOptional": true
               }
             ]
@@ -23785,7 +24970,7 @@
             "filePath": "src/product/VariantSelector.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "VariantSelectorProps",
-            "value": "{\n  /** The product handle for all of the variants */\n  handle: string;\n  /** Product options from the [Storefront API](/docs/api/storefront/2025-04/objects/ProductOption). Make sure both `name` and `values` are a part of your query. */\n  options: Array<PartialProductOption> | undefined;\n  /** Product variants from the [Storefront API](/docs/api/storefront/2025-04/objects/ProductVariant). You only need to pass this prop if you want to show product availability. If a product option combination is not found within `variants`, it is assumed to be available. Make sure to include `availableForSale` and `selectedOptions.name` and `selectedOptions.value`. */\n  variants?:\n    | PartialDeep<ProductVariantConnection>\n    | Array<PartialDeep<ProductVariant>>;\n  /** By default all products are under /products. Use this prop to provide a custom path. */\n  productPath?: string;\n  /** Should the VariantSelector wait to update until after the browser navigates to a variant. */\n  waitForNavigation?: boolean;\n  /** An optional selected variant to use for the initial state if no URL parameters are set */\n  selectedVariant?: Maybe<PartialDeep<ProductVariant>>;\n  children: ({option}: {option: VariantOption}) => ReactNode;\n}",
+            "value": "{\n  /** The product handle for all of the variants */\n  handle: string;\n  /** Product options from the [Storefront API](/docs/api/storefront/2025-07/objects/ProductOption). Make sure both `name` and `values` are a part of your query. */\n  options: Array<PartialProductOption> | undefined;\n  /** Product variants from the [Storefront API](/docs/api/storefront/2025-07/objects/ProductVariant). You only need to pass this prop if you want to show product availability. If a product option combination is not found within `variants`, it is assumed to be available. Make sure to include `availableForSale` and `selectedOptions.name` and `selectedOptions.value`. */\n  variants?:\n    | PartialDeep<ProductVariantConnection>\n    | Array<PartialDeep<ProductVariant>>;\n  /** By default all products are under /products. Use this prop to provide a custom path. */\n  productPath?: string;\n  /** Should the VariantSelector wait to update until after the browser navigates to a variant. */\n  waitForNavigation?: boolean;\n  /** An optional selected variant to use for the initial state if no URL parameters are set */\n  selectedVariant?: Maybe<PartialDeep<ProductVariant>>;\n  children: ({option}: {option: VariantOption}) => ReactNode;\n}",
             "description": "",
             "members": [
               {
@@ -23807,7 +24992,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "options",
                 "value": "Array<PartialProductOption> | undefined",
-                "description": "Product options from the [Storefront API](/docs/api/storefront/2025-04/objects/ProductOption). Make sure both `name` and `values` are a part of your query."
+                "description": "Product options from the [Storefront API](/docs/api/storefront/2025-07/objects/ProductOption). Make sure both `name` and `values` are a part of your query."
               },
               {
                 "filePath": "src/product/VariantSelector.ts",
@@ -23830,7 +25015,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "variants",
                 "value": "| PartialDeep<ProductVariantConnection>\n    | Array<PartialDeep<ProductVariant>>",
-                "description": "Product variants from the [Storefront API](/docs/api/storefront/2025-04/objects/ProductVariant). You only need to pass this prop if you want to show product availability. If a product option combination is not found within `variants`, it is assumed to be available. Make sure to include `availableForSale` and `selectedOptions.name` and `selectedOptions.value`.",
+                "description": "Product variants from the [Storefront API](/docs/api/storefront/2025-07/objects/ProductVariant). You only need to pass this prop if you want to show product availability. If a product option combination is not found within `variants`, it is assumed to be available. Make sure to include `availableForSale` and `selectedOptions.name` and `selectedOptions.value`.",
                 "isOptional": true
               },
               {
@@ -23964,7 +25149,7 @@
         "url": "/docs/api/hydrogen/components/variantselector"
       }
     ],
-    "description": "The `getSelectedProductOptions` returns the selected options from the Request search parameters. The selected options can then be easily passed to your GraphQL query with [`variantBySelectedOptions`](https://shopify.dev/docs/api/storefront/2025-04/objects/product#field-product-variantbyselectedoptions).",
+    "description": "The `getSelectedProductOptions` returns the selected options from the Request search parameters. The selected options can then be easily passed to your GraphQL query with [`variantBySelectedOptions`](https://shopify.dev/docs/api/storefront/2025-07/objects/product#field-product-variantbyselectedoptions).",
     "type": "component",
     "defaultExample": {
       "description": "I am the default example",
@@ -24565,7 +25750,7 @@
             "filePath": "src/storefront.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "I18nBase",
-            "value": "{\n  language: LanguageCode;\n  country: CountryCode;\n}",
+            "value": "{\n  language: StorefrontLanguageCode | CustomerLanguageCode;\n  country: CountryCode;\n}",
             "description": "",
             "members": [
               {
@@ -24579,7 +25764,7 @@
                 "filePath": "src/storefront.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "language",
-                "value": "LanguageCode",
+                "value": "StorefrontLanguageCode | CustomerLanguageCode",
                 "description": ""
               }
             ]
@@ -26545,7 +27730,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-autocomplete",
-                "value": "'none' | 'inline' | 'list' | 'both' | undefined",
+                "value": "\"none\" | \"inline\" | \"list\" | \"both\" | undefined",
                 "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.",
                 "isOptional": true
               },
@@ -26577,7 +27762,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-checked",
-                "value": "boolean | 'false' | 'mixed' | 'true' | undefined",
+                "value": "boolean | \"false\" | \"mixed\" | \"true\" | undefined",
                 "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets.",
                 "isOptional": true
               },
@@ -26625,7 +27810,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-current",
-                "value": "boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time' | undefined",
+                "value": "boolean | \"false\" | \"true\" | \"page\" | \"step\" | \"location\" | \"date\" | \"time\" | undefined",
                 "description": "Indicates the element that represents the current item within a container or set of related elements.",
                 "isOptional": true
               },
@@ -26665,7 +27850,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-dropeffect",
-                "value": "'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup' | undefined",
+                "value": "\"none\" | \"copy\" | \"execute\" | \"link\" | \"move\" | \"popup\" | undefined",
                 "description": "Indicates what functions can be performed when a dragged object is released on the drop target.",
                 "isOptional": true,
                 "deprecationMessage": "in ARIA 1.1"
@@ -26707,7 +27892,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-haspopup",
-                "value": "boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | undefined",
+                "value": "boolean | \"false\" | \"true\" | \"menu\" | \"listbox\" | \"tree\" | \"grid\" | \"dialog\" | undefined",
                 "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
                 "isOptional": true
               },
@@ -26723,7 +27908,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-invalid",
-                "value": "boolean | 'false' | 'true' | 'grammar' | 'spelling' | undefined",
+                "value": "boolean | \"false\" | \"true\" | \"grammar\" | \"spelling\" | undefined",
                 "description": "Indicates the entered value does not conform to the format expected by the application.",
                 "isOptional": true
               },
@@ -26763,7 +27948,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-live",
-                "value": "'off' | 'assertive' | 'polite' | undefined",
+                "value": "\"off\" | \"assertive\" | \"polite\" | undefined",
                 "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
                 "isOptional": true
               },
@@ -26795,7 +27980,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-orientation",
-                "value": "'horizontal' | 'vertical' | undefined",
+                "value": "\"horizontal\" | \"vertical\" | undefined",
                 "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
                 "isOptional": true
               },
@@ -26827,7 +28012,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-pressed",
-                "value": "boolean | 'false' | 'mixed' | 'true' | undefined",
+                "value": "boolean | \"false\" | \"mixed\" | \"true\" | undefined",
                 "description": "Indicates the current \"pressed\" state of toggle buttons.",
                 "isOptional": true
               },
@@ -26843,7 +28028,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-relevant",
-                "value": "'additions' | 'additions removals' | 'additions text' | 'all' | 'removals' | 'removals additions' | 'removals text' | 'text' | 'text additions' | 'text removals' | undefined",
+                "value": "| \"additions\"\n            | \"additions removals\"\n            | \"additions text\"\n            | \"all\"\n            | \"removals\"\n            | \"removals additions\"\n            | \"removals text\"\n            | \"text\"\n            | \"text additions\"\n            | \"text removals\"\n            | undefined",
                 "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.",
                 "isOptional": true
               },
@@ -26915,7 +28100,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "aria-sort",
-                "value": "'none' | 'ascending' | 'descending' | 'other' | undefined",
+                "value": "\"none\" | \"ascending\" | \"descending\" | \"other\" | undefined",
                 "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
                 "isOptional": true
               },
@@ -26955,7 +28140,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "autoCapitalize",
-                "value": "string | undefined",
+                "value": "\"off\" | \"none\" | \"on\" | \"sentences\" | \"words\" | \"characters\" | undefined | (string & {})",
                 "description": "",
                 "isOptional": true
               },
@@ -27019,7 +28204,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "contentEditable",
-                "value": "Booleanish | \"inherit\" | undefined",
+                "value": "Booleanish | \"inherit\" | \"plaintext-only\" | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -27066,7 +28251,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "defaultValue",
-                "value": "string | number | ReadonlyArray<string> | undefined",
+                "value": "string | number | readonly string[] | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -27083,6 +28268,22 @@
                 "syntaxKind": "PropertySignature",
                 "name": "draggable",
                 "value": "Booleanish | undefined",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/MediaFile.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "enterKeyHint",
+                "value": "\"enter\" | \"done\" | \"go\" | \"next\" | \"previous\" | \"search\" | \"send\" | undefined",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/MediaFile.tsx",
+                "syntaxKind": "PropertySignature",
+                "name": "exportparts",
+                "value": "string | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -27114,7 +28315,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "inputMode",
-                "value": "'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search' | undefined",
+                "value": "\"none\" | \"text\" | \"tel\" | \"url\" | \"email\" | \"numeric\" | \"decimal\" | \"search\" | undefined",
                 "description": "Hints at the type of data that might be entered by the user while editing the element or its contents",
                 "isOptional": true
               },
@@ -27274,7 +28475,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "onBeforeInput",
-                "value": "FormEventHandler<T> | undefined",
+                "value": "InputEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -27773,7 +28974,7 @@
                 "value": "KeyboardEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true,
-                "deprecationMessage": "Deprecated"
+                "deprecationMessage": "Use `onKeyUp` or `onKeyDown` instead"
               },
               {
                 "filePath": "src/MediaFile.tsx",
@@ -27782,7 +28983,7 @@
                 "value": "KeyboardEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true,
-                "deprecationMessage": "Deprecated"
+                "deprecationMessage": "Use `onKeyUpCapture` or `onKeyDownCapture` instead"
               },
               {
                 "filePath": "src/MediaFile.tsx",
@@ -28083,23 +29284,7 @@
               {
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
-                "name": "onPointerEnterCapture",
-                "value": "PointerEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/MediaFile.tsx",
-                "syntaxKind": "PropertySignature",
                 "name": "onPointerLeave",
-                "value": "PointerEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/MediaFile.tsx",
-                "syntaxKind": "PropertySignature",
-                "name": "onPointerLeaveCapture",
                 "value": "PointerEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true
@@ -28213,22 +29398,6 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onResetCapture",
                 "value": "FormEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/MediaFile.tsx",
-                "syntaxKind": "PropertySignature",
-                "name": "onResize",
-                "value": "ReactEventHandler<T> | undefined",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/MediaFile.tsx",
-                "syntaxKind": "PropertySignature",
-                "name": "onResizeCapture",
-                "value": "ReactEventHandler<T> | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -28491,7 +29660,7 @@
               {
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
-                "name": "placeholder",
+                "name": "part",
                 "value": "string | undefined",
                 "description": "",
                 "isOptional": true
@@ -28628,7 +29797,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "translate",
-                "value": "'yes' | 'no' | undefined",
+                "value": "\"yes\" | \"no\" | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -28644,7 +29813,7 @@
                 "filePath": "src/MediaFile.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "unselectable",
-                "value": "'on' | 'off' | undefined",
+                "value": "\"on\" | \"off\" | undefined",
                 "description": "",
                 "isOptional": true
               },
@@ -28948,8 +30117,8 @@
                 "filePath": "src/Money.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "data",
-                "value": "PartialDeep<AnyMoneyV2, {recurseIntoArrays: true}>",
-                "description": "An object with fields that correspond to the Storefront API's [MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) or Customer Account API's MoneyV2 object."
+                "value": "PartialDeep<MoneyV2, {recurseIntoArrays: true}>",
+                "description": "An object with fields that correspond to the [Storefront API's MoneyV2 object](https://shopify.dev/docs/api/storefront/2025-07/objects/MoneyV2) or [Customer Account API's MoneyV2 object](https://shopify.dev/docs/api/customer/2025-07/objects/moneyv2)."
               },
               {
                 "filePath": "src/Money.tsx",
@@ -28984,14 +30153,14 @@
                 "isOptional": true
               }
             ],
-            "value": "export interface MoneyPropsBase<ComponentGeneric extends React.ElementType> {\n  /** An HTML tag or React Component to be rendered as the base element wrapper. The default is `div`. */\n  as?: ComponentGeneric;\n  /** An object with fields that correspond to the Storefront API's [MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) or Customer Account API's MoneyV2 object. */\n  data: PartialDeep<AnyMoneyV2, {recurseIntoArrays: true}>;\n  /** Whether to remove the currency symbol from the output. */\n  withoutCurrency?: boolean;\n  /** Whether to remove trailing zeros (fractional money) from the output. */\n  withoutTrailingZeros?: boolean;\n  /** A [UnitPriceMeasurement object](https://shopify.dev/api/storefront/2025-07/objects/unitpricemeasurement). */\n  measurement?: PartialDeep<UnitPriceMeasurement, {recurseIntoArrays: true}>;\n  /** Customizes the separator between the money output and the measurement output. Used with the `measurement` prop. Defaults to `'/'`. */\n  measurementSeparator?: ReactNode;\n}"
+            "value": "export interface MoneyPropsBase<ComponentGeneric extends React.ElementType> {\n  /** An HTML tag or React Component to be rendered as the base element wrapper. The default is `div`. */\n  as?: ComponentGeneric;\n  /** An object with fields that correspond to the [Storefront API's MoneyV2 object](https://shopify.dev/docs/api/storefront/2025-07/objects/MoneyV2) or [Customer Account API's MoneyV2 object](https://shopify.dev/docs/api/customer/2025-07/objects/moneyv2). */\n  data: PartialDeep<MoneyV2, {recurseIntoArrays: true}>;\n  /** Whether to remove the currency symbol from the output. */\n  withoutCurrency?: boolean;\n  /** Whether to remove trailing zeros (fractional money) from the output. */\n  withoutTrailingZeros?: boolean;\n  /** A [UnitPriceMeasurement object](https://shopify.dev/api/storefront/2025-07/objects/unitpricemeasurement). */\n  measurement?: PartialDeep<UnitPriceMeasurement, {recurseIntoArrays: true}>;\n  /** Customizes the separator between the money output and the measurement output. Used with the `measurement` prop. Defaults to `'/'`. */\n  measurementSeparator?: ReactNode;\n}"
           },
-          "AnyMoneyV2": {
+          "MoneyV2": {
             "filePath": "src/Money.tsx",
             "syntaxKind": "TypeAliasDeclaration",
-            "name": "AnyMoneyV2",
-            "value": "MoneyV2 | CustomerMoneyV2",
-            "description": ""
+            "name": "MoneyV2",
+            "value": "StorefrontApiMoneyV2 | CustomerAccountApiMoneyV2",
+            "description": "Supports MoneyV2 from both Storefront API and Customer Account API. The APIs may have different CurrencyCode enums (e.g., Customer Account API added USDC in 2025-07, but Storefront API doesn't support USDC in 2025-07). This union type ensures Money component works with data from either API."
           }
         }
       }
@@ -29637,12 +30806,12 @@
           "UseMoneyGeneratedType": {
             "filePath": "src/useMoney.tsx",
             "name": "UseMoneyGeneratedType",
-            "description": "The `useMoney` hook takes a [MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) and returns a default-formatted string of the amount with the correct currency indicator, along with some of the parts provided by [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). Uses `locale` from `ShopifyProvider` &nbsp;",
+            "description": "The `useMoney` hook takes a [MoneyV2 object from the Storefront API](https://shopify.dev/docs/api/storefront/2025-07/objects/MoneyV2) or a [MoneyV2 object from the Customer Account API](https://shopify.dev/docs/api/customer/2025-07/objects/moneyv2) and returns a default-formatted string of the amount with the correct currency indicator, along with some of the parts provided by [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). Uses `locale` from `ShopifyProvider` &nbsp;",
             "params": [
               {
                 "name": "money",
                 "description": "",
-                "value": "AnyMoneyV2",
+                "value": "MoneyV2",
                 "filePath": "src/useMoney.tsx"
               }
             ],
@@ -29652,7 +30821,7 @@
               "name": "UseMoneyValue",
               "value": "UseMoneyValue"
             },
-            "value": "export function useMoney(money: AnyMoneyV2): UseMoneyValue {\n  const {countryIsoCode, languageIsoCode} = useShop();\n  const locale = languageIsoCode.includes('_')\n    ? languageIsoCode.replace('_', '-')\n    : `${languageIsoCode}-${countryIsoCode}`;\n\n  if (!locale) {\n    throw new Error(\n      `useMoney(): Unable to get 'locale' from 'useShop()', which means that 'locale' was not passed to '<ShopifyProvider/>'. 'locale' is required for 'useMoney()' to work`,\n    );\n  }\n\n  const amount = parseFloat(money.amount);\n\n  // Check if the currency code is supported by Intl.NumberFormat\n  let isCurrencySupported = true;\n  try {\n    new Intl.NumberFormat(locale, {style: 'currency', currency: money.currencyCode});\n  } catch (e) {\n    if (e instanceof RangeError && e.message.includes('currency')) {\n      isCurrencySupported = false;\n    }\n  }\n\n  const {\n    defaultFormatter,\n    nameFormatter,\n    narrowSymbolFormatter,\n    withoutTrailingZerosFormatter,\n    withoutCurrencyFormatter,\n    withoutTrailingZerosOrCurrencyFormatter,\n  } = useMemo(() => {\n    // For unsupported currencies (like USDC cryptocurrency), use decimal formatting with 2 decimal places\n    // We default to 2 decimal places based on research showing USDC displays like USD to reinforce its 1:1 peg\n    const options = isCurrencySupported \n      ? {\n          style: 'currency' as const,\n          currency: money.currencyCode,\n        }\n      : {\n          style: 'decimal' as const,\n          minimumFractionDigits: 2,\n          maximumFractionDigits: 2,\n        };\n\n    return {\n      defaultFormatter: getLazyFormatter(locale, options),\n      nameFormatter: getLazyFormatter(locale, {\n        ...options,\n        currencyDisplay: 'name',\n      }),\n      narrowSymbolFormatter: getLazyFormatter(locale, {\n        ...options,\n        currencyDisplay: 'narrowSymbol',\n      }),\n      withoutTrailingZerosFormatter: getLazyFormatter(locale, {\n        ...options,\n        minimumFractionDigits: 0,\n        maximumFractionDigits: 0,\n      }),\n      withoutCurrencyFormatter: getLazyFormatter(locale, {\n        minimumFractionDigits: 2,\n        maximumFractionDigits: 2,\n      }),\n      withoutTrailingZerosOrCurrencyFormatter: getLazyFormatter(locale, {\n        minimumFractionDigits: 0,\n        maximumFractionDigits: 0,\n      }),\n    };\n  }, [money.currencyCode, locale, isCurrencySupported]);\n\n  const isPartCurrency = (part: Intl.NumberFormatPart): boolean =>\n    part.type === 'currency';\n\n  // By wrapping these properties in functions, we only\n  // create formatters if they are going to be used.\n  const lazyFormatters = useMemo(\n    () => ({\n      original: (): AnyMoneyV2 => money,\n      currencyCode: (): AnyCurrencyCode => money.currencyCode,\n\n      localizedString: (): string => {\n        const formatted = defaultFormatter().format(amount);\n        // For unsupported currencies, append the currency code\n        return isCurrencySupported ? formatted : `${formatted} ${money.currencyCode}`;\n      },\n\n      parts: (): Intl.NumberFormatPart[] => {\n        const parts = defaultFormatter().formatToParts(amount);\n        // For unsupported currencies, add currency code as a currency part\n        if (!isCurrencySupported) {\n          parts.push(\n            {type: 'literal', value: ' '},\n            {type: 'currency', value: money.currencyCode}\n          );\n        }\n        return parts;\n      },\n\n      withoutTrailingZeros: (): string => {\n        const formatted = amount % 1 === 0\n          ? withoutTrailingZerosFormatter().format(amount)\n          : defaultFormatter().format(amount);\n        // For unsupported currencies, append the currency code\n        return isCurrencySupported ? formatted : `${formatted} ${money.currencyCode}`;\n      },\n\n      withoutTrailingZerosAndCurrency: (): string =>\n        amount % 1 === 0\n          ? withoutTrailingZerosOrCurrencyFormatter().format(amount)\n          : withoutCurrencyFormatter().format(amount),\n\n      currencyName: (): string =>\n        nameFormatter().formatToParts(amount).find(isPartCurrency)?.value ??\n        money.currencyCode, // e.g. \"US dollars\"\n\n      currencySymbol: (): string =>\n        defaultFormatter().formatToParts(amount).find(isPartCurrency)?.value ??\n        money.currencyCode, // e.g. \"USD\"\n\n      currencyNarrowSymbol: (): string =>\n        narrowSymbolFormatter().formatToParts(amount).find(isPartCurrency)\n          ?.value ?? '', // e.g. \"$\"\n\n      amount: (): string =>\n        defaultFormatter()\n          .formatToParts(amount)\n          .filter((part) =>\n            ['decimal', 'fraction', 'group', 'integer', 'literal'].includes(\n              part.type,\n            ),\n          )\n          .map((part) => part.value)\n          .join(''),\n    }),\n    [\n      money,\n      amount,\n      isCurrencySupported,\n      nameFormatter,\n      defaultFormatter,\n      narrowSymbolFormatter,\n      withoutCurrencyFormatter,\n      withoutTrailingZerosFormatter,\n      withoutTrailingZerosOrCurrencyFormatter,\n    ],\n  );\n\n  // Call functions automatically when the properties are accessed\n  // to keep these functions as an implementation detail.\n  return useMemo(\n    () =>\n      new Proxy(lazyFormatters as unknown as UseMoneyValue, {\n        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call\n        get: (target, key) => Reflect.get(target, key)?.call(null),\n      }),\n    [lazyFormatters],\n  );\n}",
+            "value": "export function useMoney(money: MoneyV2): UseMoneyValue {\n  const {countryIsoCode, languageIsoCode} = useShop();\n  const locale = languageIsoCode.includes('_')\n    ? languageIsoCode.replace('_', '-')\n    : `${languageIsoCode}-${countryIsoCode}`;\n\n  if (!locale) {\n    throw new Error(\n      `useMoney(): Unable to get 'locale' from 'useShop()', which means that 'locale' was not passed to '<ShopifyProvider/>'. 'locale' is required for 'useMoney()' to work`,\n    );\n  }\n\n  const amount = parseFloat(money.amount);\n\n  // Check if the currency code is supported by Intl.NumberFormat\n  let isCurrencySupported = true;\n  try {\n    new Intl.NumberFormat(locale, {\n      style: 'currency',\n      currency: money.currencyCode,\n    });\n  } catch (e) {\n    if (e instanceof RangeError && e.message.includes('currency')) {\n      isCurrencySupported = false;\n    }\n  }\n\n  const {\n    defaultFormatter,\n    nameFormatter,\n    narrowSymbolFormatter,\n    withoutTrailingZerosFormatter,\n    withoutCurrencyFormatter,\n    withoutTrailingZerosOrCurrencyFormatter,\n  } = useMemo(() => {\n    // For unsupported currencies (like USDC cryptocurrency), use decimal formatting with 2 decimal places\n    // We default to 2 decimal places based on research showing USDC displays like USD to reinforce its 1:1 peg\n    const options = isCurrencySupported\n      ? {\n          style: 'currency' as const,\n          currency: money.currencyCode,\n        }\n      : {\n          style: 'decimal' as const,\n          minimumFractionDigits: 2,\n          maximumFractionDigits: 2,\n        };\n\n    return {\n      defaultFormatter: getLazyFormatter(locale, options),\n      nameFormatter: getLazyFormatter(locale, {\n        ...options,\n        currencyDisplay: 'name',\n      }),\n      narrowSymbolFormatter: getLazyFormatter(locale, {\n        ...options,\n        currencyDisplay: 'narrowSymbol',\n      }),\n      withoutTrailingZerosFormatter: getLazyFormatter(locale, {\n        ...options,\n        minimumFractionDigits: 0,\n        maximumFractionDigits: 0,\n      }),\n      withoutCurrencyFormatter: getLazyFormatter(locale, {\n        minimumFractionDigits: 2,\n        maximumFractionDigits: 2,\n      }),\n      withoutTrailingZerosOrCurrencyFormatter: getLazyFormatter(locale, {\n        minimumFractionDigits: 0,\n        maximumFractionDigits: 0,\n      }),\n    };\n  }, [money.currencyCode, locale, isCurrencySupported]);\n\n  const isPartCurrency = (part: Intl.NumberFormatPart): boolean =>\n    part.type === 'currency';\n\n  // By wrapping these properties in functions, we only\n  // create formatters if they are going to be used.\n  const lazyFormatters = useMemo(\n    () => ({\n      original: (): MoneyV2 => money,\n      currencyCode: (): CurrencyCode => money.currencyCode,\n\n      localizedString: (): string => {\n        const formatted = defaultFormatter().format(amount);\n        // For unsupported currencies, append the currency code\n        return isCurrencySupported\n          ? formatted\n          : `${formatted} ${money.currencyCode}`;\n      },\n\n      parts: (): Intl.NumberFormatPart[] => {\n        const parts = defaultFormatter().formatToParts(amount);\n        // For unsupported currencies, add currency code as a currency part\n        if (!isCurrencySupported) {\n          parts.push(\n            {type: 'literal', value: ' '},\n            {type: 'currency', value: money.currencyCode},\n          );\n        }\n        return parts;\n      },\n\n      withoutTrailingZeros: (): string => {\n        const formatted =\n          amount % 1 === 0\n            ? withoutTrailingZerosFormatter().format(amount)\n            : defaultFormatter().format(amount);\n        // For unsupported currencies, append the currency code\n        return isCurrencySupported\n          ? formatted\n          : `${formatted} ${money.currencyCode}`;\n      },\n\n      withoutTrailingZerosAndCurrency: (): string =>\n        amount % 1 === 0\n          ? withoutTrailingZerosOrCurrencyFormatter().format(amount)\n          : withoutCurrencyFormatter().format(amount),\n\n      currencyName: (): string =>\n        nameFormatter().formatToParts(amount).find(isPartCurrency)?.value ??\n        money.currencyCode, // e.g. \"US dollars\"\n\n      currencySymbol: (): string =>\n        defaultFormatter().formatToParts(amount).find(isPartCurrency)?.value ??\n        money.currencyCode, // e.g. \"USD\"\n\n      currencyNarrowSymbol: (): string =>\n        narrowSymbolFormatter().formatToParts(amount).find(isPartCurrency)\n          ?.value ?? '', // e.g. \"$\"\n\n      amount: (): string =>\n        defaultFormatter()\n          .formatToParts(amount)\n          .filter((part) =>\n            ['decimal', 'fraction', 'group', 'integer', 'literal'].includes(\n              part.type,\n            ),\n          )\n          .map((part) => part.value)\n          .join(''),\n    }),\n    [\n      money,\n      amount,\n      isCurrencySupported,\n      nameFormatter,\n      defaultFormatter,\n      narrowSymbolFormatter,\n      withoutCurrencyFormatter,\n      withoutTrailingZerosFormatter,\n      withoutTrailingZerosOrCurrencyFormatter,\n    ],\n  );\n\n  // Call functions automatically when the properties are accessed\n  // to keep these functions as an implementation detail.\n  return useMemo(\n    () =>\n      new Proxy(lazyFormatters as unknown as UseMoneyValue, {\n        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call\n        get: (target, key) => Reflect.get(target, key)?.call(null),\n      }),\n    [lazyFormatters],\n  );\n}",
             "examples": [
               {
                 "title": "Example",
@@ -29778,18 +30947,18 @@
               }
             ]
           },
-          "AnyMoneyV2": {
+          "MoneyV2": {
             "filePath": "src/useMoney.tsx",
             "syntaxKind": "TypeAliasDeclaration",
-            "name": "AnyMoneyV2",
-            "value": "MoneyV2 | CustomerMoneyV2",
-            "description": ""
+            "name": "MoneyV2",
+            "value": "StorefrontApiMoneyV2 | CustomerAccountApiMoneyV2",
+            "description": "Supports MoneyV2 from both Storefront API and Customer Account API. The APIs may have different CurrencyCode enums (e.g., Customer Account API added USDC in 2025-07, but Storefront API doesn't support USDC in 2025-07). This union type ensures useMoney works with data from either API."
           },
           "UseMoneyValue": {
             "filePath": "src/useMoney.tsx",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "UseMoneyValue",
-            "value": "{\n  /**\n   * The currency code from the `MoneyV2` object.\n   */\n  currencyCode: AnyCurrencyCode;\n  /**\n   * The name for the currency code, returned by `Intl.NumberFormat`.\n   */\n  currencyName?: string;\n  /**\n   * The currency symbol returned by `Intl.NumberFormat`.\n   */\n  currencySymbol?: string;\n  /**\n   * The currency narrow symbol returned by `Intl.NumberFormat`.\n   */\n  currencyNarrowSymbol?: string;\n  /**\n   * The localized amount, without any currency symbols or non-number types from the `Intl.NumberFormat.formatToParts` parts.\n   */\n  amount: string;\n  /**\n   * All parts returned by `Intl.NumberFormat.formatToParts`.\n   */\n  parts: Intl.NumberFormatPart[];\n  /**\n   * A string returned by `new Intl.NumberFormat` for the amount and currency code,\n   * using the `locale` value in the [`LocalizationProvider` component](https://shopify.dev/api/hydrogen/components/localization/localizationprovider).\n   */\n  localizedString: string;\n  /**\n   * The `MoneyV2` object provided as an argument to the hook.\n   */\n  original: AnyMoneyV2;\n  /**\n   * A string with trailing zeros removed from the fractional part, if any exist. If there are no trailing zeros, then the fractional part remains.\n   * For example, `$640.00` turns into `$640`.\n   * `$640.42` remains `$640.42`.\n   */\n  withoutTrailingZeros: string;\n  /**\n   * A string without currency and without trailing zeros removed from the fractional part, if any exist. If there are no trailing zeros, then the fractional part remains.\n   * For example, `$640.00` turns into `640`.\n   * `$640.42` turns into `640.42`.\n   */\n  withoutTrailingZerosAndCurrency: string;\n}",
+            "value": "{\n  /**\n   * The currency code from the `MoneyV2` object.\n   */\n  currencyCode: CurrencyCode;\n  /**\n   * The name for the currency code, returned by `Intl.NumberFormat`.\n   */\n  currencyName?: string;\n  /**\n   * The currency symbol returned by `Intl.NumberFormat`.\n   */\n  currencySymbol?: string;\n  /**\n   * The currency narrow symbol returned by `Intl.NumberFormat`.\n   */\n  currencyNarrowSymbol?: string;\n  /**\n   * The localized amount, without any currency symbols or non-number types from the `Intl.NumberFormat.formatToParts` parts.\n   */\n  amount: string;\n  /**\n   * All parts returned by `Intl.NumberFormat.formatToParts`.\n   */\n  parts: Intl.NumberFormatPart[];\n  /**\n   * A string returned by `new Intl.NumberFormat` for the amount and currency code,\n   * using the `locale` value in the [`LocalizationProvider` component](https://shopify.dev/api/hydrogen/components/localization/localizationprovider).\n   */\n  localizedString: string;\n  /**\n   * The `MoneyV2` object provided as an argument to the hook.\n   */\n  original: MoneyV2;\n  /**\n   * A string with trailing zeros removed from the fractional part, if any exist. If there are no trailing zeros, then the fractional part remains.\n   * For example, `$640.00` turns into `$640`.\n   * `$640.42` remains `$640.42`.\n   */\n  withoutTrailingZeros: string;\n  /**\n   * A string without currency and without trailing zeros removed from the fractional part, if any exist. If there are no trailing zeros, then the fractional part remains.\n   * For example, `$640.00` turns into `640`.\n   * `$640.42` turns into `640.42`.\n   */\n  withoutTrailingZerosAndCurrency: string;\n}",
             "description": "",
             "members": [
               {
@@ -29803,7 +30972,7 @@
                 "filePath": "src/useMoney.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "currencyCode",
-                "value": "AnyCurrencyCode",
+                "value": "CurrencyCode",
                 "description": "The currency code from the `MoneyV2` object."
               },
               {
@@ -29841,7 +31010,7 @@
                 "filePath": "src/useMoney.tsx",
                 "syntaxKind": "PropertySignature",
                 "name": "original",
-                "value": "AnyMoneyV2",
+                "value": "MoneyV2",
                 "description": "The `MoneyV2` object provided as an argument to the hook."
               },
               {
@@ -29867,12 +31036,12 @@
               }
             ]
           },
-          "AnyCurrencyCode": {
+          "CurrencyCode": {
             "filePath": "src/useMoney.tsx",
             "syntaxKind": "TypeAliasDeclaration",
-            "name": "AnyCurrencyCode",
-            "value": "CurrencyCode | CustomerCurrencyCode",
-            "description": ""
+            "name": "CurrencyCode",
+            "value": "StorefrontApiCurrencyCode | CustomerAccountApiCurrencyCode",
+            "description": "Supports CurrencyCode from both Storefront API and Customer Account API. The APIs may have different CurrencyCode enums (e.g., Customer Account API added USDC in 2025-07, but Storefront API doesn't support USDC in 2025-07). This union type ensures useMoney works with data from either API."
           }
         }
       }
@@ -30069,7 +31238,7 @@
       {
         "name": "isOptionValueCombinationInEncodedVariant",
         "type": "utility",
-        "url": "/docs/api/hydrogen/2025-04/utilities/isOptionValueCombinationInEncodedVariant"
+        "url": "/docs/api/hydrogen//utilities/isOptionValueCombinationInEncodedVariant"
       }
     ],
     "description": "Decodes an encoded option value string into an array of option value combinations.",
@@ -30565,7 +31734,7 @@
       {
         "name": "decodeEncodedVariant",
         "type": "utility",
-        "url": "/docs/api/hydrogen/2025-04/utilities/decodeEncodedVariant"
+        "url": "/docs/api/hydrogen/utilities/decodeEncodedVariant"
       }
     ],
     "description": "\n    Determines whether an option value combination is present in an encoded option value string.\n\n`targetOptionValueCombination` - Indices of option values to look up in the encoded option value string. A partial set of indices may be passed to determine whether a node or any children is present. For example, if a product has 3 options, passing `[0]` will return true if any option value combination for the first option's option value is present in the encoded string.\n  ",
@@ -30775,7 +31944,7 @@
               "name": "ReturnGeneric",
               "value": "ReturnGeneric"
             },
-            "value": "export function parseMetafield<ReturnGeneric>(\n  metafield: PartialDeep<MetafieldBaseType, {recurseIntoArrays: true}>,\n): ReturnGeneric {\n  if (!metafield.type) {\n    const noTypeError = `parseMetafield(): The 'type' field is required in order to parse the Metafield.`;\n    if (__HYDROGEN_DEV__) {\n      throw new Error(noTypeError);\n    } else {\n      console.error(`${noTypeError} Returning 'parsedValue' of 'null'`);\n      return {\n        ...metafield,\n        parsedValue: null,\n      } as ReturnGeneric;\n    }\n  }\n\n  switch (metafield.type) {\n    case 'boolean':\n      return {\n        ...metafield,\n        parsedValue: metafield.value === 'true',\n      } as ReturnGeneric;\n\n    case 'collection_reference':\n    case 'file_reference':\n    case 'page_reference':\n    case 'product_reference':\n    case 'variant_reference':\n      return {\n        ...metafield,\n        parsedValue: metafield.reference,\n      } as ReturnGeneric;\n\n    case 'color':\n    case 'multi_line_text_field':\n    case 'single_line_text_field':\n    case 'url':\n      return {\n        ...metafield,\n        parsedValue: metafield.value,\n      } as ReturnGeneric;\n\n    // TODO: 'money' should probably be parsed even further to like `useMoney()`, but that logic needs to be extracted first so it's not a hook\n    case 'dimension':\n    case 'money':\n    case 'json':\n    case 'rating':\n    case 'volume':\n    case 'weight':\n    case 'rich_text_field':\n    case 'list.color':\n    case 'list.dimension':\n    case 'list.number_integer':\n    case 'list.number_decimal':\n    case 'list.rating':\n    case 'list.single_line_text_field':\n    case 'list.url':\n    case 'list.volume':\n    case 'list.weight': {\n      let parsedValue = null;\n      try {\n        parsedValue = parseJSON(metafield.value ?? '');\n      } catch (err) {\n        const parseError = `parseMetafield(): attempted to JSON.parse the 'metafield.value' property, but failed.`;\n        if (__HYDROGEN_DEV__) {\n          throw new Error(parseError);\n        } else {\n          console.error(`${parseError} Returning 'null' for 'parsedValue'`);\n        }\n        parsedValue = null;\n      }\n      return {\n        ...metafield,\n        parsedValue,\n      } as ReturnGeneric;\n    }\n\n    case 'date':\n    case 'date_time':\n      return {\n        ...metafield,\n        parsedValue: new Date(metafield.value ?? ''),\n      } as ReturnGeneric;\n\n    case 'list.date':\n    case 'list.date_time': {\n      const jsonParseValue = parseJSON(metafield?.value ?? '') as string[];\n      return {\n        ...metafield,\n        parsedValue: jsonParseValue.map((dateString) => new Date(dateString)),\n      } as ReturnGeneric;\n    }\n\n    case 'number_decimal':\n    case 'number_integer':\n      return {\n        ...metafield,\n        parsedValue: Number(metafield.value),\n      } as ReturnGeneric;\n\n    case 'list.collection_reference':\n    case 'list.file_reference':\n    case 'list.page_reference':\n    case 'list.product_reference':\n    case 'list.variant_reference':\n      return {\n        ...metafield,\n        parsedValue: flattenConnection(metafield.references ?? undefined),\n      } as ReturnGeneric;\n\n    default: {\n      const typeNotFoundError = `parseMetafield(): the 'metafield.type' you passed in is not supported. Your type: \"${metafield.type}\". If you believe this is an error, please open an issue on GitHub.`;\n      if (__HYDROGEN_DEV__) {\n        throw new Error(typeNotFoundError);\n      } else {\n        console.error(\n          `${typeNotFoundError}  Returning 'parsedValue' of 'null'`,\n        );\n        return {\n          ...metafield,\n          parsedValue: null,\n        } as ReturnGeneric;\n      }\n    }\n  }\n}"
+            "value": "export function parseMetafield<ReturnGeneric>(\n  metafield: PartialDeep<MetafieldBaseType, {recurseIntoArrays: true}>,\n): ReturnGeneric {\n  if (!metafield.type) {\n    const noTypeError = `parseMetafield(): The 'type' field is required in order to parse the Metafield.`;\n    if (__HYDROGEN_DEV__) {\n      throw new Error(noTypeError);\n    } else {\n      console.error(`${noTypeError} Returning 'parsedValue' of 'null'`);\n      return {\n        ...metafield,\n        parsedValue: null,\n      } as ReturnGeneric;\n    }\n  }\n\n  switch (metafield.type) {\n    case 'boolean':\n      return {\n        ...metafield,\n        parsedValue: metafield.value === 'true',\n      } as ReturnGeneric;\n\n    case 'collection_reference':\n    case 'file_reference':\n    case 'page_reference':\n    case 'product_reference':\n    case 'variant_reference':\n      return {\n        ...metafield,\n        parsedValue: metafield.reference,\n      } as ReturnGeneric;\n\n    case 'color':\n    case 'multi_line_text_field':\n    case 'single_line_text_field':\n    case 'url':\n      return {\n        ...metafield,\n        parsedValue: metafield.value,\n      } as ReturnGeneric;\n\n    // TODO: 'money' should probably be parsed even further to like `useMoney()`, but that logic needs to be extracted first so it's not a hook\n    case 'money': {\n      let parsedValue: MoneyV2 | null = null;\n      try {\n        const parsed = parseJSON(metafield.value ?? '');\n        // Transform currency_code from Storefront API to currencyCode to match MoneyV2 type\n        if (parsed && typeof parsed === 'object' && 'currency_code' in parsed) {\n          const moneyData = parsed as {amount: string; currency_code: string};\n          parsedValue = {\n            amount: moneyData.amount,\n            currencyCode: moneyData.currency_code as CurrencyCode,\n          };\n        } else if (\n          parsed &&\n          typeof parsed === 'object' &&\n          'currencyCode' in parsed\n        ) {\n          // Already in correct format (for backward compatibility)\n          parsedValue = parsed as MoneyV2;\n        } else {\n          parsedValue = parsed as MoneyV2 | null;\n        }\n      } catch (err) {\n        const parseError = `parseMetafield(): attempted to JSON.parse the 'metafield.value' property, but failed.`;\n        if (__HYDROGEN_DEV__) {\n          throw new Error(parseError);\n        } else {\n          console.error(`${parseError} Returning 'null' for 'parsedValue'`);\n        }\n        parsedValue = null;\n      }\n      return {\n        ...metafield,\n        parsedValue,\n      } as ReturnGeneric;\n    }\n\n    case 'dimension':\n    case 'json':\n    case 'rating':\n    case 'volume':\n    case 'weight':\n    case 'rich_text_field':\n    case 'list.color':\n    case 'list.dimension':\n    case 'list.number_integer':\n    case 'list.number_decimal':\n    case 'list.rating':\n    case 'list.single_line_text_field':\n    case 'list.url':\n    case 'list.volume':\n    case 'list.weight': {\n      let parsedValue = null;\n      try {\n        parsedValue = parseJSON(metafield.value ?? '');\n      } catch (err) {\n        const parseError = `parseMetafield(): attempted to JSON.parse the 'metafield.value' property, but failed.`;\n        if (__HYDROGEN_DEV__) {\n          throw new Error(parseError);\n        } else {\n          console.error(`${parseError} Returning 'null' for 'parsedValue'`);\n        }\n        parsedValue = null;\n      }\n      return {\n        ...metafield,\n        parsedValue,\n      } as ReturnGeneric;\n    }\n\n    case 'date':\n    case 'date_time':\n      return {\n        ...metafield,\n        parsedValue: new Date(metafield.value ?? ''),\n      } as ReturnGeneric;\n\n    case 'list.date':\n    case 'list.date_time': {\n      const jsonParseValue = parseJSON(metafield?.value ?? '') as string[];\n      return {\n        ...metafield,\n        parsedValue: jsonParseValue.map((dateString) => new Date(dateString)),\n      } as ReturnGeneric;\n    }\n\n    case 'number_decimal':\n    case 'number_integer':\n      return {\n        ...metafield,\n        parsedValue: Number(metafield.value),\n      } as ReturnGeneric;\n\n    case 'list.collection_reference':\n    case 'list.file_reference':\n    case 'list.page_reference':\n    case 'list.product_reference':\n    case 'list.variant_reference':\n      return {\n        ...metafield,\n        parsedValue: flattenConnection(metafield.references ?? undefined),\n      } as ReturnGeneric;\n\n    default: {\n      const typeNotFoundError = `parseMetafield(): the 'metafield.type' you passed in is not supported. Your type: \"${metafield.type}\". If you believe this is an error, please open an issue on GitHub.`;\n      if (__HYDROGEN_DEV__) {\n        throw new Error(typeNotFoundError);\n      } else {\n        console.error(\n          `${typeNotFoundError}  Returning 'parsedValue' of 'null'`,\n        );\n        return {\n          ...metafield,\n          parsedValue: null,\n        } as ReturnGeneric;\n      }\n    }\n  }\n}"
           }
         }
       }
@@ -30922,14 +32091,6 @@
               {
                 "filePath": "src/analytics-types.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "ccpaEnforced",
-                "value": "boolean",
-                "description": "Result of `!customerPrivacyApi.saleOfDataAllowed()`",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/analytics-types.ts",
-                "syntaxKind": "PropertySignature",
                 "name": "collectionHandle",
                 "value": "string",
                 "description": "Shopify collection handle.",
@@ -30956,14 +32117,6 @@
                 "name": "customerId",
                 "value": "string",
                 "description": "Shopify customer id in the form of `gid://shopify/Customer/<id>`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/analytics-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "gdprEnforced",
-                "value": "boolean",
-                "description": "Result of `!(customerPrivacyApi.marketingAllowed() && customerPrivacy.analyticsProcessingAllowed())`",
                 "isOptional": true
               },
               {
@@ -31133,6 +32286,13 @@
             ],
             "value": "export interface ShopifyPageViewPayload\n  extends ShopifyAnalyticsBase,\n    ClientBrowserParameters {\n  /** Canonical url. */\n  canonicalUrl?: string;\n  /** Shopify page type. */\n  pageType?: string;\n  /** Shopify resource id in the form of `gid://shopify/<type>/<id>`. */\n  resourceId?: string;\n  /** Shopify collection handle. */\n  collectionHandle?: string;\n  /** Shopify collection id. */\n  collectionId?: string;\n  /** Search term used on a search results page. */\n  searchString?: string;\n}"
           },
+          "CurrencyCode": {
+            "filePath": "src/useMoney.tsx",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CurrencyCode",
+            "value": "StorefrontApiCurrencyCode | CustomerAccountApiCurrencyCode",
+            "description": "Supports CurrencyCode from both Storefront API and Customer Account API. The APIs may have different CurrencyCode enums (e.g., Customer Account API added USDC in 2025-07, but Storefront API doesn't support USDC in 2025-07). This union type ensures useMoney works with data from either API."
+          },
           "ShopifyAnalyticsProduct": {
             "filePath": "src/analytics-types.ts",
             "syntaxKind": "TypeAliasDeclaration",
@@ -31301,14 +32461,6 @@
               {
                 "filePath": "src/analytics-types.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "ccpaEnforced",
-                "value": "boolean",
-                "description": "Result of `!customerPrivacyApi.saleOfDataAllowed()`",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/analytics-types.ts",
-                "syntaxKind": "PropertySignature",
                 "name": "currency",
                 "value": "CurrencyCode",
                 "description": "Currency code."
@@ -31319,14 +32471,6 @@
                 "name": "customerId",
                 "value": "string",
                 "description": "Shopify customer id in the form of `gid://shopify/Customer/<id>`.",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/analytics-types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "gdprEnforced",
-                "value": "boolean",
-                "description": "Result of `!(customerPrivacyApi.marketingAllowed() && customerPrivacy.analyticsProcessingAllowed())`",
                 "isOptional": true
               },
               {

--- a/packages/hydrogen/src/analytics-manager/ShopifyAnalytics.tsx
+++ b/packages/hydrogen/src/analytics-manager/ShopifyAnalytics.tsx
@@ -148,21 +148,21 @@ function prepareBasePageViewPayload(
     return;
   }
 
-  const eventPayload: ShopifyPageViewPayload = {
+  const eventPayload = {
     shopifySalesChannel: 'hydrogen',
     assetVersionId: version,
     ...payload.shop,
     hasUserConsent,
     ...getClientBrowserParameters(),
+    analyticsAllowed: customerPrivacy.analyticsProcessingAllowed(),
+    marketingAllowed: customerPrivacy.marketingAllowed(),
+    saleOfDataAllowed: customerPrivacy.saleOfDataAllowed(),
     ccpaEnforced: !customerPrivacy.saleOfDataAllowed(),
     gdprEnforced: !(
       customerPrivacy.marketingAllowed() &&
       customerPrivacy.analyticsProcessingAllowed()
     ),
-    analyticsAllowed: customerPrivacy.analyticsProcessingAllowed(),
-    marketingAllowed: customerPrivacy.marketingAllowed(),
-    saleOfDataAllowed: customerPrivacy.saleOfDataAllowed(),
-  };
+  } as ShopifyPageViewPayload;
 
   return eventPayload;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses caution-tape-bot feedback from [Shopify/shopify-dev#63408](https://github.com/Shopify/shopify-dev/pull/63408#issuecomment-3357828606)

When updating API documentation to shopify-dev, the automated bot flagged usage of regulation-specific terminology (`gdprEnforced`, `ccpaEnforced`) in generated docs. Using regulation-specific terms makes the platform less adaptable to changing privacy requirements.

### WHAT is this pull request doing?

Removes `ccpaEnforced` and `gdprEnforced` from public API types while maintaining backward compatibility.

**Changes:**

| Component | Change | Impact |
|-----------|--------|--------|
| `ShopifyAnalyticsBase` | Removed `ccpaEnforced` and `gdprEnforced` fields | Public API documentation cleaner |
| Internal types | Added `ShopifyAnalyticsBaseWithPrivacyFields` with `@internal` tag | No developer-facing changes |
| Analytics schema | Updated to accept both public and internal types | Full backward compatibility |
| Hydrogen analytics | Uses type assertion to add fields at runtime | Backend still receives all fields |

**Type Structure:**

```diff
type ShopifyAnalyticsBase = {
  shopId: string;
  currency: CurrencyCode;
  products?: ShopifyAnalyticsProduct[];
- ccpaEnforced?: boolean;
- gdprEnforced?: boolean;
  analyticsAllowed?: boolean;
  marketingAllowed?: boolean;
  saleOfDataAllowed?: boolean;
};

+ // @internal
+ type ShopifyAnalyticsBaseWithPrivacyFields = ShopifyAnalyticsBase & {
+   ccpaEnforced?: boolean;
+   gdprEnforced?: boolean;
+ };
```

**Result:**
- Public API docs only show generalized privacy fields
- Internal analytics backend still receives regulation-specific fields
- Zero breaking changes (all exported type names unchanged)

### HOW to test your changes?

#### Verify Build and Tests

```bash
npm run build
npm run test --workspace=packages/hydrogen-react -- analytics-schema-custom-storefront-customer-tracking.test.ts
```

#### Verify Documentation

```bash
npm run docs:build
grep -c "gdprEnforced\|ccpaEnforced" packages/hydrogen-react/docs/generated/generated_docs_data.json
# Should output: 0
```

#### Verify Runtime Behavior

Analytics events should still include all privacy fields when sent to Shopify backend (check browser network tab for monorail requests).

#### Checklist

- [x] I've read the Contributing Guidelines
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a changeset if this PR contains user-facing or noteworthy changes
- [x] I've added tests to cover my changes (existing tests cover this)
- [x] I've added or updated the documentation (generated docs updated)