### PR TITLE
test: refactor smoke tests

### DIFF
--- a/e2e/specs/smoke/home.spec.ts
+++ b/e2e/specs/smoke/home.spec.ts
@@ -7,7 +7,6 @@ test.describe('Home Page', () => {
     page,
   }) => {
     const consoleErrors: string[] = [];
-
     page.on('console', (msg) => {
       if (msg.type() === 'error') {
         consoleErrors.push(msg.text());
@@ -16,21 +15,20 @@ test.describe('Home Page', () => {
 
     await page.goto('/');
 
-    const featuredCollection = page.locator('.featured-collection').first();
-    await expect(featuredCollection).toBeVisible();
+    const heroImage = page
+      .getByRole('link')
+      .filter({
+        has: page.getByRole('heading', {level: 1}),
+      })
+      .getByRole('img');
 
-    const featuredImage = page
-      .locator('.featured-collection-image img')
-      .first();
-    await expect(featuredImage).toBeVisible();
+    const productGridImage = page
+      .getByRole('region', {name: 'Recommended Products'})
+      .getByRole('link', {name: "Women's T-shirt"})
+      .getByRole('img');
 
-    const recommendedProducts = page
-      .locator('.recommended-products-grid')
-      .first();
-    await expect(recommendedProducts).toBeVisible();
-
-    const productItems = page.locator('.product-item');
-    await expect(productItems.first()).toBeVisible();
+    await expect(heroImage).toBeVisible();
+    await expect(productGridImage).toBeVisible();
 
     expect(consoleErrors).toHaveLength(0);
   });

--- a/e2e/specs/smoke/pages.spec.ts
+++ b/e2e/specs/smoke/pages.spec.ts
@@ -3,7 +3,9 @@ import {test, expect, setTestStore} from '../../fixtures';
 setTestStore('mockShop');
 
 test.describe('Pages', () => {
-  test('should display all static page content', async ({page}) => {
+  test('When visiting static pages, each should display its heading', async ({
+    page,
+  }) => {
     const pages = [
       {url: '/pages/contact', heading: 'Contact'},
       {url: '/collections', heading: 'Collections'},
@@ -16,12 +18,12 @@ test.describe('Pages', () => {
 
     for (const {url, heading} of pages) {
       await page.goto(url);
-      const pageContent = page.getByRole('heading', {level: 1, name: heading});
-      await expect(pageContent).toBeVisible();
+      const pageHeading = page.getByRole('heading', {level: 1, name: heading});
+      await expect(pageHeading).toBeVisible();
     }
 
     await page.goto('/graphiql');
-    const graphiqlPage = page.getByText('Storefront API');
-    await expect(graphiqlPage).toBeVisible();
+    const storefrontApiText = page.getByText('Storefront API');
+    await expect(storefrontApiText).toBeVisible();
   });
 });

--- a/templates/skeleton/app/routes/_index.tsx
+++ b/templates/skeleton/app/routes/_index.tsx
@@ -1,8 +1,4 @@
-import {
-  Await,
-  useLoaderData,
-  Link,
-} from 'react-router';
+import {Await, useLoaderData, Link} from 'react-router';
 import type {Route} from './+types/_index';
 import {Suspense} from 'react';
 import {Image} from '@shopify/hydrogen';
@@ -84,7 +80,11 @@ function FeaturedCollection({
     >
       {image && (
         <div className="featured-collection-image">
-          <Image data={image} sizes="100vw" />
+          <Image
+            data={image}
+            sizes="100vw"
+            alt={image.altText || collection.title}
+          />
         </div>
       )}
       <h1>{collection.title}</h1>
@@ -98,8 +98,11 @@ function RecommendedProducts({
   products: Promise<RecommendedProductsQuery | null>;
 }) {
   return (
-    <div className="recommended-products">
-      <h2>Recommended Products</h2>
+    <section
+      className="recommended-products"
+      aria-labelledby="recommended-products"
+    >
+      <h2 id="recommended-products">Recommended Products</h2>
       <Suspense fallback={<div>Loading...</div>}>
         <Await resolve={products}>
           {(response) => (
@@ -114,7 +117,7 @@ function RecommendedProducts({
         </Await>
       </Suspense>
       <br />
-    </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

Part of https://github.com/Shopify/developer-tools-team/issues/1075 

[Referring to Freddie's example test](https://github.com/Shopify/hydrogen/pull/3505), this refactors the other smoke tests and improves skeleton accessibility. 

- makes tests less smart (no dynamically choosing selectors - uses accessibility features) 
- assumes stable product

Note: We're making the decision to use consts for all Playwright locators, to help enable more consistent AI output in future.

To check tests pass locally: `npx playwright test --project=smoke e2e/specs/smoke/home.spec.ts e2e/specs/smoke/pages.spec.ts` (use --ui flag if desired)
