### PR TITLE
fix: h2 upgrade command handles cumulative dependency removal

### DIFF
--- a/.changeset/funky-points-itch.md
+++ b/.changeset/funky-points-itch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Upgrade now cumulatively removes dependencies

--- a/.changeset/funky-points-itch.md
+++ b/.changeset/funky-points-itch.md
@@ -2,4 +2,4 @@
 '@shopify/cli-hydrogen': patch
 ---
 
-Upgrade now cumulatively removes dependencies
+Fixed `h2 upgrade` to correctly handle dependency removals when upgrading across multiple versions. Dependencies removed in intermediate releases are now properly removed even when jumping versions.

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -1039,6 +1039,85 @@ describe('upgrade', async () => {
 
       expect(removeDependencies).toContain('@shopify/remix-oxygen');
     });
+
+    it('includes removal when package moves from devDependencies to dependencies', () => {
+      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
+        ({
+          version,
+          hash: 'abc',
+          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
+          pr: 'https://github.com/Shopify/hydrogen/pull/1',
+          date: '2025-01-01',
+          title: '',
+          dependencies: {'@shopify/hydrogen': version},
+          devDependencies: {},
+          features: [],
+          fixes: [],
+          ...overrides,
+        }) as Release;
+
+      // Scenario: typescript is removed from devDependencies, then re-added as a regular dependency
+      // The removal from devDependencies should still appear in removeDevDependencies
+      const targetRelease = makeRelease('2025.10.0', {
+        dependencies: {
+          '@shopify/hydrogen': '2025.10.0',
+          typescript: '5.0.0',
+        },
+      });
+      const intermediateRelease = makeRelease('2025.7.0', {
+        removeDevDependencies: ['typescript'],
+      });
+      const fromRelease = makeRelease('2025.5.0');
+
+      const {removeDependencies, removeDevDependencies} = getCumulativeRelease({
+        availableUpgrades: [targetRelease, intermediateRelease, fromRelease],
+        selectedRelease: targetRelease,
+        currentVersion: '2025.5.0',
+      });
+
+      // typescript should be removed from devDependencies (not suppressed by cross-type re-addition)
+      expect(removeDevDependencies).toContain('typescript');
+      expect(removeDependencies).not.toContain('typescript');
+    });
+
+    it('includes removal when package moves from dependencies to devDependencies', () => {
+      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
+        ({
+          version,
+          hash: 'abc',
+          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
+          pr: 'https://github.com/Shopify/hydrogen/pull/1',
+          date: '2025-01-01',
+          title: '',
+          dependencies: {'@shopify/hydrogen': version},
+          devDependencies: {},
+          features: [],
+          fixes: [],
+          ...overrides,
+        }) as Release;
+
+      // Scenario: lodash is removed from dependencies, then re-added as a devDependency
+      // The removal from dependencies should still appear in removeDependencies
+      const targetRelease = makeRelease('2025.10.0', {
+        devDependencies: {
+          lodash: '4.17.21',
+        },
+      });
+      const intermediateRelease = makeRelease('2025.7.0', {
+        removeDependencies: ['lodash'],
+      });
+      const fromRelease = makeRelease('2025.5.0');
+
+      const {removeDependencies, removeDevDependencies} = getCumulativeRelease({
+        availableUpgrades: [targetRelease, intermediateRelease, fromRelease],
+        selectedRelease: targetRelease,
+        currentVersion: '2025.5.0',
+      });
+
+      // lodash should be removed from dependencies (not suppressed by cross-type re-addition)
+      expect(removeDependencies).toContain('lodash');
+      expect(removeDevDependencies).not.toContain('lodash');
+    });
   });
 
   describe('displayConfirmation', () => {

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -785,7 +785,7 @@ describe('upgrade', async () => {
             getCumulativeRelease({
               availableUpgrades,
               ...current,
-              // @ts-ignore - we know this release version exists
+              // @ts-expect-error - we know this release version exists
               selectedRelease,
             });
 

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -18,7 +18,7 @@ import {
   displayConfirmation,
   getAbsoluteVersion,
   getAvailableUpgrades,
-  getCummulativeRelease,
+  getCumulativeRelease,
   getHydrogenVersion,
   getPackageVersion,
   getSelectedRelease,
@@ -761,7 +761,7 @@ describe('upgrade', async () => {
     });
   });
 
-  describe('getCummulativeRelease', () => {
+  describe('getCumulativeRelease', () => {
     it('returns the correct fixes and features for a release range thats outdated', async () => {
       await inTemporaryHydrogenRepo(
         async (appPath) => {
@@ -782,20 +782,20 @@ describe('upgrade', async () => {
 
           // testing from 2023.1.6 (outdated) to 2023.4.1
           const {features, fixes, removeDependencies, removeDevDependencies} =
-            getCummulativeRelease({
+            getCumulativeRelease({
               availableUpgrades,
               ...current,
               // @ts-ignore - we know this release version exists
               selectedRelease,
             });
 
-          expect(features).toMatchObject(CUMMLATIVE_RELEASE.features);
-          expect(fixes).toMatchObject(CUMMLATIVE_RELEASE.fixes);
+          expect(features).toMatchObject(CUMULATIVE_RELEASE.features);
+          expect(fixes).toMatchObject(CUMULATIVE_RELEASE.fixes);
           expect(removeDependencies).toMatchObject(
-            CUMMLATIVE_RELEASE.removeDependencies,
+            CUMULATIVE_RELEASE.removeDependencies,
           );
           expect(removeDevDependencies).toMatchObject(
-            CUMMLATIVE_RELEASE.removeDevDependencies,
+            CUMULATIVE_RELEASE.removeDevDependencies,
           );
         },
         {
@@ -824,7 +824,7 @@ describe('upgrade', async () => {
           );
 
           const {removeDependencies, removeDevDependencies} =
-            getCummulativeRelease({
+            getCumulativeRelease({
               availableUpgrades,
               ...current,
               // @ts-ignore - we know this release version exists
@@ -874,13 +874,11 @@ describe('upgrade', async () => {
       });
       const from = makeRelease('2025.5.0');
 
-      const {removeDependencies, removeDevDependencies} = getCummulativeRelease(
-        {
-          availableUpgrades: [target, intermediate, from],
-          selectedRelease: target,
-          currentVersion: '2025.5.0',
-        },
-      );
+      const {removeDependencies, removeDevDependencies} = getCumulativeRelease({
+        availableUpgrades: [target, intermediate, from],
+        selectedRelease: target,
+        currentVersion: '2025.5.0',
+      });
 
       expect(removeDependencies).toContain('@shopify/remix-oxygen');
       expect(removeDependencies).toContain('@remix-run/react');
@@ -915,7 +913,7 @@ describe('upgrade', async () => {
       });
       const from = makeRelease('2025.5.0');
 
-      const {removeDependencies} = getCummulativeRelease({
+      const {removeDependencies} = getCumulativeRelease({
         availableUpgrades: [target, intermediate, from],
         selectedRelease: target,
         currentVersion: '2025.5.0',
@@ -949,7 +947,7 @@ describe('upgrade', async () => {
       });
       const from = makeRelease('2025.5.0');
 
-      const {removeDependencies} = getCummulativeRelease({
+      const {removeDependencies} = getCumulativeRelease({
         availableUpgrades: [target, intermediate, from],
         selectedRelease: target,
         currentVersion: '2025.5.0',
@@ -974,7 +972,7 @@ describe('upgrade', async () => {
 
           await expect(
             displayConfirmation({
-              cumulativeRelease: CUMMLATIVE_RELEASE,
+              cumulativeRelease: CUMULATIVE_RELEASE,
               selectedRelease,
             }),
           ).resolves.toEqual(false);
@@ -982,7 +980,7 @@ describe('upgrade', async () => {
           const info = outputMock.info();
           expect(info).toMatch('Included in this upgrade');
 
-          [...CUMMLATIVE_RELEASE.features, ...CUMMLATIVE_RELEASE.fixes].forEach(
+          [...CUMULATIVE_RELEASE.features, ...CUMULATIVE_RELEASE.fixes].forEach(
             (feat) =>
               // Cut the string to avoid matching the banner
               expect(info).toMatch(feat.title.slice(0, 15)),
@@ -1524,8 +1522,8 @@ describe('upgrade', async () => {
   });
 });
 
-// cummlative result when upgrading from 2023.1.6 (outdated) to 2023.4.1
-const CUMMLATIVE_RELEASE = {
+// cumulative result when upgrading from 2023.1.6 (outdated) to 2023.4.1
+const CUMULATIVE_RELEASE = {
   fixes: [
     {
       title: 'Add a default Powered-By: Shopify-Hydrogen header',

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -958,7 +958,7 @@ describe('upgrade', async () => {
       ).toHaveLength(1);
     });
 
-    it('includes removals for dependencies that exist early and are removed later without being re-added', () => {
+    it('includes removals when an intermediate release has a dep and a later intermediate release removes it', () => {
       const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
         ({
           version,
@@ -975,11 +975,11 @@ describe('upgrade', async () => {
         }) as Release;
 
       // Scenario: upgrading from 2025.5.0 → 2025.10.0
-      // remix exists in 2025.5.0, is removed in 2025.7.0, never re-added
-      // Should be included in cumulative removals (order-sensitive behavior)
-      const releaseWithRemix = makeRelease('2025.5.0', {
+      // remix exists in an intermediate release (2025.6.0), is removed in 2025.7.0,
+      // and is never re-added. It should be included in cumulative removals.
+      const intermediateWithRemix = makeRelease('2025.6.0', {
         dependencies: {
-          '@shopify/hydrogen': '2025.5.0',
+          '@shopify/hydrogen': '2025.6.0',
           remix: '4.0.0',
         },
       });
@@ -992,7 +992,7 @@ describe('upgrade', async () => {
         availableUpgrades: [
           targetRelease,
           releaseRemovingRemix,
-          releaseWithRemix,
+          intermediateWithRemix,
         ],
         selectedRelease: targetRelease,
         currentVersion: '2025.5.0',

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -795,17 +795,22 @@ describe('upgrade', async () => {
             (release) => release.version === '2023.4.1',
           );
 
+          if (!selectedRelease) {
+            throw new Error(
+              'Test setup: 2023.4.1 not found in changelog - is this fixture stale?',
+            );
+          }
+
           // testing from 2023.1.6 (outdated) to 2023.4.1
           const {features, fixes, removeDependencies, removeDevDependencies} =
             getCumulativeRelease({
               availableUpgrades,
               ...current,
-              // @ts-expect-error - we know this release version exists
               selectedRelease,
             });
 
-          expect(features).toMatchObject(CUMULATIVE_RELEASE.features);
-          expect(fixes).toMatchObject(CUMULATIVE_RELEASE.fixes);
+          expect(features).toEqual(CUMULATIVE_RELEASE.features);
+          expect(fixes).toEqual(CUMULATIVE_RELEASE.fixes);
           expect(removeDependencies).toEqual(
             CUMULATIVE_RELEASE.removeDependencies,
           );

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -920,6 +920,31 @@ describe('upgrade', async () => {
       expect(removeDependencies).not.toContain('react-router');
     });
 
+    it('excludes removeDependencies when removed and re-added in the same release (>= operator behavior)', () => {
+      // This test specifically validates the >= operator in upgrade.ts:652 and upgrade.ts:659.
+      // When a package appears in both removeDependencies AND dependencies of the SAME release,
+      // it should be excluded from cumulative removals (treated as a version upgrade, not removal).
+      // This is the React Router 7 migration scenario: old react-router removed, new react-router added.
+      const singleRelease = makeRelease('2025.7.0', {
+        dependencies: {
+          '@shopify/hydrogen': '2025.7.0',
+          'react-router': '7.9.2', // Re-added in same release
+        },
+        removeDependencies: ['react-router'], // Also removed in same release
+      });
+      const from = makeRelease('2025.5.0');
+
+      const {removeDependencies} = getCumulativeRelease({
+        availableUpgrades: [singleRelease, from],
+        selectedRelease: singleRelease,
+        currentVersion: '2025.5.0',
+      });
+
+      // react-router is removed and re-added in the SAME release (i >= removalI)
+      // so it should NOT appear in cumulative removeDependencies
+      expect(removeDependencies).not.toContain('react-router');
+    });
+
     it('deduplicates removeDependencies listed in multiple releases', () => {
       const target = makeRelease('2025.10.0', {
         removeDependencies: ['@shopify/remix-oxygen'],
@@ -1039,6 +1064,64 @@ describe('upgrade', async () => {
       // lodash should be removed from dependencies (not suppressed by cross-type re-addition)
       expect(removeDependencies).toContain('lodash');
       expect(removeDevDependencies).not.toContain('lodash');
+    });
+
+    it('integration: upgradeNodeModules accepts cumulative removals from getCumulativeRelease', async () => {
+      const testRelease = makeRelease('2025.10.0', {
+        dependencies: {'@shopify/hydrogen': '2025.10.0'},
+        devDependencies: {},
+      });
+      const intermediateRelease = makeRelease('2025.7.0', {
+        removeDependencies: ['@shopify/remix-oxygen', '@remix-run/react'],
+        removeDevDependencies: ['@remix-run/dev'],
+      });
+      const fromRelease = makeRelease('2025.5.0');
+
+      const cumulativeRelease = getCumulativeRelease({
+        availableUpgrades: [testRelease, intermediateRelease, fromRelease],
+        selectedRelease: testRelease,
+        currentVersion: '2025.5.0',
+      });
+
+      expect(cumulativeRelease.removeDependencies).toContain(
+        '@shopify/remix-oxygen',
+      );
+      expect(cumulativeRelease.removeDependencies).toContain(
+        '@remix-run/react',
+      );
+      expect(cumulativeRelease.removeDevDependencies).toContain(
+        '@remix-run/dev',
+      );
+
+      await inTemporaryHydrogenRepo(
+        async (appPath) => {
+          const currentDependencies = {
+            '@shopify/hydrogen': '2025.5.0',
+            '@shopify/remix-oxygen': '2.0.0',
+            '@remix-run/react': '2.0.0',
+            '@remix-run/dev': '2.0.0',
+          };
+
+          await upgradeNodeModules({
+            appPath,
+            selectedRelease: testRelease,
+            currentDependencies,
+            cumulativeRemoveDependencies: cumulativeRelease.removeDependencies,
+            cumulativeRemoveDevDependencies:
+              cumulativeRelease.removeDevDependencies,
+          });
+
+          expect(renderTasks).toHaveBeenCalled();
+        },
+        {
+          cleanGitRepo: true,
+          packageJson: {
+            dependencies: {
+              '@shopify/hydrogen': '2025.5.0',
+            },
+          },
+        },
+      );
     });
   });
 
@@ -1303,6 +1386,8 @@ describe('upgrade', async () => {
             appPath,
             selectedRelease,
             currentDependencies,
+            cumulativeRemoveDependencies: [],
+            cumulativeRemoveDevDependencies: [],
           });
 
           expect(renderTasks).toHaveBeenCalled();

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -762,6 +762,21 @@ describe('upgrade', async () => {
   });
 
   describe('getCumulativeRelease', () => {
+    const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
+      ({
+        version,
+        hash: 'abc',
+        commit: 'https://github.com/Shopify/hydrogen/commit/abc',
+        pr: 'https://github.com/Shopify/hydrogen/pull/1',
+        date: '2025-01-01',
+        title: '',
+        dependencies: {'@shopify/hydrogen': version},
+        devDependencies: {},
+        features: [],
+        fixes: [],
+        ...overrides,
+      }) as Release;
+
     it('returns the correct fixes and features for a release range thats outdated', async () => {
       await inTemporaryHydrogenRepo(
         async (appPath) => {
@@ -791,10 +806,10 @@ describe('upgrade', async () => {
 
           expect(features).toMatchObject(CUMULATIVE_RELEASE.features);
           expect(fixes).toMatchObject(CUMULATIVE_RELEASE.fixes);
-          expect(removeDependencies).toMatchObject(
+          expect(removeDependencies).toEqual(
             CUMULATIVE_RELEASE.removeDependencies,
           );
-          expect(removeDevDependencies).toMatchObject(
+          expect(removeDevDependencies).toEqual(
             CUMULATIVE_RELEASE.removeDevDependencies,
           );
         },
@@ -818,16 +833,23 @@ describe('upgrade', async () => {
             releases,
           });
 
-          // 2025.7.0 is the release that drops @shopify/remix-oxygen and Remix packages
+          // 2025.7.0 is the React Router migration release that drops @shopify/remix-oxygen and Remix packages.
+          // This test ensures cumulative dependency removal works for the actual migration scenario.
+          // If the migration release version ever changes, update this version string.
           const selectedRelease = releases.find(
             (release) => release.version === '2025.7.0',
           );
+
+          if (!selectedRelease) {
+            throw new Error(
+              'Test setup: 2025.7.0 not found in changelog - is this fixture stale?',
+            );
+          }
 
           const {removeDependencies, removeDevDependencies} =
             getCumulativeRelease({
               availableUpgrades,
               ...current,
-              // @ts-ignore - we know this release version exists
               selectedRelease,
             });
 
@@ -849,21 +871,6 @@ describe('upgrade', async () => {
     });
 
     it('accumulates removeDependencies from intermediate releases', () => {
-      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
-        ({
-          version,
-          hash: 'abc',
-          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
-          pr: 'https://github.com/Shopify/hydrogen/pull/1',
-          date: '2025-01-01',
-          title: '',
-          dependencies: {'@shopify/hydrogen': version},
-          devDependencies: {},
-          features: [],
-          fixes: [],
-          ...overrides,
-        }) as Release;
-
       // Simulates: user on 2025.5.0, upgrading to 2025.10.0.
       // 2025.7.0 removes @shopify/remix-oxygen (a breaking migration).
       // 2025.10.0 is the target and knows nothing about remix-oxygen.
@@ -886,21 +893,6 @@ describe('upgrade', async () => {
     });
 
     it('excludes removeDependencies for deps that are re-added in any release', () => {
-      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
-        ({
-          version,
-          hash: 'abc',
-          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
-          pr: 'https://github.com/Shopify/hydrogen/pull/1',
-          date: '2025-01-01',
-          title: '',
-          dependencies: {'@shopify/hydrogen': version},
-          devDependencies: {},
-          features: [],
-          fixes: [],
-          ...overrides,
-        }) as Release;
-
       // react-router is removed (old Remix version) AND re-added at a new version
       // in the same release — it should not appear in cumulative removeDependencies.
       const target = makeRelease('2025.10.0');
@@ -924,21 +916,6 @@ describe('upgrade', async () => {
     });
 
     it('deduplicates removeDependencies listed in multiple releases', () => {
-      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
-        ({
-          version,
-          hash: 'abc',
-          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
-          pr: 'https://github.com/Shopify/hydrogen/pull/1',
-          date: '2025-01-01',
-          title: '',
-          dependencies: {'@shopify/hydrogen': version},
-          devDependencies: {},
-          features: [],
-          fixes: [],
-          ...overrides,
-        }) as Release;
-
       const target = makeRelease('2025.10.0', {
         removeDependencies: ['@shopify/remix-oxygen'],
       });
@@ -959,21 +936,6 @@ describe('upgrade', async () => {
     });
 
     it('includes removals when an intermediate release has a dep and a later intermediate release removes it', () => {
-      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
-        ({
-          version,
-          hash: 'abc',
-          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
-          pr: 'https://github.com/Shopify/hydrogen/pull/1',
-          date: '2025-01-01',
-          title: '',
-          dependencies: {'@shopify/hydrogen': version},
-          devDependencies: {},
-          features: [],
-          fixes: [],
-          ...overrides,
-        }) as Release;
-
       // Scenario: upgrading from 2025.5.0 → 2025.10.0
       // remix exists in an intermediate release (2025.6.0), is removed in 2025.7.0,
       // and is never re-added. It should be included in cumulative removals.
@@ -1002,21 +964,6 @@ describe('upgrade', async () => {
     });
 
     it('handles releases that omit dependencies maps', () => {
-      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
-        ({
-          version,
-          hash: 'abc',
-          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
-          pr: 'https://github.com/Shopify/hydrogen/pull/1',
-          date: '2025-01-01',
-          title: '',
-          dependencies: {'@shopify/hydrogen': version},
-          devDependencies: {},
-          features: [],
-          fixes: [],
-          ...overrides,
-        }) as Release;
-
       const targetRelease = makeRelease('2025.10.0');
       const releaseWithoutDependencyMaps = {
         ...makeRelease('2025.7.0', {
@@ -1041,21 +988,6 @@ describe('upgrade', async () => {
     });
 
     it('includes removal when package moves from devDependencies to dependencies', () => {
-      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
-        ({
-          version,
-          hash: 'abc',
-          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
-          pr: 'https://github.com/Shopify/hydrogen/pull/1',
-          date: '2025-01-01',
-          title: '',
-          dependencies: {'@shopify/hydrogen': version},
-          devDependencies: {},
-          features: [],
-          fixes: [],
-          ...overrides,
-        }) as Release;
-
       // Scenario: typescript is removed from devDependencies, then re-added as a regular dependency
       // The removal from devDependencies should still appear in removeDevDependencies
       const targetRelease = makeRelease('2025.10.0', {
@@ -1081,21 +1013,6 @@ describe('upgrade', async () => {
     });
 
     it('includes removal when package moves from dependencies to devDependencies', () => {
-      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
-        ({
-          version,
-          hash: 'abc',
-          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
-          pr: 'https://github.com/Shopify/hydrogen/pull/1',
-          date: '2025-01-01',
-          title: '',
-          dependencies: {'@shopify/hydrogen': version},
-          devDependencies: {},
-          features: [],
-          fixes: [],
-          ...overrides,
-        }) as Release;
-
       // Scenario: lodash is removed from dependencies, then re-added as a devDependency
       // The removal from dependencies should still appear in removeDependencies
       const targetRelease = makeRelease('2025.10.0', {
@@ -1551,7 +1468,7 @@ describe('upgrade', async () => {
       const {releases} = await getChangelog();
 
       const selectedRelease = Object.create(
-        // @ts-ignore - we know this release version exists
+        // @ts-expect-error - we know this release version exists
         releases.find((release) => release.version === '2023.10.0'),
       ) as (typeof releases)[0];
 
@@ -1607,7 +1524,7 @@ describe('upgrade', async () => {
         '@shopify/hydrogen@2023.10.0',
         '@shopify/remix-oxygen@2.0.0',
         `typescript@${getAbsoluteVersion(
-          // @ts-ignore - we know this release version exists
+          // @ts-expect-error - we know this release version exists
           selectedRelease.devDependencies.typescript,
         )}`,
       ];
@@ -1668,7 +1585,7 @@ describe('upgrade', async () => {
         '@shopify/cli-hydrogen@6.0.0',
         '@shopify/remix-oxygen@2.0.0',
         `typescript@${getAbsoluteVersion(
-          // @ts-ignore - we know this release version exists
+          // @ts-expect-error - we know this release version exists
           selectedRelease.devDependencies.typescript,
         )}`,
       ];

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -1000,6 +1000,45 @@ describe('upgrade', async () => {
 
       expect(removeDependencies).toContain('remix');
     });
+
+    it('handles releases that omit dependencies maps', () => {
+      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
+        ({
+          version,
+          hash: 'abc',
+          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
+          pr: 'https://github.com/Shopify/hydrogen/pull/1',
+          date: '2025-01-01',
+          title: '',
+          dependencies: {'@shopify/hydrogen': version},
+          devDependencies: {},
+          features: [],
+          fixes: [],
+          ...overrides,
+        }) as Release;
+
+      const targetRelease = makeRelease('2025.10.0');
+      const releaseWithoutDependencyMaps = {
+        ...makeRelease('2025.7.0', {
+          removeDependencies: ['@shopify/remix-oxygen'],
+        }),
+        dependencies: undefined,
+        devDependencies: undefined,
+      } as unknown as Release;
+      const fromRelease = makeRelease('2025.5.0');
+
+      const {removeDependencies} = getCumulativeRelease({
+        availableUpgrades: [
+          targetRelease,
+          releaseWithoutDependencyMaps,
+          fromRelease,
+        ],
+        selectedRelease: targetRelease,
+        currentVersion: '2025.5.0',
+      });
+
+      expect(removeDependencies).toContain('@shopify/remix-oxygen');
+    });
   });
 
   describe('displayConfirmation', () => {

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -2097,6 +2097,48 @@ describe('--version=next functionality', () => {
 
       expect(result.version).toBe('2025.7.0');
     });
+
+    it('preserves dependency removals in cumulative release for synthetic next upgrades', async () => {
+      const latestRelease = {
+        title: 'Latest release',
+        version: '2025.7.0',
+        hash: 'abc123',
+        commit: 'https://github.com/test' as `https://${string}`,
+        pr: 'https://github.com/test' as `https://${string}`,
+        date: '2025-09-17',
+        dependencies: {
+          '@shopify/hydrogen': '2025.7.0',
+          'react-router': '7.9.2',
+        },
+        devDependencies: {
+          '@shopify/mini-oxygen': '4.0.0',
+        },
+        removeDependencies: ['@remix-run/react'],
+        removeDevDependencies: ['@remix-run/dev'],
+        fixes: [],
+        features: [],
+      } as Release;
+
+      const selectedRelease = await getSelectedRelease({
+        targetVersion: 'next',
+        availableUpgrades: [latestRelease],
+        currentVersion: '2025.4.0',
+        currentDependencies: {'@shopify/hydrogen': '2025.4.0'},
+      });
+
+      const cumulativeRelease = getCumulativeRelease({
+        availableUpgrades: [latestRelease],
+        selectedRelease,
+        currentVersion: '2025.4.0',
+      });
+
+      expect(cumulativeRelease.removeDependencies).toEqual([
+        '@remix-run/react',
+      ]);
+      expect(cumulativeRelease.removeDevDependencies).toEqual([
+        '@remix-run/dev',
+      ]);
+    });
   });
 
   describe('buildUpgradeCommandArgs with --version=next', () => {

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -957,6 +957,49 @@ describe('upgrade', async () => {
         removeDependencies.filter((d) => d === '@shopify/remix-oxygen'),
       ).toHaveLength(1);
     });
+
+    it('includes removals for dependencies that exist early and are removed later without being re-added', () => {
+      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
+        ({
+          version,
+          hash: 'abc',
+          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
+          pr: 'https://github.com/Shopify/hydrogen/pull/1',
+          date: '2025-01-01',
+          title: '',
+          dependencies: {'@shopify/hydrogen': version},
+          devDependencies: {},
+          features: [],
+          fixes: [],
+          ...overrides,
+        }) as Release;
+
+      // Scenario: upgrading from 2025.5.0 → 2025.10.0
+      // remix exists in 2025.5.0, is removed in 2025.7.0, never re-added
+      // Should be included in cumulative removals (order-sensitive behavior)
+      const releaseWithRemix = makeRelease('2025.5.0', {
+        dependencies: {
+          '@shopify/hydrogen': '2025.5.0',
+          remix: '4.0.0',
+        },
+      });
+      const releaseRemovingRemix = makeRelease('2025.7.0', {
+        removeDependencies: ['remix'],
+      });
+      const targetRelease = makeRelease('2025.10.0');
+
+      const {removeDependencies} = getCumulativeRelease({
+        availableUpgrades: [
+          targetRelease,
+          releaseRemovingRemix,
+          releaseWithRemix,
+        ],
+        selectedRelease: targetRelease,
+        currentVersion: '2025.5.0',
+      });
+
+      expect(removeDependencies).toContain('remix');
+    });
   });
 
   describe('displayConfirmation', () => {

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -110,8 +110,32 @@ async function createOutdatedSkeletonPackageJsonWithReactRouter() {
   return packageJson;
 }
 
+async function createPreMigrationPackageJson() {
+  const require = createRequire(import.meta.url);
+  // Deep clone to avoid mutating the require() cache, which is shared
+  // across all createXxx helpers in this file.
+  const packageJson: PackageJson = JSON.parse(
+    JSON.stringify(require(joinPath(getSkeletonSourceDir(), 'package.json'))),
+  ) as PackageJson;
+
+  if (!packageJson) throw new Error('Could not parse package.json');
+  if (!packageJson?.dependencies)
+    throw new Error('Could not parse package.json dependencies');
+  if (!packageJson?.devDependencies)
+    throw new Error('Could not parse package.json devDependencies');
+
+  // Pin to pre-React Router migration version so the upgrade to 2025.7.0 triggers cumulative removals
+  packageJson.dependencies['@shopify/hydrogen'] = '~2025.5.1';
+  packageJson.dependencies['@remix-run/react'] = '^2.0.0';
+  packageJson.dependencies['@remix-run/server-runtime'] = '^2.0.0';
+  packageJson.devDependencies['@shopify/remix-oxygen'] = '^2.0.0';
+  packageJson.devDependencies['@remix-run/dev'] = '^2.0.0';
+
+  return packageJson;
+}
+
 const REACT_ROUTER_RELEASE = {
-  title: 'React Rotuer 7.5',
+  title: 'React Router 7.5',
   version: '2025.5.0',
   hash: '-',
   commit: 'https://github.com/Shopify/hydrogen/pull/2819',
@@ -225,6 +249,8 @@ describe('upgrade', async () => {
 
   const OUTDATED_HYDROGEN_PACKAGE_JSON_WITH_REACT_ROUTER =
     await createOutdatedSkeletonPackageJsonWithReactRouter();
+
+  const PRE_MIGRATION_PACKAGE_JSON = await createPreMigrationPackageJson();
 
   describe('checkIsGitRepo', () => {
     it('renders an error message when not in a git repo', async () => {
@@ -755,21 +781,183 @@ describe('upgrade', async () => {
           );
 
           // testing from 2023.1.6 (outdated) to 2023.4.1
-          const {features, fixes} = getCummulativeRelease({
-            availableUpgrades,
-            ...current,
-            // @ts-ignore - we know this release version exists
-            selectedRelease,
-          });
+          const {features, fixes, removeDependencies, removeDevDependencies} =
+            getCummulativeRelease({
+              availableUpgrades,
+              ...current,
+              // @ts-ignore - we know this release version exists
+              selectedRelease,
+            });
 
           expect(features).toMatchObject(CUMMLATIVE_RELEASE.features);
           expect(fixes).toMatchObject(CUMMLATIVE_RELEASE.fixes);
+          expect(removeDependencies).toMatchObject(
+            CUMMLATIVE_RELEASE.removeDependencies,
+          );
+          expect(removeDevDependencies).toMatchObject(
+            CUMMLATIVE_RELEASE.removeDevDependencies,
+          );
         },
         {
           cleanGitRepo: true,
           packageJson: OUTDATED_HYDROGEN_PACKAGE_JSON,
         },
       );
+    });
+
+    it('accumulates real removeDependencies when upgrading across the React Router migration', async () => {
+      await inTemporaryHydrogenRepo(
+        async (appPath) => {
+          const {releases} = await getChangelog();
+          const current = await getHydrogenVersion({appPath});
+
+          expect(current?.currentVersion).toBeDefined();
+
+          const {availableUpgrades} = getAvailableUpgrades({
+            ...current,
+            releases,
+          });
+
+          // 2025.7.0 is the release that drops @shopify/remix-oxygen and Remix packages
+          const selectedRelease = releases.find(
+            (release) => release.version === '2025.7.0',
+          );
+
+          const {removeDependencies, removeDevDependencies} =
+            getCummulativeRelease({
+              availableUpgrades,
+              ...current,
+              // @ts-ignore - we know this release version exists
+              selectedRelease,
+            });
+
+          // @shopify/remix-oxygen and @remix-run/* are removed without being re-added
+          expect(removeDependencies).toContain('@shopify/remix-oxygen');
+          expect(removeDependencies).toContain('@remix-run/react');
+          expect(removeDependencies).toContain('@remix-run/server-runtime');
+          expect(removeDevDependencies).toContain('@remix-run/dev');
+
+          // react-router is re-added at a new version so it stays
+          expect(removeDependencies).not.toContain('react-router');
+          expect(removeDependencies).not.toContain('react-router-dom');
+        },
+        {
+          cleanGitRepo: true,
+          packageJson: PRE_MIGRATION_PACKAGE_JSON,
+        },
+      );
+    });
+
+    it('accumulates removeDependencies from intermediate releases', () => {
+      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
+        ({
+          version,
+          hash: 'abc',
+          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
+          pr: 'https://github.com/Shopify/hydrogen/pull/1',
+          date: '2025-01-01',
+          title: '',
+          dependencies: {'@shopify/hydrogen': version},
+          devDependencies: {},
+          features: [],
+          fixes: [],
+          ...overrides,
+        }) as Release;
+
+      // Simulates: user on 2025.5.0, upgrading to 2025.10.0.
+      // 2025.7.0 removes @shopify/remix-oxygen (a breaking migration).
+      // 2025.10.0 is the target and knows nothing about remix-oxygen.
+      const target = makeRelease('2025.10.0');
+      const intermediate = makeRelease('2025.7.0', {
+        removeDependencies: ['@shopify/remix-oxygen', '@remix-run/react'],
+        removeDevDependencies: ['@remix-run/dev'],
+      });
+      const from = makeRelease('2025.5.0');
+
+      const {removeDependencies, removeDevDependencies} = getCummulativeRelease(
+        {
+          availableUpgrades: [target, intermediate, from],
+          selectedRelease: target,
+          currentVersion: '2025.5.0',
+        },
+      );
+
+      expect(removeDependencies).toContain('@shopify/remix-oxygen');
+      expect(removeDependencies).toContain('@remix-run/react');
+      expect(removeDevDependencies).toContain('@remix-run/dev');
+    });
+
+    it('excludes removeDependencies for deps that are re-added in any release', () => {
+      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
+        ({
+          version,
+          hash: 'abc',
+          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
+          pr: 'https://github.com/Shopify/hydrogen/pull/1',
+          date: '2025-01-01',
+          title: '',
+          dependencies: {'@shopify/hydrogen': version},
+          devDependencies: {},
+          features: [],
+          fixes: [],
+          ...overrides,
+        }) as Release;
+
+      // react-router is removed (old Remix version) AND re-added at a new version
+      // in the same release — it should not appear in cumulative removeDependencies.
+      const target = makeRelease('2025.10.0');
+      const intermediate = makeRelease('2025.7.0', {
+        dependencies: {
+          '@shopify/hydrogen': '2025.7.0',
+          'react-router': '7.9.2',
+        },
+        removeDependencies: ['@shopify/remix-oxygen', 'react-router'],
+      });
+      const from = makeRelease('2025.5.0');
+
+      const {removeDependencies} = getCummulativeRelease({
+        availableUpgrades: [target, intermediate, from],
+        selectedRelease: target,
+        currentVersion: '2025.5.0',
+      });
+
+      expect(removeDependencies).toContain('@shopify/remix-oxygen');
+      expect(removeDependencies).not.toContain('react-router');
+    });
+
+    it('deduplicates removeDependencies listed in multiple releases', () => {
+      const makeRelease = (version: string, overrides: Partial<Release> = {}) =>
+        ({
+          version,
+          hash: 'abc',
+          commit: 'https://github.com/Shopify/hydrogen/commit/abc',
+          pr: 'https://github.com/Shopify/hydrogen/pull/1',
+          date: '2025-01-01',
+          title: '',
+          dependencies: {'@shopify/hydrogen': version},
+          devDependencies: {},
+          features: [],
+          fixes: [],
+          ...overrides,
+        }) as Release;
+
+      const target = makeRelease('2025.10.0', {
+        removeDependencies: ['@shopify/remix-oxygen'],
+      });
+      const intermediate = makeRelease('2025.7.0', {
+        removeDependencies: ['@shopify/remix-oxygen'],
+      });
+      const from = makeRelease('2025.5.0');
+
+      const {removeDependencies} = getCummulativeRelease({
+        availableUpgrades: [target, intermediate, from],
+        selectedRelease: target,
+        currentVersion: '2025.5.0',
+      });
+
+      expect(
+        removeDependencies.filter((d) => d === '@shopify/remix-oxygen'),
+      ).toHaveLength(1);
     });
   });
 
@@ -1503,6 +1691,8 @@ const CUMMLATIVE_RELEASE = {
       id: '642',
     },
   ],
+  removeDependencies: [],
+  removeDevDependencies: [],
 } as CumulativeRelease;
 
 describe('dependency removal', () => {
@@ -1912,6 +2102,8 @@ describe('--version=next functionality', () => {
       const cumulativeRelease = {
         features: [],
         fixes: [],
+        removeDependencies: [],
+        removeDevDependencies: [],
       };
 
       const selectedRelease = {
@@ -1931,13 +2123,15 @@ describe('--version=next functionality', () => {
       const cumulativeRelease = {
         features: [],
         fixes: [],
+        removeDependencies: [],
+        removeDevDependencies: [],
       };
 
       const selectedRelease = {
         version: '2025.7.0',
       } as Release;
 
-      const result = await displayConfirmation({
+      await displayConfirmation({
         cumulativeRelease,
         selectedRelease,
         // No targetVersion specified

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -631,14 +631,17 @@ export function getCumulativeRelease({
 
     if (!release) continue;
 
-    Object.keys(release.dependencies).forEach((dep) => {
+    const dependencies = release.dependencies ?? {};
+    const devDependencies = release.devDependencies ?? {};
+
+    Object.keys(dependencies).forEach((dep) => {
       const removalI = removedAt.get(dep);
       if (removalI !== undefined && i >= removalI) {
         reinstalledDeps.add(dep);
       }
     });
 
-    Object.keys(release.devDependencies).forEach((dep) => {
+    Object.keys(devDependencies).forEach((dep) => {
       const removalI = removedAt.get(dep);
       if (removalI !== undefined && i >= removalI) {
         reinstalledDeps.add(dep);

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -557,7 +557,7 @@ export async function getSelectedRelease({
 }
 
 /**
- * Gets an aggregate list of features and fixes included in the upgrade versions range
+ * Gets an aggregate list of features, fixes, and dependency removals included in the upgrade versions range
  */
 export function getCumulativeRelease({
   availableUpgrades,
@@ -649,6 +649,7 @@ export function getCumulativeRelease({
     // Only mark as reinstalled if it returns to the same dependency type
     Object.keys(dependencies).forEach((dep) => {
       const removalI = removedDepsAt.get(dep);
+      // >= allows same-release remove+add (e.g., react-router upgraded in 2025.7.0)
       if (removalI !== undefined && i >= removalI) {
         reinstalledDeps.add(dep);
       }
@@ -656,6 +657,7 @@ export function getCumulativeRelease({
 
     Object.keys(devDependencies).forEach((dep) => {
       const removalI = removedDevDepsAt.get(dep);
+      // >= allows same-release remove+add
       if (removalI !== undefined && i >= removalI) {
         reinstalledDevDeps.add(dep);
       }
@@ -936,25 +938,24 @@ export function buildUpgradeCommandArgs({
 /**
  * Installs the new Hydrogen dependencies
  *
- * When upgrading across multiple versions, callers should pass cumulative removal lists
- * from `getCumulativeRelease()` to ensure dependencies removed in intermediate releases
- * are properly cleaned up. The defaults fall back to the target release's own removal
- * lists, which only provides single-release behavior and may miss intermediate removals.
+ * Callers must pass cumulative removal lists from `getCumulativeRelease()` to ensure
+ * dependencies removed in intermediate releases are properly cleaned up when upgrading
+ * across multiple versions.
  */
 export async function upgradeNodeModules({
   appPath,
   selectedRelease,
   currentDependencies,
   targetVersion,
-  cumulativeRemoveDependencies = selectedRelease.removeDependencies ?? [],
-  cumulativeRemoveDevDependencies = selectedRelease.removeDevDependencies ?? [],
+  cumulativeRemoveDependencies,
+  cumulativeRemoveDevDependencies,
 }: {
   appPath: string;
   selectedRelease: Release;
   currentDependencies: Record<string, string>;
   targetVersion?: string;
-  cumulativeRemoveDependencies?: string[];
-  cumulativeRemoveDevDependencies?: string[];
+  cumulativeRemoveDependencies: string[];
+  cumulativeRemoveDevDependencies: string[];
 }) {
   const tasks: Array<{title: string; task: () => Promise<void>}> = [];
 

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -206,7 +206,7 @@ export async function runUpgrade({
     });
 
     // Get an aggregate list of features and fixes included in the upgrade versions range
-    cumulativeRelease = getCummulativeRelease({
+    cumulativeRelease = getCumulativeRelease({
       availableUpgrades,
       currentVersion,
       currentDependencies,
@@ -559,7 +559,7 @@ export async function getSelectedRelease({
 /**
  * Gets an aggregate list of features and fixes included in the upgrade versions range
  */
-export function getCummulativeRelease({
+export function getCumulativeRelease({
   availableUpgrades,
   selectedRelease,
   currentVersion,

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -78,6 +78,8 @@ type ChangeLog = {
 export type CumulativeRelease = {
   features: Array<ReleaseItem>;
   fixes: Array<ReleaseItem>;
+  removeDependencies: string[];
+  removeDevDependencies: string[];
 };
 
 const INSTRUCTIONS_FOLDER = '.hydrogen';
@@ -231,6 +233,8 @@ export async function runUpgrade({
     selectedRelease,
     currentDependencies,
     targetVersion,
+    cumulativeRemoveDependencies: cumulativeRelease.removeDependencies,
+    cumulativeRemoveDevDependencies: cumulativeRelease.removeDevDependencies,
   });
   await validateUpgrade({
     appPath,
@@ -568,13 +572,19 @@ export function getCummulativeRelease({
 }): CumulativeRelease {
   const currentPinnedVersion = getAbsoluteVersion(currentVersion);
 
-  if (!availableUpgrades?.length) {
-    return {features: [], fixes: []};
-  }
+  const empty: CumulativeRelease = {
+    features: [],
+    fixes: [],
+    removeDependencies: [],
+    removeDevDependencies: [],
+  };
+
+  if (!availableUpgrades?.length) return empty;
 
   // For synthetic next releases, return features/fixes directly
   if (selectedRelease.dependencies?.['@shopify/hydrogen'] === 'next') {
     return {
+      ...empty,
       features: selectedRelease.features || [],
       fixes: selectedRelease.fixes || [],
     };
@@ -595,14 +605,36 @@ export function getCummulativeRelease({
     return hasOutdatedDependencies({release, currentDependencies});
   });
 
-  return upgradingReleases.reduce(
-    (acc, release) => {
-      acc.features = [...acc.features, ...release.features];
-      acc.fixes = [...acc.fixes, ...release.fixes];
-      return acc;
-    },
-    {features: [], fixes: []} as CumulativeRelease,
+  const features = upgradingReleases.flatMap((r) => r.features);
+  const fixes = upgradingReleases.flatMap((r) => r.fixes);
+
+  // Track deps that are re-added anywhere in the upgrade range.
+  // A dep removed in one release but re-added in another (e.g. react-router
+  // renamed/upgraded) should not appear in the cumulative removal list.
+  const reinstalledDeps = new Set(
+    upgradingReleases.flatMap((r) => [
+      ...Object.keys(r.dependencies),
+      ...Object.keys(r.devDependencies),
+    ]),
   );
+
+  const removeDependencies = [
+    ...new Set(
+      upgradingReleases
+        .flatMap((r) => r.removeDependencies ?? [])
+        .filter((dep) => !reinstalledDeps.has(dep)),
+    ),
+  ];
+
+  const removeDevDependencies = [
+    ...new Set(
+      upgradingReleases
+        .flatMap((r) => r.removeDevDependencies ?? [])
+        .filter((dep) => !reinstalledDeps.has(dep)),
+    ),
+  ];
+
+  return {features, fixes, removeDependencies, removeDevDependencies};
 }
 
 /**
@@ -865,18 +897,23 @@ export async function upgradeNodeModules({
   selectedRelease,
   currentDependencies,
   targetVersion,
+  cumulativeRemoveDependencies = selectedRelease.removeDependencies ?? [],
+  cumulativeRemoveDevDependencies = selectedRelease.removeDevDependencies ?? [],
 }: {
   appPath: string;
   selectedRelease: Release;
   currentDependencies: Record<string, string>;
   targetVersion?: string;
+  cumulativeRemoveDependencies?: string[];
+  cumulativeRemoveDevDependencies?: string[];
 }) {
   const tasks: Array<{title: string; task: () => Promise<void>}> = [];
 
-  // Remove deprecated dependencies first if specified
+  // Cumulative removals cover intermediate releases (multi-version jumps).
+  // Defaults to the target release's own removals when not upgrading across multiple versions.
   const depsToRemove = [
-    ...(selectedRelease.removeDependencies || []),
-    ...(selectedRelease.removeDevDependencies || []),
+    ...cumulativeRemoveDependencies,
+    ...cumulativeRemoveDevDependencies,
   ].filter((dep) => dep in currentDependencies);
 
   if (depsToRemove.length > 0) {

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -618,18 +618,21 @@ export function getCumulativeRelease({
   // A dep removed in one release but re-added in a later release (e.g. react-router
   // renamed/upgraded) should not appear in the cumulative removal list.
   // Use chronological ordering so this is independent from changelog input order.
-  const removedAt = new Map<string, number>();
+  // Track each dependency type separately to handle cross-type moves correctly.
+  const removedDepsAt = new Map<string, number>();
+  const removedDevDepsAt = new Map<string, number>();
 
   releasesByVersion.forEach((release, i) => {
     release.removeDependencies?.forEach((dep) => {
-      removedAt.set(dep, i);
+      removedDepsAt.set(dep, i);
     });
     release.removeDevDependencies?.forEach((dep) => {
-      removedAt.set(dep, i);
+      removedDevDepsAt.set(dep, i);
     });
   });
 
   const reinstalledDeps = new Set<string>();
+  const reinstalledDevDeps = new Set<string>();
 
   for (let i = 0; i < releasesByVersion.length; i++) {
     const release = releasesByVersion[i];
@@ -639,17 +642,18 @@ export function getCumulativeRelease({
     const dependencies = release.dependencies ?? {};
     const devDependencies = release.devDependencies ?? {};
 
+    // Only mark as reinstalled if it returns to the same dependency type
     Object.keys(dependencies).forEach((dep) => {
-      const removalI = removedAt.get(dep);
+      const removalI = removedDepsAt.get(dep);
       if (removalI !== undefined && i >= removalI) {
         reinstalledDeps.add(dep);
       }
     });
 
     Object.keys(devDependencies).forEach((dep) => {
-      const removalI = removedAt.get(dep);
+      const removalI = removedDevDepsAt.get(dep);
       if (removalI !== undefined && i >= removalI) {
-        reinstalledDeps.add(dep);
+        reinstalledDevDeps.add(dep);
       }
     });
   }
@@ -666,7 +670,7 @@ export function getCumulativeRelease({
     ...new Set(
       releasesByVersion
         .flatMap((r) => r.removeDevDependencies ?? [])
-        .filter((dep) => !reinstalledDeps.has(dep)),
+        .filter((dep) => !reinstalledDevDeps.has(dep)),
     ),
   ];
 

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -699,7 +699,7 @@ export function displayConfirmation({
   if (features.length || fixes.length) {
     renderInfo({
       headline: `Included in this upgrade:`,
-      //@ts-ignore we know that filter(Boolean) will always return an array
+      // @ts-expect-error - filter(Boolean) removes falsy values, leaving only objects
       customSections: [
         features.length && {
           title: 'Features',

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -587,6 +587,8 @@ export function getCumulativeRelease({
       ...empty,
       features: selectedRelease.features || [],
       fixes: selectedRelease.fixes || [],
+      removeDependencies: selectedRelease.removeDependencies ?? [],
+      removeDevDependencies: selectedRelease.removeDevDependencies ?? [],
     };
   }
 

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -608,15 +608,43 @@ export function getCumulativeRelease({
   const features = upgradingReleases.flatMap((r) => r.features);
   const fixes = upgradingReleases.flatMap((r) => r.fixes);
 
-  // Track deps that are re-added anywhere in the upgrade range.
-  // A dep removed in one release but re-added in another (e.g. react-router
+  // Track deps that are re-added after being removed in the upgrade range.
+  // A dep removed in one release but re-added in a later release (e.g. react-router
   // renamed/upgraded) should not appear in the cumulative removal list.
-  const reinstalledDeps = new Set(
-    upgradingReleases.flatMap((r) => [
-      ...Object.keys(r.dependencies),
-      ...Object.keys(r.devDependencies),
-    ]),
-  );
+  // This must be order-sensitive: a dep existing early then removed later shouldn't
+  // be treated as "reinstalled" just because it existed before the removal.
+  const removedAt = new Map<string, number>();
+
+  upgradingReleases.forEach((release, i) => {
+    release.removeDependencies?.forEach((dep) => {
+      removedAt.set(dep, i);
+    });
+    release.removeDevDependencies?.forEach((dep) => {
+      removedAt.set(dep, i);
+    });
+  });
+
+  const reinstalledDeps = new Set<string>();
+
+  for (let i = 0; i < upgradingReleases.length; i++) {
+    const release = upgradingReleases[i];
+
+    if (!release) continue;
+
+    Object.keys(release.dependencies).forEach((dep) => {
+      const removalI = removedAt.get(dep);
+      if (removalI !== undefined && i >= removalI) {
+        reinstalledDeps.add(dep);
+      }
+    });
+
+    Object.keys(release.devDependencies).forEach((dep) => {
+      const removalI = removedAt.get(dep);
+      if (removalI !== undefined && i >= removalI) {
+        reinstalledDeps.add(dep);
+      }
+    });
+  }
 
   const removeDependencies = [
     ...new Set(

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -608,14 +608,17 @@ export function getCumulativeRelease({
   const features = upgradingReleases.flatMap((r) => r.features);
   const fixes = upgradingReleases.flatMap((r) => r.fixes);
 
+  const releasesByVersion = [...upgradingReleases].sort((a, b) =>
+    semver.compare(a.version, b.version),
+  );
+
   // Track deps that are re-added after being removed in the upgrade range.
   // A dep removed in one release but re-added in a later release (e.g. react-router
   // renamed/upgraded) should not appear in the cumulative removal list.
-  // This must be order-sensitive: a dep existing early then removed later shouldn't
-  // be treated as "reinstalled" just because it existed before the removal.
+  // Use chronological ordering so this is independent from changelog input order.
   const removedAt = new Map<string, number>();
 
-  upgradingReleases.forEach((release, i) => {
+  releasesByVersion.forEach((release, i) => {
     release.removeDependencies?.forEach((dep) => {
       removedAt.set(dep, i);
     });
@@ -626,8 +629,8 @@ export function getCumulativeRelease({
 
   const reinstalledDeps = new Set<string>();
 
-  for (let i = 0; i < upgradingReleases.length; i++) {
-    const release = upgradingReleases[i];
+  for (let i = 0; i < releasesByVersion.length; i++) {
+    const release = releasesByVersion[i];
 
     if (!release) continue;
 
@@ -651,7 +654,7 @@ export function getCumulativeRelease({
 
   const removeDependencies = [
     ...new Set(
-      upgradingReleases
+      releasesByVersion
         .flatMap((r) => r.removeDependencies ?? [])
         .filter((dep) => !reinstalledDeps.has(dep)),
     ),
@@ -659,7 +662,7 @@ export function getCumulativeRelease({
 
   const removeDevDependencies = [
     ...new Set(
-      upgradingReleases
+      releasesByVersion
         .flatMap((r) => r.removeDevDependencies ?? [])
         .filter((dep) => !reinstalledDeps.has(dep)),
     ),

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -581,7 +581,9 @@ export function getCumulativeRelease({
 
   if (!availableUpgrades?.length) return empty;
 
-  // For synthetic next releases, return features/fixes directly
+  // For synthetic next releases, return features/fixes directly without accumulation.
+  // Synthetic "next" releases are constructed from the latest real release and already
+  // carry all necessary removals, so no additional accumulation is needed.
   if (selectedRelease.dependencies?.['@shopify/hydrogen'] === 'next') {
     return {
       ...empty,
@@ -622,6 +624,8 @@ export function getCumulativeRelease({
   const removedDepsAt = new Map<string, number>();
   const removedDevDepsAt = new Map<string, number>();
 
+  // Last-write-wins: If a dep is removed in multiple releases, the map stores the *last* removal index.
+  // This ensures that a re-addition between two removal occurrences won't suppress the later removal.
   releasesByVersion.forEach((release, i) => {
     release.removeDependencies?.forEach((dep) => {
       removedDepsAt.set(dep, i);
@@ -931,6 +935,11 @@ export function buildUpgradeCommandArgs({
 
 /**
  * Installs the new Hydrogen dependencies
+ *
+ * When upgrading across multiple versions, callers should pass cumulative removal lists
+ * from `getCumulativeRelease()` to ensure dependencies removed in intermediate releases
+ * are properly cleaned up. The defaults fall back to the target release's own removal
+ * lists, which only provides single-release behavior and may miss intermediate removals.
  */
 export async function upgradeNodeModules({
   appPath,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/1078 

Fixes an issue where the `h2 upgrade` command would fail to remove dependencies when upgrading across multiple releases.

When upgrading from version A to version C (skipping version B), dependencies removed in version B were not being removed from the user's project. This was particularly problematic for the React Router 7 migration (2025.7.0) where Remix packages needed to be removed.

**Example scenario:**

- User is on Hydrogen 2025.5.0 (uses Remix)
- Upgrades directly to 2025.10.0 (uses React Router)
- Version 2025.7.0 (in between) removed Remix packages
- **Before this fix:** Remix packages remained in the project ❌
- **After this fix:** Remix packages are correctly removed ✅

### WHAT is this pull request doing?

This PR implements order-sensitive tracking of cumulative dependency removals across multiple releases:

1. **Extended `CumulativeRelease` type** to include `removeDependencies` and `removeDevDependencies` arrays
2. **Enhanced `getCumulativeRelease()` function** to accumulate removals from all intermediate releases
3. **Added smart filtering** to exclude dependencies that are removed and then re-added (e.g., `react-router` being upgraded, not replaced)
4. **Updated `upgradeNodeModules()`** to accept cumulative removal lists instead of only using the target release's removals

**Key implementation detail:**
The logic is order-sensitive - it tracks when each dependency was removed, and only marks it as "reinstalled" if it's added back in a release at or after the removal. This prevents dependencies that existed early in the range from being incorrectly filtered out.

### HOW to test your changes?

#### Run the Test Suite

The most reliable way to verify this fix is through the comprehensive test suite:

```bash
# From the hydrogen repo root
pnpm install
pnpm run build
pnpm run test --filter=@shopify/cli-hydrogen -- upgrade.test.ts
```

**Expected Result:**

- ✅ All 54 tests pass (3 skipped)
- ✅ Includes 5 new test cases specifically for cumulative dependency removal:
  - Real React Router migration test (2025.5.0 → 2025.7.0)
  - Accumulation across intermediate releases
  - Filtering reinstalled dependencies
  - Deduplication of removals
  - Order-sensitive removal tracking

#### Review the Test Coverage

The tests cover all critical scenarios:

1. **Single version jump** (`upgrade.test.ts:808-849`)
   - Tests upgrading from 2025.5.1 (Remix) to 2025.7.0 (React Router)
   - Verifies Remix packages are removed and React Router is added

2. **Multi-version jump** (`upgrade.test.ts:851-893`)
   - Tests upgrading from 2025.5.0 to 2025.10.0 (skipping 2025.7.0)
   - Verifies intermediate removals are still applied

3. **Reinstalled dependencies** (`upgrade.test.ts:895-925`)
   - Tests that deps removed then re-added (like `react-router` being upgraded) are NOT in the removal list

4. **Deduplication** (`upgrade.test.ts:927-960`)
   - Tests that deps listed for removal in multiple releases only appear once

5. **Order-sensitive behavior** (`upgrade.test.ts:962-998`)
   - Tests that deps existing early and removed later ARE included in removals
   - This is the critical edge case the order-sensitive logic handles

### What This PR Fixes

**Before this PR**: If you upgraded from 2025.5.0 → 2025.10.0, dependencies removed in intermediate releases (like the Remix packages removed in 2025.7.0) would NOT be removed from your project.

**After this PR**: The upgrade command correctly accumulates dependency removals across all intermediate releases, ensuring your project stays clean even when jumping multiple versions.

---

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
