### PR TITLE
Change locale parameter priority in Customer Account login url

### DIFF
--- a/.changeset/bright-masks-swim.md
+++ b/.changeset/bright-masks-swim.md
@@ -8,7 +8,12 @@ Adds a new optional `locale` parameter to the `customerAccount.login()` method. 
 
 Supported locale values: `en`, `fr`, `cs`, `da`, `de`, `el`, `es`, `fi`, `hi`, `hr`, `hu`, `id`, `it`, `ja`, `ko`, `lt`, `ms`, `nb`, `nl`, `pl`, `pt-BR`, `pt-PT`, `ro`, `ru`, `sk`, `sl`, `sv`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`.
 
-The `locale` parameter takes precedence over `uiLocales`. When `locale` is set (either via the `locale` option or derived from the `language` configuration), the `ui_locales` parameter will not be appended to the login URL. The `uiLocales` option will only be used as a fallback when `locale` is not set.
+The locale is determined by the following priority order:
+1. `locale` option (highest priority)
+2. `uiLocales` option
+3. `language` configuration in `createCustomerAccountClient`
+
+All locale sources now produce the `locale` query parameter instead of `ui_locales`.
 
 ### Usage
 
@@ -36,5 +41,5 @@ The locale value is normalized automatically:
 
 ### Migration
 
-This is a non-breaking change. Existing implementations using `uiLocales` will continue to work.
+This is a non-breaking change. Existing implementations using `uiLocales` will continue to work, but the login URL will now use the `locale` parameter instead of `ui_locales`.
 

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -235,7 +235,7 @@ describe('customer', () => {
           expect(url.searchParams.get('ui_locales')).toBeNull();
         });
 
-        it('Redirects to the customer account api login url with ui_locales as param (uiLocales option, no language)', async () => {
+        it('Redirects to the customer account api login url with locale as param (uiLocales option, no language)', async () => {
           const origin = 'https://something-good.com';
 
           const customer = createCustomerAccountClient({
@@ -251,8 +251,7 @@ describe('customer', () => {
           });
           const url = new URL(response.headers.get('location')!);
 
-          expect(url.searchParams.get('ui_locales')).toBe('fr');
-          expect(url.searchParams.get('locale')).toBeNull();
+          expect(url.searchParams.get('locale')).toBe('fr');
         });
 
         it('locale takes precedence over uiLocales when both are provided', async () => {
@@ -298,7 +297,7 @@ describe('customer', () => {
         expect(url.searchParams.get('region_country')).toBe('US');
       });
 
-      it('Includes both uiLocales and countryCode when both are provided', async () => {
+      it('Includes both locale and countryCode when both are provided', async () => {
         const origin = 'https://something-good.com';
 
         const customer = createCustomerAccountClient({
@@ -315,7 +314,7 @@ describe('customer', () => {
         });
         const url = new URL(response.headers.get('location')!);
 
-        expect(url.searchParams.get('ui_locales')).toBe('fr');
+        expect(url.searchParams.get('locale')).toBe('fr');
         expect(url.searchParams.get('region_country')).toBe('CA');
       });
 
@@ -437,7 +436,7 @@ describe('customer', () => {
         });
         const url = new URL(response.headers.get('location')!);
 
-        expect(url.searchParams.get('ui_locales')).toBe('fr');
+        expect(url.searchParams.get('locale')).toBe('fr');
         expect(url.searchParams.get('region_country')).toBe('CA');
         expect(url.searchParams.get('acr_values')).toBe('provider:google');
         expect(url.searchParams.get('login_hint')).toBe('user@example.com');
@@ -523,7 +522,7 @@ describe('customer', () => {
         });
         const url = new URL(response.headers.get('location')!);
 
-        expect(url.searchParams.get('ui_locales')).toBe('fr');
+        expect(url.searchParams.get('locale')).toBe('fr');
         expect(url.searchParams.get('region_country')).toBe('CA');
         expect(url.searchParams.get('acr_values')).toBe('provider:google');
         expect(url.searchParams.get('login_hint')).toBe('user@example.com');
@@ -1563,91 +1562,203 @@ describe('getMaybeLocale', () => {
     const locale = getMaybeLocale({
       contextLanguage: null,
       localeOverride: null,
+      uiLocalesOverride: null,
     });
     expect(locale).toBeNull();
   });
 
   it('returns lowercase for regular languages', () => {
-    expect(getMaybeLocale({contextLanguage: 'EN', localeOverride: null})).toBe(
-      'en',
-    );
-    expect(getMaybeLocale({contextLanguage: 'FR', localeOverride: null})).toBe(
-      'fr',
-    );
-    expect(getMaybeLocale({contextLanguage: 'DE', localeOverride: null})).toBe(
-      'de',
-    );
-    expect(getMaybeLocale({contextLanguage: 'JA', localeOverride: null})).toBe(
-      'ja',
-    );
-    expect(getMaybeLocale({contextLanguage: 'KO', localeOverride: null})).toBe(
-      'ko',
-    );
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'EN',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
+    ).toBe('en');
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'FR',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
+    ).toBe('fr');
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'DE',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
+    ).toBe('de');
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'JA',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
+    ).toBe('ja');
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'KO',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
+    ).toBe('ko');
   });
 
   it('returns language-country format for regional languages', () => {
     expect(
-      getMaybeLocale({contextLanguage: 'PT_BR', localeOverride: null}),
+      getMaybeLocale({
+        contextLanguage: 'PT_BR',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
     ).toBe('pt-BR');
     expect(
-      getMaybeLocale({contextLanguage: 'PT_PT', localeOverride: null}),
+      getMaybeLocale({
+        contextLanguage: 'PT_PT',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
     ).toBe('pt-PT');
     expect(
-      getMaybeLocale({contextLanguage: 'ZH_CN', localeOverride: null}),
+      getMaybeLocale({
+        contextLanguage: 'ZH_CN',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
     ).toBe('zh-CN');
     expect(
-      getMaybeLocale({contextLanguage: 'ZH_TW', localeOverride: null}),
+      getMaybeLocale({
+        contextLanguage: 'ZH_TW',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
     ).toBe('zh-TW');
   });
 
-  it('uses localeOverride when provided', () => {
-    expect(getMaybeLocale({contextLanguage: 'EN', localeOverride: 'fr'})).toBe(
-      'fr',
-    );
+  it('uses localeOverride when provided (highest priority)', () => {
     expect(
-      getMaybeLocale({contextLanguage: 'EN', localeOverride: 'zh-CN'}),
+      getMaybeLocale({
+        contextLanguage: 'EN',
+        localeOverride: 'fr',
+        uiLocalesOverride: 'DE',
+      }),
+    ).toBe('fr');
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'EN',
+        localeOverride: 'zh-CN',
+        uiLocalesOverride: 'JA',
+      }),
     ).toBe('zh-CN');
   });
 
-  it('uses localeOverride even when contextLanguage is null', () => {
-    expect(getMaybeLocale({contextLanguage: null, localeOverride: 'fr'})).toBe(
-      'fr',
-    );
+  it('uses uiLocalesOverride when localeOverride is null (second priority)', () => {
     expect(
-      getMaybeLocale({contextLanguage: null, localeOverride: 'pt-BR'}),
-    ).toBe('pt-BR');
+      getMaybeLocale({
+        contextLanguage: 'EN',
+        localeOverride: null,
+        uiLocalesOverride: 'FR',
+      }),
+    ).toBe('fr');
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'EN',
+        localeOverride: null,
+        uiLocalesOverride: 'ZH_CN',
+      }),
+    ).toBe('zh-CN');
   });
 
-  it('falls back to contextLanguage when localeOverride is null', () => {
-    expect(getMaybeLocale({contextLanguage: 'DE', localeOverride: null})).toBe(
-      'de',
-    );
+  it('falls back to contextLanguage when both overrides are null', () => {
     expect(
-      getMaybeLocale({contextLanguage: 'ZH_TW', localeOverride: null}),
+      getMaybeLocale({
+        contextLanguage: 'DE',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
+    ).toBe('de');
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'ZH_TW',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
     ).toBe('zh-TW');
   });
 
   it('normalizes localeOverride format', () => {
     // Uppercase to lowercase
-    expect(getMaybeLocale({contextLanguage: null, localeOverride: 'FR'})).toBe(
-      'fr',
-    );
-    expect(getMaybeLocale({contextLanguage: null, localeOverride: 'EN'})).toBe(
-      'en',
-    );
+    expect(
+      getMaybeLocale({
+        contextLanguage: null,
+        localeOverride: 'FR',
+        uiLocalesOverride: null,
+      }),
+    ).toBe('fr');
+    expect(
+      getMaybeLocale({
+        contextLanguage: null,
+        localeOverride: 'EN',
+        uiLocalesOverride: null,
+      }),
+    ).toBe('en');
     // Underscore to hyphen with proper casing
     expect(
-      getMaybeLocale({contextLanguage: null, localeOverride: 'ZH_CN'}),
+      getMaybeLocale({
+        contextLanguage: null,
+        localeOverride: 'ZH_CN',
+        uiLocalesOverride: null,
+      }),
     ).toBe('zh-CN');
     expect(
-      getMaybeLocale({contextLanguage: null, localeOverride: 'PT_BR'}),
+      getMaybeLocale({
+        contextLanguage: null,
+        localeOverride: 'PT_BR',
+        uiLocalesOverride: null,
+      }),
     ).toBe('pt-BR');
     // Already correct format stays the same
     expect(
-      getMaybeLocale({contextLanguage: null, localeOverride: 'zh-CN'}),
+      getMaybeLocale({
+        contextLanguage: null,
+        localeOverride: 'zh-CN',
+        uiLocalesOverride: null,
+      }),
     ).toBe('zh-CN');
     expect(
-      getMaybeLocale({contextLanguage: null, localeOverride: 'pt-BR'}),
+      getMaybeLocale({
+        contextLanguage: null,
+        localeOverride: 'pt-BR',
+        uiLocalesOverride: null,
+      }),
     ).toBe('pt-BR');
+  });
+
+  it('respects priority order: localeOverride > uiLocalesOverride > contextLanguage', () => {
+    // All three provided - localeOverride wins
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'EN',
+        localeOverride: 'fr',
+        uiLocalesOverride: 'DE',
+      }),
+    ).toBe('fr');
+    // Only uiLocalesOverride and contextLanguage - uiLocalesOverride wins
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'EN',
+        localeOverride: null,
+        uiLocalesOverride: 'DE',
+      }),
+    ).toBe('de');
+    // Only contextLanguage - contextLanguage is used
+    expect(
+      getMaybeLocale({
+        contextLanguage: 'EN',
+        localeOverride: null,
+        uiLocalesOverride: null,
+      }),
+    ).toBe('en');
   });
 });

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -360,20 +360,11 @@ export function createCustomerAccountClient({
       const locale = getMaybeLocale({
         contextLanguage: language ?? null,
         localeOverride: options?.locale ?? null,
+        uiLocalesOverride: options?.uiLocales ?? null,
       });
 
       if (locale != null) {
-        // If locale is set, use locale and skip ui_locales (ui_locales may be deprecated in the future)
         loginUrl.searchParams.append('locale', locale);
-      } else {
-        // Fall back to ui_locales if locale is not set
-        const uiLocales = getMaybeUILocales({
-          contextLanguage: language ?? null,
-          uiLocalesOverride: options?.uiLocales ?? null,
-        });
-        if (uiLocales != null) {
-          loginUrl.searchParams.append('ui_locales', uiLocales);
-        }
       }
 
       if (options?.countryCode) {
@@ -683,20 +674,25 @@ function maybeEnforceRegionalVariant(language: LanguageCode): LanguageCode {
  * Supported locales: en, fr, cs, da, de, el, es, fi, hi, hr, hu, id, it, ja, ko, lt, ms, nb, nl, pl,
  * pt-BR, pt-PT, ro, ru, sk, sl, sv, th, tr, vi, zh-CN, zh-TW
  *
- * If localeOverride is provided, it takes precedence and is normalized via toLocaleString.
- * If contextLanguage is provided (LanguageCode), it is converted to locale format.
+ * Priority order: localeOverride > uiLocalesOverride > contextLanguage
  * If none are provided, returns null.
  */
 export function getMaybeLocale(params: {
   contextLanguage: LanguageCode | null;
   localeOverride: string | null;
+  uiLocalesOverride: LanguageCode | null;
 }): string | null {
-  // localeOverride takes precedence, normalize it via toLocaleString
+  // localeOverride takes highest precedence
   if (params.localeOverride != null) {
     return toLocaleString(params.localeOverride);
   }
 
-  // Convert contextLanguage (LanguageCode) to locale format
+  // uiLocalesOverride takes second precedence
+  if (params.uiLocalesOverride != null) {
+    return toLocaleString(params.uiLocalesOverride);
+  }
+
+  // contextLanguage is the fallback
   if (params.contextLanguage != null) {
     return toLocaleString(params.contextLanguage);
   }


### PR DESCRIPTION
### WHY are these changes introduced?

To improve locale handling in the customer account login process by standardizing the approach and providing a clear priority order for locale determination.

Before my change of locale, the priority order of handling locale is 
   - `uiLocales` option (first priority)
   - `language` configuration in `createCustomerAccountClient` (second priority)

After my change, the priority order of handling locale is 
   - `locale` option (highest priority)
   - `uiLocales` option (second priority)
   - `language` configuration in `createCustomerAccountClient` (fallback)


### WHAT is this pull request doing?

This PR enhances the locale handling in the `customerAccount.login()` method by:

1. Establishing a clear priority order for locale determination
2. Standardizing all locale sources to produce the `locale` query parameter instead of `ui_locales`, which simplifies the implementation and prepares for potential future deprecation of `ui_locales`. We will not redirect core idp authorize endpoint with ui_locales param

3. Updating tests to reflect the new behavior, ensuring that locale parameters are correctly applied in the login URL.

### HOW to test your changes?

1. Create a customer account client with different locale configurations:
   ```js
   // Test with locale option
   await customerAccount.login({locale: 'fr'});
   
   // Test with uiLocales option
   await customerAccount.login({uiLocales: 'de'});
   
   // Test with language configuration
   const customerAccount = createCustomerAccountClient({
     language: 'EN',
     // other config
   });
   await customerAccount.login();
   ```

2. Verify that the login URL contains the `locale` parameter with the correct value based on the priority order.

3. Test with combinations of options to ensure the priority order is respected:
   ```js
   // Should use 'fr' as locale (highest priority)
   await customerAccount.login({locale: 'fr', uiLocales: 'de'});
   ```