### PR TITLE
feat(ci): add scaffolding tests for npm, pnpm, bun, and yarn

### DIFF
--- a/.changeset/hungry-pears-return.md
+++ b/.changeset/hungry-pears-return.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fixed `--package-manager` flag being ignored when `--install-deps` was explicitly passed. Projects now correctly use the specified package manager for dependency installation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,75 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
+  test_scaffolding:
+    name: ⬣ Scaffolding tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: ci-scaffolding-${{ matrix.pm }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        pm: [npm, pnpm, yarn, bun]
+        include:
+          - pm: npm
+            lockfile: package-lock.json
+          - pm: pnpm
+            lockfile: pnpm-lock.yaml
+            setup: |
+              npm i -g pnpm@9
+          - pm: yarn
+            lockfile: yarn.lock
+          - pm: bun
+            lockfile: bun.lock
+            setup: |
+              npm i -g bun
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: 📦 Setup ${{ matrix.pm }}
+        if: matrix.setup
+        run: ${{ matrix.setup }}
+
+      - name: 📥 Install dependencies
+        run: |
+          npm ci
+          npm rebuild
+
+      - name: 📦 Build packages
+        run: SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npm run build:pkg
+
+      - name: 🧪 Scaffold with ${{ matrix.pm }}
+        run: |
+          node packages/create-hydrogen/dist/create-app.js \
+            --path "$RUNNER_TEMP/h2-test-${{ matrix.pm }}" \
+            --language ts \
+            --mock-shop \
+            --install-deps \
+            --no-git \
+            --package-manager ${{ matrix.pm }} \
+            --no-shortcut \
+            --routes \
+            --markets none \
+            --styling none
+
+      - name: ✅ Verify lockfile
+        run: test -f "$RUNNER_TEMP/h2-test-${{ matrix.pm }}/${{ matrix.lockfile }}"
+
+      - name: ✅ Verify app builds
+        run: |
+          cd "$RUNNER_TEMP/h2-test-${{ matrix.pm }}"
+          npm run build
+
   test_unit:
     name: ⬣ Unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
       - name: ✅ Verify app builds
         run: |
           cd "$RUNNER_TEMP/h2-test-${{ matrix.pm }}"
-          npm run build
+          ${{ matrix.pm }} run build
 
   test_unit:
     name: ⬣ Unit tests

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -467,7 +467,7 @@ export async function handleCssStrategy(
 /**
  * Prompts the user to choose whether to install dependencies and which package manager to use.
  * It infers the package manager used for creating the project and uses that as the default.
- * @returns The chosen pacakge manager and a function that optionally installs dependencies.
+ * @returns The chosen package manager and a function that optionally installs dependencies.
  */
 export async function handleDependencies(
   projectDir: string,
@@ -507,6 +507,8 @@ export async function handleDependencies(
         cancellationMessage: 'No',
         abortSignal: controller.signal,
       });
+    } else {
+      actualPackageManager = detectedPackageManager;
     }
   }
 

--- a/packages/cli/src/lib/onboarding/local.test.ts
+++ b/packages/cli/src/lib/onboarding/local.test.ts
@@ -10,6 +10,7 @@ import {setupTemplate} from './index.js';
 import {getSkeletonSourceDir} from '../build.js';
 import {basename} from '@shopify/cli-kit/node/path';
 import {renderSelectPrompt} from '@shopify/cli-kit/node/ui';
+import {installNodeModules} from '@shopify/cli-kit/node/node-package-manager';
 import {execAsync} from '../process.js';
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output';
 
@@ -356,6 +357,25 @@ describe('local templates', () => {
             expect.stringContaining('Setup markets support using domains'),
             expect.stringContaining('Scaffold Storefront'),
           ]),
+        );
+      });
+    });
+  });
+
+  describe('package manager', () => {
+    it('uses the specified package manager when installDeps is true', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        await setupTemplate({
+          path: tmpDir,
+          git: false,
+          language: 'ts',
+          mockShop: true,
+          installDeps: true,
+          packageManager: 'pnpm',
+        });
+
+        expect(installNodeModules).toHaveBeenCalledWith(
+          expect.objectContaining({packageManager: 'pnpm'}),
         );
       });
     });


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves [developer-tools-team/issues/1042](https://github.com/Shopify/developer-tools-team/issues/1042)

  There were no CI checks validating that `create-hydrogen` correctly scaffolds projects with  different package managers. A bug in `handleDependencies` was silently causing  `--package-manager` to be ignored when `--install-deps` was explicitly `true` — all scaffolded projects used npm regardless of the specified package manager.

  ### WHAT is this pull request doing?

  **CI scaffolding tests** — Adds a new `test_scaffolding` job to CI that uses a GitHub Actions matrix to test each package manager (npm, pnpm, yarn, bun) in parallel. Each matrix entry:
  1. Installs the package manager (if not pre-installed)
  2. Runs `create-hydrogen` with `--package-manager`
  3. Verifies the correct lockfile exists
  4. Builds the scaffolded app

  **Bug fix** — Adds a missing `else` branch in `handleDependencies`
  (`packages/cli/src/lib/onboarding/common.ts`). When `--install-deps` was `true` and `--package-manager` was a known PM (not `unknown`), `actualPackageManager` stayed as the default `'npm'` because neither the `unknown` nor `undefined` branches executed.

  **Unit test** — Verifies that `setupTemplate` with `installDeps: true` and `packageManager:
  'pnpm'` calls `installNodeModules` with `pnpm`.

  ### HOW to test your changes?

  The CI scaffolding tests run automatically on the PR. 

  ### Checklist

  - [x] I've read the https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md
  - [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
  - [x] I've added a https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets if this
  PR contains user-facing or noteworthy changes
  - [x] I've added https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing to cover my
  changes