### PR TITLE
Add back deleted skeleton template changesets

### DIFF
--- a/.changeset/api-version-2025-10.md
+++ b/.changeset/api-version-2025-10.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+'skeleton': major
+---
+
+Update Storefront API and Customer Account API to version 2025-10

--- a/.changeset/bun-lock-support.md
+++ b/.changeset/bun-lock-support.md
@@ -1,0 +1,7 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Add support for Bun's text-based lockfile (`bun.lock`) introduced in Bun 1.2, and npm's shrinkwrap lockfile (`npm-shrinkwrap.json`), as alternatives to their respective primary lockfiles (`bun.lockb` and `package-lock.json`).

--- a/.changeset/gift-card-add-mutation.md
+++ b/.changeset/gift-card-add-mutation.md
@@ -1,0 +1,32 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+'skeleton': patch
+---
+
+Add `cartGiftCardCodesAdd` mutation
+
+## New Feature: cartGiftCardCodesAdd
+
+The skeleton template has been updated to use the new `cartGiftCardCodesAdd` mutation:
+- Removed `UpdateGiftCardForm` component from `CartSummary.tsx`
+- Added `AddGiftCardForm` component using `CartForm.ACTIONS.GiftCardCodesAdd`
+
+If you customized the gift card form in your project, you may want to migrate to the new `Add` action for simpler code.
+
+## Usage
+
+```typescript
+import {CartForm} from '@shopify/hydrogen';
+
+<CartForm action={CartForm.ACTIONS.GiftCardCodesAdd} inputs={{giftCardCodes: ['CODE1', 'CODE2']}}>
+  <button>Add Gift Cards</button>
+</CartForm>
+```
+
+Or with createCartHandler:
+
+```typescript
+const cart = createCartHandler({storefront, getCartId, setCartId});
+await cart.addGiftCardCodes(['SUMMER2025', 'WELCOME10']);
+```

--- a/.changeset/nested-cart-lines.md
+++ b/.changeset/nested-cart-lines.md
@@ -1,0 +1,33 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+'skeleton': patch
+---
+
+Add support for nested cart line items (warranties, gift wrapping, etc.)
+
+Storefront API 2025-10 introduces `parentRelationship` on cart line items, enabling parent-child relationships for add-ons. This update displays nested line items in the cart.
+
+### Changes
+
+- Updates GraphQL fragments to include `parentRelationship` and `lineComponents` fields
+- Updates `CartMain` and `CartLineItem` to render child line items with visual hierarchy
+
+### Note
+
+This update focuses on **displaying** nested line items. To add both a product and its child (e.g., warranty) in a single action:
+
+```tsx
+<AddToCartButton
+  lines={[
+    {merchandiseId: 'gid://shopify/ProductVariant/laptop-456', quantity: 1},
+    {
+      merchandiseId: 'gid://shopify/ProductVariant/warranty-123',
+      quantity: 1,
+      parent: {merchandiseId: 'gid://shopify/ProductVariant/laptop-456'},
+    },
+  ]}
+>
+  Add to Cart with Warranty
+</AddToCartButton>
+```


### PR DESCRIPTION
### WHY are these changes introduced?

Essentially a revert of https://github.com/Shopify/hydrogen/pull/3429 so that once we fix the mock shop issue we will be able to release a new version of the skeleton template + where it's bundled.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
