### PR TITLE
test: upload report on failure

### DIFF
--- a/e2e/specs/smoke/cart.spec.ts
+++ b/e2e/specs/smoke/cart.spec.ts
@@ -8,6 +8,8 @@ test.describe('Cart Functionality', () => {
   }) => {
     await page.goto('/');
 
+    if (Math.random() > 0) throw new Error('this error is expected');
+
     const cartBadgeBefore = page.locator('a[href="/cart"]').first();
     const initialCartText = await cartBadgeBefore.textContent();
     const initialCount = initialCartText?.match(/\d+/)?.[0] || '0';

--- a/e2e/specs/smoke/cart.spec.ts
+++ b/e2e/specs/smoke/cart.spec.ts
@@ -8,8 +8,6 @@ test.describe('Cart Functionality', () => {
   }) => {
     await page.goto('/');
 
-    if (Math.random() > 0) throw new Error('this error is expected');
-
     const cartBadgeBefore = page.locator('a[href="/cart"]').first();
     const initialCartText = await cartBadgeBefore.textContent();
     const initialCount = initialCartText?.match(/\d+/)?.[0] || '0';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ const isCI = !!process.env.CI;
 export default defineConfig({
   testMatch: /\.spec\.ts$/,
   retries: isCI ? 1 : 0,
-  reporter: isCI ? 'html' : 'list',
+  reporter: [['html', {open: 'on-failure', outputFolder: 'playwright-report'}]],
   workers: 1,
   fullyParallel: true,
   timeout: 60 * 1000,


### PR DESCRIPTION
### WHY are these changes introduced?

We were not saving the playwright reports which makes it harder for us to debug failing tests in CI. By adding this config, we can now see the files at the bottom of the action:

<img width="2536" height="1526" alt="image" src="https://github.com/user-attachments/assets/13cdb2b6-36c5-4cce-a785-ed6db0e8ed30" />

Opening the folder allows us to see info about the test failure, including a screenshot of where it last failed:
<img width="2000" height="1552" alt="image" src="https://github.com/user-attachments/assets/fe1a1750-1fd6-4bd2-88bc-4d60abcece12" />

### HOW to test your changes?

- see this deliberately broken run of actions in this branch: https://github.com/Shopify/hydrogen/actions/runs/22440930819
- check assets, download it an open the html file

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- I've added or updated the documentation