### PR TITLE
Fix recipes

### DIFF
--- a/cookbook/recipes/express/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/express/patches/package.json.f30b0a.patch
@@ -2,7 +2,7 @@ index e9ebd1d3..00a7b42d 100644
 --- a/templates/skeleton/package.json
 +++ b/templates/skeleton/package.json
 @@ -5,58 +5,51 @@
-   "version": "2025.7.0",
+   "version": "2025.7.1",
    "type": "module",
    "scripts": {
 -    "build": "shopify hydrogen build --codegen",
@@ -21,7 +21,7 @@ index e9ebd1d3..00a7b42d 100644
 +    "@react-router/express": "7.12.0",
 +    "@react-router/node": "7.12.0",
 +    "@remix-run/eslint-config": "^2.16.1",
-     "@shopify/hydrogen": "2025.7.0",
+     "@shopify/hydrogen": "2025.7.1",
 +    "compression": "^1.7.4",
 +    "cross-env": "^7.0.3",
 +    "express": "^4.19.2",

--- a/cookbook/recipes/multipass/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/multipass/patches/package.json.f30b0a.patch
@@ -4,7 +4,7 @@ index e9ebd1d3..939811db 100644
 @@ -15,6 +15,7 @@
    "prettier": "@shopify/prettier-config",
    "dependencies": {
-     "@shopify/hydrogen": "2025.7.0",
+     "@shopify/hydrogen": "2025.7.1",
 +    "crypto-js": "^4.2.0",
      "graphql": "^16.10.0",
      "graphql-tag": "^2.12.6",

--- a/cookbook/recipes/partytown/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/partytown/patches/package.json.f30b0a.patch
@@ -15,6 +15,6 @@ index e9ebd1d3..deace7c0 100644
    "prettier": "@shopify/prettier-config",
    "dependencies": {
 +    "@qwik.dev/partytown": "^0.11.2",
-     "@shopify/hydrogen": "2025.7.0",
+     "@shopify/hydrogen": "2025.7.1",
      "graphql": "^16.10.0",
      "graphql-tag": "^2.12.6",


### PR DESCRIPTION
The Skeleton template was updated to use `@shopify/hydrogen` version `2025.7.1` which caused these recipes to start failing.

CI probably should have failed on https://github.com/Shopify/hydrogen/pull/3237 but it looks like that PR did not run the right checks?