### PR TITLE
Support loginHintMode customer account login url

### DIFF
--- a/.changeset/cool-lions-dance.md
+++ b/.changeset/cool-lions-dance.md
@@ -1,0 +1,23 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add `loginHintMode` parameter to Customer Account login
+
+Adds a new optional `loginHintMode` parameter to the `customerAccount.login()` method. When provided along with `loginHint`, it's passed as the `login_hint_mode` query parameter to the OAuth authorization URL. The only supported value is `'submit'`. This parameter is ignored if `loginHint` is not provided.
+
+When set to `'submit'` along with `loginHint`, the login form will automatically submit with the provided email, skipping the email input step.
+
+### Usage
+
+```tsx
+// Auto-submit with a known email
+await context.customerAccount.login({
+  loginHint: 'customer@example.com',
+  loginHintMode: 'submit',
+});
+```
+
+### Migration
+
+This is a non-breaking change. The parameter is optional and existing implementations will continue to work without modification.

--- a/cookbook/recipes/express/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/express/patches/package.json.f30b0a.patch
@@ -2,7 +2,7 @@ index e9ebd1d3..00a7b42d 100644
 --- a/templates/skeleton/package.json
 +++ b/templates/skeleton/package.json
 @@ -5,59 +5,52 @@
-   "version": "2025.7.1",
+   "version": "2025.7.2",
    "type": "module",
    "scripts": {
 -    "build": "shopify hydrogen build --codegen",
@@ -21,7 +21,7 @@ index e9ebd1d3..00a7b42d 100644
 +    "@react-router/express": "7.12.0",
 +    "@react-router/node": "7.12.0",
 +    "@remix-run/eslint-config": "^2.16.1",
-     "@shopify/hydrogen": "2025.7.1",
+     "@shopify/hydrogen": "2025.7.2",
 +    "compression": "^1.7.4",
 +    "cross-env": "^7.0.3",
 +    "express": "^4.19.2",

--- a/cookbook/recipes/multipass/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/multipass/patches/package.json.f30b0a.patch
@@ -4,7 +4,7 @@ index e9ebd1d3..939811db 100644
 @@ -15,6 +15,7 @@
    "prettier": "@shopify/prettier-config",
    "dependencies": {
-     "@shopify/hydrogen": "2025.7.1",
+     "@shopify/hydrogen": "2025.7.2",
 +    "crypto-js": "^4.2.0",
      "graphql": "^16.10.0",
      "graphql-tag": "^2.12.6",

--- a/cookbook/recipes/partytown/patches/package.json.f30b0a.patch
+++ b/cookbook/recipes/partytown/patches/package.json.f30b0a.patch
@@ -15,6 +15,6 @@ index e9ebd1d3..deace7c0 100644
    "prettier": "@shopify/prettier-config",
    "dependencies": {
 +    "@qwik.dev/partytown": "^0.11.2",
-     "@shopify/hydrogen": "2025.7.1",
+     "@shopify/hydrogen": "2025.7.2",
      "graphql": "^16.10.0",
      "graphql-tag": "^2.12.6",

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -413,6 +413,96 @@ describe('customer', () => {
       });
     });
 
+    describe('loginHintMode', () => {
+      it('Includes loginHintMode when loginHint is also provided', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login({
+          loginHint: 'user@example.com',
+          loginHintMode: 'submit',
+        });
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('login_hint')).toBe('user@example.com');
+        expect(url.searchParams.get('login_hint_mode')).toBe('submit');
+      });
+
+      it('Does not include loginHintMode when loginHint is not provided', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login({
+          loginHintMode: 'submit',
+        });
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('login_hint')).toBeNull();
+        expect(url.searchParams.get('login_hint_mode')).toBeNull();
+      });
+
+      it('Includes loginHintMode with other login options', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login({
+          uiLocales: 'FR',
+          countryCode: 'CA',
+          acrValues: 'provider:google',
+          loginHint: 'user@example.com',
+          loginHintMode: 'submit',
+        });
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('ui_locales')).toBe('fr');
+        expect(url.searchParams.get('region_country')).toBe('CA');
+        expect(url.searchParams.get('acr_values')).toBe('provider:google');
+        expect(url.searchParams.get('login_hint')).toBe('user@example.com');
+        expect(url.searchParams.get('login_hint_mode')).toBe('submit');
+      });
+
+      it('Does not include login_hint_mode param when loginHintMode is not provided', async () => {
+        const origin = 'https://something-good.com';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request(origin),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login({
+          loginHint: 'user@example.com',
+        });
+        const url = new URL(response.headers.get('location')!);
+
+        expect(url.searchParams.get('login_hint')).toBe('user@example.com');
+        expect(url.searchParams.get('login_hint_mode')).toBeNull();
+      });
+    });
+
     describe('logout', () => {
       describe('using new auth url when shopId is present in env', () => {
         it('Redirects to the customer account api logout url', async () => {

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -375,6 +375,13 @@ export function createCustomerAccountClient({
 
       if (options?.loginHint) {
         loginUrl.searchParams.append('login_hint', options.loginHint);
+
+        if (options?.loginHintMode) {
+          loginUrl.searchParams.append(
+            'login_hint_mode',
+            options.loginHintMode,
+          );
+        }
       }
 
       const verifier = generateCodeVerifier();

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -55,6 +55,7 @@ export type LoginOptions = {
   countryCode?: CountryCode;
   acrValues?: string;
   loginHint?: string;
+  loginHintMode?: string;
 };
 
 export type LogoutOptions = {


### PR DESCRIPTION
# Add `loginHintMode` parameter to `customerAccount.login()` method

### WHY are these changes introduced?

This PR enhances the customer login flow by adding a new parameter that allows for automatically submitting the login form with a provided email address, creating a more streamlined authentication experience.

### WHAT is this pull request doing?

Adds a new optional `loginHintMode` parameter to the `customerAccount.login()` method:

- When set to `'submit'` along with `loginHint`, the login form will automatically submit with the provided email, skipping the email input step
- Updates the changeset to document this new parameter and its usage
- Adds comprehensive tests to verify the functionality works as expected

Example usage:
```tsx
// Auto-submit with a known email
await context.customerAccount.login({
  loginHint: 'customer@example.com',
  loginHintMode: 'submit',
});
```

This is a non-breaking change - all parameters remain optional and existing implementations will continue to work without modification.

 