### PR TITLE
fix(test): unit tests in cli change user git configs

### DIFF
--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -2,10 +2,7 @@ import {createRequire} from 'node:module';
 import {tmpdir} from 'node:os';
 import {mkdtemp, rm} from 'node:fs/promises';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {
-  writeFile,
-  fileExists,
-} from '@shopify/cli-kit/node/fs';
+import {writeFile, fileExists} from '@shopify/cli-kit/node/fs';
 import {joinPath} from '@shopify/cli-kit/node/path';
 import {
   renderSelectPrompt,
@@ -182,9 +179,13 @@ async function inTemporaryHydrogenRepo(
       await exec('git', ['add', 'package.json'], {cwd: tmpDir});
 
       if (process.env.SHOPIFY_UNIT_TEST || process.env.CI) {
-        await exec('git', ['config', '--local', 'user.email', 'test@hydrogen.shop'], {
-          cwd: tmpDir,
-        });
+        await exec(
+          'git',
+          ['config', '--local', 'user.email', 'test@hydrogen.shop'],
+          {
+            cwd: tmpDir,
+          },
+        );
         await exec('git', ['config', '--local', 'user.name', 'Hydrogen Test'], {
           cwd: tmpDir,
         });

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -1,7 +1,8 @@
 import {createRequire} from 'node:module';
+import {tmpdir} from 'node:os';
+import {mkdtemp, rm} from 'node:fs/promises';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {
-  inTemporaryDirectory,
   writeFile,
   fileExists,
 } from '@shopify/cli-kit/node/fs';
@@ -136,7 +137,20 @@ const REACT_ROUTER_RELEASE = {
 } satisfies Release;
 
 /**
- * Creates a temporary directory with a git repo and a package.json
+ * Creates a temporary directory in OS temp (not in repo)
+ */
+async function inTemporaryDirectory(cb: (tmpDir: string) => Promise<void>) {
+  const tmpDir = await mkdtemp(joinPath(tmpdir(), 'hydrogen-test-'));
+
+  try {
+    await cb(tmpDir);
+  } finally {
+    await rm(tmpDir, {recursive: true, force: true});
+  }
+}
+
+/**
+ * Creates a temporary directory in OS temp (not in repo) with a git repo and a package.json
  */
 async function inTemporaryHydrogenRepo(
   cb: (tmpDir: string) => Promise<void>,
@@ -148,7 +162,10 @@ async function inTemporaryHydrogenRepo(
     packageJson?: PackageJson;
   } = {cleanGitRepo: true},
 ) {
-  return inTemporaryDirectory(async (tmpDir) => {
+  // Create temp directory in OS temp folder, not in the repo
+  const tmpDir = await mkdtemp(joinPath(tmpdir(), 'hydrogen-test-'));
+
+  try {
     // init the git repo
     await exec('git', ['init'], {cwd: tmpDir});
 
@@ -165,10 +182,10 @@ async function inTemporaryHydrogenRepo(
       await exec('git', ['add', 'package.json'], {cwd: tmpDir});
 
       if (process.env.SHOPIFY_UNIT_TEST || process.env.CI) {
-        await exec('git', ['config', 'user.email', 'test@hydrogen.shop'], {
+        await exec('git', ['config', '--local', 'user.email', 'test@hydrogen.shop'], {
           cwd: tmpDir,
         });
-        await exec('git', ['config', 'user.name', 'Hydrogen Test'], {
+        await exec('git', ['config', '--local', 'user.name', 'Hydrogen Test'], {
           cwd: tmpDir,
         });
       }
@@ -176,7 +193,10 @@ async function inTemporaryHydrogenRepo(
     }
 
     await cb(tmpDir);
-  });
+  } finally {
+    // Clean up: remove the temporary directory
+    await rm(tmpDir, {recursive: true, force: true});
+  }
 }
 
 function increasePatchVersion(depName: string, deps: Record<string, string>) {


### PR DESCRIPTION
tests currently create temporary directories inside the Hydrogen repo **root**. When running `git config` commands, Git would walk up and modify the Hydrogen repo's `.git/config` instead of the test directory's config, polluting local git settings with test values.

### Solution

Updated tests to create temporary directories in the OS temp folder (`/tmp/` or `/var/folders/`) using Node.js `mkdtemp()` instead of inside the repo. Added explicit `--local` flags to git config commands and proper cleanup.