### PR TITLE
chore(deps): bump RR7 to v7.12.0

### DIFF
--- a/.changeset/floppy-years-live.md
+++ b/.changeset/floppy-years-live.md
@@ -1,0 +1,10 @@
+---
+'@shopify/remix-oxygen': patch
+'skeleton': patch
+'@shopify/hydrogen': patch
+'@shopify/cli-hydrogen': patch
+---
+
+Update React Router to 7.12.0 with stabilized future flags
+
+This release uses React Router's newly stabilized future flags (`v8_splitRouteModules`, `v8_middleware`) instead of their unstable counterparts

--- a/cookbook/recipes/express/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/express/patches/package.json.f30b0a.patch
@@ -18,8 +18,8 @@ index e9ebd1d3..00a7b42d 100644
    },
    "prettier": "@shopify/prettier-config",
    "dependencies": {
-+    "@react-router/express": "7.9.2",
-+    "@react-router/node": "7.9.2",
++    "@react-router/express": "7.12.0",
++    "@react-router/node": "7.12.0",
 +    "@remix-run/eslint-config": "^2.16.1",
      "@shopify/hydrogen": "2025.7.0",
 +    "compression": "^1.7.4",
@@ -31,16 +31,16 @@ index e9ebd1d3..00a7b42d 100644
 +    "morgan": "^1.10.0",
      "react": "18.3.1",
      "react-dom": "18.3.1",
-     "react-router": "7.9.2",
-     "react-router-dom": "7.9.2"
+     "react-router": "7.12.0",
+     "react-router-dom": "7.12.0"
    },
    "devDependencies": {
 -    "@eslint/compat": "^1.2.5",
 -    "@eslint/eslintrc": "^3.2.0",
      "@eslint/js": "^9.18.0",
      "@graphql-codegen/cli": "5.0.2",
-     "@react-router/dev": "7.9.2",
-     "@react-router/fs-routes": "7.9.2",
+     "@react-router/dev": "7.12.0",
+     "@react-router/fs-routes": "7.12.0",
      "@shopify/cli": "3.85.4",
      "@shopify/hydrogen-codegen": "^0.3.3",
 -    "@shopify/mini-oxygen": "^4.0.0",

--- a/cookbook/recipes/infinite-scroll/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/infinite-scroll/patches/package.json.f30b0a.patch
@@ -6,6 +6,6 @@ index e9ebd1d3..e51634ee 100644
      "react": "18.3.1",
      "react-dom": "18.3.1",
 +    "react-intersection-observer": "^8.34.0",
-     "react-router": "7.9.2",
-     "react-router-dom": "7.9.2"
+     "react-router": "7.12.0",
+     "react-router-dom": "7.12.0"
    },

--- a/cookbook/recipes/metaobjects/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/metaobjects/patches/package.json.f30b0a.patch
@@ -4,9 +4,9 @@ index e9ebd1d3..1731cce2 100644
 @@ -21,7 +21,9 @@
      "react": "18.3.1",
      "react-dom": "18.3.1",
-     "react-router": "7.9.2",
--    "react-router-dom": "7.9.2"
-+    "react-router-dom": "7.9.2",
+     "react-router": "7.12.0",
+-    "react-router-dom": "7.12.0"
++    "react-router-dom": "7.12.0",
 +    "slate": "^0.101.4",
 +    "slate-react": "^0.101.3"
    },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-intersection-observer": "^8.32.0",
-        "react-router": "7.9.2",
-        "react-router-dom": "7.9.2",
+        "react-router": "7.12.0",
+        "react-router-dom": "7.12.0",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -35,8 +35,8 @@
         "@eslint/js": "9.19.0",
         "@playwright/test": "^1.57.0",
         "@qwik.dev/partytown": "^0.11.2",
