### PR TITLE
Add acrValues and loginHint to customerAccount.login()

### DIFF
--- a/cookbook/recipes/legacy-customer-account-flow/patches/account_.login.tsx.3fb3f2.patch
+++ b/cookbook/recipes/legacy-customer-account-flow/patches/account_.login.tsx.3fb3f2.patch
@@ -1,14 +1,20 @@
-index 825648a1..7536e037 100644
 --- a/templates/skeleton/app/routes/account_.login.tsx
 +++ b/templates/skeleton/app/routes/account_.login.tsx
-@@ -1,7 +1,139 @@
+@@ -1,13 +1,139 @@
 +import {Form, Link, useActionData, data, redirect} from 'react-router';
  import type {Route} from './+types/account_.login';
  
 -export async function loader({request, context}: Route.LoaderArgs) {
+-  const url = new URL(request.url);
+-  const acrValues = url.searchParams.get('acr_values') || undefined;
+-  const loginHint = url.searchParams.get('login_hint') || undefined;
+-
 -  return context.customerAccount.login({
 -    countryCode: context.storefront.i18n.country,
+-    acrValues,
+-    loginHint,
 -  });
+-}
 +type ActionResponse = {
 +  error: string | null;
 +};
@@ -22,7 +28,7 @@ index 825648a1..7536e037 100644
 +    return redirect('/account');
 +  }
 +  return {};
- }
++}
 +
 +export async function action({request, context}: Route.ActionArgs) {
 +  const {session, storefront} = context;
@@ -145,4 +151,3 @@ index 825648a1..7536e037 100644
 +    }
 +  }
 +` as const;
-\ No newline at end of file

--- a/cookbook/recipes/multipass/patches/account_.login.tsx.3fb3f2.patch
+++ b/cookbook/recipes/multipass/patches/account_.login.tsx.3fb3f2.patch
@@ -1,14 +1,20 @@
-index 825648a1..4c33c9f6 100644
 --- a/templates/skeleton/app/routes/account_.login.tsx
 +++ b/templates/skeleton/app/routes/account_.login.tsx
-@@ -1,7 +1,134 @@
+@@ -1,13 +1,134 @@
 +import {Form, Link, useActionData, data, redirect} from 'react-router';
  import type {Route} from './+types/account_.login';
  
 -export async function loader({request, context}: Route.LoaderArgs) {
+-  const url = new URL(request.url);
+-  const acrValues = url.searchParams.get('acr_values') || undefined;
+-  const loginHint = url.searchParams.get('login_hint') || undefined;
+-
 -  return context.customerAccount.login({
 -    countryCode: context.storefront.i18n.country,
+-    acrValues,
+-    loginHint,
 -  });
+-}
 +type ActionResponse = {
 +  error: string | null;
 +};
@@ -22,7 +28,7 @@ index 825648a1..4c33c9f6 100644
 +    return redirect('/account');
 +  }
 +  return {};
- }
++}
 +
 +export async function action({request, context}: Route.ActionArgs) {
 +  const {session, storefront} = context;
@@ -139,4 +145,3 @@ index 825648a1..4c33c9f6 100644
 +    }
 +  }
 +` as const;
-+

--- a/templates/skeleton/app/routes/account_.login.tsx
+++ b/templates/skeleton/app/routes/account_.login.tsx
@@ -1,7 +1,13 @@
 import type {Route} from './+types/account_.login';
 
 export async function loader({request, context}: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const acrValues = url.searchParams.get('acr_values') || undefined;
+  const loginHint = url.searchParams.get('login_hint') || undefined;
+
   return context.customerAccount.login({
     countryCode: context.storefront.i18n.country,
+    acrValues,
+    loginHint,
   });
 }


### PR DESCRIPTION
# Support `acr_values` and `login_hint` URL parameters in the login route

### WHY are these changes introduced?

This PR enhances the login functionality by supporting URL parameters that can trigger social login or pre-fill email fields, improving the user experience during authentication.

### WHAT is this pull request doing?

The `account_.login.tsx` route now automatically reads `acr_values` and `login_hint` from the request URL and passes them to the `customerAccount.login()` method. This enables:

- `/account/login?acr_values=provider:google` — triggers Google sign-in
- `/account/login?login_hint=user@example.com` — pre-fills the email field
 
#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation