### PR TITLE
test(cli): skip unreliable version upgrade tests

### DIFF
--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -766,7 +766,7 @@ describe('upgrade', async () => {
       );
     });
 
-    it('shows up a notice if there are related dependencies to upgrade', async () => {
+    it.skip('shows up a notice if there are related dependencies to upgrade', async () => {
       const latestHydrogenVersion = (await (
         await getChangelog()
       ).releases[0]?.version) as string;
@@ -848,7 +848,7 @@ describe('upgrade', async () => {
       expect(availableUpgrades[0]?.version).toBe('2025.7.0');
     });
 
-    it('displayDevUpgradeNotice shows correct versions when current version is not in changelog', async () => {
+    it.skip('displayDevUpgradeNotice shows correct versions when current version is not in changelog', async () => {
       const mockPackageJson = {
         dependencies: {
           '@shopify/hydrogen': '2025.5.0',
@@ -881,7 +881,7 @@ describe('upgrade', async () => {
       );
     });
 
-    it('displayDevUpgradeNotice shows versions in correct order (newest first, next version last)', async () => {
+    it.skip('displayDevUpgradeNotice shows versions in correct order (newest first, next version last)', async () => {
       const mockPackageJson = {
         dependencies: {
           '@shopify/hydrogen': '2025.1.0',


### PR DESCRIPTION
these tests will always break when new versions come out as it downloads it from the npm package. these tests need to be largely rewritten but i have pushed it to tech debt here: https://github.com/orgs/Shopify/projects/4613/views/113?pane=issue&itemId=155982991&issue=Shopify%7Cdeveloper-tools-team%7C1046