### PR TITLE
Security: bump @remix-run/node to ^2.17.2

### DIFF
--- a/docs/preview/package.json
+++ b/docs/preview/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@remix-run/node": "^2.17.2",
-    "@remix-run/react": "^2.16.1",
-    "@remix-run/serve": "^2.16.1",
+    "@remix-run/react": "^2.17.2",
+    "@remix-run/serve": "^2.17.2",
     "he": "^1.2.0",
     "isbot": "^5.1.21",
     "marked": "^9.1.0",
@@ -19,7 +19,7 @@
     "react-syntax-highlighter": "^15.5.0"
   },
   "devDependencies": {
-    "@remix-run/dev": "^2.16.1",
+    "@remix-run/dev": "^2.17.2",
     "@tailwindcss/vite": "^4.0.14",
     "@types/he": "^1.2.1",
     "@types/react": "^18.2.20",

--- a/docs/preview/package.json
+++ b/docs/preview/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@remix-run/node": "^2.16.1",
+    "@remix-run/node": "^2.17.2",
     "@remix-run/react": "^2.16.1",
     "@remix-run/serve": "^2.16.1",
     "he": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -381,8 +381,8 @@
       "name": "docs-preview",
       "dependencies": {
         "@remix-run/node": "^2.17.2",
-        "@remix-run/react": "^2.16.1",
-        "@remix-run/serve": "^2.16.1",
+        "@remix-run/react": "^2.17.2",
+        "@remix-run/serve": "^2.17.2",
         "he": "^1.2.0",
         "isbot": "^5.1.21",
         "marked": "^9.1.0",
@@ -391,7 +391,7 @@
         "react-syntax-highlighter": "^15.5.0"
       },
       "devDependencies": {
-        "@remix-run/dev": "^2.16.1",
+        "@remix-run/dev": "^2.17.2",
         "@tailwindcss/vite": "^4.0.14",
         "@types/he": "^1.2.1",
         "@types/react": "^18.2.20",
@@ -403,67 +403,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "docs/preview/node_modules/@remix-run/node": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
-      "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/server-runtime": "2.17.4",
-        "@remix-run/web-fetch": "^4.4.2",
-        "@web3-storage/multipart-parser": "^1.0.0",
-        "cookie-signature": "^1.1.0",
-        "source-map-support": "^0.5.21",
-        "stream-slice": "^0.1.2",
-        "undici": "^6.21.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "docs/preview/node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "docs/preview/node_modules/@remix-run/server-runtime": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
-      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "@types/cookie": "^0.6.0",
-        "@web3-storage/multipart-parser": "^1.0.0",
-        "cookie": "^0.7.2",
-        "set-cookie-parser": "^2.4.8",
-        "source-map": "^0.7.3",
-        "turbo-stream": "2.4.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5380,21 +5319,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@react-router/dev/node_modules/valibot": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
-      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@react-router/fs-routes": {
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/@react-router/fs-routes/-/fs-routes-7.12.0.tgz",
@@ -5466,9 +5390,9 @@
       }
     },
     "node_modules/@remix-run/dev": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.17.0.tgz",
-      "integrity": "sha512-L2W8PYH3jUvCKlJeUkFMGyOMzUsM0goZg4n0NU69O85TNlB1jgiqSbSMb69xhviphGpwzAoH+D/p3/cUnw4DbQ==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.17.4.tgz",
+      "integrity": "sha512-El7r5W6ErX9KIy27+urbc4SIZnIlVDgTOUqzA7Zbv7caKYrsvgj/Z3i/LPy4VNfv0G1EdawPOrygJgIKT4r2FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5482,9 +5406,9 @@
         "@babel/types": "^7.22.5",
         "@mdx-js/mdx": "^2.3.0",
         "@npmcli/package-json": "^4.0.1",
-        "@remix-run/node": "2.17.0",
-        "@remix-run/router": "1.23.0",
-        "@remix-run/server-runtime": "2.17.0",
+        "@remix-run/node": "2.17.4",
+        "@remix-run/router": "1.23.2",
+        "@remix-run/server-runtime": "2.17.4",
         "@types/mdx": "^2.0.5",
         "@vanilla-extract/integration": "^6.2.0",
         "arg": "^5.0.1",
@@ -5525,7 +5449,7 @@
         "set-cookie-parser": "^2.6.0",
         "tar-fs": "^2.1.3",
         "tsconfig-paths": "^4.0.0",
-        "valibot": "^0.41.0",
+        "valibot": "^1.2.0",
         "vite-node": "^3.1.3",
         "ws": "^7.5.10"
       },
@@ -6955,12 +6879,12 @@
       }
     },
     "node_modules/@remix-run/express": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.17.0.tgz",
-      "integrity": "sha512-VUNpdrX3WSLPOkRBbsTQao5Vu/xdKcB8AY+44pAyC7iW5iIKHDb6EYlDvpbMLcMNh9ErYGhpPtshaBiBTMvjiw==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/express/-/express-2.17.4.tgz",
+      "integrity": "sha512-4zZs0L7v2pvAq896zHRLNMhoOKIPXM9qnYdHLbz4mpZUMbNAgQacGazArIrUV3M4g0gRMY0dLrt5CqMNrlBeYg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/node": "2.17.0"
+        "@remix-run/node": "2.17.4"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -6976,12 +6900,12 @@
       }
     },
     "node_modules/@remix-run/node": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.0.tgz",
-      "integrity": "sha512-ISy3N4peKB+Fo8ddh+mU6ki3HzQqLXwJxUrAtqxYxrBDM4Pwc7EvISrcQ4QasB6ORBknJeEZSBu69WDRhGzrjA==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
+      "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/server-runtime": "2.17.0",
+        "@remix-run/server-runtime": "2.17.4",
         "@remix-run/web-fetch": "^4.4.2",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie-signature": "^1.1.0",
