### PR TITLE
chore: mark deprecated gql fields as deprecated

### DIFF
--- a/.changeset/slick-dingos-clap.md
+++ b/.changeset/slick-dingos-clap.md
@@ -3,3 +3,4 @@
 ---
 
 CardCost component: `amountType`s of `tax` and `duty` are now marked as deprecated. They will be removed in a future release.
+Please see [the changelog](https://shopify.dev/changelog/tax-and-duties-are-deprecated-in-storefront-cart-api) for more information.

--- a/.changeset/slick-dingos-clap.md
+++ b/.changeset/slick-dingos-clap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+CardCost component: `amountType`s of `tax` and `duty` are now marked as deprecated. They will be removed in a future release.

--- a/packages/hydrogen-react/src/CartCost.example.jsx
+++ b/packages/hydrogen-react/src/CartCost.example.jsx
@@ -7,9 +7,6 @@ export default function CartTotals() {
         Subtotal: <CartCost amountType="subtotal" />
       </div>
       <div>
-        Tax: <CartCost amountType="tax" />
-      </div>
-      <div>
         Total: <CartCost />
       </div>
     </>

--- a/packages/hydrogen-react/src/CartCost.example.tsx
+++ b/packages/hydrogen-react/src/CartCost.example.tsx
@@ -7,9 +7,6 @@ export default function CartTotals() {
         Subtotal: <CartCost amountType="subtotal" />
       </div>
       <div>
-        Tax: <CartCost amountType="tax" />
-      </div>
-      <div>
         Total: <CartCost />
       </div>
     </>

--- a/packages/hydrogen-react/src/CartCost.stories.tsx
+++ b/packages/hydrogen-react/src/CartCost.stories.tsx
@@ -15,12 +15,6 @@ const Template: Story<{amountType: CartCostProps['amountType']}> = (props) => {
       <div>
         cart.cost.totalAmount will be in the <CartCost amountType="subtotal" />
       </div>
-      <div>
-        cart.cost.totalAmount will be in the <CartCost amountType="tax" />
-      </div>
-      <div>
-        cart.cost.totalAmount will be in the <CartCost amountType="duty" />
-      </div>
       <hr />
       <CartCost {...props} />
     </CartProvider>

--- a/packages/hydrogen-react/src/CartCost.tsx
+++ b/packages/hydrogen-react/src/CartCost.tsx
@@ -1,21 +1,36 @@
 import {Money, type MoneyPropsBase} from './Money.js';
 import {useCart} from './CartProvider.js';
 
-interface CartCostPropsBase {
-  /** A string type that defines the type of cost needed. Valid values: `total`, `subtotal`, `tax`, or `duty`. */
-  amountType?: 'total' | 'subtotal' | 'tax' | 'duty';
+type CartCostPropsDeprecated = Omit<
+  React.ComponentProps<typeof Money>,
+  'data'
+> & {
+  /**
+   * @deprecated Tax and duty amounts are no longer available and will be removed in a future version.
+   * Please see [the changelog](https://shopify.dev/changelog/tax-and-duties-are-deprecated-in-storefront-cart-api) for more information.
+   */
+  amountType?: 'tax' | 'duty';
   /** Any `ReactNode` elements. */
   children?: React.ReactNode;
-}
+};
 
-type CartCostProps = Omit<React.ComponentProps<typeof Money>, 'data'> &
-  CartCostPropsBase;
+type CartCostPropsBase = Omit<React.ComponentProps<typeof Money>, 'data'> & {
+  /** A string type that defines the type of cost needed. Valid values: `total`, `subtotal`, `tax`, or `duty`.
+   */
+  amountType?: 'total' | 'subtotal';
+  /** Any `ReactNode` elements. */
+  children?: React.ReactNode;
+};
+
+type CartCostProps = CartCostPropsBase | CartCostPropsDeprecated;
 
 /**
  * The `CartCost` component renders a `Money` component with the cost associated with the `amountType` prop.
  * If no `amountType` prop is specified, then it defaults to `totalAmount`.
  * Depends on `useCart()` and must be a child of `<CartProvider/>`
  */
+export function CartCost(props: CartCostPropsBase): JSX.Element | null;
+export function CartCost(props: CartCostPropsDeprecated): JSX.Element | null;
 export function CartCost(props: CartCostProps): JSX.Element | null {
   const {cost} = useCart();
   const {amountType = 'total', children, ...passthroughProps} = props;
@@ -43,6 +58,5 @@ export function CartCost(props: CartCostProps): JSX.Element | null {
 }
 
 // This is only for documentation purposes, and it is not used in the code.
-export interface CartCostPropsForDocs<AsType extends React.ElementType = 'div'>
-  extends Omit<MoneyPropsBase<AsType>, 'data'>,
-    CartCostPropsBase {}
+export type CartCostPropsForDocs<AsType extends React.ElementType = 'div'> =
+  Omit<MoneyPropsBase<AsType>, 'data'> & CartCostPropsBase;


### PR DESCRIPTION
# Deprecate tax and duty amounts in CartCost component

### WHY are these changes introduced?

Aligns with the Storefront API changes where tax and duty amounts are no longer available in the cart API.

### WHAT is this pull request doing?

- Deprecates `tax` and `duty` as valid values for the `amountType` prop in the `CartCost` component
- Updates the component's type definitions to properly mark these options as deprecated
- Adds a deprecation notice referencing the changelog
- Removes tax and duty examples from component examples and stories
- Improves TypeScript definitions with proper function overloads

### HOW to test your changes?

1. Verify that the component still works with `total` and `subtotal` amount types
2. Check that TypeScript shows appropriate deprecation warnings when using `tax` or `duty` amount types
3. Ensure the component continues to render correctly in all supported use cases

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation