### PR TITLE
feat: enable parallel Playwright workers for E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
   test_e2e:
     name: ⬣ E2E tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     concurrency:
       group: ci-e2e-${{ github.ref }}
       cancel-in-progress: true
@@ -229,7 +229,7 @@ jobs:
           echo "$HOME/go/bin" >> $GITHUB_PATH
 
       - name: 🧪 Run E2E tests
-        run: pnpm exec playwright test --workers=1
+        run: pnpm exec playwright test
         env:
           EJSON_PRIVATE_KEY: ${{ secrets.EJSON_PRIVATE_KEY }}
 

--- a/e2e/fixtures/server.ts
+++ b/e2e/fixtures/server.ts
@@ -1,6 +1,9 @@
 import {spawn} from 'node:child_process';
 import path from 'node:path';
 
+const STARTUP_TIMEOUT_IN_MS = 120_000;
+const SIGKILL_GRACE_PERIOD_IN_MS = 5_000;
+
 type DevServerOptions = {
   id?: number;
   port?: number;
@@ -23,7 +26,7 @@ export class DevServer {
   constructor(options: DevServerOptions = {}) {
     this.id = options.id;
     this.storeKey = options.storeKey;
-    this.port = options.port ?? 3100;
+    this.port = options.port ?? 0;
     this.projectPath =
       options.projectPath ?? path.join(__dirname, '../../templates/skeleton');
     this.customerAccountPush = options.customerAccountPush ?? false;
@@ -31,7 +34,13 @@ export class DevServer {
   }
 
   getUrl() {
-    return this.capturedUrl || `http://localhost:${this.port}`;
+    if (this.capturedUrl) return this.capturedUrl;
+    if (this.port === 0) {
+      throw new Error(
+        `Server ${this.id} has not started yet — cannot determine URL with dynamic port allocation`,
+      );
+    }
+    return `http://localhost:${this.port}`;
   }
 
   start() {
@@ -40,7 +49,10 @@ export class DevServer {
     }
 
     return new Promise((resolve, reject) => {
-      const args = ['run', 'dev', '--'];
+      // Spawn `shopify hydrogen dev` directly instead of via `npm run dev`
+      // so we have full control over flags. The skeleton's npm script includes
+      // `--codegen` which causes file write conflicts under parallel execution.
+      const args = ['shopify', 'hydrogen', 'dev'];
       if (this.customerAccountPush) {
         args.push('--customer-account-push');
       }
@@ -49,8 +61,9 @@ export class DevServer {
         args.push('--env-file', this.envFile);
       }
 
-      this.process = spawn('npm', args, {
+      this.process = spawn('npx', args, {
         cwd: this.projectPath,
+        detached: true,
         env: {
           ...process.env,
           NODE_ENV: 'development',
@@ -63,16 +76,25 @@ export class DevServer {
       const timeout = setTimeout(() => {
         if (!started) {
           this.stop();
-          reject(new Error(`Server ${this.id} failed to start within timeout`));
+          reject(
+            new Error(
+              `Server ${this.id} failed to start within ${STARTUP_TIMEOUT_IN_MS / 1000}s timeout`,
+            ),
+          );
         }
-      }, 60000);
+      }, STARTUP_TIMEOUT_IN_MS);
 
       let localUrl: string | undefined;
       let tunnelUrl: string | undefined;
 
       const handleOutput = (output: string) => {
         if (!localUrl) {
-          localUrl = output.match(/(http:\/\/localhost:\d+)/)?.[1];
+          const match = output.match(/(http:\/\/localhost:(\d+))/);
+          // Reject port 0 from captured output — it means the server echoed
+          // back the requested port before actually binding to an ephemeral one.
+          if (match && match[2] !== '0') {
+            localUrl = match[1];
+          }
         }
         if (this.customerAccountPush && !tunnelUrl) {
           tunnelUrl = output.match(/(https:\/\/[^\s]+)/)?.[1];
@@ -125,7 +147,6 @@ export class DevServer {
       if (this.process.stdout) {
         this.process.stdout.on('data', (data) => {
           const output = data.toString();
-          // !started && console.log(output);
           handleOutput(output);
         });
       }
@@ -133,7 +154,6 @@ export class DevServer {
       if (this.process.stderr) {
         this.process.stderr.on('data', (data) => {
           const output = data.toString();
-          // !started && console.log(output);
           handleOutput(output);
         });
       }
@@ -154,19 +174,52 @@ export class DevServer {
 
   stop() {
     return new Promise((resolve) => {
-      if (!this.process) return resolve(false);
+      if (!this.process?.pid) {
+        this.process = undefined;
+        return resolve(false);
+      }
+
+      // Capture PID upfront to avoid non-null assertion races between
+      // the exit handler (which clears this.process) and the SIGKILL timeout.
+      const pid = this.process.pid;
       console.log(`[test-server ${this.id}] Stopping server...`);
 
+      // If the process already exited (e.g. dev server crashed during a test),
+      // the exit listener would never fire and this promise would hang forever.
+      if (this.process.exitCode !== null) {
+        this.process = undefined;
+        return resolve(true);
+      }
+
+      const killTimeoutId = setTimeout(() => {
+        try {
+          process.kill(-pid, 'SIGKILL');
+        } catch {
+          // Process already dead
+        }
+        // Whether SIGKILL succeeded or the process was already dead,
+        // we've done everything we can. Resolve to unblock teardown.
+        this.process = undefined;
+        resolve(false);
+      }, SIGKILL_GRACE_PERIOD_IN_MS);
+
       this.process.on('exit', () => {
+        clearTimeout(killTimeoutId);
         this.process = undefined;
         resolve(true);
       });
 
-      this.process.kill('SIGTERM');
-
-      setTimeout(() => {
-        this.process?.kill('SIGKILL');
-      }, 5000);
+      // Kill the entire process group (negative PID) so child processes
+      // (vite, workerd, etc.) are also terminated, not just the npm parent.
+      try {
+        process.kill(-pid, 'SIGTERM');
+      } catch {
+        try {
+          this.process.kill('SIGTERM');
+        } catch {
+          // Process already dead
+        }
+      }
     });
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   testMatch: /\.spec\.ts$/,
   retries: isCI ? 1 : 0,
   reporter: [['html', {open: 'on-failure', outputFolder: 'playwright-report'}]],
-  workers: 1,
+  // 3 workers in CI (ubuntu-latest: 2 vCPUs, 7GB RAM).
+  // Each worker spawns a Vite dev server + Chromium. Increase with caution.
+  workers: process.env.CI ? 3 : 4,
   fullyParallel: true,
   timeout: 60 * 1000,
   use: {


### PR DESCRIPTION
## Summary

- E2E tests were limited to 1 Playwright worker because every `DevServer` defaulted to port 3100, causing bind failures under parallel execution
- Enables 3 workers in CI (4 locally) by using OS-assigned ports, fixing process tree cleanup, and bypassing codegen conflicts

## Changes

**`e2e/fixtures/server.ts`** (main changes):
- Default port changed from `3100` to `0` (OS-assigned) — port collision is now structurally impossible
- Spawn `shopify hydrogen dev` directly instead of `npm run dev` to avoid `--codegen` file write conflicts in shared `templates/skeleton/` directory
- Process group kill via `detached: true` + negative PID ensures child processes (vite, workerd) are terminated, not just the npm parent
- `stop()` hardened: handles already-dead processes, captures PID upfront to avoid races, SIGKILL timeout always resolves the promise
- `getUrl()` throws clear error instead of returning nonsensical `http://localhost:0`
- Server startup timeout increased from 60s to 120s for CPU contention during parallel startup
- Stdout URL capture rejects port 0 (guards against pre-binding echo)

**`playwright.config.ts`**:
- `workers: process.env.CI ? 3 : 4` (was `1`)
- Comment explains CI runner constraints (2 vCPUs, 7GB RAM)

**`.github/workflows/ci.yml`**:
- Removed `--workers=1` override (config is now single source of truth)
- E2E job timeout increased from 15 to 20 minutes

## Test plan

- [x] Smoke tests pass locally with 4 workers (3 servers on ports 5173, 5174, 5175)
- [x] Full E2E suite passes in CI with 3 workers
- [ ] Monitor first 10-20 CI runs for startup timeouts, OOM kills, or flakiness