@@ -7009,15 +6933,15 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/react": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.0.tgz",
-      "integrity": "sha512-muOLHqcimMCrIk6VOuqIn51P3buYjKpdYc6qpNy6zE5HlKfyaKEY00a5pzdutRmevYTQy7FiEF/LK4M8sxk70Q==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/react/-/react-2.17.4.tgz",
+      "integrity": "sha512-MeXHacIBoohr9jzec5j/Rmk57xk34korkPDDb0OPHgkdvh20lO5fJoSAcnZfjTIOH+Vsq1ZRQlmvG5PRQ/64Sw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "@remix-run/server-runtime": "2.17.0",
-        "react-router": "6.30.0",
-        "react-router-dom": "6.30.0",
+        "@remix-run/router": "1.23.2",
+        "@remix-run/server-runtime": "2.17.4",
+        "react-router": "6.30.3",
+        "react-router-dom": "6.30.3",
         "turbo-stream": "2.4.1"
       },
       "engines": {
@@ -7035,12 +6959,12 @@
       }
     },
     "node_modules/@remix-run/react/node_modules/react-router": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7050,13 +6974,13 @@
       }
     },
     "node_modules/@remix-run/react/node_modules/react-router-dom": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.0.tgz",
-      "integrity": "sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.0"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7067,27 +6991,27 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@remix-run/serve": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.17.0.tgz",
-      "integrity": "sha512-eq0A7A89uqg+rQiGVHoUwb1NUawmPpjAY3RWn4KG4uCp4QwhqJausML63fIxnfdp7zu2OplXhfSXCNiTekQ0rw==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/serve/-/serve-2.17.4.tgz",
+      "integrity": "sha512-c632agTDib70cytmxMVqSbBMlhFKawcg5048yZZK/qeP2AmUweM7OY6Ivgcmv/pgjLXYOu17UBKhtGU8T5y8cQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/express": "2.17.0",
-        "@remix-run/node": "2.17.0",
+        "@remix-run/express": "2.17.4",
+        "@remix-run/node": "2.17.4",
         "chokidar": "^3.5.3",
-        "compression": "^1.7.4",
+        "compression": "^1.8.1",
         "express": "^4.20.0",
         "get-port": "5.1.1",
-        "morgan": "^1.10.0",
+        "morgan": "^1.10.1",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -7158,12 +7082,12 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.0.tgz",
-      "integrity": "sha512-X0zfGLgvukhuTIL0tdWKnlvHy4xUe7Z17iQ0KMQoITK0SkTZPSud/6cJCsKhPqC8kfdYT1GNFLJKRhHz7Aapmw==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
+      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
+        "@remix-run/router": "1.23.2",
         "@types/cookie": "^0.6.0",
         "@web3-storage/multipart-parser": "^1.0.0",
         "cookie": "^0.7.2",
@@ -29849,9 +29773,9 @@
       "license": "MIT"
     },
     "node_modules/valibot": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.41.0.tgz",
-      "integrity": "sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -380,7 +380,7 @@
     "docs/preview": {
       "name": "docs-preview",
       "dependencies": {
-        "@remix-run/node": "^2.16.1",
+        "@remix-run/node": "^2.17.2",
         "@remix-run/react": "^2.16.1",
         "@remix-run/serve": "^2.16.1",
         "he": "^1.2.0",
@@ -403,6 +403,67 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "docs/preview/node_modules/@remix-run/node": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.17.4.tgz",
+      "integrity": "sha512-9A29JaYiGHDEmaiQuD1IlO/TrQxnnkj98GpytihU+Nz6yTt6RwzzyMMqTAoasRd1dPD4OeSaSqbwkcim/eE76Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/server-runtime": "2.17.4",
+        "@remix-run/web-fetch": "^4.4.2",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie-signature": "^1.1.0",
+        "source-map-support": "^0.5.21",
+        "stream-slice": "^0.1.2",
+        "undici": "^6.21.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "docs/preview/node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "docs/preview/node_modules/@remix-run/server-runtime": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.17.4.tgz",
+      "integrity": "sha512-oCsFbPuISgh8KpPKsfBChzjcntvTz5L+ggq9VNYWX8RX3yA7OgQpKspRHOSxb05bw7m0Hx+L1KRHXjf3juKX8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.7.2",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3",
+        "turbo-stream": "2.4.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -32983,7 +33044,7 @@
     },
     "packages/hydrogen": {
       "name": "@shopify/hydrogen",
-      "version": "2025.7.1",
+      "version": "2025.7.2",
       "license": "MIT",
       "dependencies": {
         "@shopify/graphql-client": "1.4.1",
@@ -35389,9 +35450,9 @@
       }
     },
     "templates/skeleton": {
-      "version": "2025.7.1",
+      "version": "2025.7.2",
       "dependencies": {
-        "@shopify/hydrogen": "2025.7.1",
+        "@shopify/hydrogen": "2025.7.2",
         "graphql": "^16.10.0",
         "graphql-tag": "^2.12.6",
         "isbot": "^5.1.22",


### PR DESCRIPTION
## Summary
This PR bumps vulnerable Remix/React Router Node packages to safe versions:
- @remix-run/node >= 2.17.2
- @react-router/node >= 7.9.4
- @remix-run/deno >= 2.17.2

## Context
This addresses a security advisory for the packages above.
- https://nvd.nist.gov/vuln/detail/CVE-2025-61686


## Updated packages
- @remix-run/node@^2.17.2

## Notes
No lockfile detected; updated package.json only.