### PR TITLE
test: template pack edge cases

### DIFF
--- a/packages/cli/src/lib/template-pack.test.ts
+++ b/packages/cli/src/lib/template-pack.test.ts
@@ -48,7 +48,8 @@ describe('replaceWorkspaceProtocolVersions', () => {
         await readFile(copiedPackageJsonPath, 'utf8'),
       ) as Record<string, Record<string, string> | undefined>;
 
-      // Simulate a dependency managed through pnpm catalog.
+      // Use a real workspace dependency from the packed manifest and swap it to
+      // catalog: so the test validates resolution against an actual package entry.
       copiedPackageJsonBefore.dependencies ??= {};
       copiedPackageJsonBefore.dependencies['@shopify/hydrogen'] = 'catalog:';
 

--- a/packages/cli/src/lib/template-pack.test.ts
+++ b/packages/cli/src/lib/template-pack.test.ts
@@ -23,6 +23,7 @@ function getCatalogVersion(sourceTemplateDir: string, packageName: string) {
     },
   ).trim();
 
+  // pnpm config get returns the literal string "undefined" for missing keys.
   if (!catalogVersion || catalogVersion === 'undefined') {
     throw new Error(`Expected pnpm catalog entry for ${packageName}.`);
   }

--- a/packages/cli/src/lib/template-pack.test.ts
+++ b/packages/cli/src/lib/template-pack.test.ts
@@ -76,6 +76,9 @@ describe('replaceWorkspaceProtocolVersions', () => {
       }
 
       expect(copiedPackageJson.dependencies?.react).toBe(expectedReactVersion);
+      expect(
+        copiedPackageJson.devDependencies?.['@shopify/mini-oxygen'],
+      ).toMatch(/^\d+\.\d+\.\d+/);
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

`replaceWorkspaceProtocolVersions` runs in the template packaging path used for releases. The existing integration coverage verified that `workspace:` and `catalog:` prefixes were removed, but it did not verify exact `catalog:` resolution or the error behavior when protocol-based dependencies cannot be found in the packed manifest.

### WHAT is this pull request doing?

- Adds a helper in `template-pack.test.ts` to read a dependency version from the `catalog` section of `pnpm-workspace.yaml`.
- Strengthens the existing integration test to assert the exact resolved value for `react` (from `catalog`) instead of only checking protocol prefix removal.
- Adds a test that asserts a clear error is thrown when a `workspace:*` dependency is missing from the packed manifest.
- Adds a test that asserts a clear error is thrown when a `catalog:` dependency is missing from the packed manifest.

### HOW to test your changes?

1. Run `cd packages/cli`
2. Run `pnpm exec vitest run src/lib/template-pack.test.ts`
3. Confirm all tests pass (currently `3` tests in this file)

#### Post-merge steps

None.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
