### PR TITLE
Fix test failing due to version bumps

### DIFF
--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -907,7 +907,7 @@ describe('upgrade', async () => {
             versionLineMatches[versionLineMatches.length - 1];
 
           expect(firstVersionLine).toContain('2025.7.1');
-          expect(lastVersionLine).toMatch(/2025\.1\.[1-4]/);
+          expect(lastVersionLine).toMatch(/2025\.4\.[1-2]/);
         },
         {
           cleanGitRepo: false,


### PR DESCRIPTION
We're seeing different values now and this needs to be updated to fix `main`:

```
╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  There are 11 new @shopify/hydrogen versions available.                      │
│                                                                              │
│  Current: 2025.1.0 | Latest: 2025.7.1                                        │
│                                                                              │
│  The next 5 version(s) include                                               │
│    • 2025.7.1 - New Shopify cookie system, React Router 7.12, and analytics  │
│      improvements                                                            │
│    • 2025.7.0 - Migrate to React Router 7 and API version 2025-07            │
│    • 2025.5.1 - [ONLY USE IF YOU ARE CURRENTLY ON 2025.5.0; ELSE SKIP TO     │
│      >=2025.7.0 UPGRADE] New Shopify cookie system and analytics             │
│      improvements                                                            │
│    • 2025.4.2 - New Shopify cookie system and analytics improvements         │
│    • 2025.4.1 - New tokenless Storefront API route, add buyerIdentity to     │
│      create handlers                                                         │
│    • ...more                                                                 │
│                                                                              │
│  Next steps                                                                  │
│    • Run `h2 upgrade` or `h2 upgrade --version 2025.7.1`                     │
│    • Read release notes at https://hydrogen.shopify.dev/releases             │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

- Example in CI: https://github.com/Shopify/hydrogen/actions/runs/21149479945/job/60822309014?pr=3136

This PR just gets `main` back in a good place but we might want to consider the flakiness of a lot of these tests.