### PR TITLE
chore: remove exception to storefront client url

### DIFF
--- a/packages/hydrogen-react/src/storefront-client.test.ts
+++ b/packages/hydrogen-react/src/storefront-client.test.ts
@@ -121,7 +121,9 @@ describe(`createStorefrontClient`, () => {
         generateConfig({storeDomain: 'mock.shop'}),
       );
 
-      expect(client.getStorefrontApiUrl()).toBe(`https://mock.shop/api`);
+      expect(client.getStorefrontApiUrl()).toBe(
+        `https://mock.shop/api/${SFAPI_VERSION}/graphql.json`,
+      );
     });
   });
 

--- a/packages/hydrogen-react/src/storefront-client.ts
+++ b/packages/hydrogen-react/src/storefront-client.ts
@@ -89,8 +89,6 @@ export function createStorefrontClient({
       const domain = getShopifyDomain(overrideProps);
       const apiUrl = domain + (domain.endsWith('/') ? 'api' : '/api');
 
-      if (isMockShop(domain)) return apiUrl;
-
       return `${apiUrl}/${
         overrideProps?.storefrontApiVersion ?? storefrontApiVersion
       }/graphql.json`;


### PR DESCRIPTION
### WHY are these changes introduced?

Mock shop now supports versioned SFAPI calls, making it easier for us to upgrade versions. we no longer need this exception.

I did not create a changeset as this is invisible for users

### WHAT is this pull request doing?

This PR removes the special case handling for mock shop domains in the `getStorefrontApiUrl` function. Previously, mock shop domains would return a URL without the API version and GraphQL endpoint path (`/api` instead of `/api/{version}/graphql.json`). This change ensures that all domains, including mock shops, return the complete API URL with version and GraphQL endpoint.

The test has been updated to reflect this change, now expecting the full API URL path for mock shop domains.

### HOW to test your changes?

- ensure `.env` in skeleton has no urls
- run `npm run build --filter=skeleton` to make sure we have built the libs with the new URLs
- run `npm run dev:app` and open pages. if they work, its good
- if you want extra assurance, try adding a log to `storefront-client.ts` line 95 to verify which URL is being called

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- I've added or updated the documentation