### PR TITLE
Fix upgrade notice showing incorrect versions for missing changelog entries

### DIFF
--- a/.changeset/dummy-cli-hydrogen-test.md
+++ b/.changeset/dummy-cli-hydrogen-test.md
@@ -1,5 +1,0 @@
----
-"@shopify/cli-hydrogen": patch
----
-
-Test changeset to validate independent patches and synced majors logic for SemVer packages

--- a/.changeset/fix-upgrade-notice-missing-version.md
+++ b/.changeset/fix-upgrade-notice-missing-version.md
@@ -1,0 +1,5 @@
+---
+"@shopify/cli-hydrogen": patch
+---
+
+Fix upgrade notice showing incorrect old versions when current version is missing from changelog. The `shopify hydrogen dev` command now correctly displays available upgrades using semver comparison when the current version doesn't exist in changelog.json.

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1384,8 +1384,8 @@ export async function displayDevUpgradeNotice({
       relevantReleases = changelog.releases.slice(0, currentReleaseIndex);
     }
 
-    // Reverse for deduplication priority: older releases have more info.
-    // Then reverse back for display: newest version top, next version bottom.
+    // First, reverse so that during deduplication (reduce), older releases of the same version are kept.
+    // Then, reverse again after deduplication to restore chronological order for display (newest version at the top).
     const nextReleases = Object.values(
       [...relevantReleases].reverse().reduce(
         (acc, release) => {

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1369,11 +1369,23 @@ export async function displayDevUpgradeNotice({
             getAbsoluteVersion(release.version) === pinnedCurrentVersion,
         );
 
-    const relevantReleases = changelog.releases.slice(0, currentReleaseIndex);
+    let relevantReleases: Release[];
+    if (currentReleaseIndex === -1) {
+      // Current version not found in changelog. Use semver to find releases newer than current.
+      const insertionIndex = changelog.releases.findIndex((release) =>
+        semver.lte(getAbsoluteVersion(release.version), pinnedCurrentVersion),
+      );
 
-    // By reversing the releases array, we give priority to older releases
-    // for the same version. Older releases (the first one of a version) probably
-    // have more information than a newer release that only changes dependencies.
+      relevantReleases =
+        insertionIndex === -1
+          ? changelog.releases
+          : changelog.releases.slice(0, insertionIndex);
+    } else {
+      relevantReleases = changelog.releases.slice(0, currentReleaseIndex);
+    }
+
+    // Reverse for deduplication priority: older releases have more info.
+    // Then reverse back for display: newest version top, next version bottom.
     const nextReleases = Object.values(
       [...relevantReleases].reverse().reduce(
         (acc, release) => {
@@ -1382,7 +1394,9 @@ export async function displayDevUpgradeNotice({
         },
         {} as Record<string, string>,
       ),
-    ).slice(0, 5);
+    )
+      .reverse()
+      .slice(0, 5);
 
     let headline =
       Object.keys(uniqueAvailableUpgrades).length > 1


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3250

When a user runs `shopify hydrogen dev` on a project with version 2025.5.0, the upgrade notice incorrectly displays very old 2023 versions instead of the actual available future upgrades (2025.7.0). This occurs when the current version exists in npm but is missing from the `changelog.json` file. This bug does not affect `h2 upgrade` which runs through a shorter version of the same codepath.

### WHAT is this pull request doing?

Adds a fallback in `displayDevUpgradeNotice()` that uses semver comparison to find releases newer than the current version when the version is not found in the changelog.

Changes:

- When `currentReleaseIndex === -1`, find the first release `<=` current version using semver
- Take all releases before that index (these are the newer releases)
- Maintains existing behavior when version is found in changelog
- Added unit tests to validate fix and prevent regression

### HOW to test your changes?

#### Prerequisites

1. Build the CLI:

   ```bash
   cd packages/cli
   npm run build
   ```

2. Link the local CLI plugin:

   ```bash
   shopify plugins link ./
   ```

3. Verify plugin is linked:

   ```bash
   shopify plugins
   ```

   Should show `@shopify/cli-hydrogen` with link indicator.

#### Test 1: Verify Fix Works

1. Use a Hydrogen project on version 2025.5.0 (adjust path as needed):

   ```bash
   FORCE_CHANGELOG_SOURCE=local shopify hydrogen dev --path /Users/yourusername/path/to/2025.5.0/project
   ```

##### Example 2025.5.0 `package.json`

<details>

```json
{
  "name": "2025-5-0",
  "private": true,
  "sideEffects": false,
  "version": "2025.5.0",
  "type": "module",
  "scripts": {
    "build": "shopify hydrogen build --codegen",
    "dev": "shopify hydrogen dev --codegen",
    "preview": "shopify hydrogen preview --build",
    "lint": "eslint --no-error-on-unmatched-pattern .",
    "typecheck": "tsc --noEmit",
    "codegen": "shopify hydrogen codegen"
  },
  "prettier": "@shopify/prettier-config",
  "dependencies": {
    "@shopify/hydrogen": "2025.5.0",
    "@shopify/remix-oxygen": "^3.0.0",
    "graphql": "^16.10.0",
    "graphql-tag": "^2.12.6",
    "isbot": "^5.1.22",
    "react": "^18.2.0",
    "react-dom": "^18.2.0",
    "react-router": "7.6.0",
    "react-router-dom": "7.6.0"
  },
  "devDependencies": {
    "@eslint/compat": "^1.2.5",
    "@eslint/eslintrc": "^3.2.0",
    "@eslint/js": "^9.18.0",
    "@graphql-codegen/cli": "5.0.2",
    "@react-router/dev": "7.6.0",
    "@react-router/fs-routes": "7.6.0",
    "@shopify/cli": "~3.80.4",
    "@shopify/hydrogen-codegen": "^0.3.3",
    "@shopify/mini-oxygen": "^3.2.1",
    "@shopify/oxygen-workers-types": "^4.1.6",
    "@shopify/prettier-config": "^1.1.2",
    "@total-typescript/ts-reset": "^0.6.1",
    "@types/eslint": "^9.6.1",
    "@types/react": "^18.2.22",
    "@types/react-dom": "^18.2.7",
    "@typescript-eslint/eslint-plugin": "^8.21.0",
    "@typescript-eslint/parser": "^8.21.0",
    "eslint": "^9.18.0",
    "eslint-config-prettier": "^10.0.1",
    "eslint-import-resolver-typescript": "^3.7.0",
    "eslint-plugin-eslint-comments": "^3.2.0",
    "eslint-plugin-import": "^2.31.0",
    "eslint-plugin-jest": "^28.11.0",
    "eslint-plugin-jsx-a11y": "^6.10.2",
    "eslint-plugin-react": "^7.37.4",
    "eslint-plugin-react-hooks": "^5.1.0",
    "globals": "^15.14.0",
    "prettier": "^3.4.2",
    "typescript": "^5.2.2",
    "vite": "^6.2.4",
    "vite-tsconfig-paths": "^4.3.1"
  },
  "engines": {
    "node": ">=18.0.0"
  }
}
```

</details>

2. Expected output:

   ```
   Current: 2025.5.0 | Latest: 2025.7.0
   The next 1 version(s) include
     • 2025.7.0 - Migrate to React Router 7 and API version 2025-07
   ```

3. Should NOT show:

   ```
   The next 5 version(s) include
     • 2023.1.1 - Update dependencies
     • 2023.1.2 - ...
   ```

#### Test 2: Demonstrate Bug (Disable Fix)

1. Comment out the fix in `packages/cli/src/commands/hydrogen/upgrade.ts` (lines 1373-1383):

   ```typescript
   let relevantReleases: Release[];
   // if (currentReleaseIndex === -1) {
   //   // Current version not found in changelog. Use semver to find releases newer than current.
   //   const insertionIndex = changelog.releases.findIndex((release) =>
   //     semver.lte(getAbsoluteVersion(release.version), pinnedCurrentVersion),
   //   );
   //
   //   relevantReleases =
   //     insertionIndex === -1
   //       ? changelog.releases
   //       : changelog.releases.slice(0, insertionIndex);
   // } else {
   relevantReleases = changelog.releases.slice(0, currentReleaseIndex);
   // }
   ```

2. Rebuild:

   ```bash
   cd packages/cli && npm run build
   ```

3. Run dev:

   ```bash
   FORCE_CHANGELOG_SOURCE=local shopify hydrogen dev --path /path/to/2025.5.0/project
   ```

4. Shows incorrect output (bug):

   ```
   The next 5 version(s) include
     • 2023.1.1 - Update dependencies
     • 2023.1.2 - Add license files and readmes for all packages
     • 2023.1.3 - Improved Windows support, Send Hydrogen version in requests
     • 2023.1.4 - Fix imports and improve onboarding styling
     • 2023.1.5 - Fix the latest tag release
   ```

5. Re-enable fix by uncommenting the block and rebuilding:

   ```bash
   git checkout packages/cli/src/commands/hydrogen/upgrade.ts
   cd packages/cli && npm run build
   ```

#### Test 3: Run Tests

```bash
cd packages/cli
npm run test -- src/commands/hydrogen/upgrade.test.ts -t "when current version is not in changelog|shows versions in correct order"
```

All 3 tests should pass:

- `getAvailableUpgrades` correctly identifies upgrades
- `displayDevUpgradeNotice` shows correct versions
- Versions displayed in correct order (newest top, next version bottom)

#### Test 4: Regression Test

Test with a version that exists in changelog (2025.4.1):

```bash
FORCE_CHANGELOG_SOURCE=local shopify hydrogen dev --path /path/to/2025.4.1/project
```

Example 2025.4.1 `package.json` (demo store)

<details>

```json
{
  "name": "demo-store",
  "private": true,
  "sideEffects": false,
  "version": "2.1.6",
  "type": "module",
  "scripts": {
    "dev": "shopify hydrogen dev --codegen",
    "build": "shopify hydrogen build --codegen",
    "preview": "npm run build && shopify hydrogen preview",
    "e2e": "npx playwright test",
    "e2e:ui": "npx playwright test --ui",
    "lint": "eslint --no-error-on-unmatched-pattern --ext .js,.ts,.jsx,.tsx .",
    "format": "prettier --write --ignore-unknown .",
    "format:check": "prettier --check --ignore-unknown .",
    "typecheck": "tsc --noEmit"
  },
  "browserslist": [
    "defaults"
  ],
  "prettier": "@shopify/prettier-config",
  "dependencies": {
    "@headlessui/react": "^1.7.2",
    "@remix-run/node": "^2.16.1",
    "@remix-run/react": "^2.16.1",
    "@remix-run/server-runtime": "^2.16.1",
    "@shopify/cli": "^3.83.3",
    "@shopify/hydrogen": "^2025.4.1",
    "@shopify/remix-oxygen": "^2.0.12",
    "clsx": "^1.2.1",
    "cross-env": "^7.0.3",
    "graphql": "^16.6.0",
    "graphql-tag": "^2.12.6",
    "isbot": "^3.8.0",
    "react": "^18.2.0",
    "react-dom": "^18.2.0",
    "react-intersection-observer": "^9.4.1",
    "react-use": "^17.4.0",
    "schema-dts": "^1.1.0",
    "tiny-invariant": "^1.2.0",
    "typographic-base": "^1.0.4"
  },
  "devDependencies": {
    "@graphql-codegen/cli": "^5.0.2",
    "@playwright/test": "^1.48.2",
    "@remix-run/dev": "^2.16.1",
    "@remix-run/eslint-config": "^2.16.1",
    "@shopify/eslint-plugin": "^42.0.1",
    "@shopify/hydrogen-codegen": "^0.3.3",
    "@shopify/mini-oxygen": "^3.2.1",
    "@shopify/oxygen-workers-types": "^4.1.6",
    "@shopify/prettier-config": "^1.1.2",
    "@tailwindcss/forms": "^0.5.3",
    "@tailwindcss/typography": "^0.5.9",
    "@total-typescript/ts-reset": "^0.4.2",
    "@types/eslint": "^8.4.10",
    "@types/node": "^22.8.4",
    "@types/react": "^18.2.22",
    "@types/react-dom": "^18.2.7",
    "cross-env": "^7.0.3",
    "eslint": "^8.20.0",
    "eslint-plugin-hydrogen": "0.12.2",
    "postcss": "^8.4.21",
    "postcss-import": "^15.1.0",
    "postcss-preset-env": "^8.2.0",
    "prettier": "^2.8.4",
    "rimraf": "^3.0.2",
    "tailwindcss": "^3.3.0",
    "typescript": "^5.2.2",
    "vite": "^6.2.7",
    "vite-tsconfig-paths": "^4.3.1"
  },
  "overrides": {
    "@shopify/cli": {
      "@shopify/cli-hydrogen": "file:/Users/juanp.prieto/github.com/Shopify/hydrogen/packages/cli/dist/index.js"
    }
  },
  "engines": {
    "node": ">=20.0.0"
  }
}
```
</details>

Should still work correctly and show 2025.7.0 as available upgrade.

#### Cleanup

```bash
shopify plugins unlink @shopify/cli-hydrogen
```

#### Checklist

- [x] I've read the Contributing Guidelines
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a changeset if this PR contains user-facing or noteworthy changes
- [x] I've added tests to cover my changes
- [ ] I've added or updated the documentation
