### PR TITLE
fix: strip key from cart token

### DIFF
--- a/.changeset/fix-add-to-cart-analytics-cart-token.md
+++ b/.changeset/fix-add-to-cart-analytics-cart-token.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen': patch
+'@shopify/hydrogen-react': patch
+---
+
+Fixed a regression where add-to-cart analytics could include the cart key in `cart_token`, which could prevent `product_added_to_cart` events from being attributed in Shopify Admin analytics.

--- a/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.test.ts
+++ b/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.test.ts
@@ -323,6 +323,16 @@ describe(`analytics schema - custom storefront customer tracking`, () => {
         price: parseFloat(productPayload.price),
       });
     });
+
+    it('strips cart key from cart_token', () => {
+      const events = addToCart({
+        ...BASE_PAYLOAD,
+        cartId: 'gid://shopify/Cart/abc123?key=secret',
+        products: [BASE_PRODUCT_PAYLOAD],
+      });
+
+      expect(events[0]?.payload?.cart_token).toBe('abc123');
+    });
   });
 });
 

--- a/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.ts
+++ b/packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.ts
@@ -203,6 +203,8 @@ export function addToCart(
 ): ShopifyMonorailEvent[] {
   const addToCartPayload = payload;
   const cartToken = parseGid(addToCartPayload.cartId);
+  const cartTokenValue = cartToken.resourceId || cartToken.id || null;
+
   return [
     schemaWrapper(
       SCHEMA_ID,
@@ -210,7 +212,7 @@ export function addToCart(
         {
           event_name: PRODUCT_ADDED_TO_CART_EVENT_NAME,
           customerId: addToCartPayload.customerId,
-          cart_token: cartToken?.id ? `${cartToken.id}` : null,
+          cart_token: cartTokenValue,
           total_value: addToCartPayload.totalValue,
           products: formatProductPayload(addToCartPayload.products),
           customer_id: parseInt(


### PR DESCRIPTION
### WHY are these changes introduced?

tentatively Fixes https://github.com/Shopify/hydrogen/issues/3467

Theory:
- User submits add-to-cart form in templates/skeleton/app/components/AddToCartButton.tsx:18 (used by templates/skeleton/app/components/ProductForm.tsx:104).
- /cart action adds lines via cart.addLines(...) in templates/skeleton/app/routes/cart.tsx:28.
- App is wrapped in Analytics.Provider at templates/skeleton/app/root.tsx:174.
- Provider mounts CartAnalytics, which diffs cart lines and publishes product_added_to_cart in packages/hydrogen/src/analytics-manager/CartAnalytics.tsx:115 and packages/hydrogen/src/analytics-manager/CartAnalytics.tsx:141.
- ShopifyAnalytics subscribes and handles that event in packages/hydrogen/src/analytics-manager/ShopifyAnalytics.tsx:122 and packages/hydrogen/src/analytics-manager/ShopifyAnalytics.tsx:297.
- That handler calls sendShopifyAnalytics(ADD_TO_CART) in packages/hydrogen/src/analytics-manager/ShopifyAnalytics.tsx:345.
- sendShopifyAnalytics routes ADD_TO_CART to customerAddToCart(...) in packages/hydrogen-react/src/analytics.ts:43 (this is the path that uses your change in packages/hydrogen-react/src/analytics-schema-custom-storefront-customer-tracking.ts).

Investigation showed `product_added_to_cart` events were still emitted client-side, but `cart_token` included the cart query string (for example `?key=...`) in the payload.

### WHAT is this pull request doing?

- Normalize `cart_token` in add-to-cart analytics payloads to use the cart resource ID (without query/hash), instead of the full parsed ID.
- Keep backward-safe fallback behavior when resource ID is unavailable.
- Add a regression test that verifies `gid://shopify/Cart/abc123?key=secret` serializes to `cart_token: "abc123"`.

### HOW to test your changes?

1. Run targeted analytics tests:

```bash
npm run test --workspace=@shopify/hydrogen-react -- analytics-schema-custom-storefront-customer-tracking.test.ts analytics-utils.test.ts
```

2. Optional runtime verification in a storefront:
   - Add an item to cart.
   - Inspect the Monorail `/produce_batch` request payload.
   - Confirm `event_name` is `product_added_to_cart`.
   - Confirm `cart_token` does not include `?key=...`.

#### Post-merge steps

None.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- I've added or updated the documentation