-        "@react-router/dev": "7.9.2",
-        "@react-router/fs-routes": "7.9.2",
+        "@react-router/dev": "7.12.0",
+        "@react-router/fs-routes": "7.12.0",
         "@shopify/cli": "3.85.4",
         "@total-typescript/ts-reset": "^0.6.1",
         "@types/eslint": "9.6.1",
@@ -5226,9 +5226,9 @@
       }
     },
     "node_modules/@react-router/dev": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.9.2.tgz",
-      "integrity": "sha512-uGDupa6S64Yv9pAtEWchPKQTyl9Ab59ztqyPilNAFYnktMEweOHTBfN4tMUinnxAJQByB6hAoLQmHcy0u6RdTA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.12.0.tgz",
+      "integrity": "sha512-5GpwXgq4pnOVeG7l6ADkCHA1rthJus1q/A3NRYJAIypclUQDYAzg1/fDNjvaKuTSrq+Nr3u6aj2v+oC+47MX6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5239,8 +5239,7 @@
         "@babel/preset-typescript": "^7.27.1",
         "@babel/traverse": "^7.27.7",
         "@babel/types": "^7.27.7",
-        "@npmcli/package-json": "^4.0.1",
-        "@react-router/node": "7.9.2",
+        "@react-router/node": "7.12.0",
         "@remix-run/node-fetch-server": "^0.9.0",
         "arg": "^5.0.1",
         "babel-dead-code-elimination": "^1.0.6",
@@ -5251,13 +5250,15 @@
         "isbot": "^5.1.11",
         "jsesc": "3.0.2",
         "lodash": "^4.17.21",
+        "p-map": "^7.0.3",
         "pathe": "^1.1.2",
         "picocolors": "^1.1.1",
+        "pkg-types": "^2.3.0",
         "prettier": "^3.6.2",
         "react-refresh": "^0.14.0",
         "semver": "^7.3.7",
         "tinyglobby": "^0.2.14",
-        "valibot": "^0.41.0",
+        "valibot": "^1.2.0",
         "vite-node": "^3.2.2"
       },
       "bin": {
@@ -5267,9 +5268,10 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@react-router/serve": "^7.9.2",
-        "@vitejs/plugin-rsc": "*",
-        "react-router": "^7.9.2",
+        "@react-router/serve": "7.12.0",
+        "@vitejs/plugin-rsc": "~0.5.7",
+        "react-router": "7.12.0",
+        "react-server-dom-webpack": "^19.2.3",
         "typescript": "^5.1.0",
         "vite": "^5.1.0 || ^6.0.0 || ^7.0.0",
         "wrangler": "^3.28.2 || ^4.0.0"
@@ -5279,6 +5281,9 @@
           "optional": true
         },
         "@vitejs/plugin-rsc": {
+          "optional": true
+        },
+        "react-server-dom-webpack": {
           "optional": true
         },
         "typescript": {
@@ -5302,10 +5307,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/@react-router/dev/node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-router/dev/node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@react-router/fs-routes": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@react-router/fs-routes/-/fs-routes-7.9.2.tgz",
-      "integrity": "sha512-HgweLCJRkNtyKEAz18vxGCF4n+46pmxbY/WjvnWmtm4Q9WwvbxZ5MBIQevjwoTWzjXfuTVNwT+t/o8nmCmTUSA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@react-router/fs-routes/-/fs-routes-7.12.0.tgz",
+      "integrity": "sha512-otlOIrIsJsqY5ACfgMsIkHPq1rfuvdwxBGWZRSscU+HK+BcHAz8ZDq+wYDGonOLcU6wUn33+G+/1skznIV1L8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5315,7 +5348,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@react-router/dev": "^7.9.2",
+        "@react-router/dev": "7.12.0",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -5351,9 +5384,9 @@
       }
     },
     "node_modules/@react-router/node": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.9.2.tgz",
-      "integrity": "sha512-mGqpEXVWs1XmwpJdbESE2fzvS3a43EdMCuiL2U3Nmm1IuGdSjc60gQK/IeKWjNGdgj1pZEyyQK17fYXPqjp5Uw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.12.0.tgz",
+      "integrity": "sha512-o/t10Cse4LK8kFefqJ8JjC6Ng6YuKD2I87S2AiJs17YAYtXU5W731ZqB73AWyCDd2G14R0dSuqXiASRNK/xLjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5363,7 +5396,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react-router": "7.9.2",
+        "react-router": "7.12.0",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -25148,9 +25181,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.2.tgz",
-      "integrity": "sha512-i2TPp4dgaqrOqiRGLZmqh2WXmbdFknUyiCRmSKs0hf6fWXkTKg5h56b+9F22NbGRAMxjYfqQnpi63egzD2SuZA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -25170,12 +25203,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.2.tgz",
-      "integrity": "sha512-pagqpVJnjZOfb+vIM23eTp7Sp/AAJjOgaowhP1f1TWOdk5/W8Uk8d/M/0wfleqx7SgjitjNPPsKeCZE1hTSp3w==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
+      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.9.2"
+        "react-router": "7.12.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -32106,7 +32139,7 @@
         "cli-hydrogen": "dist/create-app.js"
       },
       "devDependencies": {
-        "@react-router/dev": "7.9.2",
+        "@react-router/dev": "7.12.0",
         "@types/diff": "^5.0.2",
         "@types/gunzip-maybe": "^1.4.0",
         "@types/prettier": "^2.7.2",
@@ -32126,7 +32159,7 @@
       },
       "peerDependencies": {
         "@graphql-codegen/cli": "^5.0.2",
-        "@react-router/dev": "7.9.2",
+        "@react-router/dev": "7.12.0",
         "@shopify/hydrogen-codegen": "^0.3.3",
         "@shopify/mini-oxygen": "^4.0.0",
         "graphql-config": "^5.0.3",
@@ -33051,7 +33084,7 @@
         "worktop": "^0.7.3"
       },
       "devDependencies": {
-        "@react-router/dev": "7.9.2",
+        "@react-router/dev": "7.12.0",
         "@shopify/generate-docs": "0.16.4",
         "@shopify/hydrogen-codegen": "*",
         "@testing-library/jest-dom": "^5.17.0",
@@ -33060,14 +33093,14 @@
         "formdata-polyfill": "^4.0.10",
         "happy-dom": "^17.0.0",
         "react": "18.3.1",
-        "react-router": "7.9.2",
+        "react-router": "7.12.0",
         "schema-dts": "^1.1.2",
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@react-router/dev": "7.9.2",
+        "@react-router/dev": "7.12.0",
         "react": "18.3.1",
-        "react-router": "7.9.2",
+        "react-router": "7.12.0",
         "vite": "^5.1.0 || ^6.2.1"
       },
       "peerDependenciesMeta": {
@@ -34487,11 +34520,6 @@
         "node": ">=18"
       }
     },
