### PR TITLE
Add support for bun.lock text-based lockfile

### DIFF
--- a/.changeset/bun-lock-support.md
+++ b/.changeset/bun-lock-support.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add support for Bun's text-based lockfile (`bun.lock`) introduced in Bun 1.2, in addition to the existing binary lockfile (`bun.lockb`).

--- a/.changeset/bun-lock-support.md
+++ b/.changeset/bun-lock-support.md
@@ -2,4 +2,4 @@
 '@shopify/cli-hydrogen': patch
 ---
 
-Add support for Bun's text-based lockfile (`bun.lock`) introduced in Bun 1.2, in addition to the existing binary lockfile (`bun.lockb`).
+Add support for Bun's text-based lockfile (`bun.lock`) introduced in Bun 1.2, and npm's shrinkwrap lockfile (`npm-shrinkwrap.json`), as alternatives to their respective primary lockfiles (`bun.lockb` and `package-lock.json`).

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -291,15 +291,21 @@ export async function runDeploy(
       if (changedFiles) {
         errorMessage += `:\n\n${changedFiles.trimEnd()}`;
 
-        packageManagers.forEach(({name, lockfile, installCommand}) => {
-          if (changedFiles.includes(lockfile)) {
-            nextSteps.push([
-              `If you are using ${name}, try running`,
-              {command: installCommand},
-              `to avoid changes to ${lockfile}.`,
-            ]);
-          }
-        });
+        packageManagers.forEach(
+          ({name, lockfile, alternativeLockfiles, installCommand}) => {
+            const allLockfiles = [lockfile, ...(alternativeLockfiles || [])];
+            const changedLockfile = allLockfiles.find((lf) =>
+              changedFiles.includes(lf),
+            );
+            if (changedLockfile) {
+              nextSteps.push([
+                `If you are using ${name}, try running`,
+                {command: installCommand},
+                `to avoid changes to ${changedLockfile}.`,
+              ]);
+            }
+          },
+        );
       }
 
       throw new AbortError(errorMessage, null, nextSteps);

--- a/packages/cli/src/lib/check-lockfile.test.ts
+++ b/packages/cli/src/lib/check-lockfile.test.ts
@@ -33,6 +33,26 @@ describe('checkLockfileStatus()', () => {
       });
     });
 
+    it('detects bun.lock (text-based lockfile)', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        await writeFile(joinPath(tmpDir, 'bun.lock'), '');
+
+        await checkLockfileStatus(tmpDir);
+
+        expect(outputMock.warn()).toBe('');
+      });
+    });
+
+    it('detects bun.lockb (binary lockfile)', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        await writeFile(joinPath(tmpDir, 'bun.lockb'), '');
+
+        await checkLockfileStatus(tmpDir);
+
+        expect(outputMock.warn()).toBe('');
+      });
+    });
+
     describe('and it is being ignored by Git', () => {
       beforeEach(() => {
         vi.mocked(checkIgnoreMock).mockResolvedValue(['package-lock.json']);

--- a/packages/cli/src/lib/check-lockfile.ts
+++ b/packages/cli/src/lib/check-lockfile.ts
@@ -35,12 +35,14 @@ interface FoundPackageManager {
 }
 
 function multipleLockfilesWarning(
-  foundManagers: FoundPackageManager[],
+  foundPackageManagers: FoundPackageManager[],
   shouldExit: boolean,
 ) {
-  const lockfileList = foundManagers.map(({packageManager, foundLockfile}) => {
-    return `${foundLockfile} (created by ${packageManager.name})`;
-  });
+  const lockfileList = foundPackageManagers.map(
+    ({packageManager, foundLockfile}) => {
+      return `${foundLockfile} (created by ${packageManager.name})`;
+    },
+  );
 
   const headline = 'Multiple lockfiles found';
   const body = [
@@ -81,7 +83,7 @@ export async function checkLockfileStatus(
 ) {
   if (isHydrogenMonorepo && !process.env.SHOPIFY_UNIT_TEST) return;
 
-  const foundManagers: FoundPackageManager[] = [];
+  const foundPackageManagers: FoundPackageManager[] = [];
   for (const packageManager of packageManagers) {
     const allLockfiles = [
       packageManager.lockfile,
@@ -89,21 +91,21 @@ export async function checkLockfileStatus(
     ];
     for (const lockfile of allLockfiles) {
       if (await fileExists(resolvePath(directory, lockfile))) {
-        foundManagers.push({packageManager, foundLockfile: lockfile});
+        foundPackageManagers.push({packageManager, foundLockfile: lockfile});
         break;
       }
     }
   }
 
-  if (foundManagers.length === 0) {
+  if (foundPackageManagers.length === 0) {
     return missingLockfileWarning(shouldExit);
   }
 
-  if (foundManagers.length > 1) {
-    return multipleLockfilesWarning(foundManagers, shouldExit);
+  if (foundPackageManagers.length > 1) {
+    return multipleLockfilesWarning(foundPackageManagers, shouldExit);
   }
 
-  const lockfile = foundManagers[0]!.foundLockfile;
+  const lockfile = foundPackageManagers[0]!.foundLockfile;
   const ignoredLockfile = await checkIfIgnoredInGitRepository(directory, [
     lockfile,
   ]).catch(() => {

--- a/packages/cli/src/lib/package-managers.ts
+++ b/packages/cli/src/lib/package-managers.ts
@@ -14,6 +14,7 @@ export const packageManagers: PackageManager[] = [
   {
     name: 'npm',
     lockfile: 'package-lock.json',
+    alternativeLockfiles: ['npm-shrinkwrap.json'],
     installCommand: 'npm ci',
   },
   {

--- a/packages/cli/src/lib/package-managers.ts
+++ b/packages/cli/src/lib/package-managers.ts
@@ -6,6 +6,7 @@ import {
 export interface PackageManager {
   name: Name;
   lockfile: Lockfile;
+  alternativeLockfiles?: string[];
   installCommand: string;
 }
 
@@ -28,6 +29,7 @@ export const packageManagers: PackageManager[] = [
   {
     name: 'bun',
     lockfile: 'bun.lockb',
+    alternativeLockfiles: ['bun.lock'],
     installCommand: 'bun install --frozen-lockfile',
   },
 ];


### PR DESCRIPTION
## Summary

Bun 1.2 introduced `bun.lock` as a text-based alternative to the binary `bun.lockb` lockfile. This PR adds support for detecting either lockfile format in the Hydrogen CLI.

### Changes
- Added `alternativeLockfiles` property to the `PackageManager` interface to support multiple lockfile formats per package manager
- Updated lockfile detection in `check-lockfile.ts` to check both primary and alternative lockfiles
- Updated deploy error handling in `deploy.ts` to recognize changes to alternative lockfiles
- Added tests for both `bun.lock` and `bun.lockb` detection

### Related
- Similar issue in other tools: [nrwl/nx#30607](https://github.com/nrwl/nx/issues/30607)

## Test plan
- [x] Added unit tests for `bun.lock` detection
- [x] Added unit tests for `bun.lockb` detection  
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)