### PR TITLE
Make reading accept header flexible for older Safari browsers

### DIFF
--- a/packages/hydrogen/src/createRequestHandler.ts
+++ b/packages/hydrogen/src/createRequestHandler.ts
@@ -114,7 +114,7 @@ export function createRequestHandler<Context = unknown>({
       const fetchDest = request.headers.get('sec-fetch-dest');
       if (
         (fetchDest && fetchDest === 'document') ||
-        request.headers.get('accept') === 'text/html'
+        request.headers.get('accept')?.includes('text/html')
       ) {
         appendServerTimingHeader(response, {[HYDROGEN_SFAPI_PROXY_KEY]: '1'});
       }


### PR DESCRIPTION
Safari <= 16.3 doesn't send `sec-fetch-dest` header, and its `accept` header might not be exactly `text/html`. Make it flexible.