### PR TITLE
fix: align handleAuthStatus async typing and skeleton usage

### DIFF
--- a/.changeset/skeleton-handleauthstatus.md
+++ b/.changeset/skeleton-handleauthstatus.md
@@ -1,0 +1,10 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+---
+
+Updated loaders that used `customerAccount.handleAuthStatus()` to now await it.
+
+### Migration
+
+If you call `handleAuthStatus()` in your own loaders, update those callsites to use `await`.

--- a/.changeset/slow-crowds-watch.md
+++ b/.changeset/slow-crowds-watch.md
@@ -1,0 +1,10 @@
+---
+'@shopify/hydrogen': patch
+'@shopify/cli-hydrogen': patch
+---
+
+Fixed the customer account auth status typing so `customerAccount.handleAuthStatus()` is typed as async (`Promise<void>`), matching runtime behavior.
+
+Updated skeleton account loaders to `await customerAccount.handleAuthStatus()` so auth redirects propagate correctly and there are no floating promises.
+
+If you call `handleAuthStatus()` in your own loaders, update those callsites to use `await`.

--- a/.changeset/slow-crowds-watch.md
+++ b/.changeset/slow-crowds-watch.md
@@ -1,10 +1,5 @@
 ---
 '@shopify/hydrogen': patch
-'@shopify/cli-hydrogen': patch
 ---
 
 Fixed the customer account auth status typing so `customerAccount.handleAuthStatus()` is typed as async (`Promise<void>`), matching runtime behavior.
-
-Updated skeleton account loaders to `await customerAccount.handleAuthStatus()` so auth redirects propagate correctly and there are no floating promises.
-
-If you call `handleAuthStatus()` in your own loaders, update those callsites to use `await`.

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -86,7 +86,7 @@ export type CustomerAccount = {
   /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */
   isLoggedIn: () => Promise<boolean>;
   /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */
-  handleAuthStatus: () => void | DataFunctionValue;
+  handleAuthStatus: () => Promise<void>;
   /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */
   getAccessToken: () => Promise<string | undefined>;
   /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/
@@ -193,7 +193,7 @@ export type CustomerAccountForDocs = {
   /** Returns if the customer is logged in. It also checks if the access token is expired and refreshes it if needed. */
   isLoggedIn?: () => Promise<boolean>;
   /** Check for a not logged in customer and redirect customer to login page. The redirect can be overwritten with `customAuthStatusHandler` option. */
-  handleAuthStatus?: () => void | DataFunctionValue;
+  handleAuthStatus?: () => Promise<void>;
   /** Returns CustomerAccessToken if the customer is logged in. It also run a expiry check and does a token refresh if needed. */
   getAccessToken?: () => Promise<string | undefined>;
   /** Creates the fully-qualified URL to your store's GraphQL endpoint.*/

--- a/templates/skeleton/app/routes/account.$.tsx
+++ b/templates/skeleton/app/routes/account.$.tsx
@@ -3,7 +3,7 @@ import type {Route} from './+types/account.$';
 
 // fallback wild card for all unauthenticated routes in account section
 export async function loader({context}: Route.LoaderArgs) {
-  context.customerAccount.handleAuthStatus();
+  await context.customerAccount.handleAuthStatus();
 
   return redirect('/account');
 }

--- a/templates/skeleton/app/routes/account.addresses.tsx
+++ b/templates/skeleton/app/routes/account.addresses.tsx
@@ -32,7 +32,7 @@ export const meta: Route.MetaFunction = () => {
 };
 
 export async function loader({context}: Route.LoaderArgs) {
-  context.customerAccount.handleAuthStatus();
+  await context.customerAccount.handleAuthStatus();
 
   return {};
 }

--- a/templates/skeleton/app/routes/account.profile.tsx
+++ b/templates/skeleton/app/routes/account.profile.tsx
@@ -20,7 +20,7 @@ export const meta: Route.MetaFunction = () => {
 };
 
 export async function loader({context}: Route.LoaderArgs) {
-  context.customerAccount.handleAuthStatus();
+  await context.customerAccount.handleAuthStatus();
 
   return {};
 }


### PR DESCRIPTION
## Summary
- update `CustomerAccount.handleAuthStatus` (and docs mirror type) to return `Promise<void>`, matching the async implementation
- await `context.customerAccount.handleAuthStatus()` in skeleton account loaders to avoid floating promises
- keep behavior unchanged while making auth status handling type-safe for consumers

## Validation
- `pnpm run typecheck` (packages/hydrogen)
- `pnpm run test -- src/customer/customer.test.ts` (packages/hydrogen)
- `pnpm run typecheck` (templates/skeleton)