### PR TITLE
Fix upgrade tests to point to correct Hydrogen version

### DIFF
--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -864,7 +864,7 @@ describe('upgrade', async () => {
 
           const output = outputMock.info();
 
-          expect(output).toMatch(/Current: 2025\.5\.0.*Latest: 2025\.7\.0/);
+          expect(output).toMatch(/Current: 2025\.5\.0.*Latest: 2025\.7\.1/);
 
           expect(output).toMatch(/2025\.7\.0/);
 
@@ -906,7 +906,7 @@ describe('upgrade', async () => {
           const lastVersionLine =
             versionLineMatches[versionLineMatches.length - 1];
 
-          expect(firstVersionLine).toContain('2025.7.0');
+          expect(firstVersionLine).toContain('2025.7.1');
           expect(lastVersionLine).toMatch(/2025\.1\.[1-4]/);
         },
         {


### PR DESCRIPTION
Tests are expecting 2025.7.1 (oddly not 2025.7.2 despite that being available on NPM's registry).