### PR TITLE
Fix hydrogen upgrade failing with yarn

### DIFF
--- a/.changeset/fix-yarn-upgrade-command.md
+++ b/.changeset/fix-yarn-upgrade-command.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix `hydrogen upgrade` failing with yarn by using `yarn add` instead of `yarn install` when upgrading dependencies

--- a/.changeset/fix-yarn-upgrade-command.md
+++ b/.changeset/fix-yarn-upgrade-command.md
@@ -2,4 +2,4 @@
 '@shopify/cli-hydrogen': patch
 ---
 
-Fix `hydrogen upgrade` failing with yarn by using `yarn add` instead of `yarn install` when upgrading dependencies
+Fix `hydrogen upgrade` failing with yarn and pnpm by using the correct package-specific install subcommand (`add` for yarn/pnpm, `install` for npm/bun) when upgrading dependencies

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -23,7 +23,6 @@ import {
 } from '@shopify/cli-kit/node/fs';
 import {
   getDependencies,
-  installNodeModules,
   getPackageManager,
   type PackageJson,
 } from '@shopify/cli-kit/node/node-package-manager';
@@ -903,10 +902,13 @@ export async function upgradeNodeModules({
     tasks.push({
       title: `Upgrading dependencies`,
       task: async () => {
-        await installNodeModules({
-          directory: appPath,
-          packageManager: await getPackageManager(appPath),
-          args: upgradeArgs,
+        const packageManager = await getPackageManager(appPath);
+        const command = packageManager === 'yarn' ? 'add' : 'install';
+        const actualPackageManager =
+          packageManager === 'unknown' ? 'npm' : packageManager;
+
+        await exec(actualPackageManager, [command, ...upgradeArgs], {
+          cwd: appPath,
         });
       },
     });

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -891,7 +891,9 @@ export async function upgradeNodeModules({
     });
   }
 
-  // Then install/upgrade dependencies
+  // Install/upgrade dependencies using exec() directly instead of cli-kit's
+  // installNodeModules(), which runs `<pm> install` and doesn't support adding
+  // specific packages with version specifiers (yarn/pnpm require `add`).
   const upgradeArgs = buildUpgradeCommandArgs({
     selectedRelease,
     currentDependencies,

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -913,12 +913,13 @@ export async function upgradeNodeModules({
                 : packageManager === 'bun'
                   ? 'install'
                   : 'install'; // fallback to npm for 'unknown'
-        const actualPackageManager =
-          packageManager === 'unknown' ? 'npm' : packageManager;
-
-        await exec(actualPackageManager, [command, ...upgradeArgs], {
-          cwd: appPath,
-        });
+        await exec(
+          resolvePackageManagerName(packageManager),
+          [command, ...upgradeArgs],
+          {
+            cwd: appPath,
+          },
+        );
       },
     });
   }
@@ -926,6 +927,15 @@ export async function upgradeNodeModules({
   if (tasks.length > 0) {
     await renderTasks(tasks, {});
   }
+}
+
+/**
+ * Normalizes the package manager name, falling back to npm for 'unknown'.
+ */
+function resolvePackageManagerName(
+  packageManager: 'npm' | 'yarn' | 'pnpm' | 'unknown' | 'bun',
+): 'npm' | 'yarn' | 'pnpm' | 'bun' {
+  return packageManager === 'unknown' ? 'npm' : packageManager;
 }
 
 /**
@@ -953,10 +963,9 @@ async function uninstallNodeModules({
             ? 'remove'
             : 'uninstall'; // fallback to npm for 'unknown'
 
-  const actualPackageManager =
-    packageManager === 'unknown' ? 'npm' : packageManager;
-
-  await exec(actualPackageManager, [command, ...args], {cwd: directory});
+  await exec(resolvePackageManagerName(packageManager), [command, ...args], {
+    cwd: directory,
+  });
 }
 
 /**

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -903,7 +903,16 @@ export async function upgradeNodeModules({
       title: `Upgrading dependencies`,
       task: async () => {
         const packageManager = await getPackageManager(appPath);
-        const command = packageManager === 'yarn' ? 'add' : 'install';
+        const command =
+          packageManager === 'npm'
+            ? 'install'
+            : packageManager === 'yarn'
+              ? 'add'
+              : packageManager === 'pnpm'
+                ? 'add'
+                : packageManager === 'bun'
+                  ? 'install'
+                  : 'install'; // fallback to npm for 'unknown'
         const actualPackageManager =
           packageManager === 'unknown' ? 'npm' : packageManager;
 


### PR DESCRIPTION
## Summary

- The `hydrogen upgrade` command was using `installNodeModules()` from cli-kit, which always runs `<pm> install <packages>`. This works for npm, pnpm, and bun, but fails for yarn which requires `add` instead of `install` when adding/upgrading specific packages.
- Replaced with a direct `exec()` call that maps the correct subcommand per package manager (`install` for npm, `add` for yarn/pnpm/bun), mirroring the pattern already used by `uninstallNodeModules()` in the same file.

## Error before fix

```
Error coming from `yarn install @shopify/hydrogen@2025.7.1 react-router@7.12.0 ...`

Command failed with exit code 1: yarn install @shopify/hydrogen@2025.7.1 ...
error `install` has been replaced with `add` to add new dependencies.
```

## Test plan

- [x] Existing `upgradeNodeModules` and `buildUpgradeCommandArgs` tests pass
- [ ] Manual test: run `shopify hydrogen upgrade` in a yarn-based Hydrogen project
- [ ] Manual test: run `shopify hydrogen upgrade` in an npm-based Hydrogen project (no regression)