### PR TITLE
Add changelog posts for h2 upgrade for cookie back-fixes

### DIFF
--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -772,6 +772,7 @@
       "dependencies": {
         "@shopify/hydrogen": "2025.1.5"
       },
+      "devDependencies": {},
       "fixes": [
         {
           "title": "Fix Privacy Banner and analytics event issues",
@@ -1358,6 +1359,7 @@
       "dependencies": {
         "@shopify/hydrogen": "2024.10.2"
       },
+      "devDependencies": {},
       "fixes": [
         {
           "title": "Fix Privacy Banner and analytics event issues",
@@ -1610,6 +1612,7 @@
       "dependencies": {
         "@shopify/hydrogen": "2024.7.10"
       },
+      "devDependencies": {},
       "fixes": [
         {
           "title": "Fix Privacy Banner and analytics event issues",

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -478,7 +478,7 @@
       ]
     },
     {
-      "title": "New Shopify cookie system and analytics improvements",
+      "title": "[ONLY USE IF YOU ARE CURRENTLY ON 2025.5.0; ELSE SKIP TO >=2025.7.0 UPGRADE] New Shopify cookie system and analytics improvements",
       "version": "2025.5.1",
       "date": "2026-01-13",
       "hash": "37373ce4903c32a215e7f1d22066634c7a909bab",

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -478,6 +478,90 @@
       ]
     },
     {
+      "title": "New Shopify cookie system and analytics improvements",
+      "version": "2025.5.1",
+      "date": "2026-01-13",
+      "hash": "37373ce4903c32a215e7f1d22066634c7a909bab",
+      "commit": "https://github.com/Shopify/hydrogen/commit/37373ce4903c32a215e7f1d22066634c7a909bab",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3368",
+      "dependencies": {
+        "@shopify/hydrogen": "2025.5.1"
+      },
+      "devDependencies": {
+        "@shopify/cli": "^3.83.3"
+      },
+      "fixes": [
+        {
+          "title": "Fix Privacy Banner and analytics event issues",
+          "info": "Fixed irregular behaviors between Privacy Banner and Hydrogen's analytics events.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3350",
+          "id": "3350-privacy"
+        }
+      ],
+      "features": [
+        {
+          "title": "Migrate to Shopify's new cookie system",
+          "info": "Hydrogen now supports Shopify's new `_shopify_analytics` and `_shopify_marketing` http-only cookies while keeping the deprecated `_shopify_y` and `_shopify_s` cookies working as long as they remain active. This keeps analytics and privacy behavior aligned with Shopify Admin while preserving backward compatibility.",
+          "breaking": false,
+          "steps": [
+            {
+              "title": "Understand the new cookie model and compatibility story",
+              "info": "Shopify is deprecating `_shopify_y` and `_shopify_s` in favor of `_shopify_analytics` and `_shopify_marketing`, which are http-only cookies set via the Storefront API on your storefront domain. Hydrogen now reads and writes these cookies through a Storefront API proxy while still honoring the legacy cookies when present. You don't need to migrate values manually, but you must ensure that requests flow through the proxy so cookies are set before analytics run."
+            },
+            {
+              "title": "Set up a Storefront API proxy for your deployment",
+              "info": "Depending on how you host your app, you must ensure Storefront API calls go through a proxy on your storefront domain.",
+              "code": "IyMjIFJlYWN0IFJvdXRlciArIEh5ZHJvZ2VuIG9uIE94eWdlbgoKSWYgeW91IHNjYWZmb2xkZWQgZnJvbSB0aGUgZGVmYXVsdCBIeWRyb2dlbiBza2VsZXRvbiBhbmQgZGVwbG95IHRvIE94eWdlbiwgdGhlIGBjcmVhdGVSZXF1ZXN0SGFuZGxlcmAgdXRpbGl0eSBmcm9tIGBAc2hvcGlmeS9oeWRyb2dlbi9veHlnZW5gIChub3cgYWxzbyBleHBvcnRlZCBmcm9tIGBAc2hvcGlmeS9oeWRyb2dlbmApIGFscmVhZHkgc2V0cyB1cCBhIFN0b3JlZnJvbnQgQVBJIHByb3h5IG9uIHRoZSBzYW1lIGRvbWFpbiBhcyB5b3VyIHN0b3JlZnJvbnQuCgoqKkluIG1vc3QgY2FzZXMsIG5vIGNoYW5nZXMgYXJlIHJlcXVpcmVkKio7IGp1c3QgY29uZmlybSB5b3VyIHNlcnZlciBlbnRyeSBzdGlsbCB1c2VzIGl0OgoKYGBgdHMKLy8gc2VydmVyLnRzIChPeHlnZW4pCmltcG9ydCB7Y3JlYXRlUmVxdWVzdEhhbmRsZXIsIGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dH0gZnJvbSAnQHNob3BpZnkvaHlkcm9nZW4nOwoKZXhwb3J0IGRlZmF1bHQgewogIGFzeW5jIGZldGNoKHJlcXVlc3QsIGVudikgewogICAgY29uc3QgaHlkcm9nZW5Db250ZXh0ID0gY3JlYXRlSHlkcm9nZW5Db250ZXh0KHsKICAgICAgZW52LAogICAgICByZXF1ZXN0LAogICAgICAvKiAuLi4gKi8KICAgIH0pOwoKICAgIGNvbnN0IGhhbmRsZVJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0SGFuZGxlcih7CiAgICAgIC8qIC4uLiAqLwogICAgICBnZXRMb2FkQ29udGV4dDogKCkgPT4gaHlkcm9nZW5Db250ZXh0LAogICAgICAvLyBBbHRlcm5hdGl2ZWx5LCBwYXNzIGF0IGxlYXN0IHN0b3JlZnJvbnQgY2xpZW50OgogICAgICAvLyBnZXRMb2FkQ29udGV4dDogKCkgPT4gKHtzdG9yZWZyb250OiBjcmVhdGVTdG9yZWZyb250Q2xpZW50KC4uLil9KQogICAgfSk7CgogICAgcmV0dXJuIGhhbmRsZVJlcXVlc3QocmVxdWVzdCk7CiAgfSwKfTsKYGBgCgpLZWVwIHVzaW5nIGA8QW5hbHl0aWNzLlByb3ZpZGVyPmAgY29tcG9uZW50IG9yIGB1c2VDdXN0b21lclByaXZhY3lgIGhvb2sgdG8gZ2V0IGNvb2tpZXMgaW4gdGhlIGJyb3dzZXIgYXV0b21hdGljYWxseS4KCkZvciBhIGZ1bGwgZXhhbXBsZSwgcmVmZXIgdG8gb3VyIFtza2VsZXRvbiB0ZW1wbGF0ZV0oaHR0cHM6Ly9naXRodWIuY29tL1Nob3BpZnkvaHlkcm9nZW4vYmxvYi9tYWluL3RlbXBsYXRlcy9za2VsZXRvbi9zZXJ2ZXIudHMpLgoKIyMjIFJlYWN0IFJvdXRlciArIEh5ZHJvZ2VuIG9uIG90aGVyIGhvc3RzCgojIyMjIEhvc3RzIHRoYXQgc3VwcG9ydCBXZWIgRmV0Y2ggQVBJIChSZXF1ZXN0L1Jlc3BvbnNlKQoKT24gaG9zdHMgdGhhdCBzdXBwb3J0IHRoZSBzdGFuZGFyZCBXZWIgRmV0Y2ggQVBJIChXb3JrZXJzLXN0eWxlIGVudmlyb25tZW50cyksIGltcG9ydCBgY3JlYXRlUmVxdWVzdEhhbmRsZXJgIGZyb20gYEBzaG9waWZ5L2h5ZHJvZ2VuYCAoaW5zdGVhZCBvZiBgcmVhY3Qtcm91dGVyYCkgYW5kIHJvdXRlIHJlcXVlc3RzIHRocm91Z2ggaXQ6CgpgYGB0cwppbXBvcnQge2NyZWF0ZVJlcXVlc3RIYW5kbGVyLCBjcmVhdGVIeWRyb2dlbkNvbnRleHR9IGZyb20gJ0BzaG9waWZ5L2h5ZHJvZ2VuJzsKCmNvbnN0IGh5ZHJvZ2VuQ29udGV4dCA9IGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dCh7CiAgLyogLi4uICovCn0pOwoKY29uc3QgaGFuZGxlUmVxdWVzdCA9IGNyZWF0ZVJlcXVlc3RIYW5kbGVyKHsKICAvKiAuLi4gKi8KICBnZXRMb2FkQ29udGV4dDogKCkgPT4gaHlkcm9nZW5Db250ZXh0LAp9KTsKYGBgCgojIyMjIE5vZGUuanMgYW5kIG90aGVyIGhvc3RzCgpGb3IgTm9kZS1saWtlIGVudmlyb25tZW50cywgYWRhcHQgTm9kZSByZXF1ZXN0cyB0byBGZXRjaCB3aXRoIFtgQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcmBdKGh0dHBzOi8vd3d3Lm5wbWpzLmNvbS9wYWNrYWdlL0ByZW1peC1ydW4vbm9kZS1mZXRjaC1zZXJ2ZXIpLCB0aGVuIGRlbGVnYXRlIHRvIEh5ZHJvZ2VuJ3MgaGFuZGxlcjoKCmBgYHRzCmltcG9ydCB7Y3JlYXRlUmVxdWVzdEhhbmRsZXIsIGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dH0gZnJvbSAnQHNob3BpZnkvaHlkcm9nZW4nOwppbXBvcnQge2NyZWF0ZVJlcXVlc3RMaXN0ZW5lcn0gZnJvbSAnQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcic7CmltcG9ydCBodHRwIGZyb20gJ2h0dHAnOwoKY29uc3QgaGFuZGxlTm9kZVJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0TGlzdGVuZXIoKHJlcXVlc3QpID0+IHsKICBjb25zdCBoeWRyb2dlbkNvbnRleHQgPSBjcmVhdGVIeWRyb2dlbkNvbnRleHQoewogICAgLyogLi4uICovCiAgfSk7CgogIGNvbnN0IGhhbmRsZVdlYlJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0SGFuZGxlcih7CiAgICAvKiAuLi4gKi8KICAgIGdldExvYWRDb250ZXh0OiAoKSA9PiBoeWRyb2dlbkNvbnRleHQsCiAgfSk7CgogIHJldHVybiBoYW5kbGVXZWJSZXF1ZXN0KHJlcXVlc3QpOwp9KTsKCmh0dHAuY3JlYXRlU2VydmVyKGhhbmRsZU5vZGVSZXF1ZXN0KTsKYGBgCgpBbHRlcm5hdGl2ZWx5LCBpZiB5b3UgY2FuJ3QgZGVsZWdhdGUgdG8gSHlkcm9nZW4ncyBgY3JlYXRlUmVxdWVzdEhhbmRsZXJgLCB5b3UgY2FuIHByb3ZpZGUgYSBjdXN0b20gU3RvcmVmcm9udCBBUEkgcHJveHkgaW4geW91ciBzZXJ2ZXIuIFNlZSBbSHlkcm9nZW4ncyBpbXBsZW1lbnRhdGlvbl0oaHR0cHM6Ly9naXRodWIuY29tL1Nob3BpZnkvaHlkcm9nZW4vYmxvYi8yNzA2NmEyODU3NzQ4NGY0MDYyMjIxMTZhOTU5ZWI0NjNkMjU1Njg1L3BhY2thZ2VzL2h5ZHJvZ2VuL3NyYy9zdG9yZWZyb250LnRzI0w1NDYtTDYxMSkgYXMgYSByZWZlcmVuY2UuIEluIHRoaXMgY2FzZSwgZW5zdXJlIHlvdSBtYW51YWxseSBwYXNzIGBzYW1lRG9tYWluRm9yU3RvcmVmcm9udEFwaTogdHJ1ZWAgaW4gdGhlIGBjb25zZW50YCBvYmplY3QgZm9yIGA8QW5hbHl0aWNzLlByb3ZpZGVyPmAgb3IgYXMgYSBwcm9wIHRvIHRoZSBgdXNlQ3VzdG9tZXJQcml2YWN5YCBob29rLgo="
+            }
+          ],
+          "pr": "https://github.com/Shopify/hydrogen/pull/3350",
+          "id": "3350"
+        }
+      ]
+    },
+    {
+      "title": "New Shopify cookie system and analytics improvements",
+      "version": "2025.4.2",
+      "date": "2026-01-14",
+      "hash": "6a8d5ff69b87a66c1ddb771d733ce7a4a0460001",
+      "commit": "https://github.com/Shopify/hydrogen/commit/6a8d5ff69b87a66c1ddb771d733ce7a4a0460001",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3343",
+      "dependencies": {
+        "@shopify/hydrogen": "2025.4.2"
+      },
+      "devDependencies": {
+        "@shopify/cli": "^3.83.3"
+      },
+      "fixes": [
+        {
+          "title": "Fix Privacy Banner and analytics event issues",
+          "info": "Fixed irregular behaviors between Privacy Banner and Hydrogen's analytics events.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3332",
+          "id": "3332-privacy"
+        }
+      ],
+      "features": [
+        {
+          "title": "Migrate to Shopify's new cookie system",
+          "info": "Hydrogen now supports Shopify's new `_shopify_analytics` and `_shopify_marketing` http-only cookies while keeping the deprecated `_shopify_y` and `_shopify_s` cookies working as long as they remain active. This keeps analytics and privacy behavior aligned with Shopify Admin while preserving backward compatibility.",
+          "breaking": false,
+          "steps": [
+            {
+              "title": "Understand the new cookie model and compatibility story",
+              "info": "Shopify is deprecating `_shopify_y` and `_shopify_s` in favor of `_shopify_analytics` and `_shopify_marketing`, which are http-only cookies set via the Storefront API on your storefront domain. Hydrogen now reads and writes these cookies through a Storefront API proxy while still honoring the legacy cookies when present. You don't need to migrate values manually, but you must ensure that requests flow through the proxy so cookies are set before analytics run."
+            },
+            {
+              "title": "Set up a Storefront API proxy for your deployment",
+              "info": "Depending on how you host your app, you must ensure Storefront API calls go through a proxy on your storefront domain.",
+              "code": "IyMjIFJlbWl4ICsgSHlkcm9nZW4gb24gT3h5Z2VuCgpJZiB5b3Ugc2NhZmZvbGRlZCBmcm9tIHRoZSBkZWZhdWx0IEh5ZHJvZ2VuIHNrZWxldG9uIGFuZCBkZXBsb3kgdG8gT3h5Z2VuLCB0aGUgYGNyZWF0ZVJlcXVlc3RIYW5kbGVyYCB1dGlsaXR5IGZyb20gYEBzaG9waWZ5L3JlbWl4LW94eWdlbmAgYWxyZWFkeSBzZXRzIHVwIGEgU3RvcmVmcm9udCBBUEkgcHJveHkgb24gdGhlIHNhbWUgZG9tYWluIGFzIHlvdXIgc3RvcmVmcm9udC4KCioqSW4gbW9zdCBjYXNlcywgbm8gY2hhbmdlcyBhcmUgcmVxdWlyZWQqKjsganVzdCBjb25maXJtIHlvdXIgc2VydmVyIGVudHJ5IHN0aWxsIHVzZXMgaXQ6CgpgYGB0cwovLyBzZXJ2ZXIudHMgKE94eWdlbikKaW1wb3J0IHtjcmVhdGVSZXF1ZXN0SGFuZGxlcn0gZnJvbSAnQHNob3BpZnkvcmVtaXgtb3h5Z2VuJzsKaW1wb3J0IHtjcmVhdGVIeWRyb2dlbkNvbnRleHR9IGZyb20gJ0BzaG9waWZ5L2h5ZHJvZ2VuJzsKCmV4cG9ydCBkZWZhdWx0IHsKICBhc3luYyBmZXRjaChyZXF1ZXN0LCBlbnYpIHsKICAgIGNvbnN0IGh5ZHJvZ2VuQ29udGV4dCA9IGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dCh7CiAgICAgIGVudiwKICAgICAgcmVxdWVzdCwKICAgICAgLyogLi4uICovCiAgICB9KTsKCiAgICBjb25zdCBoYW5kbGVSZXF1ZXN0ID0gY3JlYXRlUmVxdWVzdEhhbmRsZXIoewogICAgICAvKiAuLi4gKi8KICAgICAgZ2V0TG9hZENvbnRleHQ6ICgpID0+IGh5ZHJvZ2VuQ29udGV4dCwKICAgIH0pOwoKICAgIHJldHVybiBoYW5kbGVSZXF1ZXN0KHJlcXVlc3QpOwogIH0sCn07CmBgYAoKS2VlcCB1c2luZyBgPEFuYWx5dGljcy5Qcm92aWRlcj5gIGNvbXBvbmVudCBvciBgdXNlQ3VzdG9tZXJQcml2YWN5YCBob29rIHRvIGdldCBjb29raWVzIGluIHRoZSBicm93c2VyIGF1dG9tYXRpY2FsbHkuCgpGb3IgYSBmdWxsIGV4YW1wbGUsIHJlZmVyIHRvIHlvdXIgc2tlbGV0b24gdGVtcGxhdGUncyBzZXJ2ZXIudHMuCgojIyMgUmVtaXggKyBIeWRyb2dlbiBvbiBvdGhlciBob3N0cwoKIyMjIyBIb3N0cyB0aGF0IHN1cHBvcnQgV2ViIEZldGNoIEFQSSAoUmVxdWVzdC9SZXNwb25zZSkKCk9uIGhvc3RzIHRoYXQgc3VwcG9ydCB0aGUgc3RhbmRhcmQgV2ViIEZldGNoIEFQSSAoV29ya2Vycy1zdHlsZSBlbnZpcm9ubWVudHMpLCBpbXBvcnQgYGNyZWF0ZVJlcXVlc3RIYW5kbGVyYCBmcm9tIGBAc2hvcGlmeS9oeWRyb2dlbmAgYW5kIHJvdXRlIHJlcXVlc3RzIHRocm91Z2ggaXQ6CgpgYGB0cwppbXBvcnQge2NyZWF0ZVJlcXVlc3RIYW5kbGVyLCBjcmVhdGVIeWRyb2dlbkNvbnRleHR9IGZyb20gJ0BzaG9waWZ5L2h5ZHJvZ2VuJzsKCmNvbnN0IGh5ZHJvZ2VuQ29udGV4dCA9IGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dCh7CiAgLyogLi4uICovCn0pOwoKY29uc3QgaGFuZGxlUmVxdWVzdCA9IGNyZWF0ZVJlcXVlc3RIYW5kbGVyKHsKICAvKiAuLi4gKi8KICBnZXRMb2FkQ29udGV4dDogKCkgPT4gaHlkcm9nZW5Db250ZXh0LAp9KTsKYGBgCgojIyMjIE5vZGUuanMgYW5kIG90aGVyIGhvc3RzCgpGb3IgTm9kZS1saWtlIGVudmlyb25tZW50cywgYWRhcHQgTm9kZSByZXF1ZXN0cyB0byBGZXRjaCB3aXRoIFtgQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcmBdKGh0dHBzOi8vd3d3Lm5wbWpzLmNvbS9wYWNrYWdlL0ByZW1peC1ydW4vbm9kZS1mZXRjaC1zZXJ2ZXIpLCB0aGVuIGRlbGVnYXRlIHRvIEh5ZHJvZ2VuJ3MgaGFuZGxlcjoKCmBgYHRzCmltcG9ydCB7Y3JlYXRlUmVxdWVzdEhhbmRsZXIsIGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dH0gZnJvbSAnQHNob3BpZnkvaHlkcm9nZW4nOwppbXBvcnQge2NyZWF0ZVJlcXVlc3RMaXN0ZW5lcn0gZnJvbSAnQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcic7CmltcG9ydCBodHRwIGZyb20gJ2h0dHAnOwoKY29uc3QgaGFuZGxlTm9kZVJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0TGlzdGVuZXIoKHJlcXVlc3QpID0+IHsKICBjb25zdCBoeWRyb2dlbkNvbnRleHQgPSBjcmVhdGVIeWRyb2dlbkNvbnRleHQoewogICAgLyogLi4uICovCiAgfSk7CgogIGNvbnN0IGhhbmRsZVdlYlJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0SGFuZGxlcih7CiAgICAvKiAuLi4gKi8KICAgIGdldExvYWRDb250ZXh0OiAoKSA9PiBoeWRyb2dlbkNvbnRleHQsCiAgfSk7CgogIHJldHVybiBoYW5kbGVXZWJSZXF1ZXN0KHJlcXVlc3QpOwp9KTsKCmh0dHAuY3JlYXRlU2VydmVyKGhhbmRsZU5vZGVSZXF1ZXN0KTsKYGBgCgpBbHRlcm5hdGl2ZWx5LCBpZiB5b3UgY2FuJ3QgZGVsZWdhdGUgdG8gSHlkcm9nZW4ncyBgY3JlYXRlUmVxdWVzdEhhbmRsZXJgLCB5b3UgY2FuIHByb3ZpZGUgYSBjdXN0b20gU3RvcmVmcm9udCBBUEkgcHJveHkgaW4geW91ciBzZXJ2ZXIuIFNlZSBbSHlkcm9nZW4ncyBpbXBsZW1lbnRhdGlvbl0oaHR0cHM6Ly9naXRodWIuY29tL1Nob3BpZnkvaHlkcm9nZW4vYmxvYi8yNzA2NmEyODU3NzQ4NGY0MDYyMjIxMTZhOTU5ZWI0NjNkMjU1Njg1L3BhY2thZ2VzL2h5ZHJvZ2VuL3NyYy9zdG9yZWZyb250LnRzI0w1NDYtTDYxMSkgYXMgYSByZWZlcmVuY2UuIEluIHRoaXMgY2FzZSwgZW5zdXJlIHlvdSBtYW51YWxseSBwYXNzIGBzYW1lRG9tYWluRm9yU3RvcmVmcm9udEFwaTogdHJ1ZWAgaW4gdGhlIGBjb25zZW50YCBvYmplY3QgZm9yIGA8QW5hbHl0aWNzLlByb3ZpZGVyPmAgb3IgYXMgYSBwcm9wIHRvIHRoZSBgdXNlQ3VzdG9tZXJQcml2YWN5YCBob29rLgo="
+            }
+          ],
+          "pr": "https://github.com/Shopify/hydrogen/pull/3332",
+          "id": "3332"
+        }
+      ]
+    },
+    {
       "title": "[COMPLETE BEFORE ATTEMPTING 2025.7.0 UPGRADE] Bump Shopify CLI version",
       "version": "2025.4.1",
       "hash": "e4f44954a5dc53e6dfccd1b7e96de593bbb0887a",
@@ -675,6 +759,45 @@
           "title": "Update SFAPI and CAAPI versions to 2025.04",
           "pr": "https://github.com/Shopify/hydrogen/pull/2886",
           "id": "2886"
+        }
+      ]
+    },
+    {
+      "title": "New Shopify cookie system and analytics improvements",
+      "version": "2025.1.5",
+      "date": "2026-01-14",
+      "hash": "dba02cc0f67cef4f2495b6bb042f7a76e4149d4b",
+      "commit": "https://github.com/Shopify/hydrogen/commit/dba02cc0f67cef4f2495b6bb042f7a76e4149d4b",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3369",
+      "dependencies": {
+        "@shopify/hydrogen": "2025.1.5"
+      },
+      "fixes": [
+        {
+          "title": "Fix Privacy Banner and analytics event issues",
+          "info": "Fixed irregular behaviors between Privacy Banner and Hydrogen's analytics events.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3354",
+          "id": "3354-privacy"
+        }
+      ],
+      "features": [
+        {
+          "title": "Migrate to Shopify's new cookie system",
+          "info": "Hydrogen now supports Shopify's new `_shopify_analytics` and `_shopify_marketing` http-only cookies while keeping the deprecated `_shopify_y` and `_shopify_s` cookies working as long as they remain active. This keeps analytics and privacy behavior aligned with Shopify Admin while preserving backward compatibility.",
+          "breaking": false,
+          "steps": [
+            {
+              "title": "Understand the new cookie model and compatibility story",
+              "info": "Shopify is deprecating `_shopify_y` and `_shopify_s` in favor of `_shopify_analytics` and `_shopify_marketing`, which are http-only cookies set via the Storefront API on your storefront domain. Hydrogen now reads and writes these cookies through a Storefront API proxy while still honoring the legacy cookies when present. You don't need to migrate values manually, but you must ensure that requests flow through the proxy so cookies are set before analytics run."
+            },
+            {
+              "title": "Set up a Storefront API proxy for your deployment",
+              "info": "Depending on how you host your app, you must ensure Storefront API calls go through a proxy on your storefront domain.",
+              "code": "IyMjIFJlbWl4ICsgSHlkcm9nZW4gb24gT3h5Z2VuCgpJZiB5b3Ugc2NhZmZvbGRlZCBmcm9tIHRoZSBkZWZhdWx0IEh5ZHJvZ2VuIHNrZWxldG9uIGFuZCBkZXBsb3kgdG8gT3h5Z2VuLCB0aGUgYGNyZWF0ZVJlcXVlc3RIYW5kbGVyYCB1dGlsaXR5IGZyb20gYEBzaG9waWZ5L3JlbWl4LW94eWdlbmAgYWxyZWFkeSBzZXRzIHVwIGEgU3RvcmVmcm9udCBBUEkgcHJveHkgb24gdGhlIHNhbWUgZG9tYWluIGFzIHlvdXIgc3RvcmVmcm9udC4KCioqSW4gbW9zdCBjYXNlcywgbm8gY2hhbmdlcyBhcmUgcmVxdWlyZWQqKjsganVzdCBjb25maXJtIHlvdXIgc2VydmVyIGVudHJ5IHN0aWxsIHVzZXMgaXQ6CgpgYGB0cwovLyBzZXJ2ZXIudHMgKE94eWdlbikKaW1wb3J0IHtjcmVhdGVSZXF1ZXN0SGFuZGxlcn0gZnJvbSAnQHNob3BpZnkvcmVtaXgtb3h5Z2VuJzsKaW1wb3J0IHtjcmVhdGVIeWRyb2dlbkNvbnRleHR9IGZyb20gJ0BzaG9waWZ5L2h5ZHJvZ2VuJzsKCmV4cG9ydCBkZWZhdWx0IHsKICBhc3luYyBmZXRjaChyZXF1ZXN0LCBlbnYpIHsKICAgIGNvbnN0IGh5ZHJvZ2VuQ29udGV4dCA9IGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dCh7CiAgICAgIGVudiwKICAgICAgcmVxdWVzdCwKICAgICAgLyogLi4uICovCiAgICB9KTsKCiAgICBjb25zdCBoYW5kbGVSZXF1ZXN0ID0gY3JlYXRlUmVxdWVzdEhhbmRsZXIoewogICAgICAvKiAuLi4gKi8KICAgICAgZ2V0TG9hZENvbnRleHQ6ICgpID0+IGh5ZHJvZ2VuQ29udGV4dCwKICAgIH0pOwoKICAgIHJldHVybiBoYW5kbGVSZXF1ZXN0KHJlcXVlc3QpOwogIH0sCn07CmBgYAoKS2VlcCB1c2luZyBgPEFuYWx5dGljcy5Qcm92aWRlcj5gIGNvbXBvbmVudCBvciBgdXNlQ3VzdG9tZXJQcml2YWN5YCBob29rIHRvIGdldCBjb29raWVzIGluIHRoZSBicm93c2VyIGF1dG9tYXRpY2FsbHkuCgpGb3IgYSBmdWxsIGV4YW1wbGUsIHJlZmVyIHRvIHlvdXIgc2tlbGV0b24gdGVtcGxhdGUncyBzZXJ2ZXIudHMuCgojIyMgUmVtaXggKyBIeWRyb2dlbiBvbiBvdGhlciBob3N0cwoKIyMjIyBIb3N0cyB0aGF0IHN1cHBvcnQgV2ViIEZldGNoIEFQSSAoUmVxdWVzdC9SZXNwb25zZSkKCk9uIGhvc3RzIHRoYXQgc3VwcG9ydCB0aGUgc3RhbmRhcmQgV2ViIEZldGNoIEFQSSAoV29ya2Vycy1zdHlsZSBlbnZpcm9ubWVudHMpLCBpbXBvcnQgYGNyZWF0ZVJlcXVlc3RIYW5kbGVyYCBmcm9tIGBAc2hvcGlmeS9oeWRyb2dlbmAgYW5kIHJvdXRlIHJlcXVlc3RzIHRocm91Z2ggaXQ6CgpgYGB0cwppbXBvcnQge2NyZWF0ZVJlcXVlc3RIYW5kbGVyLCBjcmVhdGVIeWRyb2dlbkNvbnRleHR9IGZyb20gJ0BzaG9waWZ5L2h5ZHJvZ2VuJzsKCmNvbnN0IGh5ZHJvZ2VuQ29udGV4dCA9IGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dCh7CiAgLyogLi4uICovCn0pOwoKY29uc3QgaGFuZGxlUmVxdWVzdCA9IGNyZWF0ZVJlcXVlc3RIYW5kbGVyKHsKICAvKiAuLi4gKi8KICBnZXRMb2FkQ29udGV4dDogKCkgPT4gaHlkcm9nZW5Db250ZXh0LAp9KTsKYGBgCgojIyMjIE5vZGUuanMgYW5kIG90aGVyIGhvc3RzCgpGb3IgTm9kZS1saWtlIGVudmlyb25tZW50cywgYWRhcHQgTm9kZSByZXF1ZXN0cyB0byBGZXRjaCB3aXRoIFtgQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcmBdKGh0dHBzOi8vd3d3Lm5wbWpzLmNvbS9wYWNrYWdlL0ByZW1peC1ydW4vbm9kZS1mZXRjaC1zZXJ2ZXIpLCB0aGVuIGRlbGVnYXRlIHRvIEh5ZHJvZ2VuJ3MgaGFuZGxlcjoKCmBgYHRzCmltcG9ydCB7Y3JlYXRlUmVxdWVzdEhhbmRsZXIsIGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dH0gZnJvbSAnQHNob3BpZnkvaHlkcm9nZW4nOwppbXBvcnQge2NyZWF0ZVJlcXVlc3RMaXN0ZW5lcn0gZnJvbSAnQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcic7CmltcG9ydCBodHRwIGZyb20gJ2h0dHAnOwoKY29uc3QgaGFuZGxlTm9kZVJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0TGlzdGVuZXIoKHJlcXVlc3QpID0+IHsKICBjb25zdCBoeWRyb2dlbkNvbnRleHQgPSBjcmVhdGVIeWRyb2dlbkNvbnRleHQoewogICAgLyogLi4uICovCiAgfSk7CgogIGNvbnN0IGhhbmRsZVdlYlJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0SGFuZGxlcih7CiAgICAvKiAuLi4gKi8KICAgIGdldExvYWRDb250ZXh0OiAoKSA9PiBoeWRyb2dlbkNvbnRleHQsCiAgfSk7CgogIHJldHVybiBoYW5kbGVXZWJSZXF1ZXN0KHJlcXVlc3QpOwp9KTsKCmh0dHAuY3JlYXRlU2VydmVyKGhhbmRsZU5vZGVSZXF1ZXN0KTsKYGBgCgpBbHRlcm5hdGl2ZWx5LCBpZiB5b3UgY2FuJ3QgZGVsZWdhdGUgdG8gSHlkcm9nZW4ncyBgY3JlYXRlUmVxdWVzdEhhbmRsZXJgLCB5b3UgY2FuIHByb3ZpZGUgYSBjdXN0b20gU3RvcmVmcm9udCBBUEkgcHJveHkgaW4geW91ciBzZXJ2ZXIuIFNlZSBbSHlkcm9nZW4ncyBpbXBsZW1lbnRhdGlvbl0oaHR0cHM6Ly9naXRodWIuY29tL1Nob3BpZnkvaHlkcm9nZW4vYmxvYi8yNzA2NmEyODU3NzQ4NGY0MDYyMjIxMTZhOTU5ZWI0NjNkMjU1Njg1L3BhY2thZ2VzL2h5ZHJvZ2VuL3NyYy9zdG9yZWZyb250LnRzI0w1NDYtTDYxMSkgYXMgYSByZWZlcmVuY2UuIEluIHRoaXMgY2FzZSwgZW5zdXJlIHlvdSBtYW51YWxseSBwYXNzIGBzYW1lRG9tYWluRm9yU3RvcmVmcm9udEFwaTogdHJ1ZWAgaW4gdGhlIGBjb25zZW50YCBvYmplY3QgZm9yIGA8QW5hbHl0aWNzLlByb3ZpZGVyPmAgb3IgYXMgYSBwcm9wIHRvIHRoZSBgdXNlQ3VzdG9tZXJQcml2YWN5YCBob29rLgo="
+            }
+          ],
+          "pr": "https://github.com/Shopify/hydrogen/pull/3354",
+          "id": "3354"
         }
       ]
     },
@@ -1226,6 +1349,45 @@
       ]
     },
     {
+      "title": "New Shopify cookie system and analytics improvements",
+      "version": "2024.10.2",
+      "date": "2026-01-14",
+      "hash": "d1aac68acbb53c875acf94788b91c38a009e24f2",
+      "commit": "https://github.com/Shopify/hydrogen/commit/d1aac68acbb53c875acf94788b91c38a009e24f2",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3375",
+      "dependencies": {
+        "@shopify/hydrogen": "2024.10.2"
+      },
+      "fixes": [
+        {
+          "title": "Fix Privacy Banner and analytics event issues",
+          "info": "Fixed irregular behaviors between Privacy Banner and Hydrogen's analytics events.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3342",
+          "id": "3342-privacy"
+        }
+      ],
+      "features": [
+        {
+          "title": "Migrate to Shopify's new cookie system",
+          "info": "Hydrogen now supports Shopify's new `_shopify_analytics` and `_shopify_marketing` http-only cookies while keeping the deprecated `_shopify_y` and `_shopify_s` cookies working as long as they remain active. This keeps analytics and privacy behavior aligned with Shopify Admin while preserving backward compatibility.",
+          "breaking": false,
+          "steps": [
+            {
+              "title": "Understand the new cookie model and compatibility story",
+              "info": "Shopify is deprecating `_shopify_y` and `_shopify_s` in favor of `_shopify_analytics` and `_shopify_marketing`, which are http-only cookies set via the Storefront API on your storefront domain. Hydrogen now reads and writes these cookies through a Storefront API proxy while still honoring the legacy cookies when present. You don't need to migrate values manually, but you must ensure that requests flow through the proxy so cookies are set before analytics run."
+            },
+            {
+              "title": "Set up a Storefront API proxy for your deployment",
+              "info": "Depending on how you host your app, you must ensure Storefront API calls go through a proxy on your storefront domain.",
+              "code": "IyMjIFJlbWl4ICsgSHlkcm9nZW4gb24gT3h5Z2VuCgpJZiB5b3Ugc2NhZmZvbGRlZCBmcm9tIHRoZSBkZWZhdWx0IEh5ZHJvZ2VuIHNrZWxldG9uIGFuZCBkZXBsb3kgdG8gT3h5Z2VuLCB0aGUgYGNyZWF0ZVJlcXVlc3RIYW5kbGVyYCB1dGlsaXR5IGZyb20gYEBzaG9waWZ5L3JlbWl4LW94eWdlbmAgYWxyZWFkeSBzZXRzIHVwIGEgU3RvcmVmcm9udCBBUEkgcHJveHkgb24gdGhlIHNhbWUgZG9tYWluIGFzIHlvdXIgc3RvcmVmcm9udC4KCioqSW4gbW9zdCBjYXNlcywgbm8gY2hhbmdlcyBhcmUgcmVxdWlyZWQqKjsganVzdCBjb25maXJtIHlvdXIgc2VydmVyIGVudHJ5IHN0aWxsIHVzZXMgaXQ6CgpgYGB0cwovLyBzZXJ2ZXIudHMgKE94eWdlbikKaW1wb3J0IHtjcmVhdGVSZXF1ZXN0SGFuZGxlcn0gZnJvbSAnQHNob3BpZnkvcmVtaXgtb3h5Z2VuJzsKaW1wb3J0IHtjcmVhdGVIeWRyb2dlbkNvbnRleHR9IGZyb20gJ0BzaG9waWZ5L2h5ZHJvZ2VuJzsKCmV4cG9ydCBkZWZhdWx0IHsKICBhc3luYyBmZXRjaChyZXF1ZXN0LCBlbnYpIHsKICAgIGNvbnN0IGh5ZHJvZ2VuQ29udGV4dCA9IGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dCh7CiAgICAgIGVudiwKICAgICAgcmVxdWVzdCwKICAgICAgLyogLi4uICovCiAgICB9KTsKCiAgICBjb25zdCBoYW5kbGVSZXF1ZXN0ID0gY3JlYXRlUmVxdWVzdEhhbmRsZXIoewogICAgICAvKiAuLi4gKi8KICAgICAgZ2V0TG9hZENvbnRleHQ6ICgpID0+IGh5ZHJvZ2VuQ29udGV4dCwKICAgIH0pOwoKICAgIHJldHVybiBoYW5kbGVSZXF1ZXN0KHJlcXVlc3QpOwogIH0sCn07CmBgYAoKS2VlcCB1c2luZyBgPEFuYWx5dGljcy5Qcm92aWRlcj5gIGNvbXBvbmVudCBvciBgdXNlQ3VzdG9tZXJQcml2YWN5YCBob29rIHRvIGdldCBjb29raWVzIGluIHRoZSBicm93c2VyIGF1dG9tYXRpY2FsbHkuCgpGb3IgYSBmdWxsIGV4YW1wbGUsIHJlZmVyIHRvIHlvdXIgc2tlbGV0b24gdGVtcGxhdGUncyBzZXJ2ZXIudHMuCgojIyMgUmVtaXggKyBIeWRyb2dlbiBvbiBvdGhlciBob3N0cwoKIyMjIyBIb3N0cyB0aGF0IHN1cHBvcnQgV2ViIEZldGNoIEFQSSAoUmVxdWVzdC9SZXNwb25zZSkKCk9uIGhvc3RzIHRoYXQgc3VwcG9ydCB0aGUgc3RhbmRhcmQgV2ViIEZldGNoIEFQSSAoV29ya2Vycy1zdHlsZSBlbnZpcm9ubWVudHMpLCBpbXBvcnQgYGNyZWF0ZVJlcXVlc3RIYW5kbGVyYCBmcm9tIGBAc2hvcGlmeS9oeWRyb2dlbmAgYW5kIHJvdXRlIHJlcXVlc3RzIHRocm91Z2ggaXQ6CgpgYGB0cwppbXBvcnQge2NyZWF0ZVJlcXVlc3RIYW5kbGVyLCBjcmVhdGVIeWRyb2dlbkNvbnRleHR9IGZyb20gJ0BzaG9waWZ5L2h5ZHJvZ2VuJzsKCmNvbnN0IGh5ZHJvZ2VuQ29udGV4dCA9IGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dCh7CiAgLyogLi4uICovCn0pOwoKY29uc3QgaGFuZGxlUmVxdWVzdCA9IGNyZWF0ZVJlcXVlc3RIYW5kbGVyKHsKICAvKiAuLi4gKi8KICBnZXRMb2FkQ29udGV4dDogKCkgPT4gaHlkcm9nZW5Db250ZXh0LAp9KTsKYGBgCgojIyMjIE5vZGUuanMgYW5kIG90aGVyIGhvc3RzCgpGb3IgTm9kZS1saWtlIGVudmlyb25tZW50cywgYWRhcHQgTm9kZSByZXF1ZXN0cyB0byBGZXRjaCB3aXRoIFtgQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcmBdKGh0dHBzOi8vd3d3Lm5wbWpzLmNvbS9wYWNrYWdlL0ByZW1peC1ydW4vbm9kZS1mZXRjaC1zZXJ2ZXIpLCB0aGVuIGRlbGVnYXRlIHRvIEh5ZHJvZ2VuJ3MgaGFuZGxlcjoKCmBgYHRzCmltcG9ydCB7Y3JlYXRlUmVxdWVzdEhhbmRsZXIsIGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dH0gZnJvbSAnQHNob3BpZnkvaHlkcm9nZW4nOwppbXBvcnQge2NyZWF0ZVJlcXVlc3RMaXN0ZW5lcn0gZnJvbSAnQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcic7CmltcG9ydCBodHRwIGZyb20gJ2h0dHAnOwoKY29uc3QgaGFuZGxlTm9kZVJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0TGlzdGVuZXIoKHJlcXVlc3QpID0+IHsKICBjb25zdCBoeWRyb2dlbkNvbnRleHQgPSBjcmVhdGVIeWRyb2dlbkNvbnRleHQoewogICAgLyogLi4uICovCiAgfSk7CgogIGNvbnN0IGhhbmRsZVdlYlJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0SGFuZGxlcih7CiAgICAvKiAuLi4gKi8KICAgIGdldExvYWRDb250ZXh0OiAoKSA9PiBoeWRyb2dlbkNvbnRleHQsCiAgfSk7CgogIHJldHVybiBoYW5kbGVXZWJSZXF1ZXN0KHJlcXVlc3QpOwp9KTsKCmh0dHAuY3JlYXRlU2VydmVyKGhhbmRsZU5vZGVSZXF1ZXN0KTsKYGBgCgpBbHRlcm5hdGl2ZWx5LCBpZiB5b3UgY2FuJ3QgZGVsZWdhdGUgdG8gSHlkcm9nZW4ncyBgY3JlYXRlUmVxdWVzdEhhbmRsZXJgLCB5b3UgY2FuIHByb3ZpZGUgYSBjdXN0b20gU3RvcmVmcm9udCBBUEkgcHJveHkgaW4geW91ciBzZXJ2ZXIuIFNlZSBbSHlkcm9nZW4ncyBpbXBsZW1lbnRhdGlvbl0oaHR0cHM6Ly9naXRodWIuY29tL1Nob3BpZnkvaHlkcm9nZW4vYmxvYi8yNzA2NmEyODU3NzQ4NGY0MDYyMjIxMTZhOTU5ZWI0NjNkMjU1Njg1L3BhY2thZ2VzL2h5ZHJvZ2VuL3NyYy9zdG9yZWZyb250LnRzI0w1NDYtTDYxMSkgYXMgYSByZWZlcmVuY2UuIEluIHRoaXMgY2FzZSwgZW5zdXJlIHlvdSBtYW51YWxseSBwYXNzIGBzYW1lRG9tYWluRm9yU3RvcmVmcm9udEFwaTogdHJ1ZWAgaW4gdGhlIGBjb25zZW50YCBvYmplY3QgZm9yIGA8QW5hbHl0aWNzLlByb3ZpZGVyPmAgb3IgYXMgYSBwcm9wIHRvIHRoZSBgdXNlQ3VzdG9tZXJQcml2YWN5YCBob29rLgo="
+            }
+          ],
+          "pr": "https://github.com/Shopify/hydrogen/pull/3342",
+          "id": "3342"
+        }
+      ]
+    },
+    {
       "title": "Support for 2,000 variants and combined listings",
       "version": "2024.10.1",
       "hash": "c915b67d81ff01e25eeefce8cf0510805d620d64",
@@ -1435,6 +1597,45 @@
               "desc": "Starting from this major version, on each deploy to Oxygen, Hydrogen will be on Cloudflare worker compatibility date `2024-10-01`. Onwards, Hydrogen will update worker compatibility date on every SFAPI release. There is no specific project update that needs to be done in order to get this feature. However, please ensure your project is working properly in an Oxygen deployment when updating to this Hydrogen version."
             }
           ]
+        }
+      ]
+    },
+    {
+      "title": "New Shopify cookie system and analytics improvements",
+      "version": "2024.7.10",
+      "date": "2026-01-14",
+      "hash": "9568a1f71a924c56d0cc0c2a30803a773b731ad6",
+      "commit": "https://github.com/Shopify/hydrogen/commit/9568a1f71a924c56d0cc0c2a30803a773b731ad6",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3374",
+      "dependencies": {
+        "@shopify/hydrogen": "2024.7.10"
+      },
+      "fixes": [
+        {
+          "title": "Fix Privacy Banner and analytics event issues",
+          "info": "Fixed irregular behaviors between Privacy Banner and Hydrogen's analytics events.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3355",
+          "id": "3355-privacy"
+        }
+      ],
+      "features": [
+        {
+          "title": "Migrate to Shopify's new cookie system",
+          "info": "Hydrogen now supports Shopify's new `_shopify_analytics` and `_shopify_marketing` http-only cookies while keeping the deprecated `_shopify_y` and `_shopify_s` cookies working as long as they remain active. This keeps analytics and privacy behavior aligned with Shopify Admin while preserving backward compatibility.",
+          "breaking": false,
+          "steps": [
+            {
+              "title": "Understand the new cookie model and compatibility story",
+              "info": "Shopify is deprecating `_shopify_y` and `_shopify_s` in favor of `_shopify_analytics` and `_shopify_marketing`, which are http-only cookies set via the Storefront API on your storefront domain. Hydrogen now reads and writes these cookies through a Storefront API proxy while still honoring the legacy cookies when present. You don't need to migrate values manually, but you must ensure that requests flow through the proxy so cookies are set before analytics run."
+            },
+            {
+              "title": "Set up a Storefront API proxy for your deployment",
+              "info": "Depending on how you host your app, you must ensure Storefront API calls go through a proxy on your storefront domain.",
+              "code": "IyMjIFJlbWl4ICsgSHlkcm9nZW4gb24gT3h5Z2VuCgpJZiB5b3Ugc2NhZmZvbGRlZCBmcm9tIHRoZSBkZWZhdWx0IEh5ZHJvZ2VuIHNrZWxldG9uIGFuZCBkZXBsb3kgdG8gT3h5Z2VuLCB0aGUgYGNyZWF0ZVJlcXVlc3RIYW5kbGVyYCB1dGlsaXR5IGZyb20gYEBzaG9waWZ5L3JlbWl4LW94eWdlbmAgYWxyZWFkeSBzZXRzIHVwIGEgU3RvcmVmcm9udCBBUEkgcHJveHkgb24gdGhlIHNhbWUgZG9tYWluIGFzIHlvdXIgc3RvcmVmcm9udC4KCioqSW4gbW9zdCBjYXNlcywgbm8gY2hhbmdlcyBhcmUgcmVxdWlyZWQqKjsganVzdCBjb25maXJtIHlvdXIgc2VydmVyIGVudHJ5IHN0aWxsIHVzZXMgaXQ6CgpgYGB0cwovLyBzZXJ2ZXIudHMgKE94eWdlbikKaW1wb3J0IHtjcmVhdGVSZXF1ZXN0SGFuZGxlcn0gZnJvbSAnQHNob3BpZnkvcmVtaXgtb3h5Z2VuJzsKaW1wb3J0IHtjcmVhdGVIeWRyb2dlbkNvbnRleHR9IGZyb20gJ0BzaG9waWZ5L2h5ZHJvZ2VuJzsKCmV4cG9ydCBkZWZhdWx0IHsKICBhc3luYyBmZXRjaChyZXF1ZXN0LCBlbnYpIHsKICAgIGNvbnN0IGh5ZHJvZ2VuQ29udGV4dCA9IGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dCh7CiAgICAgIGVudiwKICAgICAgcmVxdWVzdCwKICAgICAgLyogLi4uICovCiAgICB9KTsKCiAgICBjb25zdCBoYW5kbGVSZXF1ZXN0ID0gY3JlYXRlUmVxdWVzdEhhbmRsZXIoewogICAgICAvKiAuLi4gKi8KICAgICAgZ2V0TG9hZENvbnRleHQ6ICgpID0+IGh5ZHJvZ2VuQ29udGV4dCwKICAgIH0pOwoKICAgIHJldHVybiBoYW5kbGVSZXF1ZXN0KHJlcXVlc3QpOwogIH0sCn07CmBgYAoKS2VlcCB1c2luZyBgPEFuYWx5dGljcy5Qcm92aWRlcj5gIGNvbXBvbmVudCBvciBgdXNlQ3VzdG9tZXJQcml2YWN5YCBob29rIHRvIGdldCBjb29raWVzIGluIHRoZSBicm93c2VyIGF1dG9tYXRpY2FsbHkuCgpGb3IgYSBmdWxsIGV4YW1wbGUsIHJlZmVyIHRvIHlvdXIgc2tlbGV0b24gdGVtcGxhdGUncyBzZXJ2ZXIudHMuCgojIyMgUmVtaXggKyBIeWRyb2dlbiBvbiBvdGhlciBob3N0cwoKIyMjIyBIb3N0cyB0aGF0IHN1cHBvcnQgV2ViIEZldGNoIEFQSSAoUmVxdWVzdC9SZXNwb25zZSkKCk9uIGhvc3RzIHRoYXQgc3VwcG9ydCB0aGUgc3RhbmRhcmQgV2ViIEZldGNoIEFQSSAoV29ya2Vycy1zdHlsZSBlbnZpcm9ubWVudHMpLCBpbXBvcnQgYGNyZWF0ZVJlcXVlc3RIYW5kbGVyYCBmcm9tIGBAc2hvcGlmeS9oeWRyb2dlbmAgYW5kIHJvdXRlIHJlcXVlc3RzIHRocm91Z2ggaXQ6CgpgYGB0cwppbXBvcnQge2NyZWF0ZVJlcXVlc3RIYW5kbGVyLCBjcmVhdGVIeWRyb2dlbkNvbnRleHR9IGZyb20gJ0BzaG9waWZ5L2h5ZHJvZ2VuJzsKCmNvbnN0IGh5ZHJvZ2VuQ29udGV4dCA9IGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dCh7CiAgLyogLi4uICovCn0pOwoKY29uc3QgaGFuZGxlUmVxdWVzdCA9IGNyZWF0ZVJlcXVlc3RIYW5kbGVyKHsKICAvKiAuLi4gKi8KICBnZXRMb2FkQ29udGV4dDogKCkgPT4gaHlkcm9nZW5Db250ZXh0LAp9KTsKYGBgCgojIyMjIE5vZGUuanMgYW5kIG90aGVyIGhvc3RzCgpGb3IgTm9kZS1saWtlIGVudmlyb25tZW50cywgYWRhcHQgTm9kZSByZXF1ZXN0cyB0byBGZXRjaCB3aXRoIFtgQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcmBdKGh0dHBzOi8vd3d3Lm5wbWpzLmNvbS9wYWNrYWdlL0ByZW1peC1ydW4vbm9kZS1mZXRjaC1zZXJ2ZXIpLCB0aGVuIGRlbGVnYXRlIHRvIEh5ZHJvZ2VuJ3MgaGFuZGxlcjoKCmBgYHRzCmltcG9ydCB7Y3JlYXRlUmVxdWVzdEhhbmRsZXIsIGNyZWF0ZUh5ZHJvZ2VuQ29udGV4dH0gZnJvbSAnQHNob3BpZnkvaHlkcm9nZW4nOwppbXBvcnQge2NyZWF0ZVJlcXVlc3RMaXN0ZW5lcn0gZnJvbSAnQHJlbWl4LXJ1bi9ub2RlLWZldGNoLXNlcnZlcic7CmltcG9ydCBodHRwIGZyb20gJ2h0dHAnOwoKY29uc3QgaGFuZGxlTm9kZVJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0TGlzdGVuZXIoKHJlcXVlc3QpID0+IHsKICBjb25zdCBoeWRyb2dlbkNvbnRleHQgPSBjcmVhdGVIeWRyb2dlbkNvbnRleHQoewogICAgLyogLi4uICovCiAgfSk7CgogIGNvbnN0IGhhbmRsZVdlYlJlcXVlc3QgPSBjcmVhdGVSZXF1ZXN0SGFuZGxlcih7CiAgICAvKiAuLi4gKi8KICAgIGdldExvYWRDb250ZXh0OiAoKSA9PiBoeWRyb2dlbkNvbnRleHQsCiAgfSk7CgogIHJldHVybiBoYW5kbGVXZWJSZXF1ZXN0KHJlcXVlc3QpOwp9KTsKCmh0dHAuY3JlYXRlU2VydmVyKGhhbmRsZU5vZGVSZXF1ZXN0KTsKYGBgCgpBbHRlcm5hdGl2ZWx5LCBpZiB5b3UgY2FuJ3QgZGVsZWdhdGUgdG8gSHlkcm9nZW4ncyBgY3JlYXRlUmVxdWVzdEhhbmRsZXJgLCB5b3UgY2FuIHByb3ZpZGUgYSBjdXN0b20gU3RvcmVmcm9udCBBUEkgcHJveHkgaW4geW91ciBzZXJ2ZXIuIFNlZSBbSHlkcm9nZW4ncyBpbXBsZW1lbnRhdGlvbl0oaHR0cHM6Ly9naXRodWIuY29tL1Nob3BpZnkvaHlkcm9nZW4vYmxvYi8yNzA2NmEyODU3NzQ4NGY0MDYyMjIxMTZhOTU5ZWI0NjNkMjU1Njg1L3BhY2thZ2VzL2h5ZHJvZ2VuL3NyYy9zdG9yZWZyb250LnRzI0w1NDYtTDYxMSkgYXMgYSByZWZlcmVuY2UuIEluIHRoaXMgY2FzZSwgZW5zdXJlIHlvdSBtYW51YWxseSBwYXNzIGBzYW1lRG9tYWluRm9yU3RvcmVmcm9udEFwaTogdHJ1ZWAgaW4gdGhlIGBjb25zZW50YCBvYmplY3QgZm9yIGA8QW5hbHl0aWNzLlByb3ZpZGVyPmAgb3IgYXMgYSBwcm9wIHRvIHRoZSBgdXNlQ3VzdG9tZXJQcml2YWN5YCBob29rLgo="
+            }
+          ],
+          "pr": "https://github.com/Shopify/hydrogen/pull/3355",
+          "id": "3355"
         }
       ]
     },


### PR DESCRIPTION
### WHY are these changes introduced?

`docs/changelog.json` is read by the `h2 upgrade` command, which developers use to upgrade their Hydrogen version. This command updates their dependencies and generates a markdown file containing information about the change.

### WHAT is this pull request doing?

Same as https://github.com/Shopify/hydrogen/pull/3334, but for the back-fixes.

### HOW to test your changes?

Sanity check that the links and versions are accurate.

For the "code" section with upgrade instructions, paste it into a base 64 decoder [like this one](https://www.base64decode.org/).

The "code" section for the cookie updates really only has 2 versions:
- React Router 7 version: used in 2025.7.1 and 2025.5.1 (the cookie updates for RR7 versions)
- Remix version: used in 2025.4.2, 2025.1.5, 2024.10.2, and 2024.7.10

So you really only need to decode one of the Remix versions and one of the RR7 versions, and then you can easily double check that the rest are copies by looking for matches in the document. Video below showing this:

https://github.com/user-attachments/assets/22b959a2-36f4-443b-b86d-9596eb3b7741




#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
