### PR TITLE
ci: run ci on main too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: 🚀 CI
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   check-node-version:


### PR DESCRIPTION
### WHY are these changes introduced?

`ci.yml` currently runs only on `pull_request`, which means `main` can drift into a broken state without immediate CI signal.

Running the same CI workflow on pushes to `main` gives us direct post-merge validation for typecheck, unit tests, e2e tests, and the rest of the existing suite, so we catch breakage before the next PR is opened.

### WHAT is this pull request doing?

Updates `/.github/workflows/ci.yml` to trigger on:

- `pull_request` (existing behavior)
- `push` to `main` (new behavior)

No CI jobs were added, removed, or changed. This keeps one workflow as the single source of truth and avoids duplicating job definitions across multiple action files.

### HOW to test your changes?

1. Confirm `/.github/workflows/ci.yml` has both `pull_request` and `push` (`main`) triggers.
2. Open/update a PR and verify the CI workflow still runs as expected.
3. After merge, verify the same `🚀 CI` workflow runs on the `main` push and includes the full suite.

#### Post-merge steps

None.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- I've added or updated the documentation
