### PR TITLE
fix: add ejson to dev.yml so that people can decrypt ejson after running dev up

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,6 +3,8 @@ display_name: Hydrogen
 
 up:
   - node: 'v20.19.5' # .nvmrc uses 'v20' for nvm flexibility; dev tool needs specific version
+  - packages:
+    - ejson
   - custom:
       name: Build packages
       met?: npm run build


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

`dev` uses nix, which will only let you use packages that are explicitly specified as dependencies (to eliminate any "it works on my machine" issues). After running `dev up`, if I tried to run `npm run decrypt` I would get a nix error because ejson wasn't specified as a dependency.



### WHAT is this pull request doing?

I've now added ejson as a dependency so that now `dev up` followed by `npm run decrypt` works!

[Other repos are doing the same thing](https://grokt.shopify.io/results?q=ejson+file%3Adev.yml)

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
