### PR TITLE
[2024-10 back-fix] 🍪 Hydrogen Cookie Migration for New Shopify Cookie Architecture

### DIFF
--- a/.github/workflows/changesets-back-fix.yml
+++ b/.github/workflows/changesets-back-fix.yml
@@ -5,7 +5,7 @@ on:
     # Add calver branches - Do not add current calver branch
     # Example: If we are currently on 2023-07, do not add 2023-07
     branches:
-      - 2023-10
+      - 2024-10
 
 concurrency:
   group: changeset-${{ github.head_ref }}


### PR DESCRIPTION
### WHY are these changes introduced? + WHAT is this pull request doing?

Applies the same changes as https://github.com/Shopify/hydrogen/pull/3332, but onto 2024-10 branch.

We are doing this because the old cookies will stop working on May 1, 2026. This will break Shopify analytics for any merchants who haven't yet upgraded to a new Hydrogen version that works with the new cookies (while also being backwards compatible with the old cookies). Because May 1st is <365 days away, we are back-fixing past versions of Hydrogen so that all merchants using a Hydrogen version released in the last year will only have to do a minor version bump!

### HOW to test your changes?

Run the e2e tests locally!

#### Post-merge steps

1. Once this has merged into `2024-10`, we should get a PR automatically opened up on this branch by the back-fix workflow 
2. Before merging that PR, [we need to fix the issue with our npm release tokens](https://chat.shopify.io/share/ZZhvDdnD912FLa8QgYiQG)
3. Once that's fixed, we can merge that PR into this branch and it should do the npm release!
4. Update `docs/changelog.json` with upgrade instructions!

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
