### PR TITLE
ci: upload playwright report even if failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,10 +205,11 @@ jobs:
 
       - name: 📤 Upload Playwright Report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ !cancelled() }}
+        if: ${{ always() && !cancelled() }}
         with:
           name: playwright-report
           path: playwright-report/
+          if-no-files-found: warn
           retention-days: 30
 
   test_unit:


### PR DESCRIPTION
### WHY are these changes introduced?

Playwright reports are currently not uploaded if the previous task fails

This PR enforces we always do

### HOW to test your changes?

- look at Actions
 
