### PR TITLE
fix: ensure hydrogen seo recommendations match shopify admin

### DIFF
--- a/.changeset/spotty-peaches-know.md
+++ b/.changeset/spotty-peaches-know.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Ensure Hydrogen SEO recommendations match Shopify Admin

--- a/packages/hydrogen/src/seo/generate-seo-tags.test.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.test.ts
@@ -116,7 +116,7 @@ describe('generateSeoTags', () => {
     it('should warn if the title is too long', () => {
       // Given
       const input = {
-        title: 'Snowdevil'.padEnd(121, '.'), // 121 characters
+        title: 'Snowdevil'.padEnd(71, '.'), // 71 characters
       };
 
       // When
@@ -124,7 +124,7 @@ describe('generateSeoTags', () => {
 
       // Then
       expect(console.warn).toHaveBeenCalledWith(
-        'Error in SEO input: `title` should not be longer than 120 characters',
+        'Error in SEO input: `title` should not be longer than 70 characters',
       );
     });
   });
@@ -173,7 +173,7 @@ describe('generateSeoTags', () => {
     it('should warn if the description is too long', () => {
       // Given
       const input = {
-        description: ''.padEnd(156, '.'), // 156 characters
+        description: ''.padEnd(161, '.'), // 161 characters
       };
 
       // When
@@ -182,7 +182,7 @@ describe('generateSeoTags', () => {
       // Then
 
       expect(console.warn).toHaveBeenCalledWith(
-        'Error in SEO input: `description` should not be longer than 155 characters',
+        'Error in SEO input: `description` should not be longer than 160 characters',
       );
     });
   });

--- a/packages/hydrogen/src/seo/generate-seo-tags.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.ts
@@ -14,10 +14,10 @@ export const schema = {
         throw new Error(ERROR_PREFIX.concat('`title` should be a string'));
       }
 
-      if (typeof value === 'string' && value.length > 120) {
+      if (typeof value === 'string' && value.length > 70) {
         throw new Error(
           ERROR_PREFIX.concat(
-            '`title` should not be longer than 120 characters',
+            '`title` should not be longer than 70 characters',
           ),
         );
       }
@@ -36,7 +36,7 @@ export const schema = {
       if (typeof value === 'string' && value.length > 155) {
         throw new Error(
           ERROR_PREFIX.concat(
-            '`description` should not be longer than 155 characters',
+            '`description` should not be longer than 160 characters',
           ),
         );
       }

--- a/packages/hydrogen/src/seo/getSeoMeta.test.ts
+++ b/packages/hydrogen/src/seo/getSeoMeta.test.ts
@@ -91,7 +91,7 @@ describe('getSeoMeta', () => {
     it('should warn if the title is too long', () => {
       // Given
       const input = {
-        title: 'Snowdevil'.padEnd(121, '.'), // 121 characters
+        title: 'Snowdevil'.padEnd(71, '.'), // 71 characters
       };
 
       // When
@@ -99,7 +99,7 @@ describe('getSeoMeta', () => {
 
       // Then
       expect(console.warn).toHaveBeenCalledWith(
-        'Error in SEO input: `title` should not be longer than 120 characters',
+        'Error in SEO input: `title` should not be longer than 70 characters',
       );
     });
   });
@@ -134,7 +134,7 @@ describe('getSeoMeta', () => {
     it('should warn if the description is too long', () => {
       // Given
       const input = {
-        description: ''.padEnd(156, '.'), // 156 characters
+        description: ''.padEnd(161, '.'), // 161 characters
       };
 
       // When
@@ -143,7 +143,7 @@ describe('getSeoMeta', () => {
       // Then
 
       expect(console.warn).toHaveBeenCalledWith(
-        'Error in SEO input: `description` should not be longer than 155 characters',
+        'Error in SEO input: `description` should not be longer than 160 characters',
       );
     });
   });


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fixes #3291 <!-- link to issue if one exists -->

To align Hydrogen’s SEO description length recommendation with Shopify Admin’s guideline, which allows up to 160 characters instead of 155.
<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
Updates the SEO validation logic to raise a warning only when the description exceeds 160 characters, ensuring consistency between Hydrogen and Shopify Admin recommendations. 


#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
