### PR TITLE
feat: show a clear error when trying to use CAAPI untunnelled in localhost

### DIFF
--- a/.changeset/slow-candles-report.md
+++ b/.changeset/slow-candles-report.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Improved local Customer Account OAuth errors: in development, if you are not on a `*.tryhydrogen.dev` tunnel URL, Hydrogen now shows clear guidance to run `shopify hydrogen dev --customer-account-push` and continue from the tunnel URL.

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -1303,6 +1303,7 @@ describe('customer', () => {
 
   describe('handleAuthStatus()', async () => {
     it('Throws guidance error in development when request origin is not a tunnel', async () => {
+      expect.assertions(3);
       process.env.NODE_ENV = 'development';
 
       const customer = createCustomerAccountClient({

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -127,6 +127,7 @@ describe('customer', () => {
       });
 
       it('Throws guidance error in development when request origin is not a tunnel', async () => {
+        expect.assertions(3);
         process.env.NODE_ENV = 'development';
 
         const customer = createCustomerAccountClient({

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -58,8 +58,8 @@ function throwIfNotTunnelled(hostname: string) {
       throw new Response(
         [
           'Customer Account API OAuth requires a Hydrogen tunnel in local development.',
-          'Run `shopify hydrogen dev --customer-account-push`.',
-          'Then open the tunnel URL shown in your terminal (`https://*.tryhydrogen.dev`) instead of localhost.',
+          'Run the development server with the `--customer-account-push` flag,',
+          'then open the tunnel URL shown in your terminal (`https://*.tryhydrogen.dev`) instead of localhost.',
         ].join('\n\n'),
         {
           status: 400,

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -79,6 +79,7 @@ function defaultAuthStatusHandler(
   if (!request.url) return defaultLoginUrl;
 
   const {hostname, pathname} = new URL(request.url);
+  throwIfNotTunnelled(hostname);
 
   /**
    * Remix (single-fetch) request objects have different url
@@ -299,7 +300,6 @@ export function createCustomerAccountClient({
 
   async function handleAuthStatus() {
     if (!(await isLoggedIn())) {
-      throwIfNotTunnelled(requestUrl.hostname);
       throw authStatusHandler();
     }
   }

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -299,6 +299,7 @@ export function createCustomerAccountClient({
 
   async function handleAuthStatus() {
     if (!(await isLoggedIn())) {
+      throwIfNotTunnelled(requestUrl.hostname);
       throw authStatusHandler();
     }
   }

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -58,6 +58,25 @@ function defaultAuthStatusHandler(
 ) {
   if (!request.url) return defaultLoginUrl;
 
+  if (process.env.NODE_ENV === 'development') {
+    const {hostname} = new URL(request.url);
+    if (!hostname.endsWith('.tryhydrogen.dev')) {
+      throw new Response(
+        [
+          'Customer Account API OAuth requires a Hydrogen tunnel in local development.',
+          'Run `shopify hydrogen dev --customer-account-push`.',
+          'Then open the tunnel URL shown in your terminal (`https://*.tryhydrogen.dev`) instead of localhost.',
+        ].join('\n\n'),
+        {
+          status: 400,
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+          },
+        },
+      );
+    }
+  }
+
   const {pathname} = new URL(request.url);
 
   /**
@@ -341,6 +360,23 @@ export function createCustomerAccountClient({
     i18n: {language: language ?? ('EN' as LanguageCode)},
     login: async (options?: LoginOptions) => {
       ifInvalidCredentialThrowError();
+      if (process.env.NODE_ENV === 'development') {
+        if (!requestUrl.hostname.endsWith('.tryhydrogen.dev')) {
+          throw new Response(
+            [
+              'Customer Account API OAuth requires a Hydrogen tunnel in local development.',
+              'Run `shopify hydrogen dev --customer-account-push`.',
+              'Then open the tunnel URL shown in your terminal (`https://*.tryhydrogen.dev`) instead of localhost.',
+            ].join('\n\n'),
+            {
+              status: 400,
+              headers: {
+                'Content-Type': 'text/plain; charset=utf-8',
+              },
+            },
+          );
+        }
+      }
       const loginUrl = new URL(getCustomerAccountUrl(URL_TYPE.AUTH));
 
       const state = generateState();

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -645,7 +645,7 @@ function createIfInvalidCredentialThrowError(
       const publicMessage =
         process.env.NODE_ENV === 'production'
           ? 'Internal Server Error'
-          : 'You do not have a valid credential to use Customer Account API (/account).';
+          : 'You do not have valid credentials to use Customer Account API (/account).';
 
       throw new Response(publicMessage, {status: 500});
     }

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -52,14 +52,17 @@ import {createCustomerAccountHelper, URL_TYPE} from './customer-account-helper';
 import {warnOnce} from '../utils/warning';
 import {LanguageCode} from '@shopify/hydrogen-react/customer-account-api-types';
 
+const HYDROGEN_TUNNEL_DOMAIN_SUFFIX = '.tryhydrogen.dev';
+
 function throwIfNotTunnelled(hostname: string) {
   if (process.env.NODE_ENV === 'development') {
-    if (!hostname.endsWith('.tryhydrogen.dev')) {
+    // Keep this suffix in sync with the domain used by --customer-account-push.
+    if (!hostname.endsWith(HYDROGEN_TUNNEL_DOMAIN_SUFFIX)) {
       throw new Response(
         [
           'Customer Account API OAuth requires a Hydrogen tunnel in local development.',
           'Run the development server with the `--customer-account-push` flag,',
-          'then open the tunnel URL shown in your terminal (`https://*.tryhydrogen.dev`) instead of localhost.',
+          `then open the tunnel URL shown in your terminal (\`https://*${HYDROGEN_TUNNEL_DOMAIN_SUFFIX}\`) instead of localhost.`,
         ].join('\n\n'),
         {
           status: 400,

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -86,7 +86,7 @@ export type CustomerAccount = {
   /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */
   isLoggedIn: () => Promise<boolean>;
   /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */
-  handleAuthStatus: () => void | DataFunctionValue;
+  handleAuthStatus: () => Promise<void>;
   /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */
   getAccessToken: () => Promise<string | undefined>;
   /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -86,7 +86,7 @@ export type CustomerAccount = {
   /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */
   isLoggedIn: () => Promise<boolean>;
   /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */
-  handleAuthStatus: () => Promise<void>;
+  handleAuthStatus: () => void | DataFunctionValue;
   /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */
   getAccessToken: () => Promise<string | undefined>;
   /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/


### PR DESCRIPTION
### WHY are these changes introduced?

Local development has a bad failure mode for Customer Account OAuth:

When a developer opens `/account` on `localhost` without tunneling, the app redirects into the OAuth flow and eventually fails with a redirect URI error from Shopify. The error is late and unclear, so it does not tell developers what they need to do next.

### WHAT is this pull request doing?

- throws an error and offers a way out for users: <img width="2518" height="740" alt="image" src="https://github.com/user-attachments/assets/3c2def72-28eb-4f93-b083-4cb508fbca1c" />
- zero impact in bundle size: because NODE_ENV is static at build time, we can get rid of the code path entirely when bundling with vite

### HOW to test your changes?

1. Install deps and build Hydrogen package:
   - `pnpm --dir packages/hydrogen build`
2. Run unit tests:
   - `pnpm --dir packages/hydrogen test -- src/customer/customer.test.ts`
3. Start a dev app without customer-account tunneling and visit:
   - `http://localhost:3000/account`
4. Verify result:
   - You should not be redirected to Shopify OAuth.
   - You should see a `400` error page with guidance to use `--customer-account-push` and a `*.tryhydrogen.dev` URL.
5. Start dev with tunneling (`--customer-account-push`) and open the provided `*.tryhydrogen.dev` URL.
6. Verify `/account` continues into normal Customer Account login flow.

#### Post-merge steps

None.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- I've added or updated the documentation



