### PR TITLE
chore: update pnpm-lock.yaml after 2026.1.1 release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,7 +434,7 @@ importers:
         specifier: 1.4.1
         version: 1.4.1
       '@shopify/hydrogen-react':
-        specifier: workspace:*
+        specifier: workspace:*2026.1.1
         version: link:../hydrogen-react
       content-security-policy-builder:
         specifier: ^2.2.0
@@ -765,7 +765,7 @@ importers:
   packages/remix-oxygen:
     devDependencies:
       '@shopify/hydrogen':
-        specifier: workspace:*
+        specifier: workspace:*2026.1.1
         version: link:../hydrogen
       '@shopify/oxygen-workers-types':
         specifier: ^4.1.6
@@ -780,7 +780,7 @@ importers:
   templates/skeleton:
     dependencies:
       '@shopify/hydrogen':
-        specifier: workspace:*
+        specifier: workspace:*2026.1.1
         version: link:../../packages/hydrogen
       graphql:
         specifier: ^16.10.0


### PR DESCRIPTION
### WHY are these changes introduced?

The changesets release updated workspace specifiers in `package.json (e.g. workspace:* → workspace:*2026.1.1)` but did not regenerate the lockfile, causing CI to fail with `ERR_PNPM_OUTDATED_LOCKFILE`.

After merging the [ci] release 2026.1.1 PR, [CI began failing](https://github.com/Shopify/hydrogen/actions/runs/22468441481/job/65079792826) on `pnpm install --frozen-lockfile` because the changesets release process updated internal workspace dependency specifiers in `package.json` files but did not regenerate `pnpm-lock.yaml` to match.

### WHAT is this pull request doing?

Regenerates pnpm-lock.yaml by running pnpm install after the 2026.1.1 release. Updates 3 specifiers that were out of sync:
  - packages/hydrogen → @shopify/hydrogen-react: workspace:* → workspace:*2026.1.1
  - packages/remix-oxygen → @shopify/hydrogen: workspace:* → workspace:*2026.1.1
  - templates/skeleton → @shopify/hydrogen: workspace:* → workspace:*2026.1.1


### HOW to test your changes?

Verify CI passes — specifically the pnpm install --frozen-lockfile step that was previously failing.

#### Checklist

- I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- I've considered possible cross-platform impacts (Mac, Linux, Windows)
- I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
