### PR TITLE
fix(docs): correct post-CLI-release action guidance in CLAUDE.md

### DIFF
--- a/.claude/commands/shopify-cli-update.md
+++ b/.claude/commands/shopify-cli-update.md
@@ -359,7 +359,9 @@ skeleton template's devDependencies
 @shopify/cli-hydrogen (circular!)
 ```
 
-This may require a second cli-hydrogen release after the Shopify CLI is updated to bundle the correct skeleton version.
+Whether a second cli-hydrogen release is required depends on what the cli-hydrogen changes contained:
+- **If cli-hydrogen had actual code changes** (beyond just adding a changeset to bundle a new skeleton): manually update skeleton's `@shopify/cli` to the new Shopify CLI version and create changesets for `@shopify/cli-hydrogen` AND `@shopify/create-hydrogen` to trigger another release cycle
+- **If cli-hydrogen changes were ONLY a changeset to re-bundle the skeleton**: no further action required after Shopify CLI releases
 
 ## Exit Conditions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,7 @@ Hydrogen uses a sophisticated automated release system built on Changesets, GitH
 
 3. **Maintainer Actions - CLI Releases**
    - When cli-hydrogen has updates, create a PR in the Shopify CLI repo and coordinate with Shopify CLI team to request patch release
-   - **Update skeleton after CLI release**: Once @shopify/cli releases, update skeleton's package.json
-   - **Second cli-hydrogen release**: Often required to bundle the updated skeleton
+   - **Post-release actions**: Whether to update skeleton's `@shopify/cli` and trigger a second cli-hydrogen release depends on the nature of the cli-hydrogen changes — see **Skeleton's CLI Version (Post-Release Action)** under *Understanding the Circular Dependency* below
 
 4. **Maintainer Actions - Major Version Changes**
    - **Update latestBranch**: Edit `.github/workflows/changesets.yml` line 32 when moving to new major version
@@ -317,23 +316,20 @@ skeleton template's devDependencies
 
 We break the cycle with a simple rule: skeleton changes → bump all three packages (skeleton, cli-hydrogen, create-hydrogen). This ensures the release includes everything needed.
 
-**Skeleton's CLI Version (Maintenance Note):**
+**Skeleton's CLI Version (Post-Release Action):**
 
-The skeleton's `@shopify/cli` version should be periodically updated, but:
+After Shopify CLI releases a new version containing updated `@shopify/cli-hydrogen`, whether further action is required depends on what the cli-hydrogen changes contained:
 
-- **Don't create a PR just to bump the CLI version** — this does NOT warrant a new Hydrogen release on its own
-- **Dependabot handles CLI version updates** — Dependabot automatically creates PRs when new `@shopify/cli` versions are available. Review and merge these PRs as part of regular maintenance (they'll be bundled into the next release with other changes)
-- Bumping the CLI version immediately after a cli-hydrogen release is unnecessary
+**If cli-hydrogen had actual changes** (any code changes: bug fixes, new commands, refactors — anything beyond just adding a changeset to bundle a new skeleton template):
+- Manually update skeleton's `@shopify/cli` dependency to the new Shopify CLI version
+- Create changesets for `@shopify/cli-hydrogen` AND `@shopify/create-hydrogen`
+- This triggers another cli-hydrogen release (now bundling the updated skeleton) and another Shopify CLI release
+- Required so new Hydrogen storefronts are created with the latest cli-hydrogen changes
 
-<details>
-<summary>Why CLI version bumps in the skeleton don't need immediate releases</summary>
+**If cli-hydrogen changes were ONLY a changeset to re-bundle the skeleton** (no actual code changes to cli-hydrogen itself):
+- No further action required after Shopify CLI releases
+- The skeleton's `@shopify/cli` version does not need to be updated
 
-The CLI is a devDependency, not runtime code. If skeleton was bundled with
-`@shopify/cli@3.80.0` which included `cli-hydrogen@X`, immediately releasing again
-with `@shopify/cli@3.80.1` (containing `cli-hydrogen@X+1`) provides no benefit—
-the skeleton code itself hasn't changed.
-
-Users can update their CLI version after scaffolding. The skeleton's CLI version
-is a starting point, not a strict requirement.
-
-</details>
+**The key question**: "Were there actual code changes to cli-hydrogen, beyond just adding a changeset to bundle an updated skeleton?"
+- **Yes** → Manually update skeleton's CLI version and release another cli-hydrogen cycle
+- **No** → Done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,24 +277,27 @@ All three must be bumped to ensure `npm create @shopify/hydrogen@latest` gets yo
 
 #### I'm Updating the CLI (cli-hydrogen)
 
-**Scenario A: CLI-only change (no scaffolding impact)**
+**Scenario A: CLI-only change (no init/scaffolding impact)**
 - Just bump `@shopify/cli-hydrogen`
-- Examples: bug fixes in existing commands, new flags for existing commands
+- Examples: bug fixes in non-init commands such as `dev`, `build`, or `check`; new flags for existing commands
 
-**Scenario B: Change affects newly scaffolded projects**
+**Scenario B: Change affects the `init` command, scaffolding process, or CLI assets**
 - Bump both `@shopify/cli-hydrogen` and `@shopify/create-hydrogen`
-- Examples: new commands users need immediately, changes to init behavior
+- Examples: changes to how `hydrogen init` (which powers `npm create @shopify/hydrogen`) works; changes to virtual-route templates or other files in `packages/cli/assets/`
 
 <details>
 <summary>When does a CLI change affect scaffolding?</summary>
 
-Ask yourself: "If someone scaffolds a new project tomorrow, will they need this change?"
+`create-hydrogen` bundles two things from `@shopify/cli-hydrogen`:
+1. **The `init` command code** — tree-shaken from the `init` entry point and its transitive dependencies only
+2. **The full `dist/assets` directory** — templates, virtual routes, tailwind configs, and other shared assets
+
+**"Does this change affect the `init` command, or any files in `packages/cli/assets/`?"**
 
 - **Yes** → bump both `cli-hydrogen` and `create-hydrogen`
 - **No** → just bump `cli-hydrogen`
 
-Most CLI changes (bug fixes, improvements to existing commands) don't affect scaffolding.
-New features that users would want in fresh projects do affect scaffolding.
+For non-init command changes (bug fixes to commands such as `dev`/`build`/`check`, new non-init commands): these reach newly scaffolded projects through the skeleton's `@shopify/cli` version. If those changes need to be in new scaffolds quickly, follow the circular dependency release cycle described in **Skeleton's CLI Version (Post-Release Action)** under *Understanding the Circular Dependency* below.
 
 </details>
 


### PR DESCRIPTION
### WHY are these changes introduced?

The `CLAUDE.md` guidance for the skeleton/CLI release process contained several inaccuracies that would mislead maintainers:

1. **Incorrect skeleton changeset requirement** — the old docs said to include only `@shopify/cli-hydrogen` when changing the skeleton. The correct requirement is all three packages: `skeleton`, `@shopify/cli-hydrogen`, AND `@shopify/create-hydrogen`. Without all three, `npm create @shopify/hydrogen@latest` won't get the updated template.

2. **Wrong description of how scaffolding works** — the old docs described template fetching from GitHub at runtime via the GitHub API. The actual behavior is that the skeleton is pre-bundled inside `@shopify/create-hydrogen` at build time. No network fetch happens for the default template.

3. **Vague post-CLI-release guidance** — the old docs said the second cli-hydrogen release is "often required" and that Dependabot handles `@shopify/cli` version bumps (it does not — `.github/dependabot.yaml` only covers `github-actions`). Whether action is needed depends on what the cli-hydrogen changes actually contained.

### WHAT is this pull request doing?

**Skeleton changeset requirement** (Developer Actions section): Corrects the required packages from `@shopify/cli-hydrogen` only → all three (`skeleton` + `@shopify/cli-hydrogen` + `@shopify/create-hydrogen`), with a cross-reference to the new Quick Reference section.

**How Project Scaffolding Works**: Replaces the incorrect runtime-fetch description with the correct pre-bundling explanation, including a collapsible bundling chain diagram.

**New "Quick Reference: Contributing to Skeleton or CLI" section**: Step-by-step guidance for the two most common contribution scenarios — updating the skeleton template vs. updating cli-hydrogen only — including the correct changeset requirements for each, with a canonical example PR.

**Understanding the Circular Dependency** (replaces "CLI Release Coordination"): Replaces the old "always two releases required" narrative (with the Day 1–4 example timeline) with a precise two-scenario decision model:
- **If cli-hydrogen had actual code changes**: manually update skeleton's `@shopify/cli` and trigger another release cycle
- **If cli-hydrogen changes were ONLY a changeset to re-bundle the skeleton**: no further action needed

**Maintainer Actions - CLI Releases**: Collapses two vague bullets into one that cross-references the new decision model section.

**`shopify-cli-update` runbook** (`.claude/commands/shopify-cli-update.md`): Applies the same decision criteria inline, replacing the vague "may require" statement.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added or updated the documentation