### PR TITLE
Support OAuth query params in skeleton login route

### DIFF
--- a/.changeset/breezy-baths-pay.md
+++ b/.changeset/breezy-baths-pay.md
@@ -1,0 +1,27 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+'skeleton': patch
+---
+
+Support OAuth parameters via URL query strings in skeleton login route
+
+The skeleton template's login route (`account_.login.tsx`) now reads OAuth parameters from the URL and forwards them to `customerAccount.login()`. This enables deep linking to the login page with pre-configured authentication options.
+
+### Supported Query Parameters
+
+| Query Parameter | Description |
+|-----------------|-------------|
+| `acr_values` | Direct users to a specific login method (e.g., `provider:google` for social login) |
+| `login_hint` | Pre-fill the email address field |
+| `login_hint_mode` | When set to `submit` with `login_hint`, auto-submits the login form |
+| `locale` | Display the login page in a specific language (e.g., `fr`, `zh-CN`) |
+
+### Usage Examples
+
+```
+/account/login?login_hint=user@example.com
+/account/login?login_hint=user@example.com&login_hint_mode=submit
+/account/login?acr_values=provider:google
+/account/login?locale=fr
+```


### PR DESCRIPTION
### WHY are these changes introduced?

Add a changeset.

To enable deep linking to the login page with pre-configured authentication options, allowing for more flexible customer authentication flows.

### WHAT is this pull request doing?

Enhances the skeleton template's login route (`account_.login.tsx`) to support OAuth parameters via URL query strings. The login route now reads these parameters from the URL and forwards them to `customerAccount.login()`.

The implementation supports several query parameters:
- `acr_values`: Directs users to specific login methods (e.g., social login via Google)
- `login_hint`: Pre-fills the email address field
- `login_hint_mode`: When set to `submit` with `login_hint`, auto-submits the login form
- `locale`: Displays the login page in a specific language

Example usage:
```
/account/login?login_hint=user@example.com
/account/login?login_hint=user@example.com&login_hint_mode=submit
/account/login?acr_values=provider:google
/account/login?locale=fr
```

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation