### PR TITLE
Adds in SHOPIFY_CLI_ENV=development variable to dev.yml

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -10,6 +10,11 @@ up:
       met?: npm run build
       meet: 'true'
 
+# So the Shopify CLI loads the local @shopify/cli-hydrogen plugin when running
+# commands (e.g. skeleton dev → shopify hydrogen dev) instead of the bundled one.
+env:
+  SHOPIFY_CLI_ENV: development
+
 commands:
   server:
     desc: 'Run the skeleton template dev server'


### PR DESCRIPTION
### WHY are these changes introduced?

In the latest version of the `Shopify/cli` the [`custom-oclif-loader.ts`](https://github.com/Shopify/cli/blob/main/packages/cli-kit/src/public/node/custom-oclif-loader.ts#L10) that detects if we are in this monorepo and in development has a new `isDevelopment()` check to do the custom cli plugin loader that looks for a `SHOPIFY_CLI_ENV=development`. 

Without it, the `custom-oclif-loader.ts` will not be able to load the cli from the monorepo as it won't see we are in dev mod. 

### WHAT is this pull request doing?

Adds in `SHOPIFY_CLI_ENV=development` to `env:` in `dev.yml`. 

### HOW to test your changes?

1. Go to `dev.ts` in `hydrogen/packages/cli/src/commands/hydrogen/dev.ts`
2. Make arbitrary update to the `run()`
3. In the `cli` project run `npm run build` 
4. In the `template/skeleton` project run `npx shopify hydrogen dev`
    - To test locally i created an alias `shopify-dev` pointing to a locally built version of the `Shopiy/cli`
  
```
# Create the following file in ~/bin/shopify:#!/usr/bin/env node

process.env.SHOPIFY_RUBY_BINDIR = "/opt/rubies/3.1.2/bin"
process.env.SHOPIFY_HOMEBREW_FORMULA = "shopify-cli"

import("/Users/<your-user>/src/github.com/Shopify/cli/packages/cli/bin/run.js")
```

`alias shopify-dev='/Users/$USER/bin/shopify'`

**NOTE:** This is required for the latest version of `Shopify/cli` so by adding this its not going to do anything. However, this will be applicable when we get this `https://github.com/Shopify/cli/pull/6827` merged and `Shopify/cli` packages bumped in the monorepo

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
-  I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- I've added or updated the documentation