### PR TITLE
chore(dx): enable dev up and dev server commands for Shopify contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,69 @@ name: 🚀 CI
 on: [pull_request]
 
 jobs:
+  check-node-version:
+    name: 🔧 Node version sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate .nvmrc matches dev.yml
+        run: |
+          NVMRC_VERSION=$(tr -d 'v\n' < .nvmrc)
+          DEV_YML_RAW=$(grep "node:" dev.yml | grep -oE "'v?[^']+'" | tr -d "'" | head -1)
+          DEV_YML_VERSION=$(echo "$DEV_YML_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+
+          if [ -z "$NVMRC_VERSION" ]; then
+            echo "::error::Could not parse version from .nvmrc"
+            exit 1
+          fi
+
+          if [ -z "$DEV_YML_RAW" ]; then
+            echo "::error::Could not find node: directive in dev.yml"
+            exit 1
+          fi
+
+          if [ -z "$DEV_YML_VERSION" ]; then
+            echo "::error::dev.yml must specify a FULL Node version (X.Y.Z format)"
+            echo ""
+            echo "Found: '$DEV_YML_RAW'"
+            echo "Expected format: 'vX.Y.Z' (e.g., 'v20.19.5')"
+            echo ""
+            echo "The Shopify 'dev' tool requires a specific installable version,"
+            echo "not just a major version like 'v20'. Nix needs the exact version"
+            echo "to fetch from its package cache."
+            exit 1
+          fi
+
+          NVMRC_MAJOR=$(echo "$NVMRC_VERSION" | cut -d. -f1)
+          DEV_YML_MAJOR=$(echo "$DEV_YML_VERSION" | cut -d. -f1)
+
+          if [ "$NVMRC_MAJOR" != "$DEV_YML_MAJOR" ]; then
+            echo "::error::Node version mismatch between .nvmrc and dev.yml"
+            echo ""
+            echo "┌─────────────────────────────────────────────────────────────────┐"
+            echo "│  IMPORTANT: This is NOT a configuration oversight!              │"
+            echo "│                                                                 │"
+            echo "│  The Shopify 'dev' tool CANNOT read from .nvmrc - it requires   │"
+            echo "│  an explicit version. These files serve different tools:        │"
+            echo "│    • .nvmrc  → used by nvm (flexible major version like 'v20')  │"
+            echo "│    • dev.yml → used by dev tool (needs exact version 'v20.x.x') │"
+            echo "│                                                                 │"
+            echo "│  Both files MUST be updated TOGETHER when changing Node version.│"
+            echo "└─────────────────────────────────────────────────────────────────┘"
+            echo ""
+            echo "Current state:"
+            echo "  .nvmrc major version:  v$NVMRC_MAJOR"
+            echo "  dev.yml major version: v$DEV_YML_MAJOR"
+            echo ""
+            echo "To fix: Update both files to use the same Node major version."
+            exit 1
+          fi
+
+          echo "✅ Node versions in sync (major version: v$NVMRC_MAJOR)"
+
   lint:
     name: ⬣ ESLint
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,25 @@ Run the following commands to get started working on Hydrogen.
 | `npm run dev`                                   | Runs the `dev` command in all packages        |
 | `npm run build`                                 | `build`s packages for production distribution |
 
+### Shopify Contributors
+
+If you have access to Shopify's `dev` CLI tool, you can use these commands instead:
+
+| Command      | Description                                                |
+| ------------ | ---------------------------------------------------------- |
+| `dev up`     | Sets up the development environment (installs dependencies and builds packages) |
+| `dev server` | Starts the skeleton template dev server                    |
+| `dev watch`  | Starts a server to automatically rebuild changes in packages upon saving |
+
+
+> **Note:** When running `dev up`, if prompted about git hooks, select **"no"** to preserve the existing Husky hooks configuration. The project uses Husky for pre-commit hooks, and overriding this would disable important checks.
+
+Run `dev` in the repository root to see all available commands.
+
+#### dev server vs dev watch?
+
+If you just want to make changes in the skeleton template, `dev up && dev server` is enough. If you are ALSO making changes inside `packages/*` while running the skeleton template, then you should also run `dev watch` alongside `dev server` so that any changes to packages will get automatically rebuilt and used in the skeleton template. If you don't run `dev watch`, then any changes inside `packages/*` will require you to restart the dev server (which will do a rebuild first) in order to be applied to the skeleton template.
+
 ## Context
 
 Hydrogen is a monorepo built with [Turborepo](https://turbo.build/) and consists of the following workspaces:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Hydrogen is Shopify's stack for headless commerce. It provides a set of tools, u
 
  </div>
 
+## Contributing to Hydrogen
+
+[Read our contributing guide](CONTRIBUTING.md)
+
 ## Hydrogen Legacy v1
 
 Hydrogen legacy v1 has been moved [to a separate repo](https://github.com/Shopify/hydrogen-v1) and the [docs can be found here](https://shopify.github.io/hydrogen-v1/tutorials/getting-started).
@@ -63,10 +67,6 @@ For example, if you're using Storefront API or Customer Account API version `202
 If the Storefront API or Customer Account API version updates include breaking changes, then Hydrogen and hydrogen-react may also include breaking changes. Because the API versions are updated every three months, breaking changes could occur every three months.
 
 Learn more about API [release schedules](https://shopify.dev/api/usage/versioning#release-schedule) at Shopify.
-
-## Contributing to Hydrogen
-
-[Read our contributing guide](CONTRIBUTING.md)
 
 ## Other handy links
 

--- a/dev.yml
+++ b/dev.yml
@@ -2,12 +2,20 @@ name: hydrogen
 display_name: Hydrogen
 
 up:
-  - node: 'v20.19.5'
+  - node: 'v20.19.5' # .nvmrc uses 'v20' for nvm flexibility; dev tool needs specific version
+  - custom:
+      name: Build packages
+      met?: npm run build
+      meet: 'true'
 
 commands:
+  server:
+    desc: 'Run the skeleton template dev server'
+    run: npm run build && npm run dev:app
+
   # Standard development commands
-  dev:
-    desc: 'Run the dev command in all packages'
+  watch:
+    desc: 'Run a server to watch for changes in any packages and automatically rebuild when changes are saved'
     run: npm run dev
 
   build:


### PR DESCRIPTION
## Summary

Shopify contributors can now use `dev up` and `dev server` for a streamlined development workflow.

### Changes

**dev.yml updates:**
- `dev up` now runs `npm install` followed by `npm run build`
- Added `server` command that runs `npm run dev:app` (skeleton template dev server)
- Node version set to `v20.19.5` (specific version required by dev tool)

**CI check for Node version consistency:**
- Added new CI job that validates `.nvmrc` and `dev.yml` have matching Node major versions
- **This makes it impossible for these files to get out of sync with CI passing**
- Also validates that `dev.yml` has a **full semver version** (X.Y.Z format like `v20.19.5`), not just a major version like `v20` - the dev tool's Nix-based shadowenv needs the exact version to fetch from its package cache
- Clear error messages explain that both files must be updated together

**Documentation:**
- Added Shopify Contributors section to CONTRIBUTING.md
- Documents the `dev up` and `dev server` commands
- Includes note about selecting "no" for git hooks prompt to preserve Husky

### Why two Node version files?

The Shopify `dev` tool **cannot** read from `.nvmrc` - it requires an explicit version string. This is a tool limitation, not a configuration oversight:

| File | Tool | Version Format | Why |
|------|------|----------------|-----|
| `.nvmrc` | nvm | `v20` (major only) | nvm resolves to latest v20.x.x |
| `dev.yml` | dev tool | `v20.19.5` (exact) | Nix-based shadowenv needs concrete version |

The new CI check prevents these from drifting apart and ensures `dev.yml` always has an installable version.

### How to test

1. Run `dev up` - should install deps and build packages
2. Run `dev server` - should start skeleton template dev server
3. (CI) Modify `.nvmrc` to a different major version - CI should fail with clear message
4. (CI) Change `dev.yml` to just `v20` instead of `v20.19.5` - CI should fail requiring full X.Y.Z format

---

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation