### PR TITLE
An feat local cli hydrogen patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "patch-cli": "node scripts/patch-cli.mjs",
     "unpatch-cli": "node scripts/unpatch-cli.mjs",
-    "prepare": "husky",
+    "prepare": "husky && node scripts/patch-cli.mjs",
     "build": "pnpm run build:pkg",
     "build:pkg": "turbo build --parallel --filter=./packages/*",
     "build:templates": "turbo build --parallel --filter=./templates/*",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
+    "patch-cli": "node scripts/patch-cli.mjs",
+    "unpatch-cli": "node scripts/unpatch-cli.mjs",
     "prepare": "husky",
     "build": "pnpm run build:pkg",
     "build:pkg": "turbo build --parallel --filter=./packages/*",

--- a/packages/cli/bin/dev.js
+++ b/packages/cli/bin/dev.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+// oclif dev entry point for local hydrogen CLI development
+import {execute} from '@oclif/core';
+await execute({type: 'plugin', dir: import.meta.url});

--- a/packages/cli/bin/dev.js
+++ b/packages/cli/bin/dev.js
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-// oclif dev entry point for local hydrogen CLI development
-import {execute} from '@oclif/core';
-await execute({type: 'plugin', dir: import.meta.url});

--- a/packages/cli/src/lib/patch-cli.test.ts
+++ b/packages/cli/src/lib/patch-cli.test.ts
@@ -1,0 +1,131 @@
+import {describe, it, expect} from 'vitest';
+import {writeFileSync, readFileSync, mkdirSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {tmpdir} from 'node:os';
+import {
+  MARKER,
+  getRunJsPath,
+  isPatchApplied,
+  generatePatchedContent,
+  generateOriginalContent,
+  applyPatch,
+  removePatch,
+} from './patch-cli.js';
+
+function createTempFile(content: string): string {
+  const dir = resolve(
+    tmpdir(),
+    `patch-cli-test-${Date.now()}-${Math.random()}`,
+  );
+  mkdirSync(dir, {recursive: true});
+  const filePath = resolve(dir, 'run.js');
+  writeFileSync(filePath, content);
+  return filePath;
+}
+
+describe('patch-cli', () => {
+  describe('MARKER', () => {
+    it('is the expected string', () => {
+      expect(MARKER).toBe('// [hydrogen-monorepo-patch]');
+    });
+  });
+
+  describe('getRunJsPath', () => {
+    it('resolves the correct path from root', () => {
+      expect(getRunJsPath('/foo')).toBe(
+        '/foo/node_modules/@shopify/cli/bin/run.js',
+      );
+    });
+  });
+
+  describe('isPatchApplied', () => {
+    it('returns false for empty string', () => {
+      expect(isPatchApplied('')).toBe(false);
+    });
+
+    it('returns false for content without marker', () => {
+      expect(isPatchApplied('const x = 1;')).toBe(false);
+    });
+
+    it('returns true when marker is present', () => {
+      expect(isPatchApplied(`${MARKER}\nsome content`)).toBe(true);
+    });
+  });
+
+  describe('generatePatchedContent', () => {
+    const content = generatePatchedContent();
+
+    it('includes the marker', () => {
+      expect(content).toContain(MARKER);
+    });
+
+    it('includes monorepo root detection', () => {
+      expect(content).toContain('monorepoRoot');
+    });
+
+    it('includes pluginAdditions config', () => {
+      expect(content).toContain('pluginAdditions');
+    });
+
+    it('includes oclif imports', () => {
+      expect(content).toContain('@oclif/core');
+    });
+
+    it('sets IGNORE_HYDROGEN_MONOREPO env var', () => {
+      expect(content).toContain('IGNORE_HYDROGEN_MONOREPO');
+    });
+  });
+
+  describe('generateOriginalContent', () => {
+    const content = generateOriginalContent();
+
+    it('does not include the marker', () => {
+      expect(content).not.toContain(MARKER);
+    });
+
+    it('includes the standard CLI entrypoint', () => {
+      expect(content).toContain('runCLI({development: false})');
+    });
+  });
+
+  describe('applyPatch', () => {
+    it('writes patched content to an unpatched file and returns true', () => {
+      const filePath = createTempFile(generateOriginalContent());
+      expect(applyPatch(filePath)).toBe(true);
+      expect(readFileSync(filePath, 'utf8')).toBe(generatePatchedContent());
+    });
+
+    it('is idempotent — returns false if already patched', () => {
+      const filePath = createTempFile(generatePatchedContent());
+      expect(applyPatch(filePath)).toBe(false);
+      expect(readFileSync(filePath, 'utf8')).toBe(generatePatchedContent());
+    });
+  });
+
+  describe('removePatch', () => {
+    it('restores original content and returns true', () => {
+      const filePath = createTempFile(generatePatchedContent());
+      expect(removePatch(filePath)).toBe(true);
+      expect(readFileSync(filePath, 'utf8')).toBe(generateOriginalContent());
+    });
+
+    it('is idempotent — returns false if not patched', () => {
+      const filePath = createTempFile(generateOriginalContent());
+      expect(removePatch(filePath)).toBe(false);
+      expect(readFileSync(filePath, 'utf8')).toBe(generateOriginalContent());
+    });
+  });
+
+  describe('round-trip', () => {
+    it('apply then remove restores original content', () => {
+      const original = generateOriginalContent();
+      const filePath = createTempFile(original);
+
+      applyPatch(filePath);
+      expect(isPatchApplied(readFileSync(filePath, 'utf8'))).toBe(true);
+
+      removePatch(filePath);
+      expect(readFileSync(filePath, 'utf8')).toBe(original);
+    });
+  });
+});

--- a/packages/cli/src/lib/patch-cli.test.ts
+++ b/packages/cli/src/lib/patch-cli.test.ts
@@ -172,6 +172,24 @@ describe('patch-cli', () => {
         '@shopify/cli is not installed',
       );
     });
+
+    it('re-throws non-ENOENT errors', () => {
+      const dir = resolve(
+        tmpdir(),
+        `patch-cli-test-${Date.now()}-${Math.random()}`,
+      );
+      mkdirSync(dir, {recursive: true});
+      tempDirs.push(dir);
+
+      // readFileSync on a directory throws EISDIR, not ENOENT
+      const dirAsFile = resolve(dir, 'run.js');
+      mkdirSync(dirAsFile);
+
+      expect(() => applyPatch(dirAsFile)).toThrow();
+      expect(() => applyPatch(dirAsFile)).not.toThrow(
+        '@shopify/cli is not installed',
+      );
+    });
   });
 
   describe('removePatch', () => {
@@ -189,6 +207,15 @@ describe('patch-cli', () => {
       // No .backup file exists because we wrote patched content directly
       expect(removePatch(filePath)).toBe(true);
       expect(readFileSync(filePath, 'utf8')).toBe(generateOriginalContent());
+    });
+
+    it('returns false when file does not exist', () => {
+      const nonexistentPath = resolve(
+        tmpdir(),
+        `no-such-dir-${Date.now()}`,
+        'run.js',
+      );
+      expect(removePatch(nonexistentPath)).toBe(false);
     });
 
     it('is idempotent — returns false if not patched', () => {

--- a/packages/cli/src/lib/patch-cli.test.ts
+++ b/packages/cli/src/lib/patch-cli.test.ts
@@ -1,5 +1,11 @@
-import {describe, it, expect} from 'vitest';
-import {writeFileSync, readFileSync, mkdirSync} from 'node:fs';
+import {describe, it, expect, afterEach} from 'vitest';
+import {
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+} from 'node:fs';
 import {resolve} from 'node:path';
 import {tmpdir} from 'node:os';
 import {
@@ -12,16 +18,26 @@ import {
   removePatch,
 } from './patch-cli.js';
 
+const tempDirs: string[] = [];
+
 function createTempFile(content: string): string {
   const dir = resolve(
     tmpdir(),
     `patch-cli-test-${Date.now()}-${Math.random()}`,
   );
   mkdirSync(dir, {recursive: true});
+  tempDirs.push(dir);
   const filePath = resolve(dir, 'run.js');
   writeFileSync(filePath, content);
   return filePath;
 }
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, {recursive: true, force: true});
+  }
+  tempDirs.length = 0;
+});
 
 describe('patch-cli', () => {
   describe('MARKER', () => {
@@ -74,6 +90,20 @@ describe('patch-cli', () => {
     it('sets IGNORE_HYDROGEN_MONOREPO env var', () => {
       expect(content).toContain('IGNORE_HYDROGEN_MONOREPO');
     });
+
+    it('throws when local plugin is not found', () => {
+      expect(content).toContain(
+        'Could not find local @shopify/cli-hydrogen plugin',
+      );
+    });
+
+    it('throws when oclif internals changed', () => {
+      expect(content).toContain('Cannot replace bundled commands');
+    });
+
+    it('verifies package name during monorepo detection', () => {
+      expect(content).toContain("pkg.name === '@shopify/cli-hydrogen'");
+    });
   });
 
   describe('generateOriginalContent', () => {
@@ -85,6 +115,14 @@ describe('patch-cli', () => {
 
     it('includes the standard CLI entrypoint', () => {
       expect(content).toContain('runCLI({development: false})');
+    });
+
+    it('matches upstream @shopify/cli format with static import', () => {
+      expect(content).toContain("import runCLI from '../dist/index.js'");
+    });
+
+    it('preserves upstream removeAllListeners call', () => {
+      expect(content).toContain("process.removeAllListeners('warning')");
     });
   });
 
@@ -100,11 +138,55 @@ describe('patch-cli', () => {
       expect(applyPatch(filePath)).toBe(false);
       expect(readFileSync(filePath, 'utf8')).toBe(generatePatchedContent());
     });
+
+    it('creates a .backup file with original content', () => {
+      const original = generateOriginalContent();
+      const filePath = createTempFile(original);
+      applyPatch(filePath);
+
+      const backupPath = filePath + '.backup';
+      expect(existsSync(backupPath)).toBe(true);
+      expect(readFileSync(backupPath, 'utf8')).toBe(original);
+    });
+
+    it('does not overwrite an existing .backup file', () => {
+      const original = 'first-original-content';
+      const filePath = createTempFile(original);
+
+      applyPatch(filePath);
+      // Write new content, remove patch marker, and re-patch
+      writeFileSync(filePath, 'second-original-content');
+      applyPatch(filePath);
+
+      const backupPath = filePath + '.backup';
+      expect(readFileSync(backupPath, 'utf8')).toBe(original);
+    });
+
+    it('throws a friendly error when run.js does not exist', () => {
+      const nonexistentPath = resolve(
+        tmpdir(),
+        `no-such-dir-${Date.now()}`,
+        'run.js',
+      );
+      expect(() => applyPatch(nonexistentPath)).toThrow(
+        '@shopify/cli is not installed',
+      );
+    });
   });
 
   describe('removePatch', () => {
-    it('restores original content and returns true', () => {
+    it('restores from .backup file when available', () => {
+      const original = 'custom-original-content';
+      const filePath = createTempFile(original);
+      applyPatch(filePath);
+
+      expect(removePatch(filePath)).toBe(true);
+      expect(readFileSync(filePath, 'utf8')).toBe(original);
+    });
+
+    it('falls back to generateOriginalContent when no .backup exists', () => {
       const filePath = createTempFile(generatePatchedContent());
+      // No .backup file exists because we wrote patched content directly
       expect(removePatch(filePath)).toBe(true);
       expect(readFileSync(filePath, 'utf8')).toBe(generateOriginalContent());
     });
@@ -114,10 +196,22 @@ describe('patch-cli', () => {
       expect(removePatch(filePath)).toBe(false);
       expect(readFileSync(filePath, 'utf8')).toBe(generateOriginalContent());
     });
+
+    it('deletes the .backup file after restoring', () => {
+      const original = 'custom-original-content';
+      const filePath = createTempFile(original);
+      applyPatch(filePath);
+
+      const backupPath = filePath + '.backup';
+      expect(existsSync(backupPath)).toBe(true);
+
+      removePatch(filePath);
+      expect(existsSync(backupPath)).toBe(false);
+    });
   });
 
   describe('round-trip', () => {
-    it('apply then remove restores original content', () => {
+    it('apply then remove restores original content via backup', () => {
       const original = generateOriginalContent();
       const filePath = createTempFile(original);
 

--- a/packages/cli/src/lib/patch-cli.ts
+++ b/packages/cli/src/lib/patch-cli.ts
@@ -1,4 +1,4 @@
-import {readFileSync, writeFileSync} from 'node:fs';
+import {readFileSync, writeFileSync, existsSync, unlinkSync} from 'node:fs';
 import {resolve} from 'node:path';
 
 /** Marker comment used to detect whether the patch has been applied. */
@@ -19,13 +19,17 @@ export function generatePatchedContent(): string {
   return `#!/usr/bin/env node
 ${MARKER}
 
+// Mirrors upstream @shopify/cli/bin/run.js behavior.
+// This is not introduced by the patch — @shopify/cli ships with this line.
+// Changing it here would create a behavioral divergence between dev and production.
 process.removeAllListeners('warning')
 
 // --- Monorepo detection ---
 // Walk up from cwd to find the hydrogen monorepo root.
-// We look for packages/cli/package.json — if it exists, we know we're
-// inside the monorepo and should load the local @shopify/cli-hydrogen
-const {existsSync} = await import('node:fs');
+// We look for packages/cli/package.json with the correct package name —
+// if it matches, we know we're inside the monorepo and should load the
+// local @shopify/cli-hydrogen
+const {existsSync, readFileSync} = await import('node:fs');
 const {resolve, dirname} = await import('node:path');
 
 let monorepoRoot = null;
@@ -33,8 +37,15 @@ let dir = process.cwd();
 while (true) {
   const candidate = resolve(dir, 'packages', 'cli', 'package.json');
   if (existsSync(candidate)) {
-    monorepoRoot = dir;
-    break;
+    try {
+      const pkg = JSON.parse(readFileSync(candidate, 'utf8'));
+      if (pkg.name === '@shopify/cli-hydrogen') {
+        monorepoRoot = dir;
+        break;
+      }
+    } catch {
+      // Ignore malformed package.json and keep walking
+    }
   }
   const parent = dirname(dir);
   if (parent === dir) break; // reached filesystem root
@@ -93,31 +104,40 @@ if (monorepoRoot) {
   // --- Post-load command replacement ---
   // After loading, both the bundled hydrogen commands (from @shopify/cli's
   // root plugin) and the local ones (from pluginAdditions) are registered.
-  // Since oclif v3.83.0, determinePriority is no longer an overridable
-  // instance method, so we manually replace the bundled commands with
-  // the external plugin's versions using oclif's private _commands Map.
+  // Since @shopify/cli@3.83.0 (which upgraded to oclif v4),
+  // determinePriority is no longer an overridable instance method, so we
+  // manually replace the bundled commands with the external plugin's
+  // versions using oclif's private _commands Map.
   const externalPlugin = Array.from(config.plugins.values()).find(
     (p) => p.name === '@shopify/cli-hydrogen' && !p.isRoot,
   );
 
-  if (externalPlugin) {
-    const cmds = config._commands;
-    if (!cmds || !(cmds instanceof Map)) {
-      console.warn('[hydrogen-monorepo] Cannot replace bundled commands: oclif internals changed');
-    } else {
-      // Delete bundled hydrogen commands (canonical IDs + aliases + hidden aliases)
-      for (const command of externalPlugin.commands) {
-        if (!command.id.startsWith('hydrogen')) continue;
-        cmds.delete(command.id);
-        for (const alias of [...(command.aliases ?? []), ...(command.hiddenAliases ?? [])]) {
-          cmds.delete(alias);
-        }
-      }
-      // Re-insert commands from the local plugin. loadCommands handles
-      // alias registration and command permutations correctly.
-      config.loadCommands(externalPlugin);
+  if (!externalPlugin) {
+    throw new Error(
+      '[hydrogen-monorepo] Could not find local @shopify/cli-hydrogen plugin. ' +
+      'The patch may need updating for the current @shopify/cli version.'
+    );
+  }
+
+  const cmds = config._commands;
+  if (!cmds || !(cmds instanceof Map)) {
+    throw new Error(
+      '[hydrogen-monorepo] Cannot replace bundled commands — oclif internals changed. ' +
+      'The patch may need updating for the current oclif version.'
+    );
+  }
+
+  // Delete bundled hydrogen commands (canonical IDs + aliases + hidden aliases)
+  for (const command of externalPlugin.commands) {
+    if (!command.id.startsWith('hydrogen')) continue;
+    cmds.delete(command.id);
+    for (const alias of [...(command.aliases ?? []), ...(command.hiddenAliases ?? [])]) {
+      cmds.delete(alias);
     }
   }
+  // Re-insert commands from the local plugin. loadCommands handles
+  // alias registration and command permutations correctly.
+  config.loadCommands(externalPlugin);
 
   await run(process.argv.slice(2), config);
   await flush();
@@ -129,21 +149,46 @@ if (monorepoRoot) {
 `;
 }
 
-/** Return the original (unpatched) file content for `run.js`. */
+/**
+ * Last-resort fallback content for run.js.
+ * Prefer restoring from .backup file (see removePatch).
+ * This may drift from upstream — update when bumping @shopify/cli.
+ */
 export function generateOriginalContent(): string {
   return `#!/usr/bin/env node
-const {default: runCLI} = await import('../dist/index.js');
-runCLI({development: false});
+
+// process.removeAllListeners('warning')
+
+import runCLI from '../dist/index.js'
+
+runCLI({development: false})
 `;
 }
 
 /**
  * Apply the monorepo patch to the given `run.js` file.
  * Returns `true` if the patch was applied, `false` if it was already present.
+ * Creates a `.backup` of the original before overwriting.
  */
 export function applyPatch(runJsPath: string): boolean {
-  const current = readFileSync(runJsPath, 'utf8');
+  let current: string;
+  try {
+    current = readFileSync(runJsPath, 'utf8');
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `@shopify/cli is not installed (${runJsPath} not found). Run 'pnpm install' first.`,
+      );
+    }
+    throw err;
+  }
+
   if (isPatchApplied(current)) return false;
+
+  const backupPath = runJsPath + '.backup';
+  if (!existsSync(backupPath)) {
+    writeFileSync(backupPath, current);
+  }
 
   writeFileSync(runJsPath, generatePatchedContent());
   return true;
@@ -152,11 +197,24 @@ export function applyPatch(runJsPath: string): boolean {
 /**
  * Remove the monorepo patch from the given `run.js` file.
  * Returns `true` if the patch was removed, `false` if it was not present.
+ * Restores from `.backup` file if available, otherwise falls back to
+ * hardcoded original content.
  */
 export function removePatch(runJsPath: string): boolean {
   const current = readFileSync(runJsPath, 'utf8');
   if (!isPatchApplied(current)) return false;
 
-  writeFileSync(runJsPath, generateOriginalContent());
+  const backupPath = runJsPath + '.backup';
+  const hasBackup = existsSync(backupPath);
+  const original = hasBackup
+    ? readFileSync(backupPath, 'utf8')
+    : generateOriginalContent();
+
+  writeFileSync(runJsPath, original);
+
+  if (hasBackup) {
+    unlinkSync(backupPath);
+  }
+
   return true;
 }

--- a/packages/cli/src/lib/patch-cli.ts
+++ b/packages/cli/src/lib/patch-cli.ts
@@ -1,0 +1,162 @@
+import {readFileSync, writeFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+/** Marker comment used to detect whether the patch has been applied. */
+export const MARKER = '// [hydrogen-monorepo-patch]';
+
+/** Resolve the path to `@shopify/cli/bin/run.js` relative to a root directory. */
+export function getRunJsPath(root: string): string {
+  return resolve(root, 'node_modules', '@shopify', 'cli', 'bin', 'run.js');
+}
+
+/** Check whether the marker comment is present in the given file content. */
+export function isPatchApplied(content: string): boolean {
+  return content.includes(MARKER);
+}
+
+/** Return the full patched file content for `run.js`. */
+export function generatePatchedContent(): string {
+  return `#!/usr/bin/env node
+${MARKER}
+
+process.removeAllListeners('warning')
+
+// --- Monorepo detection ---
+// Walk up from cwd to find the hydrogen monorepo root.
+// We look for packages/cli/package.json — if it exists, we know we're
+// inside the monorepo and should load the local @shopify/cli-hydrogen
+const {existsSync} = await import('node:fs');
+const {resolve, dirname} = await import('node:path');
+
+let monorepoRoot = null;
+let dir = process.cwd();
+while (true) {
+  const candidate = resolve(dir, 'packages', 'cli', 'package.json');
+  if (existsSync(candidate)) {
+    monorepoRoot = dir;
+    break;
+  }
+  const parent = dirname(dir);
+  if (parent === dir) break; // reached filesystem root
+  dir = parent;
+}
+
+if (monorepoRoot) {
+  // We're in the hydrogen monorepo. Start @shopify/cli normally but
+  // inject pluginAdditions so oclif loads @shopify/cli-hydrogen from
+  // the monorepo's workspace (packages/cli) instead of the version
+  // bundled inside @shopify/cli/dist.
+  //
+  // This uses the same pluginAdditions mechanism that ShopifyConfig
+  // uses internally
+  const {fileURLToPath} = await import('node:url');
+  const {Config, run, flush} = await import('@oclif/core');
+
+  // root must point to @shopify/cli's installed location so oclif
+  // can find its package.json, oclif config, and bundled commands.
+  const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+  const c = '\\x1b[38;5;209m';
+  const d = '\\x1b[2m';
+  const r = '\\x1b[0m';
+  console.log('');
+  console.log(c + '  \u250c\u2500\u2500 hydrogen-monorepo \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510' + r);
+  console.log(c + '  \u2502' + r + '                                                          ' + c + '\u2502' + r);
+  console.log(c + '  \u2502' + r + '  Using local cli-hydrogen plugin from packages/cli       ' + c + '\u2502' + r);
+  console.log(c + '  \u2502' + r + d + '  Bundled commands replaced with local source             ' + r + c + '\u2502' + r);
+  console.log(c + '  \u2502' + r + '                                                          ' + c + '\u2502' + r);
+  console.log(c + '  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518' + r);
+  console.log('');
+
+  // Tell ShopifyConfig to skip its own monorepo detection since we
+  // are handling pluginAdditions ourselves.
+  process.env.IGNORE_HYDROGEN_MONOREPO = '1';
+
+  const config = new Config({
+    root: cliRoot,
+    // pluginAdditions tells oclif's plugin loader to read the
+    // monorepo root's package.json, find @shopify/cli-hydrogen in
+    // its dependencies (workspace:*), and load that as a core plugin.
+    // Because workspace:* symlinks to packages/cli, oclif loads the
+    // local source code — exactly what we want for development.
+    pluginAdditions: {
+      core: ['@shopify/cli-hydrogen'],
+      path: monorepoRoot,
+    },
+    // Skip the oclif manifest cache so commands are loaded fresh from
+    // disk rather than from a potentially stale oclif.manifest.json.
+    ignoreManifest: true,
+  });
+
+  await config.load();
+
+  // --- Post-load command replacement ---
+  // After loading, both the bundled hydrogen commands (from @shopify/cli's
+  // root plugin) and the local ones (from pluginAdditions) are registered.
+  // Since oclif v3.83.0, determinePriority is no longer an overridable
+  // instance method, so we manually replace the bundled commands with
+  // the external plugin's versions using oclif's private _commands Map.
+  const externalPlugin = Array.from(config.plugins.values()).find(
+    (p) => p.name === '@shopify/cli-hydrogen' && !p.isRoot,
+  );
+
+  if (externalPlugin) {
+    const cmds = config._commands;
+    if (!cmds || !(cmds instanceof Map)) {
+      console.warn('[hydrogen-monorepo] Cannot replace bundled commands: oclif internals changed');
+    } else {
+      // Delete bundled hydrogen commands (canonical IDs + aliases + hidden aliases)
+      for (const command of externalPlugin.commands) {
+        if (!command.id.startsWith('hydrogen')) continue;
+        cmds.delete(command.id);
+        for (const alias of [...(command.aliases ?? []), ...(command.hiddenAliases ?? [])]) {
+          cmds.delete(alias);
+        }
+      }
+      // Re-insert commands from the local plugin. loadCommands handles
+      // alias registration and command permutations correctly.
+      config.loadCommands(externalPlugin);
+    }
+  }
+
+  await run(process.argv.slice(2), config);
+  await flush();
+} else {
+  // Not in the monorepo — run the standard @shopify/cli entrypoint.
+  const {default: runCLI} = await import('../dist/index.js');
+  runCLI({development: false});
+}
+`;
+}
+
+/** Return the original (unpatched) file content for `run.js`. */
+export function generateOriginalContent(): string {
+  return `#!/usr/bin/env node
+const {default: runCLI} = await import('../dist/index.js');
+runCLI({development: false});
+`;
+}
+
+/**
+ * Apply the monorepo patch to the given `run.js` file.
+ * Returns `true` if the patch was applied, `false` if it was already present.
+ */
+export function applyPatch(runJsPath: string): boolean {
+  const current = readFileSync(runJsPath, 'utf8');
+  if (isPatchApplied(current)) return false;
+
+  writeFileSync(runJsPath, generatePatchedContent());
+  return true;
+}
+
+/**
+ * Remove the monorepo patch from the given `run.js` file.
+ * Returns `true` if the patch was removed, `false` if it was not present.
+ */
+export function removePatch(runJsPath: string): boolean {
+  const current = readFileSync(runJsPath, 'utf8');
+  if (!isPatchApplied(current)) return false;
+
+  writeFileSync(runJsPath, generateOriginalContent());
+  return true;
+}

--- a/packages/cli/src/lib/patch-cli.ts
+++ b/packages/cli/src/lib/patch-cli.ts
@@ -1,6 +1,10 @@
 import {readFileSync, writeFileSync, existsSync, unlinkSync} from 'node:fs';
 import {resolve} from 'node:path';
 
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && 'code' in err;
+}
+
 /** Marker comment used to detect whether the patch has been applied. */
 export const MARKER = '// [hydrogen-monorepo-patch]';
 
@@ -157,7 +161,7 @@ if (monorepoRoot) {
 export function generateOriginalContent(): string {
   return `#!/usr/bin/env node
 
-// process.removeAllListeners('warning')
+process.removeAllListeners('warning')
 
 import runCLI from '../dist/index.js'
 
@@ -175,7 +179,7 @@ export function applyPatch(runJsPath: string): boolean {
   try {
     current = readFileSync(runJsPath, 'utf8');
   } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+    if (isErrnoException(err) && err.code === 'ENOENT') {
       throw new Error(
         `@shopify/cli is not installed (${runJsPath} not found). Run 'pnpm install' first.`,
       );
@@ -201,7 +205,15 @@ export function applyPatch(runJsPath: string): boolean {
  * hardcoded original content.
  */
 export function removePatch(runJsPath: string): boolean {
-  const current = readFileSync(runJsPath, 'utf8');
+  let current: string;
+  try {
+    current = readFileSync(runJsPath, 'utf8');
+  } catch (err: unknown) {
+    if (isErrnoException(err) && err.code === 'ENOENT') {
+      return false;
+    }
+    throw err;
+  }
   if (!isPatchApplied(current)) return false;
 
   const backupPath = runJsPath + '.backup';

--- a/packages/cli/src/lib/patch-cli.ts
+++ b/packages/cli/src/lib/patch-cli.ts
@@ -71,7 +71,7 @@ if (monorepoRoot) {
   const d = '\\x1b[2m';
   const r = '\\x1b[0m';
   console.log('');
-  console.log(c + '  \u250c\u2500\u2500 hydrogen-monorepo \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510' + r);
+  console.log(c + '  \u250c\u2500\u2500 hydrogen-monorepo \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510' + r);
   console.log(c + '  \u2502' + r + '                                                          ' + c + '\u2502' + r);
   console.log(c + '  \u2502' + r + '  Using local cli-hydrogen plugin from packages/cli       ' + c + '\u2502' + r);
   console.log(c + '  \u2502' + r + d + '  Bundled commands replaced with local source             ' + r + c + '\u2502' + r);

--- a/scripts/patch-cli.mjs
+++ b/scripts/patch-cli.mjs
@@ -15,13 +15,21 @@ let patchModule;
 try {
   patchModule = await import('../packages/cli/dist/lib/patch-cli.js');
 } catch {
-  console.error(
-    '[patch-cli] packages/cli must be built first. Run: pnpm build --filter=@shopify/cli-hydrogen',
+  console.warn(
+    '[patch-cli] Skipping - packages/cli not built yet.',
   );
-  process.exit(1);
+  process.exit(0);
 }
 
-const {applyPatch, getRunJsPath} = patchModule;
-const runJsPath = getRunJsPath(ROOT);
-const applied = applyPatch(runJsPath);
-if (applied) console.log('[patch-cli] Patched run.js — local packages/cli will be used');
+try {
+  const {applyPatch, getRunJsPath} = patchModule;
+  const runJsPath = getRunJsPath(ROOT);
+  const applied = applyPatch(runJsPath);
+  if (applied) console.log('[patch-cli] Patched run.js — local packages/cli will be used');
+} catch (err) {
+  if (err instanceof Error && err.message.includes('@shopify/cli is not installed')) {
+    console.warn('[patch-cli] Skipping - @shopify/cli not installed yet.');
+    process.exit(0);
+  }
+  throw err;
+}

--- a/scripts/patch-cli.mjs
+++ b/scripts/patch-cli.mjs
@@ -1,146 +1,27 @@
-// scripts/patch-cli.js
+#!/usr/bin/env node
+// scripts/patch-cli.mjs
 //
-// Overwrites node_modules/@shopify/cli/bin/run.js so that `shopify hydrogen`
-// subcommands are delegated to the local packages/cli source instead of the
-// bundled plugin. The patch is version-agnostic (writes the full file rather
-// than applying a diff) and idempotent.
+// Patches @shopify/cli/bin/run.js to load local packages/cli source.
+// Requires packages/cli to be built first (pnpm build).
 
-import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-// Only patch in local development, not CI
 if (process.env.CI) process.exit(0);
 
+import {resolve, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const RUN_JS = resolve(
-  ROOT,
-  'node_modules',
-  '@shopify',
-  'cli',
-  'bin',
-  'run.js',
-);
 
-// Marker comment is how we detect if the patch has already been applied
-const MARKER = '// [hydrogen-monorepo-patch]';
-
-// Gets the @shopify/cli run.js from node_modules and then
-// checks that file for our marker comment
-// if it is there, it is patched, exit
-const current = readFileSync(RUN_JS, 'utf8');
-if (current.includes(MARKER)) process.exit(0); // already patched
-
-const patched = `#!/usr/bin/env node
-${MARKER}
-
-process.removeAllListeners('warning')
-
-// --- Monorepo detection ---
-// Walk up from cwd to find the hydrogen monorepo root.
-// We look for packages/cli/package.json — if it exists, we know we're
-// inside the monorepo and should load the local @shopify/cli-hydrogen
-const {existsSync} = await import('node:fs');
-const {resolve, dirname} = await import('node:path');
-
-let monorepoRoot = null;
-let dir = process.cwd();
-while (true) {
-  const candidate = resolve(dir, 'packages', 'cli', 'package.json');
-  if (existsSync(candidate)) {
-    monorepoRoot = dir;
-    break;
-  }
-  const parent = dirname(dir);
-  if (parent === dir) break; // reached filesystem root
-  dir = parent;
-}
-
-if (monorepoRoot) {
-  // We're in the hydrogen monorepo. Start @shopify/cli normally but
-  // inject pluginAdditions so oclif loads @shopify/cli-hydrogen from
-  // the monorepo's workspace (packages/cli) instead of the version
-  // bundled inside @shopify/cli/dist.
-  //
-  // This uses the same pluginAdditions mechanism that ShopifyConfig
-  // uses internally
-  const {fileURLToPath} = await import('node:url');
-  const {Config, run, flush} = await import('@oclif/core');
-
-  // root must point to @shopify/cli's installed location so oclif
-  // can find its package.json, oclif config, and bundled commands.
-  const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-
-  const c = '\\x1b[38;5;209m';
-  const d = '\\x1b[2m';
-  const r = '\\x1b[0m';
-  console.log('');
-  console.log(c + '  \u250C\u2500\u2500 hydrogen-monorepo \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510' + r);
-  console.log(c + '  \u2502' + r + '                                                          ' + c + '\u2502' + r);
-  console.log(c + '  \u2502' + r + '  Using local cli-hydrogen plugin from packages/cli       ' + c + '\u2502' + r);
-  console.log(c + '  \u2502' + r + d + '  Bundled commands replaced with local source             ' + r + c + '\u2502' + r);
-  console.log(c + '  \u2502' + r + '                                                          ' + c + '\u2502' + r);
-  console.log(c + '  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518' + r);
-  console.log('');
-
-  // Tell ShopifyConfig to skip its own monorepo detection since we
-  // are handling pluginAdditions ourselves.
-  process.env.IGNORE_HYDROGEN_MONOREPO = '1';
-
-  const config = new Config({
-    root: cliRoot,
-    // pluginAdditions tells oclif's plugin loader to read the
-    // monorepo root's package.json, find @shopify/cli-hydrogen in
-    // its dependencies (workspace:*), and load that as a core plugin.
-    // Because workspace:* symlinks to packages/cli, oclif loads the
-    // local source code — exactly what we want for development.
-    pluginAdditions: {
-      core: ['@shopify/cli-hydrogen'],
-      path: monorepoRoot,
-    },
-    // Skip the oclif manifest cache so commands are loaded fresh from
-    // disk rather than from a potentially stale oclif.manifest.json.
-    ignoreManifest: true,
-  });
-
-  await config.load();
-
-  // --- Post-load command replacement ---
-  // After loading, both the bundled hydrogen commands (from @shopify/cli's
-  // root plugin) and the local ones (from pluginAdditions) are registered.
-  // Since oclif v3.83.0, determinePriority is no longer an overridable
-  // instance method, so we manually replace the bundled commands with
-  // the external plugin's versions using oclif's private _commands Map.
-  const externalPlugin = Array.from(config.plugins.values()).find(
-    (p) => p.name === '@shopify/cli-hydrogen' && !p.isRoot,
+let patchModule;
+try {
+  patchModule = await import('../packages/cli/dist/lib/patch-cli.js');
+} catch {
+  console.error(
+    '[patch-cli] packages/cli must be built first. Run: pnpm build --filter=@shopify/cli-hydrogen',
   );
-
-  if (externalPlugin) {
-    const cmds = config._commands;
-    if (!cmds || !(cmds instanceof Map)) {
-      console.warn('[hydrogen-monorepo] Cannot replace bundled commands: oclif internals changed');
-    } else {
-      // Delete bundled hydrogen commands (canonical IDs + aliases + hidden aliases)
-      for (const command of externalPlugin.commands) {
-        if (!command.id.startsWith('hydrogen')) continue;
-        cmds.delete(command.id);
-        for (const alias of [...(command.aliases ?? []), ...(command.hiddenAliases ?? [])]) {
-          cmds.delete(alias);
-        }
-      }
-      // Re-insert commands from the local plugin. loadCommands handles
-      // alias registration and command permutations correctly.
-      config.loadCommands(externalPlugin);
-    }
-  }
-
-  await run(process.argv.slice(2), config);
-  await flush();
-} else {
-  // Not in the monorepo — run the standard @shopify/cli entrypoint.
-  const {default: runCLI} = await import('../dist/index.js');
-  runCLI({development: false});
+  process.exit(1);
 }
-`;
 
-writeFileSync(RUN_JS, patched);
+const {applyPatch, getRunJsPath} = patchModule;
+const runJsPath = getRunJsPath(ROOT);
+const applied = applyPatch(runJsPath);
+if (applied) console.log('[patch-cli] Patched run.js — local packages/cli will be used');

--- a/scripts/patch-cli.mjs
+++ b/scripts/patch-cli.mjs
@@ -36,41 +36,108 @@ ${MARKER}
 
 process.removeAllListeners('warning')
 
-// Only intercept "shopify hydrogen ..." commands when running inside
-// the monorepo. Everything else falls through to the standard CLI.
-let handled = false;
+// --- Monorepo detection ---
+// Walk up from cwd to find the hydrogen monorepo root.
+// We look for packages/cli/package.json — if it exists, we know we're
+// inside the monorepo and should load the local @shopify/cli-hydrogen
+const {existsSync} = await import('node:fs');
+const {resolve, dirname} = await import('node:path');
 
-if (process.argv[2] === 'hydrogen') {
-  const {existsSync} = await import('node:fs');
-  const {resolve, dirname} = await import('node:path');
-  const {pathToFileURL} = await import('node:url');
-
-  // Walk up from cwd to find the monorepo's local CLI dev entry point
-  // at packages/cli/bin/dev.js. This lets us run the locally-built
-  // cli-hydrogen plugin instead of the one bundled in node_modules.
-  let dir = process.cwd();
-
-  while (true) {
-    const candidate = resolve(dir, 'packages', 'cli', 'bin', 'dev.js');
-    if (existsSync(candidate)) {
-      // Found the monorepo's cli-hydrogen package — load it as the
-      // oclif plugin so hydrogen commands run against local source.
-      console.log('\\x1b[36m[hydrogen-monorepo] Using local cli-hydrogen plugin\\x1b[0m');
-      const {execute} = await import('@oclif/core');
-      await execute({dir: pathToFileURL(candidate).href});
-      handled = true;
-      break;
-    }
-
-    const parent = dirname(dir);
-    if (parent === dir) break; // reached filesystem root
-    dir = parent;
+let monorepoRoot = null;
+let dir = process.cwd();
+while (true) {
+  const candidate = resolve(dir, 'packages', 'cli', 'package.json');
+  if (existsSync(candidate)) {
+    monorepoRoot = dir;
+    break;
   }
+  const parent = dirname(dir);
+  if (parent === dir) break; // reached filesystem root
+  dir = parent;
 }
 
-// Non-hydrogen command, or not in the monorepo — run the standard
-// @shopify/cli entrypoint.
-if (!handled) {
+if (monorepoRoot) {
+  // We're in the hydrogen monorepo. Start @shopify/cli normally but
+  // inject pluginAdditions so oclif loads @shopify/cli-hydrogen from
+  // the monorepo's workspace (packages/cli) instead of the version
+  // bundled inside @shopify/cli/dist.
+  //
+  // This uses the same pluginAdditions mechanism that ShopifyConfig
+  // uses internally
+  const {fileURLToPath} = await import('node:url');
+  const {Config, run, flush} = await import('@oclif/core');
+
+  // root must point to @shopify/cli's installed location so oclif
+  // can find its package.json, oclif config, and bundled commands.
+  const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+  const c = '\\x1b[38;5;209m';
+  const d = '\\x1b[2m';
+  const r = '\\x1b[0m';
+  console.log('');
+  console.log(c + '  \u250C\u2500\u2500 hydrogen-monorepo \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510' + r);
+  console.log(c + '  \u2502' + r + '                                                          ' + c + '\u2502' + r);
+  console.log(c + '  \u2502' + r + '  Using local cli-hydrogen plugin from packages/cli       ' + c + '\u2502' + r);
+  console.log(c + '  \u2502' + r + d + '  Bundled commands replaced with local source             ' + r + c + '\u2502' + r);
+  console.log(c + '  \u2502' + r + '                                                          ' + c + '\u2502' + r);
+  console.log(c + '  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518' + r);
+  console.log('');
+
+  // Tell ShopifyConfig to skip its own monorepo detection since we
+  // are handling pluginAdditions ourselves.
+  process.env.IGNORE_HYDROGEN_MONOREPO = '1';
+
+  const config = new Config({
+    root: cliRoot,
+    // pluginAdditions tells oclif's plugin loader to read the
+    // monorepo root's package.json, find @shopify/cli-hydrogen in
+    // its dependencies (workspace:*), and load that as a core plugin.
+    // Because workspace:* symlinks to packages/cli, oclif loads the
+    // local source code — exactly what we want for development.
+    pluginAdditions: {
+      core: ['@shopify/cli-hydrogen'],
+      path: monorepoRoot,
+    },
+    // Skip the oclif manifest cache so commands are loaded fresh from
+    // disk rather than from a potentially stale oclif.manifest.json.
+    ignoreManifest: true,
+  });
+
+  await config.load();
+
+  // --- Post-load command replacement ---
+  // After loading, both the bundled hydrogen commands (from @shopify/cli's
+  // root plugin) and the local ones (from pluginAdditions) are registered.
+  // Since oclif v3.83.0, determinePriority is no longer an overridable
+  // instance method, so we manually replace the bundled commands with
+  // the external plugin's versions using oclif's private _commands Map.
+  const externalPlugin = Array.from(config.plugins.values()).find(
+    (p) => p.name === '@shopify/cli-hydrogen' && !p.isRoot,
+  );
+
+  if (externalPlugin) {
+    const cmds = config._commands;
+    if (!cmds || !(cmds instanceof Map)) {
+      console.warn('[hydrogen-monorepo] Cannot replace bundled commands: oclif internals changed');
+    } else {
+      // Delete bundled hydrogen commands (canonical IDs + aliases + hidden aliases)
+      for (const command of externalPlugin.commands) {
+        if (!command.id.startsWith('hydrogen')) continue;
+        cmds.delete(command.id);
+        for (const alias of [...(command.aliases ?? []), ...(command.hiddenAliases ?? [])]) {
+          cmds.delete(alias);
+        }
+      }
+      // Re-insert commands from the local plugin. loadCommands handles
+      // alias registration and command permutations correctly.
+      config.loadCommands(externalPlugin);
+    }
+  }
+
+  await run(process.argv.slice(2), config);
+  await flush();
+} else {
+  // Not in the monorepo — run the standard @shopify/cli entrypoint.
   const {default: runCLI} = await import('../dist/index.js');
   runCLI({development: false});
 }

--- a/scripts/patch-cli.mjs
+++ b/scripts/patch-cli.mjs
@@ -1,0 +1,79 @@
+// scripts/patch-cli.js
+//
+// Overwrites node_modules/@shopify/cli/bin/run.js so that `shopify hydrogen`
+// subcommands are delegated to the local packages/cli source instead of the
+// bundled plugin. The patch is version-agnostic (writes the full file rather
+// than applying a diff) and idempotent.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Only patch in local development, not CI
+if (process.env.CI) process.exit(0);
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const RUN_JS = resolve(
+  ROOT,
+  'node_modules',
+  '@shopify',
+  'cli',
+  'bin',
+  'run.js',
+);
+
+// Marker comment is how we detect if the patch has already been applied
+const MARKER = '// [hydrogen-monorepo-patch]';
+
+// Gets the @shopify/cli run.js from node_modules and then
+// checks that file for our marker comment
+// if it is there, it is patched, exit
+const current = readFileSync(RUN_JS, 'utf8');
+if (current.includes(MARKER)) process.exit(0); // already patched
+
+const patched = `#!/usr/bin/env node
+${MARKER}
+
+process.removeAllListeners('warning')
+
+// Only intercept "shopify hydrogen ..." commands when running inside
+// the monorepo. Everything else falls through to the standard CLI.
+let handled = false;
+
+if (process.argv[2] === 'hydrogen') {
+  const {existsSync} = await import('node:fs');
+  const {resolve, dirname} = await import('node:path');
+  const {pathToFileURL} = await import('node:url');
+
+  // Walk up from cwd to find the monorepo's local CLI dev entry point
+  // at packages/cli/bin/dev.js. This lets us run the locally-built
+  // cli-hydrogen plugin instead of the one bundled in node_modules.
+  let dir = process.cwd();
+
+  while (true) {
+    const candidate = resolve(dir, 'packages', 'cli', 'bin', 'dev.js');
+    if (existsSync(candidate)) {
+      // Found the monorepo's cli-hydrogen package — load it as the
+      // oclif plugin so hydrogen commands run against local source.
+      console.log('\\x1b[36m[hydrogen-monorepo] Using local cli-hydrogen plugin\\x1b[0m');
+      const {execute} = await import('@oclif/core');
+      await execute({dir: pathToFileURL(candidate).href});
+      handled = true;
+      break;
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+}
+
+// Non-hydrogen command, or not in the monorepo — run the standard
+// @shopify/cli entrypoint.
+if (!handled) {
+  const {default: runCLI} = await import('../dist/index.js');
+  runCLI({development: false});
+}
+`;
+
+writeFileSync(RUN_JS, patched);

--- a/scripts/unpatch-cli.mjs
+++ b/scripts/unpatch-cli.mjs
@@ -22,3 +22,4 @@ const {removePatch, getRunJsPath} = patchModule;
 const runJsPath = getRunJsPath(ROOT);
 const removed = removePatch(runJsPath);
 if (removed) console.log('[unpatch-cli] Restored original run.js');
+else console.log('[unpatch-cli] Nothing to unpatch - run.js is not patched');

--- a/scripts/unpatch-cli.mjs
+++ b/scripts/unpatch-cli.mjs
@@ -1,0 +1,30 @@
+// scripts/unpatch-cli.mjs
+//
+// Restores node_modules/@shopify/cli/bin/run.js to its original content,
+// undoing the patch applied by patch-cli.mjs. Idempotent.
+
+import {readFileSync, writeFileSync} from 'node:fs';
+import {resolve, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const RUN_JS = resolve(
+  ROOT,
+  'node_modules',
+  '@shopify',
+  'cli',
+  'bin',
+  'run.js',
+);
+
+const MARKER = '// [hydrogen-monorepo-patch]';
+
+const current = readFileSync(RUN_JS, 'utf8');
+if (!current.includes(MARKER)) process.exit(0); // already unpatched
+
+const original = `#!/usr/bin/env node
+const {default: runCLI} = await import('../dist/index.js');
+runCLI({development: false});
+`;
+
+writeFileSync(RUN_JS, original);

--- a/scripts/unpatch-cli.mjs
+++ b/scripts/unpatch-cli.mjs
@@ -1,30 +1,24 @@
+#!/usr/bin/env node
 // scripts/unpatch-cli.mjs
 //
-// Restores node_modules/@shopify/cli/bin/run.js to its original content,
-// undoing the patch applied by patch-cli.mjs. Idempotent.
+// Restores @shopify/cli/bin/run.js to its original content.
 
-import {readFileSync, writeFileSync} from 'node:fs';
 import {resolve, dirname} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const RUN_JS = resolve(
-  ROOT,
-  'node_modules',
-  '@shopify',
-  'cli',
-  'bin',
-  'run.js',
-);
 
-const MARKER = '// [hydrogen-monorepo-patch]';
+let patchModule;
+try {
+  patchModule = await import('../packages/cli/dist/lib/patch-cli.js');
+} catch {
+  console.error(
+    '[unpatch-cli] packages/cli must be built first. Run: pnpm build --filter=@shopify/cli-hydrogen',
+  );
+  process.exit(1);
+}
 
-const current = readFileSync(RUN_JS, 'utf8');
-if (!current.includes(MARKER)) process.exit(0); // already unpatched
-
-const original = `#!/usr/bin/env node
-const {default: runCLI} = await import('../dist/index.js');
-runCLI({development: false});
-`;
-
-writeFileSync(RUN_JS, original);
+const {removePatch, getRunJsPath} = patchModule;
+const runJsPath = getRunJsPath(ROOT);
+const removed = removePatch(runJsPath);
+if (removed) console.log('[unpatch-cli] Restored original run.js');


### PR DESCRIPTION
### WHY are these changes introduced?

Replaces: https://github.com/Shopify/cli/pull/6827

Since `@shopify/cli@3.83.0` (which upgraded oclif to v4), running `shopify hydrogen` commands in the Hydrogen monorepo no longer loads the local `packages/cli` source code. Instead, the bundled version inside `@shopify/cli/dist` is always used, making it impossible to test local CLI changes during development.

**Root cause:** The previous mechanism in `@shopify/cli-kit`'s `ShopifyConfig` relied on overriding oclif's `determinePriority` instance method to make external plugin commands win over bundled ones. In oclif v4 (shipped in `@shopify/cli@3.83.0`), `determinePriority` became a standalone utility function, so the override silently stopped working. Additionally, the monorepo detection itself is not the best:

- **Brittle regex detection** — `/(shopify|hydrogen)\/hydrogen/i` tested against `cwd()` to guess if you're in the monorepo
- **Synchronous subprocess** — ran `execSync('npm', ['prefix'])` on every CLI invocation to find the project root
- **Private API monkey-patching** — relied on overriding oclif's private `determinePriority` method

This PR introduces a self-contained patch system within the Hydrogen monorepo that replaces all of that.

### WHAT is this pull request doing?

Adds two scripts that enable local CLI development:

**`scripts/patch-cli.mjs`** — Patches `node_modules/@shopify/cli/bin/run.js` to load the local `@shopify/cli-hydrogen` plugin from `packages/cli` instead of the bundled version. The patch:

1. **Detects the monorepo reliably** by walking up from `cwd()` looking for `packages/cli/package.json` — no regex, no subprocesses
2. **Uses oclif's `pluginAdditions` mechanism** to register the local `@shopify/cli-hydrogen` as a core plugin, the same mechanism `ShopifyConfig` uses internally
3. **Replaces bundled commands post-load** by deleting hydrogen entries from oclif's internal `_commands` Map and re-inserting them from the local plugin via `loadCommands()` — this is the same strategy proposed in the upstream CLI fix (Shopify/cli#6827) and works with oclif v4
4. **Sets `IGNORE_HYDROGEN_MONOREPO=1`** so the current `ShopifyConfig` in `@shopify/cli-kit` doesn't attempt its own (broken) monorepo detection on top (**NOTE**: We can remove this if we update the `custom-oclif-loader` to become purely for letting users override `cli-hydrogen` with a different version from their project's `node_modules`.)
5. **Is idempotent and version-agnostic** — uses a marker comment to detect if already applied, writes the full file rather than applying a diff. This was a short coming with `patch-packages` or `pnpm patch`
6. **Skipped in CI** — only patches in local development environments
7. **Shows a visible banner** when active so developers know local source is being used

<img width="603" height="134" alt="image" src="https://github.com/user-attachments/assets/ff2b4a92-e9c8-49f4-abce-351f20fe01de" />

**`scripts/unpatch-cli.mjs`** — Restores `run.js` to its original content. Also idempotent.

**How the patch interacts with the CLI plugin architecture:**

```
shopify hydrogen dev (in monorepo)
  → patched run.js detects monorepo root
  → creates oclif Config with pluginAdditions pointing to monorepo root
  → oclif resolves @shopify/cli-hydrogen via workspace:* → packages/cli
  → post-load: bundled hydrogen commands deleted, local ones re-inserted
  → local packages/cli/dist/commands/ are used
```

For non-hydrogen commands or when running outside the monorepo, the standard `@shopify/cli` entrypoint is used unchanged.

**Upstream impact:** This patch is can replace [Shopify/cli#6827](https://github.com/Shopify/cli/pull/6827), which fixes the `custom-oclif-loader` for local`@shopify/cli-hydrogen`  development in the monorepo. The `custom-oclif-loader` can be simplified to remove all monorepo-specific logic (regex, `npm prefix`, `IGNORE_HYDROGEN_MONOREPO`), since this patch handles that case entirely within the Hydrogen repo.

### HOW to test your changes?

1. Run `pnpm install` (or `pnpm patch-cli` if already installed)
2. Make a visible change in `packages/cli/src/commands/hydrogen/dev.ts` (e.g. add a `console.log('test')` in the `run()` method)
3. Build the CLI: `pnpm run build --filter=@shopify/cli-hydrogen`
4. From `templates/skeleton`, run `npx shopify hydrogen dev`
5. Verify:
   - The orange `hydrogen-monorepo` banner appears
   - Your `console.log` from step 2 is printed
6. Run `pnpm unpatch-cli` and repeat step 4 — the banner should not appear and your change should not be visible (bundled version is used)

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
