### PR TITLE
fix: 'dev up' now runs 'pnpm install' instead of 'npm install'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,25 @@ jobs:
       - name: Validate .nvmrc matches dev.yml
         run: |
           NVMRC_VERSION=$(tr -d 'v\n' < .nvmrc)
-          DEV_YML_RAW=$(grep "node:" dev.yml | grep -oE "'v?[^']+'" | tr -d "'" | head -1)
+          # Expects dev.yml format:
+          #   - node:
+          #       version: vXX.YY.ZZ
+          DEV_YML_RAW=$(grep -A3 '^\s*- node:' dev.yml | grep 'version:' | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           DEV_YML_VERSION=$(echo "$DEV_YML_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 
           if [ -z "$NVMRC_VERSION" ]; then
             echo "::error::Could not parse version from .nvmrc"
+            echo "  .nvmrc contents: '$(cat .nvmrc)'"
+            echo "  dev.yml raw:     '$DEV_YML_RAW'"
             exit 1
           fi
 
           if [ -z "$DEV_YML_RAW" ]; then
-            echo "::error::Could not find node: directive in dev.yml"
+            echo "::error::Could not find node version in dev.yml"
+            echo "  .nvmrc version:  '$NVMRC_VERSION'"
+            echo "  Searched for: '- node:' followed by 'version:' line in dev.yml"
+            echo "  Relevant dev.yml lines:"
+            grep -A3 'node:' dev.yml | sed 's/^/    /'
             exit 1
           fi
 
@@ -30,6 +39,7 @@ jobs:
             echo "::error::dev.yml must specify a FULL Node version (X.Y.Z format)"
             echo ""
             echo "Found: '$DEV_YML_RAW'"
+            echo ".nvmrc version: '$NVMRC_VERSION'"
             echo "Expected format: 'vX.Y.Z' (e.g., 'v20.19.5')"
             echo ""
             echo "The Shopify 'dev' tool requires a specific installable version,"

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,9 @@ name: hydrogen
 display_name: Hydrogen
 
 up:
-  - node: 'v24.13.0' # .nvmrc uses 'v24' for nvm flexibility; dev tool needs specific version
+  - node:
+      version: v24.13.0 # .nvmrc uses 'v24' for nvm flexibility; dev tool needs specific version
+      package_manager: pnpm@10.16.1
   - packages:
       - ejson
   - custom:


### PR DESCRIPTION
### WHY are these changes introduced?

- `dev up` was failing after the switch to pnpm, because it was still trying to run `npm install` (which runs implicitly after the node version is specified). Now it actually uses pnpm and `dev up` succeeds

### HOW to test your changes?

Run `dev up` with/without my changes

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
