### PR TITLE
Add acrValues and loginHint on customer account login url

### DIFF
--- a/.changeset/silver-plums-search.md
+++ b/.changeset/silver-plums-search.md
@@ -1,0 +1,42 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Adds two new optional parameters to the `customerAccount.login()` method for more control over the authentication flow:
+
+### `acrValues`
+
+Specifies Authentication Context Class Reference values, which can be used to request specific authentication methods or identity providers. When provided, it's passed as the `acr_values` query parameter to the OAuth authorization URL.
+
+Common use case: Triggering social login flows (e.g., `'provider:google'` to initiate Google sign-in).
+
+### `loginHint`
+
+Pre-populates the login form with an email address. When provided, it's passed as the `login_hint` query parameter to the OAuth authorization URL.
+
+Common use case: Streamlining the login experience when you already know the user's email from a previous interaction.
+
+### Usage
+
+```tsx
+// Trigger Google social login
+await context.customerAccount.login({
+  acrValues: 'provider:google',
+});
+
+// Pre-fill email on login form
+await context.customerAccount.login({
+  loginHint: 'customer@example.com',
+});
+
+// Combine with existing options
+await context.customerAccount.login({
+  countryCode: context.storefront.i18n.country,
+  acrValues: 'provider:google',
+  loginHint: 'customer@example.com',
+});
+```
+
+### Migration
+
+This is a non-breaking change. Both parameters are optional and existing implementations will continue to work without modification.

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -312,6 +312,107 @@ describe('customer', () => {
       });
     });
 
+    describe('acrValues', () => {
+      it('Redirects to the customer account api login url with acrValues as param', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login({
+          acrValues: 'provider:google',
+        });
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('acr_values')).toBe('provider:google');
+      });
+
+      it('Does not include acr_values param when acrValues is not provided', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login();
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('acr_values')).toBeNull();
+      });
+    });
+
+    describe('loginHint', () => {
+      it('Redirects to the customer account api login url with loginHint as param', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login({
+          loginHint: 'user@example.com',
+        });
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('login_hint')).toBe('user@example.com');
+      });
+
+      it('Includes loginHint with other login options', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login({
+          uiLocales: 'FR',
+          countryCode: 'CA',
+          acrValues: 'provider:google',
+          loginHint: 'user@example.com',
+        });
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('ui_locales')).toBe('fr');
+        expect(url.searchParams.get('region_country')).toBe('CA');
+        expect(url.searchParams.get('acr_values')).toBe('provider:google');
+        expect(url.searchParams.get('login_hint')).toBe('user@example.com');
+      });
+
+      it('Does not include login_hint param when loginHint is not provided', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login();
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('login_hint')).toBeNull();
+      });
+    });
+
     describe('logout', () => {
       describe('using new auth url when shopId is present in env', () => {
         it('Redirects to the customer account api logout url', async () => {

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -369,6 +369,14 @@ export function createCustomerAccountClient({
         loginUrl.searchParams.append('region_country', options.countryCode);
       }
 
+      if (options?.acrValues) {
+        loginUrl.searchParams.append('acr_values', options.acrValues);
+      }
+
+      if (options?.loginHint) {
+        loginUrl.searchParams.append('login_hint', options.loginHint);
+      }
+
       const verifier = generateCodeVerifier();
       const challenge = await generateCodeChallenge(verifier);
 

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -53,6 +53,8 @@ export interface CustomerAccountMutations {
 export type LoginOptions = {
   uiLocales?: LanguageCode;
   countryCode?: CountryCode;
+  acrValues?: string;
+  loginHint?: string;
 };
 
 export type LogoutOptions = {


### PR DESCRIPTION
# Add support for acrValues and loginHint parameters in customer login

### WHY are these changes introduced?


To enhance the flexibility of the customer login process by allowing developers to specify authentication context class references (acrValues) and login hints when redirecting users to the authentication page.

### WHAT is this pull request doing?

This PR adds support for two new optional parameters in the customer login function:

1. `acrValues`: Allows specifying authentication context class references, such as identity providers (e.g., "provider:google")
2. `loginHint`: Enables pre-filling the login form with a user's email address

Both parameters are passed to the Customer Account API login URL when provided, giving developers more control over the authentication experience.

### HOW to test your changes?

1. Create a customer account client
2. Call the login method with the new parameters:
   ```typescript
   await customer.login({
     acrValues: 'provider:google',
     loginHint: 'user@example.com'
   });
   ```
3. Verify that the redirect URL contains the corresponding `acr_values` and `login_hint` parameters

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation