### PR TITLE
Display warnings and errors in the cart

### DIFF
--- a/.changeset/cart-warnings-feedback.md
+++ b/.changeset/cart-warnings-feedback.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'skeleton': patch
+---
+
+Add cart warnings component to display feedback to users when there are issues with their cart. Includes new `InlineFeedback` component and a `CartWarnings` component for collecting and displaying cart errors and warnings in an accessible way.

--- a/e2e/specs/smoke/cart.spec.ts
+++ b/e2e/specs/smoke/cart.spec.ts
@@ -1,4 +1,4 @@
-import {setTestStore, test, expect} from '../../fixtures';
+import {setTestStore, test, expect, Page} from '../../fixtures';
 
 setTestStore('mockShop');
 

--- a/e2e/specs/smoke/cart.spec.ts
+++ b/e2e/specs/smoke/cart.spec.ts
@@ -1,4 +1,4 @@
-import {setTestStore, test, expect, Page} from '../../fixtures';
+import {setTestStore, test, expect} from '../../fixtures';
 
 setTestStore('mockShop');
 

--- a/templates/skeleton/app/components/CartLineItem.tsx
+++ b/templates/skeleton/app/components/CartLineItem.tsx
@@ -2,11 +2,19 @@ import type {CartLineUpdateInput} from '@shopify/hydrogen/storefront-api-types';
 import type {CartLayout, LineItemChildrenMap} from '~/components/CartMain';
 import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
 import {useVariantUrl} from '~/lib/variants';
-import {href, Link, useFetcher, type FetcherWithComponents} from 'react-router';
+import {
+  href,
+  Link,
+  useActionData,
+  useFetcher,
+  type FetcherWithComponents,
+} from 'react-router';
 import {ProductPrice} from './ProductPrice';
 import {useAside} from './Aside';
 import type {CartApiQueryFragment} from 'storefrontapi.generated';
+import type {action as cartAction} from '~/routes/cart';
 
+type CartActionResponse = Awaited<typeof useActionData<typeof cartAction>>;
 export type CartLine = OptimisticCartLine<CartApiQueryFragment>;
 
 /**
@@ -174,7 +182,7 @@ function isKeyboardEvent(
 
 async function submitQuantity(
   e: React.ChangeEvent<HTMLInputElement>,
-  fetcher: FetcherWithComponents<any>,
+  fetcher: FetcherWithComponents<CartActionResponse>,
   line: CartLine,
 ) {
   const value = e.target.valueAsNumber;

--- a/templates/skeleton/app/components/CartLineItem.tsx
+++ b/templates/skeleton/app/components/CartLineItem.tsx
@@ -183,12 +183,18 @@ function isTextChangingEvent(
 }
 
 async function submitQuantity(
-  e: React.ChangeEvent<HTMLInputElement>,
+  e:
+    | React.ChangeEvent<HTMLInputElement>
+    | React.KeyboardEvent<HTMLInputElement>,
   fetcher: FetcherWithComponents<CartActionResponse>,
   line: CartLine,
 ) {
-  const value = e.target.valueAsNumber;
-  if (Number.isNaN(value) || value < 1) return;
+  let value = e.currentTarget.valueAsNumber;
+  /** we revert to a valid value if it was invalid */
+  if (Number.isNaN(value) || value < 1) {
+    e.currentTarget.value = line.quantity.toString();
+    value = line.quantity;
+  }
   const formData = new FormData();
   formData.set(
     CartForm.INPUT_NAME,
@@ -223,6 +229,9 @@ function CartLineQuantityInput({
       disabled={disabled}
       type="number"
       defaultValue={line.quantity}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') void submitQuantity(e, fetcher, line);
+      }}
       onChange={(e) => {
         if (isTextChangingEvent(e)) return;
         void submitQuantity(e, fetcher, line);

--- a/templates/skeleton/app/components/CartLineItem.tsx
+++ b/templates/skeleton/app/components/CartLineItem.tsx
@@ -178,6 +178,7 @@ async function submitQuantity(
   line: CartLine,
 ) {
   const value = e.target.valueAsNumber;
+  if (Number.isNaN(value) || value < 1) return;
   const formData = new FormData();
   formData.set(
     CartForm.INPUT_NAME,

--- a/templates/skeleton/app/components/CartLineItem.tsx
+++ b/templates/skeleton/app/components/CartLineItem.tsx
@@ -13,6 +13,7 @@ import {ProductPrice} from './ProductPrice';
 import {useAside} from './Aside';
 import type {CartApiQueryFragment} from 'storefrontapi.generated';
 import type {action as cartAction} from '~/routes/cart';
+import {useEffect, useRef} from 'react';
 
 type CartActionResponse = Awaited<typeof useActionData<typeof cartAction>>;
 export type CartLine = OptimisticCartLine<CartApiQueryFragment>;
@@ -165,7 +166,7 @@ function CartLineRemoveButton({
   );
 }
 
-function isKeyboardEvent(
+function isTextChangingEvent(
   e: React.ChangeEvent<HTMLInputElement>,
 ): e is typeof e & {nativeEvent: InputEvent} {
   if (e.nativeEvent instanceof InputEvent) {
@@ -177,6 +178,7 @@ function isKeyboardEvent(
       return true;
     }
   }
+
   return false;
 }
 
@@ -206,18 +208,23 @@ function CartLineQuantityInput({
   disabled: boolean;
 }) {
   const fetcher = useFetcher({key: getUpdateKey([line.id])});
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (!inputRef.current) return;
+    inputRef.current.value = line.quantity.toString();
+  }, [line.quantity]);
 
   return (
     <input
+      ref={inputRef}
       aria-label="Quantity"
       min={1}
       className="cart-line-quantity-input"
       disabled={disabled}
-      key={line.quantity}
       type="number"
       defaultValue={line.quantity}
       onChange={(e) => {
-        if (isKeyboardEvent(e)) return;
+        if (isTextChangingEvent(e)) return;
         void submitQuantity(e, fetcher, line);
       }}
       onBlur={(e) => {

--- a/templates/skeleton/app/components/CartMain.tsx
+++ b/templates/skeleton/app/components/CartMain.tsx
@@ -4,6 +4,7 @@ import type {CartApiQueryFragment} from 'storefrontapi.generated';
 import {useAside} from '~/components/Aside';
 import {CartLineItem, type CartLine} from '~/components/CartLineItem';
 import {CartSummary} from './CartSummary';
+import {CartWarnings} from './CartWarnings';
 
 export type CartLayout = 'page' | 'aside';
 
@@ -52,6 +53,7 @@ export function CartMain({layout, cart: originalCart}: CartMainProps) {
   return (
     <div className={className}>
       <CartEmpty hidden={linesCount} layout={layout} />
+      <CartWarnings />
       <div className="cart-details">
         <div aria-labelledby="cart-lines">
           <ul>

--- a/templates/skeleton/app/components/CartWarnings.tsx
+++ b/templates/skeleton/app/components/CartWarnings.tsx
@@ -13,9 +13,7 @@ type CartActionData = NonNullable<
   ReturnType<typeof useActionData<typeof cartAction>>
 >;
 /** Returns the errors and warnings from the cart fetchers
- *  Normalizes the errors to provide better UX.
- *
- *  Errors are normalized by path, warnings are normalized by code.
+ *  Groups errors and warnings by code to provide better UX.
  */
 export function useCartFeedback() {
   const [fetcherDataMap, setFetcherDataMap] = useState<

--- a/templates/skeleton/app/components/CartWarnings.tsx
+++ b/templates/skeleton/app/components/CartWarnings.tsx
@@ -1,0 +1,111 @@
+import {InlineFeedback} from './InlineFeedback';
+import {href, useActionData, useFetchers, type Fetcher} from 'react-router';
+import type {action as cartAction} from '~/routes/cart';
+import {useEffect, useState} from 'react';
+
+function isCartFetcher(
+  fetcher: Fetcher,
+): fetcher is Fetcher<CartActionData> & {key: string} {
+  return fetcher.formAction === href('/cart') && fetcher.formMethod === 'POST';
+}
+
+type CartActionData = NonNullable<
+  ReturnType<typeof useActionData<typeof cartAction>>
+>;
+/** Returns the errors and warnings from the cart fetchers
+ *  Normalizes the errors to provide better UX.
+ *
+ *  Errors are normalized by path, warnings are normalized by code.
+ */
+export function useCartFeedback() {
+  const [fetcherDataMap, setFetcherDataMap] = useState<
+    Map<string, CartActionData>
+  >(new Map());
+  const fetchers = useFetchers();
+
+  useEffect(() => {
+    let changed = false;
+    let newFetcherDataMap = new Map(fetcherDataMap);
+
+    for (const fetcher of fetchers) {
+      if (!isCartFetcher(fetcher)) continue;
+
+      switch (fetcher.state) {
+        case 'submitting':
+          newFetcherDataMap = new Map();
+          changed = true;
+          break;
+        case 'loading':
+          if (
+            fetcher.data &&
+            fetcher.data !== newFetcherDataMap.get(fetcher.key)
+          ) {
+            changed = true;
+            newFetcherDataMap.set(fetcher.key, fetcher.data);
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
+    if (changed) {
+      setFetcherDataMap(newFetcherDataMap);
+    }
+  }, [fetchers, fetcherDataMap]);
+
+  const feedback: {
+    errors: Map<string, NonNullable<CartActionData['errors']>[number]>;
+    warnings: Map<string, NonNullable<CartActionData['warnings']>[number]>;
+    userErrors: Map<string, NonNullable<CartActionData['userErrors']>[number]>;
+  } = {errors: new Map(), warnings: new Map(), userErrors: new Map()};
+  for (const fetcherData of fetcherDataMap.values()) {
+    if (fetcherData.warnings) {
+      for (const warning of fetcherData.warnings) {
+        feedback.warnings.set(warning.code, warning);
+      }
+    }
+    if (fetcherData.errors) {
+      for (const error of fetcherData.errors) {
+        feedback.errors.set(error.path?.join('.') ?? '_root', error);
+      }
+    }
+    if (fetcherData.userErrors) {
+      for (const userError of fetcherData.userErrors) {
+        feedback.userErrors.set(userError.code ?? '_root', userError);
+      }
+    }
+  }
+  return {
+    errors: Array.from(feedback.errors.values()),
+    warnings: Array.from(feedback.warnings.values()),
+    userErrors: Array.from(feedback.userErrors.values()),
+  };
+}
+
+/** Renders a list of warnings from the cart if there are any */
+export function CartWarnings() {
+  const feedback = useCartFeedback();
+  if (feedback.warnings.length === 0 && feedback.userErrors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="cart-warnings">
+      {feedback.warnings.map((warning) => (
+        <InlineFeedback
+          key={warning.code}
+          type="warning"
+          title={warning.message}
+        />
+      ))}
+      {feedback.userErrors.map((userError) => (
+        <InlineFeedback
+          key={userError.code}
+          type="error"
+          title={userError.message}
+        />
+      ))}
+    </div>
+  );
+}

--- a/templates/skeleton/app/components/CartWarnings.tsx
+++ b/templates/skeleton/app/components/CartWarnings.tsx
@@ -24,35 +24,31 @@ export function useCartFeedback() {
   const fetchers = useFetchers();
 
   useEffect(() => {
-    let changed = false;
-    let newFetcherDataMap = new Map(fetcherDataMap);
+    setFetcherDataMap((prevMap) => {
+      let changed = false;
+      const newMap = new Map(prevMap);
 
-    for (const fetcher of fetchers) {
-      if (!isCartFetcher(fetcher)) continue;
+      for (const fetcher of fetchers) {
+        if (!isCartFetcher(fetcher)) continue;
 
-      switch (fetcher.state) {
-        case 'submitting':
-          newFetcherDataMap = new Map();
-          changed = true;
-          break;
-        case 'loading':
-          if (
-            fetcher.data &&
-            fetcher.data !== newFetcherDataMap.get(fetcher.key)
-          ) {
-            changed = true;
-            newFetcherDataMap.set(fetcher.key, fetcher.data);
-          }
-          break;
-        default:
-          break;
+        switch (fetcher.state) {
+          case 'submitting':
+            if (prevMap.size > 0) {
+              return new Map(); // Clear on new submission
+            }
+            break;
+          case 'loading':
+            if (fetcher.data && fetcher.data !== prevMap.get(fetcher.key)) {
+              changed = true;
+              newMap.set(fetcher.key, fetcher.data);
+            }
+            break;
+        }
       }
-    }
 
-    if (changed) {
-      setFetcherDataMap(newFetcherDataMap);
-    }
-  }, [fetchers, fetcherDataMap]);
+      return changed ? newMap : prevMap;
+    });
+  }, [fetchers]);
 
   const feedback: {
     warnings: Map<string, NonNullable<CartActionData['warnings']>[number]>;

--- a/templates/skeleton/app/components/CartWarnings.tsx
+++ b/templates/skeleton/app/components/CartWarnings.tsx
@@ -86,9 +86,9 @@ export function CartWarnings() {
           title={warning.message}
         />
       ))}
-      {feedback.userErrors.map((userError) => (
+      {feedback.userErrors.map((userError, index) => (
         <InlineFeedback
-          key={userError.code}
+          key={userError.code ?? `_root-${index}`}
           type="error"
           title={userError.message}
         />

--- a/templates/skeleton/app/components/CartWarnings.tsx
+++ b/templates/skeleton/app/components/CartWarnings.tsx
@@ -55,19 +55,13 @@ export function useCartFeedback() {
   }, [fetchers, fetcherDataMap]);
 
   const feedback: {
-    errors: Map<string, NonNullable<CartActionData['errors']>[number]>;
     warnings: Map<string, NonNullable<CartActionData['warnings']>[number]>;
     userErrors: Map<string, NonNullable<CartActionData['userErrors']>[number]>;
-  } = {errors: new Map(), warnings: new Map(), userErrors: new Map()};
+  } = {warnings: new Map(), userErrors: new Map()};
   for (const fetcherData of fetcherDataMap.values()) {
     if (fetcherData.warnings) {
       for (const warning of fetcherData.warnings) {
         feedback.warnings.set(warning.code, warning);
-      }
-    }
-    if (fetcherData.errors) {
-      for (const error of fetcherData.errors) {
-        feedback.errors.set(error.path?.join('.') ?? '_root', error);
       }
     }
     if (fetcherData.userErrors) {
@@ -77,7 +71,6 @@ export function useCartFeedback() {
     }
   }
   return {
-    errors: Array.from(feedback.errors.values()),
     warnings: Array.from(feedback.warnings.values()),
     userErrors: Array.from(feedback.userErrors.values()),
   };

--- a/templates/skeleton/app/components/InlineFeedback.tsx
+++ b/templates/skeleton/app/components/InlineFeedback.tsx
@@ -4,18 +4,33 @@ interface InlineFeedbackProps {
   description?: string;
 }
 
+const FEEDBACK_PROPS: Record<
+  NonNullable<InlineFeedbackProps['type']>,
+  {icon: string; role: string}
+> = {
+  warning: {
+    icon: '⚠',
+    role: 'status',
+  },
+  error: {
+    icon: '✕',
+    role: 'alert',
+  },
+};
+
 /**
  * An accessible inline feedback component for warnings and errors.
+ * Uses role="status" for warnings and role="alert" for errors.
  */
 export function InlineFeedback({
   type = 'warning',
   title,
   description,
 }: InlineFeedbackProps) {
-  const icon = type === 'error' ? '✕' : '⚠';
+  const {icon, role} = FEEDBACK_PROPS[type];
 
   return (
-    <div className={`inline-feedback inline-feedback--${type}`} role="status">
+    <div className={`inline-feedback inline-feedback--${type}`} role={role}>
       <span className="inline-feedback-icon" aria-hidden="true">
         {icon}
       </span>

--- a/templates/skeleton/app/components/InlineFeedback.tsx
+++ b/templates/skeleton/app/components/InlineFeedback.tsx
@@ -6,7 +6,6 @@ interface InlineFeedbackProps {
 
 /**
  * An accessible inline feedback component for warnings and errors.
- * Uses role="alert" to announce changes to assistive technology.
  */
 export function InlineFeedback({
   type = 'warning',

--- a/templates/skeleton/app/components/InlineFeedback.tsx
+++ b/templates/skeleton/app/components/InlineFeedback.tsx
@@ -16,12 +16,7 @@ export function InlineFeedback({
   const icon = type === 'error' ? '✕' : '⚠';
 
   return (
-    <div
-      className={`inline-feedback inline-feedback--${type}`}
-      role="alert"
-      aria-live="polite"
-      aria-atomic="true"
-    >
+    <div className={`inline-feedback inline-feedback--${type}`} role="status">
       <span className="inline-feedback-icon" aria-hidden="true">
         {icon}
       </span>

--- a/templates/skeleton/app/components/InlineFeedback.tsx
+++ b/templates/skeleton/app/components/InlineFeedback.tsx
@@ -1,0 +1,36 @@
+interface InlineFeedbackProps {
+  type?: 'warning' | 'error';
+  title: string;
+  description?: string;
+}
+
+/**
+ * An accessible inline feedback component for warnings and errors.
+ * Uses role="alert" to announce changes to assistive technology.
+ */
+export function InlineFeedback({
+  type = 'warning',
+  title,
+  description,
+}: InlineFeedbackProps) {
+  const icon = type === 'error' ? '✕' : '⚠';
+
+  return (
+    <div
+      className={`inline-feedback inline-feedback--${type}`}
+      role="alert"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <span className="inline-feedback-icon" aria-hidden="true">
+        {icon}
+      </span>
+      <div className="inline-feedback-content">
+        <p className="inline-feedback-title">{title}</p>
+        {description ? (
+          <p className="inline-feedback-description">{description}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/templates/skeleton/app/components/PageLayout.tsx
+++ b/templates/skeleton/app/components/PageLayout.tsx
@@ -8,12 +8,12 @@ import type {
 import {Aside} from '~/components/Aside';
 import {Footer} from '~/components/Footer';
 import {Header, HeaderMenu} from '~/components/Header';
-import {CartMain} from '~/components/CartMain';
 import {
   SEARCH_ENDPOINT,
   SearchFormPredictive,
 } from '~/components/SearchFormPredictive';
 import {SearchResultsPredictive} from '~/components/SearchResultsPredictive';
+import {CartMain} from './CartMain';
 
 interface PageLayoutProps {
   cart: Promise<CartApiQueryFragment | null>;
@@ -60,9 +60,7 @@ function CartAside({cart}: {cart: PageLayoutProps['cart']}) {
     <Aside type="cart" heading="CART">
       <Suspense fallback={<p>Loading cart ...</p>}>
         <Await resolve={cart}>
-          {(cart) => {
-            return <CartMain cart={cart} layout="aside" />;
-          }}
+          {(cart) => <CartMain cart={cart} layout="aside" />}
         </Await>
       </Suspense>
     </Aside>

--- a/templates/skeleton/app/routes/cart.tsx
+++ b/templates/skeleton/app/routes/cart.tsx
@@ -1,8 +1,4 @@
-import {
-  useLoaderData,
-  data,
-  type HeadersFunction,
-} from 'react-router';
+import {useLoaderData, data, type HeadersFunction} from 'react-router';
 import type {Route} from './+types/cart';
 import type {CartQueryDataReturn} from '@shopify/hydrogen';
 import {CartForm} from '@shopify/hydrogen';
@@ -79,7 +75,7 @@ export async function action({request, context}: Route.ActionArgs) {
 
   const cartId = result?.cart?.id;
   const headers = cartId ? cart.setCartId(result.cart.id) : new Headers();
-  const {cart: cartResult, errors, warnings} = result;
+  const {cart: cartResult, errors, warnings, userErrors} = result;
 
   const redirectTo = formData.get('redirectTo') ?? null;
   if (typeof redirectTo === 'string') {
@@ -91,6 +87,7 @@ export async function action({request, context}: Route.ActionArgs) {
     {
       cart: cartResult,
       errors,
+      userErrors,
       warnings,
       analytics: {
         cartId,

--- a/templates/skeleton/app/styles/app.css
+++ b/templates/skeleton/app/styles/app.css
@@ -278,6 +278,12 @@ button.reset:hover:not(:has(> *)) {
 
 .cart-line-quantity {
   display: flex;
+  align-items: center;
+}
+
+.cart-line-quantity-input {
+  width: 40px;
+  height: 1rem;
 }
 
 /* Child line components (warranties, gift wrapping, etc.) */
@@ -294,6 +300,59 @@ button.reset:hover:not(:has(> *)) {
 .cart-subtotal {
   align-items: center;
   display: flex;
+}
+
+.cart-warnings {
+  margin-bottom: 1rem;
+}
+
+/*
+* --------------------------------------------------
+* components/InlineFeedback
+* --------------------------------------------------
+*/
+.inline-feedback {
+  align-items: flex-start;
+  border-radius: 4px;
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+}
+
+.inline-feedback--warning {
+  background-color: #fef3cd;
+  border: 1px solid #ffc107;
+  color: #856404;
+}
+
+.inline-feedback--error {
+  background-color: #f8d7da;
+  border: 1px solid #f5c2c7;
+  color: #842029;
+}
+
+.inline-feedback-icon {
+  flex-shrink: 0;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.inline-feedback-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.inline-feedback-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.inline-feedback-description {
+  font-size: 0.875rem;
+  margin: 0.25rem 0 0;
+  opacity: 0.9;
 }
 /*
 * --------------------------------------------------


### PR DESCRIPTION
Closes [#969](https://github.com/Shopify/developer-tools-team/issues/969)

https://github.com/Shopify/hydrogen/issues/3276

### WHY are these changes introduced?

This PR adds the ability to display warnings to users in the cart, improving the user experience by providing clear feedback when there are issues with their cart.

### WHAT is this pull request doing?

- Adds a new `InlineWarning` component for displaying warning messages in an accessible way
- Implements `useCartFeedback` hook to collect and normalize errors and warnings from cart fetchers
- Adds `CartWarnings` component to display warnings in the cart interface
- Updates the cart styling to properly display warning messages
- Integrates the warning system with the existing cart functionality

### HOW to test your changes?

1. Add items to cart
2. Trigger a cart warning (e.g., by attempting to add more items than available in inventory)
3. Verify that warnings appear properly in the cart interface
4. Check that warnings are properly styled and accessible

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation