### PR TITLE
fix: avoid rewriting workspace protocol ranges in CalVer

### DIFF
--- a/.changeset/calver-shared.js
+++ b/.changeset/calver-shared.js
@@ -221,6 +221,10 @@ function updateInternalDependencies(updates, dryRun = false) {
         Object.keys(updates).forEach((updatedPkg) => {
           if (pkg[depType][updatedPkg]) {
             const oldRange = pkg[depType][updatedPkg];
+            if (oldRange.startsWith('workspace:')) {
+              return;
+            }
+
             const operator = oldRange.match(/^([^\d]*)/)?.[1] || '';
             pkg[depType][updatedPkg] = `${operator}${updates[updatedPkg].to}`;
             modified = true;

--- a/.changeset/enforce-calver-ci.js
+++ b/.changeset/enforce-calver-ci.js
@@ -260,8 +260,12 @@ function updatePackageDependencies(pkg, versionMap) {
 
     for (const [depName, depVersion] of Object.entries(pkg[depType])) {
       if (versionMap[depName]) {
-        // Preserve any prefix like ^, ~, or workspace:
-        const prefix = depVersion.match(/^([^\d]*)/)[1];
+        if (depVersion.startsWith('workspace:')) {
+          continue;
+        }
+
+        // Preserve any prefix like ^ or ~ for non-workspace ranges.
+        const prefix = depVersion.match(/^([^\d]*)/)?.[1] || '';
         pkg[depType][depName] = prefix + versionMap[depName];
         modified = true;
       }

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -83,7 +83,7 @@
     "dist"
   ],
   "dependencies": {
-    "@shopify/hydrogen-react": "workspace:*2026.1.1",
+    "@shopify/hydrogen-react": "workspace:*",
     "content-security-policy-builder": "^2.2.0",
     "flame-chart-js": "2.3.1",
     "isbot": "^5.1.21",

--- a/packages/remix-oxygen/package.json
+++ b/packages/remix-oxygen/package.json
@@ -46,7 +46,7 @@
   ],
   "devDependencies": {
     "@shopify/oxygen-workers-types": "^4.1.6",
-    "@shopify/hydrogen": "workspace:*2026.1.1",
+    "@shopify/hydrogen": "workspace:*",
     "@types/node": "catalog:",
     "react-router": "7.12.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,7 +434,7 @@ importers:
         specifier: 1.4.1
         version: 1.4.1
       '@shopify/hydrogen-react':
-        specifier: workspace:*2026.1.1
+        specifier: workspace:*
         version: link:../hydrogen-react
       content-security-policy-builder:
         specifier: ^2.2.0
@@ -765,7 +765,7 @@ importers:
   packages/remix-oxygen:
     devDependencies:
       '@shopify/hydrogen':
-        specifier: workspace:*2026.1.1
+        specifier: workspace:*
         version: link:../hydrogen
       '@shopify/oxygen-workers-types':
         specifier: ^4.1.6
@@ -780,7 +780,7 @@ importers:
   templates/skeleton:
     dependencies:
       '@shopify/hydrogen':
-        specifier: workspace:*2026.1.1
+        specifier: workspace:*
         version: link:../../packages/hydrogen
       graphql:
         specifier: ^16.10.0

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -14,7 +14,7 @@
   },
   "prettier": "@shopify/prettier-config",
   "dependencies": {
-    "@shopify/hydrogen": "workspace:*2026.1.1",
+    "@shopify/hydrogen": "workspace:*",
     "graphql": "^16.10.0",
     "graphql-tag": "^2.12.6",
     "isbot": "^5.1.22",


### PR DESCRIPTION
### WHY are these changes introduced?

After releasing `2026.1.1`, some workspace dependency ranges were rewritten to invalid values like `workspace:*2026.1.1`, which caused lockfile-outdated failures on `main`.

The root cause is CalVer post-processing logic that appends resolved versions to dependency prefixes without handling pnpm workspace protocol ranges.

### WHAT is this pull request doing?

- Updates CalVer dependency rewrite logic to skip any range that already uses `workspace:` protocol.
- Keeps existing rewrite behavior for non-workspace ranges (preserves `^` / `~` prefixes).
- Repairs malformed workspace ranges back to `workspace:*` in:
  - `packages/hydrogen/package.json`
  - `packages/remix-oxygen/package.json`
  - `templates/skeleton/package.json`
  - `pnpm-lock.yaml`

### HOW to test your changes?

1. Check script syntax:
   - `node -c .changeset/enforce-calver-ci.js`
   - `node -c .changeset/enforce-calver-local.js`
2. Run the local CalVer dry-run:
   - `pnpm run test:calver:dry`
3. Confirm no malformed workspace ranges remain:
   - `rg 'workspace:\*\d'`

#### Post-merge steps

None.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- I've added or updated the documentation