-    "packages/hydrogen-react/node_modules/three": {
-      "version": "0.169.0",
-      "license": "MIT",
-      "peer": true
-    },
     "packages/hydrogen-react/node_modules/tinypool": {
       "version": "1.1.1",
       "dev": true,
@@ -35440,11 +35468,11 @@
       "license": "MIT",
       "devDependencies": {
         "@shopify/oxygen-workers-types": "^4.1.6",
-        "react-router": "7.9.2"
+        "react-router": "7.12.0"
       },
       "peerDependencies": {
         "@shopify/oxygen-workers-types": "^3.17.3 || ^4.1.2",
-        "react-router": "7.9.2"
+        "react-router": "7.12.0"
       }
     },
     "templates/skeleton": {
@@ -35456,16 +35484,16 @@
         "isbot": "^5.1.22",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "react-router": "7.9.2",
-        "react-router-dom": "7.9.2"
+        "react-router": "7.12.0",
+        "react-router-dom": "7.12.0"
       },
       "devDependencies": {
         "@eslint/compat": "^1.2.5",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
         "@graphql-codegen/cli": "5.0.2",
-        "@react-router/dev": "7.9.2",
-        "@react-router/fs-routes": "7.9.2",
+        "@react-router/dev": "7.12.0",
+        "@react-router/fs-routes": "7.12.0",
         "@shopify/cli": "3.85.4",
         "@shopify/hydrogen-codegen": "^0.3.3",
         "@shopify/mini-oxygen": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-intersection-observer": "^8.32.0",
-    "react-router": "7.9.2",
-    "react-router-dom": "7.9.2",
+    "react-router": "7.12.0",
+    "react-router-dom": "7.12.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
@@ -72,8 +72,8 @@
     "@eslint/js": "9.19.0",
     "@playwright/test": "^1.57.0",
     "@qwik.dev/partytown": "^0.11.2",
-    "@react-router/dev": "7.9.2",
-    "@react-router/fs-routes": "7.9.2",
+    "@react-router/dev": "7.12.0",
+    "@react-router/fs-routes": "7.12.0",
     "@shopify/cli": "3.85.4",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/eslint": "9.6.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "test:watch": "cross-env SHOPIFY_UNIT_TEST=1 LANG=en-US.UTF-8 vitest --test-timeout=60000"
   },
   "devDependencies": {
-    "@react-router/dev": "7.9.2",
+    "@react-router/dev": "7.12.0",
     "@types/diff": "^5.0.2",
     "@types/gunzip-maybe": "^1.4.0",
     "@types/prettier": "^2.7.2",
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "@graphql-codegen/cli": "^5.0.2",
-    "@react-router/dev": "7.9.2",
+    "@react-router/dev": "7.12.0",
     "@shopify/hydrogen-codegen": "^0.3.3",
     "@shopify/mini-oxygen": "^4.0.0",
     "graphql-config": "^5.0.3",

--- a/packages/cli/src/lib/react-router-version-check.ts
+++ b/packages/cli/src/lib/react-router-version-check.ts
@@ -23,7 +23,7 @@ const REACT_ROUTER_PACKAGES: ReactRouterPackage[] = [
   '@react-router/fs-routes',
 ];
 
-const EXPECTED_VERSION = '7.9.2';
+const EXPECTED_VERSION = '7.12.0';
 
 /**
  * Checks if the installed React Router packages are compatible with Hydrogen's requirements
@@ -113,7 +113,7 @@ export async function checkReactRouterVersions(appPath: string): Promise<void> {
     renderWarning({
       headline: 'React Router version mismatch detected',
       body: [
-        'Hydrogen requires React Router 7.9.x for proper functionality.',
+        'Hydrogen requires React Router 7.12.0 for proper functionality.',
         '',
         'Version mismatches found:',
         mismatchList,

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -94,8 +94,8 @@
     "@shopify/graphql-client": "1.4.1"
   },
   "devDependencies": {
-    "react-router": "7.9.2",
-    "@react-router/dev": "7.9.2",
+    "react-router": "7.12.0",
+    "@react-router/dev": "7.12.0",
     "@shopify/generate-docs": "0.16.4",
     "@shopify/hydrogen-codegen": "*",
     "@testing-library/jest-dom": "^5.17.0",
@@ -108,8 +108,8 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "react-router": "7.9.2",
-    "@react-router/dev": "7.9.2",
+    "react-router": "7.12.0",
+    "@react-router/dev": "7.12.0",
     "react": "18.3.1",
     "vite": "^5.1.0 || ^6.2.1"
   },

--- a/packages/hydrogen/src/react-router-preset.test.ts
+++ b/packages/hydrogen/src/react-router-preset.test.ts
@@ -20,10 +20,10 @@ describe('hydrogenPreset', () => {
       ssr: true,
       future: {
         v8_middleware: true,
+        v8_splitRouteModules: true,
+        v8_viteEnvironmentApi: false,
         unstable_optimizeDeps: true,
-        unstable_splitRouteModules: true,
         unstable_subResourceIntegrity: false,
-        unstable_viteEnvironmentApi: false,
       },
     });
   });
@@ -42,11 +42,11 @@ describe('hydrogenPreset', () => {
           serverBundles: undefined,
           buildEnd: undefined,
           future: {
-            unstable_subResourceIntegrity: false,
-            unstable_middleware: true,
+            v8_middleware: true,
+            v8_splitRouteModules: true,
+            v8_viteEnvironmentApi: false,
             unstable_optimizeDeps: true,
-            unstable_splitRouteModules: true,
-            unstable_viteEnvironmentApi: false,
+            unstable_subResourceIntegrity: false,
           },
           ...overrides,
         } as unknown as Parameters<
@@ -103,11 +103,11 @@ describe('hydrogenPreset', () => {
       expect(() => {
         testResolvedConfig({
           future: {
-            unstable_subResourceIntegrity: true,
-            unstable_middleware: true,
+            v8_middleware: true,
+            v8_splitRouteModules: true,
+            v8_viteEnvironmentApi: false,
             unstable_optimizeDeps: true,
-            unstable_splitRouteModules: true,
-            unstable_viteEnvironmentApi: false,
+            unstable_subResourceIntegrity: true,
           },
         });
       }).toThrow(
@@ -119,11 +119,11 @@ describe('hydrogenPreset', () => {
       expect(() => {
         testResolvedConfig({
           future: {
-            unstable_subResourceIntegrity: false,
-            unstable_middleware: true,
+            v8_middleware: true,
+            v8_splitRouteModules: true,
+            v8_viteEnvironmentApi: false,
             unstable_optimizeDeps: true,
-            unstable_splitRouteModules: true,
-            unstable_viteEnvironmentApi: false,
+            unstable_subResourceIntegrity: false,
           },
         });
       }).not.toThrow();
@@ -145,8 +145,8 @@ describe('hydrogenPreset', () => {
 
       // Verify all performance flags are enabled
       expect(config?.future?.v8_middleware).toBe(true);
+      expect(config?.future?.v8_splitRouteModules).toBe(true);
       expect(config?.future?.unstable_optimizeDeps).toBe(true);
-      expect(config?.future?.unstable_splitRouteModules).toBe(true);
     });
 
     it('should disable incompatible features', () => {
@@ -157,7 +157,7 @@ describe('hydrogenPreset', () => {
 
       // Verify incompatible features are disabled
       expect(config?.future?.unstable_subResourceIntegrity).toBe(false);
-      expect(config?.future?.unstable_viteEnvironmentApi).toBe(false);
+      expect(config?.future?.v8_viteEnvironmentApi).toBe(false);
     });
 
     it('should configure SSR correctly', () => {

--- a/packages/hydrogen/src/react-router-preset.ts
+++ b/packages/hydrogen/src/react-router-preset.ts
@@ -1,12 +1,12 @@
 import type {Preset} from '@react-router/dev/config';
 
 /**
- * Official Hydrogen Preset for React Router 7.9.x
+ * Official Hydrogen Preset for React Router 7.12.x
  *
  * Provides optimal React Router configuration for Hydrogen applications on Oxygen.
  * Enables validated performance optimizations while ensuring CLI compatibility.
  *
- * React Router 7.9.x Feature Support Matrix for Hydrogen 2025.7.0
+ * React Router 7.12.x Feature Support Matrix for Hydrogen 2025.7.0
  *
  * +----------------------------------+----------+----------------------------------+
  * | Feature                          | Status   | Notes                            |
@@ -19,9 +19,9 @@ import type {Preset} from '@react-router/dev/config';
  * +----------------------------------+----------+----------------------------------+
  * | PERFORMANCE FLAGS                                                               |
  * +----------------------------------+----------+----------------------------------+
- * | unstable_optimizeDeps            | Enabled  | Build performance optimization   |
  * | v8_middleware                    | Enabled  | Required for Hydrogen context    |
- * | unstable_splitRouteModules       | Enabled  | Route code splitting             |
+ * | v8_splitRouteModules             | Enabled  | Route code splitting             |
+ * | unstable_optimizeDeps            | Enabled  | Build performance optimization   |
  * +----------------------------------+----------+----------------------------------+
  * | ROUTE DISCOVERY                                                                 |
  * +----------------------------------+----------+----------------------------------+
@@ -35,7 +35,7 @@ import type {Preset} from '@react-router/dev/config';
  * | serverBundles: () => {}          | Blocked  | Manifest incompatibility         |
  * | buildEnd: () => {}               | Blocked  | CLI bypasses hook execution      |
  * | unstable_subResourceIntegrity    | Blocked  | CSP nonce/hash conflict          |
- * | unstable_viteEnvironmentApi      | Blocked  | CLI fallback detection used      |
+ * | v8_viteEnvironmentApi            | Blocked  | CLI fallback detection used      |
  * +----------------------------------+----------+----------------------------------+
  *
  * @version 2025.7.0
@@ -51,10 +51,10 @@ export function hydrogenPreset(): Preset {
 
       future: {
         v8_middleware: true,
+        v8_splitRouteModules: true,
+        v8_viteEnvironmentApi: false,
         unstable_optimizeDeps: true,
-        unstable_splitRouteModules: true,
         unstable_subResourceIntegrity: false,
-        unstable_viteEnvironmentApi: false,
       },
     }),
 
@@ -79,7 +79,7 @@ export function hydrogenPreset(): Preset {
         throw new Error(
           '[Hydrogen Preset] serverBundles is not supported in Hydrogen 2025.7.0.\n' +
             'Reason: React Router plugin manifest incompatibility with Hydrogen CLI.\n' +
-            'Alternative: Route-level code splitting via unstable_splitRouteModules is enabled.',
+            'Alternative: Route-level code splitting via v8_splitRouteModules is enabled.',
         );
       }
 

--- a/packages/remix-oxygen/package.json
+++ b/packages/remix-oxygen/package.json
@@ -46,10 +46,10 @@
   ],
   "devDependencies": {
     "@shopify/oxygen-workers-types": "^4.1.6",
-    "react-router": "7.9.2"
+    "react-router": "7.12.0"
   },
   "peerDependencies": {
     "@shopify/oxygen-workers-types": "^3.17.3 || ^4.1.2",
-    "react-router": "7.9.2"
+    "react-router": "7.12.0"
   }
 }

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -20,16 +20,16 @@
     "isbot": "^5.1.22",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router": "7.9.2",
-    "react-router-dom": "7.9.2"
+    "react-router": "7.12.0",
+    "react-router-dom": "7.12.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.5",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
     "@graphql-codegen/cli": "5.0.2",
-    "@react-router/dev": "7.9.2",
-    "@react-router/fs-routes": "7.9.2",
+    "@react-router/dev": "7.12.0",
+    "@react-router/fs-routes": "7.12.0",
     "@shopify/cli": "3.85.4",
     "@shopify/hydrogen-codegen": "^0.3.3",
     "@shopify/mini-oxygen": "^4.0.0",


### PR DESCRIPTION
###  WHAT is this pull request doing?

Update React Router to 7.12.0 with stabilized future flags

This release uses React Router's newly stabilized future flags (`v8_splitRouteModules`, `v8_middleware`) instead of their unstable counterparts

### HOW to test your changes?

```
git fetch origin kd-bump-rr7
git checkout kd-bump-rr7
npm ci
```

^ should succeed with no errors or warnings

#### Post-merge steps

Update the `h2 upgrade` changelog to include upgrade instructions

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
