### PR TITLE
fix(ci): attempt to fix OIDC npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
+          node-version: 24 # Needed for npm@11 for Trusted Publishing
 
       - name: Install the packages
         run: npm ci --legacy-peer-deps
@@ -114,9 +115,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upgrade npm for OIDC Trusted Publishing
-        run: npm install -g npm@latest
-
       - name: Test OIDC Token
         if: env.latest == 'true'
         run: |
@@ -167,6 +165,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
+          node-version: 24 # Needed for npm@11 for Trusted Publishing
 
       - name: Install the packages
         run: npm ci
@@ -207,10 +206,6 @@ jobs:
         if: steps.version.outputs.NEXT_VERSION
         run: npm run build
 
-      - name: Upgrade npm for OIDC Trusted Publishing
-        if: steps.version.outputs.NEXT_VERSION
-        run: npm install -g npm@latest
-
       - name: Test OIDC Token
         if: steps.version.outputs.NEXT_VERSION
         run: |
@@ -248,6 +243,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
+          node-version: 24 # Needed for npm@11 for Trusted Publishing
 
       - name: Install the packages
         run: npm ci --legacy-peer-deps
@@ -257,9 +253,6 @@ jobs:
 
       - name: Build the dist code
         run: npm run build
-
-      - name: Upgrade npm for OIDC Trusted Publishing
-        run: npm install -g npm@latest
 
       - name: Test OIDC Token
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
@@ -161,7 +160,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
@@ -239,7 +237,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
     name: Production Release
     runs-on: ubuntu-latest
     if: github.repository_owner == 'shopify' && github.ref_name == 'main'
+    permissions:
+      contents: write # enable pushing changes to the origin
+      id-token: write # enable generation of an ID token for publishing
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
@@ -111,6 +114,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upgrade npm for OIDC Trusted Publishing
+        run: npm install -g npm@latest
+
+      - name: Test OIDC Token
+        if: env.latest == 'true'
+        run: |
+          TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm" | jq -r '.value')
+          [ -n "$TOKEN" ] && echo "✅ OIDC working" || exit 1
+
       - name: Create Release Pull Request or Publish (for latest release)
         if: env.latest == 'true'
         id: changesets
@@ -135,6 +148,9 @@ jobs:
       github.repository_owner == 'shopify' &&
       github.ref_name == 'main' &&
       !startsWith(github.event.head_commit.message, '[ci] release')
+    permissions:
+      contents: write # enable pushing changes to the origin
+      id-token: write # enable generation of an ID token for publishing
     outputs:
       NEXT_VERSION: ${{ steps.version.outputs.NEXT_VERSION }}
     steps:
@@ -191,6 +207,17 @@ jobs:
         if: steps.version.outputs.NEXT_VERSION
         run: npm run build
 
+      - name: Upgrade npm for OIDC Trusted Publishing
+        if: steps.version.outputs.NEXT_VERSION
+        run: npm install -g npm@latest
+
+      - name: Test OIDC Token
+        if: steps.version.outputs.NEXT_VERSION
+        run: |
+          TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm" | jq -r '.value')
+          [ -n "$TOKEN" ] && echo "✅ OIDC working" || exit 1
+
       - name: Publish to npm
         if: steps.version.outputs.NEXT_VERSION
         run: npm run changeset -- publish --tag next
@@ -204,6 +231,9 @@ jobs:
     name: Back-fix Release
     runs-on: ubuntu-latest
     if: github.repository_owner == 'shopify' && github.ref_name != 'main'
+    permissions:
+      contents: write # enable pushing changes to the origin
+      id-token: write # enable generation of an ID token for publishing
     steps:
       - name: Checkout the code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -227,6 +257,15 @@ jobs:
 
       - name: Build the dist code
         run: npm run build
+
+      - name: Upgrade npm for OIDC Trusted Publishing
+        run: npm install -g npm@latest
+
+      - name: Test OIDC Token
+        run: |
+          TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm" | jq -r '.value')
+          [ -n "$TOKEN" ] && echo "✅ OIDC working" || exit 1
 
       - name: Create Back-fix Release Pull Request or Publish (for back-fix release)
         id: changesets


### PR DESCRIPTION
### WHY are these changes introduced?

[Our npm releases are still failing](https://github.com/Shopify/hydrogen/actions/runs/20825452472/job/59825433960) after [switching to OIDC trusted publishing](https://github.com/Shopify/hydrogen/pull/3347)

### WHAT is this pull request doing?

Update npm version prior to attempting npm release
-  OIDC trusted publishing requires npm CLI version 11.5.1 or later.

Set explicit  at the job-level rather than just workflow level
- This may/may not be necessary, but this is how React Router does it so it's worth a try

Also add explicit step to test if OIDC token is working or not before attempting to publish to npm (which should aid in debugging anything that goes wrong in the future)

### HOW to test your changes?

We can't.



#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
