### PR TITLE
docs: Add note about uiLocales limitation with third-party identity p…

### DIFF
--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -53,7 +53,8 @@ export interface CustomerAccountMutations {
 export type LoginOptions = {
   /**
    * The displayed language of the login page.
-   * Note: When using third-party identity providers, this parameter is not passed to the provider.
+   * Note: When using third-party identity providers, the login interface might not reflect
+   * this language setting because the parameter isn't passed to the provider.
    */
   uiLocales?: LanguageCode;
   /** The country code for contextualizing the login experience. */
@@ -80,9 +81,9 @@ export type CustomerAccount = {
    * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:
    * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,
    * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.
-   * Note: When using third-party identity providers with headless storefronts, the `uiLocales` parameter
-   * is not passed to the identity provider during authentication callbacks. This means the third-party
-   * login interface may not automatically reflect the customer's preferred language setting.
+   * Note: When using third-party identity providers with headless storefronts, the third-party login
+   * interface might not automatically reflect the customer's preferred language setting. That's because
+   * the `uiLocales` parameter isn't passed to the identity provider during authentication callbacks.
    * */
   login: (options?: LoginOptions) => Promise<Response>;
   /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -51,7 +51,12 @@ export interface CustomerAccountMutations {
 }
 
 export type LoginOptions = {
+  /**
+   * The displayed language of the login page.
+   * Note: When using third-party identity providers, this parameter is not passed to the provider.
+   */
   uiLocales?: LanguageCode;
+  /** The country code for contextualizing the login experience. */
   countryCode?: CountryCode;
 };
 
@@ -75,6 +80,9 @@ export type CustomerAccount = {
    * @param options.uiLocales - The displayed language of the login page. Only support for the following languages:
    * `en`, `fr`, `cs`, `da`, `de`, `es`, `fi`, `it`, `ja`, `ko`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`,
    * `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`. If supplied any other language code, it will default to `en`.
+   * Note: When using third-party identity providers with headless storefronts, the `uiLocales` parameter
+   * is not passed to the identity provider during authentication callbacks. This means the third-party
+   * login interface may not automatically reflect the customer's preferred language setting.
    * */
   login: (options?: LoginOptions) => Promise<Response>;
   /** On successful login, the customer redirects back to your app. This function validates the OAuth response and exchanges the authorization code for an access token and refresh token. It also persists the tokens on your session. This function should be called and returned from the Remix loader configured as the redirect URI within the Customer Account API settings in admin. */


### PR DESCRIPTION
Add documentation about uiLocales parameter limitation with third-party identity providers.

When using third-party identity providers with headless storefronts, the `uiLocales` parameter is not passed to the identity provider during authentication callbacks. This means the third-party login interface may not automatically reflect the customer's preferred language setting.

This change addresses a documentation gap identified by the Developer Support team.

## Context

<!--
DO NOT DESCRIBE THE CHANGE HERE. The code diff is the canonical source of truth.

- Why are you making this change? What problem does it solve?
- Include links to any relevant issues or other PRs.
- Highlight what could go wrong, and what steps you have taken to mitigate that risk.
- Describe the impact of this change on Shopify, Merchants or 3rd Party Apps.
- Link to experiments (feature flags), if applicable.
-->

- **Why**: Developers were not aware that the `uiLocales` parameter doesn't get passed to third-party identity providers, leading to confusion when the third-party login UI doesn't reflect the expected language
- **Problem it solves**: Clarifies expected behavior and helps developers understand why language settings may not propagate to third-party auth providers
- **Related to**: Developer Support feedback regarding missing documentation about this limitation
- **Impact**: This is a documentation-only change that helps developers better understand the authentication flow behavior
- **Risk**: No functional changes, only documentation updates to existing JSDoc comments

## Testing

This is a documentation-only change. The changes can be verified by:
1. Running the docs generation process
2. Checking that the JSDoc comments appear correctly in the generated documentation
3. Verifying TypeScript types still compile correctly
this page should have the listed change
https://shopify-dev.shop.dev/docs/api/hydrogen/latest/utilities/createcustomeraccountclient (check for uiLocales note)