### PR TITLE
Add Shopify MCP as part of the Hydrogen template

### DIFF
--- a/.changeset/shopify-mcp-multitool.md
+++ b/.changeset/shopify-mcp-multitool.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Adds Shopify MCP configuration for multple AI assistants (Cursor, Claude Code)

--- a/templates/skeleton/.cursor/mcp.json
+++ b/templates/skeleton/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "shopify-dev-mcp": {
+      "command": "npx",
+      "args": ["-y", "@shopify/dev-mcp@latest"]
+    }
+  }
+}

--- a/templates/skeleton/.mcp.json
+++ b/templates/skeleton/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "shopify-dev-mcp": {
+      "command": "npx",
+      "args": ["-y", "@shopify/dev-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
### WHAT and WHY are these changes introduced?

To add the Shopify official MCP as part of the Hydrogen scaffold, since it supports storefront APIs and documentation references.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
