### PR TITLE
ci: normalise dependency cache and node versions

### DIFF
--- a/.github/workflows/test-calver.yml
+++ b/.github/workflows/test-calver.yml
@@ -56,8 +56,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: '22'
           cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test-upgrade-flow.yml
+++ b/.github/workflows/test-upgrade-flow.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
### WHY are these changes introduced?

- `.github/workflows/test-calver.yml` was still pinned to Node 18, which no longer matches the repo's supported runtime (`"node": "^22 || ^24"`).
- pnpm cache setup in CI should consistently use the lockfile path for deterministic cache keys.

### WHAT is this pull request doing?

- Updates `.github/workflows/test-calver.yml` to use `node-version: '22'`.
- Adds `cache-dependency-path: 'pnpm-lock.yaml'` to both `.github/workflows/test-calver.yml` and `.github/workflows/test-upgrade-flow.yml`.

### HOW to test your changes?

1. Run the targeted CLI unit test:
   - `pnpm --filter @shopify/cli-hydrogen test -- template-pack.test.ts`
2. Confirm workflow changes in:
   - `.github/workflows/test-calver.yml`
   - `.github/workflows/test-upgrade-flow.yml`

#### Post-merge steps

None.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- I've added or updated the documentation