### PR TITLE
Add locale parameter to Customer Account login

### DIFF
--- a/.changeset/bright-masks-swim.md
+++ b/.changeset/bright-masks-swim.md
@@ -1,0 +1,40 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add `locale` parameter to Customer Account login
+
+Adds a new optional `locale` parameter to the `customerAccount.login()` method. This parameter sets the `locale` query parameter on the OAuth authorization URL to control the language of the login page.
+
+Supported locale values: `en`, `fr`, `cs`, `da`, `de`, `el`, `es`, `fi`, `hi`, `hr`, `hu`, `id`, `it`, `ja`, `ko`, `lt`, `ms`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`, `ro`, `ru`, `sk`, `sl`, `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`.
+
+The `locale` parameter takes precedence over `uiLocales`. When `locale` is set (either via the `locale` option or derived from the `language` configuration), the `ui_locales` parameter will not be appended to the login URL. The `uiLocales` option will only be used as a fallback when `locale` is not set.
+
+### Usage
+
+```tsx
+// Using locale option directly
+await context.customerAccount.login({
+  locale: 'fr',
+});
+
+// Using locale with regional variant
+await context.customerAccount.login({
+  locale: 'zh-CN',
+});
+
+// locale takes precedence over uiLocales
+await context.customerAccount.login({
+  locale: 'de',
+  uiLocales: 'FR', // This will be ignored
+});
+```
+
+The locale value is normalized automatically:
+- Lowercase languages: `'FR'` → `'fr'`
+- Regional variants: `'ZH_CN'` or `'zh-cn'` → `'zh-CN'`
+
+### Migration
+
+This is a non-breaking change. Existing implementations using `uiLocales` will continue to work.
+

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -52,6 +52,7 @@ export interface CustomerAccountMutations {
 
 export type LoginOptions = {
   uiLocales?: LanguageCode;
+  locale?: string;
   countryCode?: CountryCode;
   acrValues?: string;
   loginHint?: string;


### PR DESCRIPTION
# Add `locale` parameter to Customer Account login

### WHY are these changes introduced?

To provide better control over the language of the Customer Account login page by adding a dedicated `locale` parameter that follows standard locale formatting.

### WHAT is this pull request doing?

Adds a new optional `locale` parameter to the `customerAccount.login()` method that sets the `locale` query parameter on the OAuth authorization URL. This parameter controls the language of the login page.

Key changes:
- Added `locale` parameter to the login options
- Implemented `getMaybeLocale` function to handle locale normalization
- Added comprehensive tests for the new functionality
- Updated existing tests to verify locale parameter behavior
- Ensured `locale` takes precedence over `uiLocales` when both are provided

Supported locale values include: `en`, `fr`, `cs`, `da`, `de`, `el`, `es`, `fi`, `hi`, `hr`, `hu`, `id`, `it`, `ja`, `ko`, `lt`, `ms`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`, `ro`, `ru`, `sk`, `sl`, `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`.

The locale value is automatically normalized:
- Lowercase languages: `'FR'` → `'fr'`
- Regional variants: `'ZH_CN'` or `'zh-cn'` → `'zh-CN'`

### HOW to test your changes?

Test the login method with various locale configurations:

```tsx
// Using locale option directly
await context.customerAccount.login({
  locale: 'fr',
});

// Using locale with regional variant
await context.customerAccount.login({
  locale: 'zh-CN',
});

// Test that locale takes precedence over uiLocales
await context.customerAccount.login({
  locale: 'de',
  uiLocales: 'FR', // This should be ignored
});
```

Verify that the login URL contains the correct `locale` parameter and that the login page appears in the expected language.

#### Checklist

- [x] I've read the Contributing Guidelines
- [x] I've considered possible cross-platform impacts
- [x] I've added a changeset
- [x] I've added tests to cover my changes
- [x] I've added documentation