### PR TITLE
[#gsd:48824] Add CODEOWNERS entry for hydrogen.config.ts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,9 @@
 # For more information, see:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# Hydrogen config file requires review from developer-tools team
+templates/demo-store/hydrogen.config.ts @Shopify/developer-tools
+
 # Default owner for everything in the repo
 # The @Shopify/headless team will be requested for review on all PRs
 * @Shopify/headless


### PR DESCRIPTION
This PR updates the CODEOWNERS file to ensure that changes to the Hydrogen config template are reviewed by @Shopify/developer-tools.

## Context

This change is part of migrating away from CautionTapeBot to native GitHub features (CODEOWNERS). Previously, CautionTapeBot would automatically request reviews from this team when `templates/demo-store/hydrogen.config.ts` was modified.

## Changes

- Updates existing `.github/CODEOWNERS` file
- Adds entry for `templates/demo-store/hydrogen.config.ts` requiring review from @Shopify/developer-tools
- Maintains existing default owner (@Shopify/headless) for all other files
- ✅ Team @Shopify/developer-tools has been granted **Write** permissions to this repository

## CautionTapeBot Rule Being Removed

This PR replaces the following CautionTapeBot rule in services-db:
- [HydrogenConfigFile](https://github.com/Shopify/services-db/blob/main/components/caution_tape_bot/app/models/caution_tape_bot/rules/hydrogen_config_file.rb)

## CODEOWNERS Documentation

For more information about CODEOWNERS files, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

## Related

Part of: Shopify/services-db#29389