### PR TITLE
fix: tsx files not busting turborepo cache for build commands

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.ts"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx"],
       "outputs": ["dist/**", "build/**"]
     },
     "dev": {


### PR DESCRIPTION
ps.: we might want to add more than tsx, i see lots of js files in the source

pps.: why do we have js files in the source, could we not compile the ts(x) → js(x) for the js version?

### WHY are these changes introduced?

To ensure that TSX files are properly included as inputs for the build task in the Turbo configuration.

### WHAT is this pull request doing?

Adds `src/**/*.tsx` to the `inputs` array for the `build` task in `turbo.json`, allowing Turbo to properly track changes in TSX files when determining whether to rebuild.

### HOW to test your changes?

1. Make changes to a TSX file in the src directory
2. Run a build using Turbo
3. Verify that changes to TSX files trigger rebuilds appropriately

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation