### PR TITLE
Add locale and loginHintMode parameter to Customer Account login URL

### DIFF
--- a/cookbook/recipes/legacy-customer-account-flow/patches/account_.login.tsx.3fb3f2.patch
+++ b/cookbook/recipes/legacy-customer-account-flow/patches/account_.login.tsx.3fb3f2.patch
@@ -1,6 +1,6 @@
 --- a/templates/skeleton/app/routes/account_.login.tsx
 +++ b/templates/skeleton/app/routes/account_.login.tsx
-@@ -1,13 +1,139 @@
+@@ -1,17 +1,139 @@
 +import {Form, Link, useActionData, data, redirect} from 'react-router';
  import type {Route} from './+types/account_.login';
  
@@ -8,11 +8,15 @@
 -  const url = new URL(request.url);
 -  const acrValues = url.searchParams.get('acr_values') || undefined;
 -  const loginHint = url.searchParams.get('login_hint') || undefined;
+-  const loginHintMode = url.searchParams.get('login_hint_mode') || undefined;
+-  const locale = url.searchParams.get('locale') || undefined;
 -
 -  return context.customerAccount.login({
 -    countryCode: context.storefront.i18n.country,
 -    acrValues,
 -    loginHint,
+-    loginHintMode,
+-    locale,
 -  });
 -}
 +type ActionResponse = {

--- a/templates/skeleton/app/routes/account_.login.tsx
+++ b/templates/skeleton/app/routes/account_.login.tsx
@@ -4,10 +4,14 @@ export async function loader({request, context}: Route.LoaderArgs) {
   const url = new URL(request.url);
   const acrValues = url.searchParams.get('acr_values') || undefined;
   const loginHint = url.searchParams.get('login_hint') || undefined;
+  const loginHintMode = url.searchParams.get('login_hint_mode') || undefined;
+  const locale = url.searchParams.get('locale') || undefined;
 
   return context.customerAccount.login({
     countryCode: context.storefront.i18n.country,
     acrValues,
     loginHint,
+    loginHintMode,
+    locale,
   });
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To enhance the login functionality by supporting additional parameters that can be passed to the Customer Account API.

### WHAT is this pull request doing?

Adds support for two new parameters in the login route:
- `loginHintMode`: Allows specifying how the login hint should be interpreted
- `locale`: Enables setting the language preference for the login experience

These parameters are now extracted from the URL query parameters and passed to the `customerAccount.login()` method, providing more flexibility in customizing the login experience.

 

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation