### PR TITLE
fix: add graphql-config package to skeleton

### DIFF
--- a/cookbook/recipes/express/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/express/patches/package.json.f30b0a.patch
@@ -2,7 +2,7 @@ index e9ebd1d3..00a7b42d 100644
 --- a/templates/skeleton/package.json
 +++ b/templates/skeleton/package.json
 @@ -5,59 +5,52 @@
-   "version": "2025.7.0",
+   "version": "2025.7.1",
    "type": "module",
    "scripts": {
 -    "build": "shopify hydrogen build --codegen",

--- a/cookbook/recipes/express/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/express/patches/package.json.f30b0a.patch
@@ -1,8 +1,8 @@
 index e9ebd1d3..00a7b42d 100644
 --- a/templates/skeleton/package.json
 +++ b/templates/skeleton/package.json
-@@ -5,58 +5,51 @@
-   "version": "2025.7.1",
+@@ -5,59 +5,52 @@
+   "version": "2025.7.0",
    "type": "module",
    "scripts": {
 -    "build": "shopify hydrogen build --codegen",
@@ -65,6 +65,7 @@ index e9ebd1d3..00a7b42d 100644
 -    "eslint-plugin-react": "^7.37.4",
 -    "eslint-plugin-react-hooks": "^5.1.0",
 -    "globals": "^15.14.0",
+     "graphql-config": "^5.0.3",
 -    "prettier": "^3.4.2",
 +    "dotenv": "^16.0.3",
 +    "nodemon": "^2.0.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35515,6 +35515,7 @@
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^5.1.0",
         "globals": "^15.14.0",
+        "graphql-config": "^5.0.3",
         "prettier": "^3.4.2",
         "typescript": "^5.9.2",
         "vite": "^6.2.4",

--- a/templates/skeleton/.graphqlrc.ts
+++ b/templates/skeleton/.graphqlrc.ts
@@ -4,9 +4,8 @@ import {getSchema} from '@shopify/hydrogen-codegen';
 /**
  * GraphQL Config
  * @see https://the-guild.dev/graphql/config/docs/user/usage
- * @type {IGraphQLConfig}
  */
-export default {
+const graphqlConfig: IGraphQLConfig = {
   projects: {
     default: {
       schema: getSchema('storefront'),
@@ -24,4 +23,6 @@ export default {
 
     // Add your own GraphQL projects here for CMS, Shopify Admin API, etc.
   },
-} as IGraphQLConfig;
+};
+
+export default graphqlConfig;

--- a/templates/skeleton/.graphqlrc.ts
+++ b/templates/skeleton/.graphqlrc.ts
@@ -4,6 +4,7 @@ import {getSchema} from '@shopify/hydrogen-codegen';
 /**
  * GraphQL Config
  * @see https://the-guild.dev/graphql/config/docs/user/usage
+ * @type {IGraphQLConfig}
  */
 const graphqlConfig: IGraphQLConfig = {
   projects: {

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -54,7 +54,8 @@
     "prettier": "^3.4.2",
     "typescript": "^5.9.2",
     "vite": "^6.2.4",
-    "vite-tsconfig-paths": "^4.3.1"
+    "vite-tsconfig-paths": "^4.3.1",
+    "graphql-config": "^5.0.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -51,11 +51,11 @@
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.1.0",
     "globals": "^15.14.0",
+    "graphql-config": "^5.0.3",
     "prettier": "^3.4.2",
     "typescript": "^5.9.2",
     "vite": "^6.2.4",
-    "vite-tsconfig-paths": "^4.3.1",
-    "graphql-config": "^5.0.3"
+    "vite-tsconfig-paths": "^4.3.1"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
type error 1 out of 2 we have in base hydrogen scaffolds

### WHY are these changes introduced?

Improve TypeScript type safety and add missing GraphQL dependency in the skeleton template.

### WHAT is this pull request doing?

- Refactors `.graphqlrc.ts` to properly define the GraphQL configuration object with explicit typing **because type-casting with `as` will hide type issues such as missing required properties**
- Adds `graphql-config` as a dev dependency in `package.json` to ensure all required dependencies are properly installed

### HOW to test your changes?

1. at the root of the repo run `npm run build --no-cache`
2. run `node packages/cli/dist/create-app.js --path ./typecheck-test --mock-shop --routes --markets none --language ts --styling none`
3. run `cd typecheck-test`
4. run `npm run typecheck`
5. the error should not come from missing `graphql-config`

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation