### PR TITLE
fix(calver): skeleton major bumps no longer cascade to hydrogen packages

### DIFF
--- a/.changeset/detect-calver-bump-type.js
+++ b/.changeset/detect-calver-bump-type.js
@@ -17,7 +17,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const {CALVER_PACKAGES} = require('./calver-shared.js');
+const {CALVER_PACKAGES, CALVER_SYNC_PACKAGES} = require('./calver-shared.js');
 
 const CALVER_BUMP_FILE = path.join(__dirname, '.calver-bump-type');
 
@@ -48,16 +48,21 @@ function detectBumpType() {
     const content = fs.readFileSync(filePath, 'utf-8');
 
     for (const pkg of CALVER_PACKAGES) {
+      const canTriggerMajorSync = CALVER_SYNC_PACKAGES.includes(pkg);
+
       if (
-        content.includes(`"${pkg}": major`) ||
-        content.includes(`'${pkg}': major`)
+        canTriggerMajorSync &&
+        (content.includes(`"${pkg}": major`) ||
+          content.includes(`'${pkg}': major`))
       ) {
         hasMajor = true;
       } else if (
         content.includes(`"${pkg}": minor`) ||
         content.includes(`'${pkg}': minor`) ||
         content.includes(`"${pkg}": patch`) ||
-        content.includes(`'${pkg}': patch`)
+        content.includes(`'${pkg}': patch`) ||
+        content.includes(`"${pkg}": major`) ||
+        content.includes(`'${pkg}': major`)
       ) {
         hasMinorOrPatch = true;
       }


### PR DESCRIPTION
### WHY are these changes introduced?

Relates to #3451

The `[ci] release 2026.1.0` PR incorrectly bumps `@shopify/hydrogen` and `@shopify/hydrogen-react` to major version `2026.1.0`. The only major changeset is `'skeleton': major` in `api-version-2025-10.md` — hydrogen only has a patch changeset and hydrogen-react has none at all. The skeleton template's major bump should not force the library packages to advance to the next quarter.

### WHAT is this pull request doing?

Introduces a `CALVER_SYNC_PACKAGES` constant to separate two concerns that were conflated:
- **"Which packages use CalVer versioning?"** → `CALVER_PACKAGES` (hydrogen, hydrogen-react, skeleton)
- **"Which packages' major bumps trigger cross-package quarter advancement?"** → `CALVER_SYNC_PACKAGES` (hydrogen, hydrogen-react only)

The root cause was that `detectBumpType()` and `hasMajorChangesets()` treated all three CalVer packages identically for major detection. A `skeleton: major` changeset would set the global `hasMajor` flag, which then forced ALL CalVer packages to `getNextVersion(baseline, 'major')` — advancing them to the next quarter even when they had no major changeset.

**Files changed:**

| File | Change |
|------|--------|
| `.changeset/calver-shared.js` | Add `CALVER_SYNC_PACKAGES`, update `hasMajorChangesets()` to use it |
| `.changeset/detect-calver-bump-type.js` | Gate `hasMajor` detection to sync-eligible packages only |
| `.changeset/calver-bump-type.test.js` | Add 14 new assertions covering skeleton-major scenarios |

The fix is minimal: only 2 files needed code changes. The 4 other consumption points (`enforce-calver-ci.js` lines 137 and 165-167, `enforce-calver-local.js` lines 159 and 184) inherit the fix transitively because they call into the corrected functions.

### HOW to test your changes?

1. Run the test suite:
   ```
   node .changeset/calver-bump-type.test.js
   ```
   All 32 tests should pass (18 existing + 14 new).

2. Verify the CLI command with current changesets:
   ```
   node .changeset/calver-shared.js has-major-changesets
   ```
   Should return `false` (current changesets include `skeleton: major` but no hydrogen/hydrogen-react major).

3. Key test scenarios to verify:
   - `skeleton: major` alone → `detectBumpType()` returns `'patch'`, `hasMajorChangesets()` returns `false`
   - `@shopify/hydrogen: major` alone → returns `'major'` and `true` (no regression)
   - `skeleton: major` + `@shopify/hydrogen: patch` → returns `'patch'` and `false` (the exact PR #3451 scenario)
   - Single changeset file with both `skeleton: major` and `@shopify/hydrogen: patch` in the same frontmatter → returns `'patch'` and `false`

#### Post-merge steps

After merging, the `[ci] release` PR (#3451) should be regenerated. The changeset workflow will re-run `detect-calver-bump-type.js` and produce correct versions (skeleton advances to next quarter independently, hydrogen gets a patch bump, hydrogen-react stays unchanged).

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation