### PR TITLE
Disable recipe CI jobs during system re-evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,9 @@ jobs:
 
   validate_recipes:
     name: ⬣ Validate Recipes
+    # TEMPORARILY DISABLED: Recipe system is being re-evaluated.
+    # Remove this line to re-enable.
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -19,6 +19,9 @@ permissions:
 jobs:
   deploy:
     name: Deploy Recipe to Oxygen
+    # TEMPORARILY DISABLED: Recipe system is being re-evaluated.
+    # Remove this line to re-enable.
+    if: false
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
### WHY are these changes introduced?

The recipe/cookbook system is being re-evaluated. In the meantime, recipe-related CI jobs create confusion for new contributors when they fail on PRs unrelated to recipes.

### WHAT is this pull request doing?

Adds `if: false` to two GitHub Actions jobs to skip execution while keeping job definitions visible:

| File | Job | Effect |
|------|-----|--------|
| `.github/workflows/ci.yml` | `validate_recipes` | Skipped on all PRs |
| `.github/workflows/deploy-examples.yml` | `deploy` | Skipped on push/PR |

Jobs appear as "skipped" in the GitHub Actions UI rather than being invisible, making it easy to re-enable later.

### HOW to test your changes?

1. Check the Actions tab on this PR
2. Verify `validate_recipes` and `Deploy Recipe to Oxygen` jobs show as "skipped"
3. Confirm all other CI jobs run normally

#### Re-enabling

Remove the `if: false` line from each job when the recipe system is ready.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

_No changeset needed - CI-only change with no user-facing impact._