### PR TITLE
fix(ci): fix scaffolding tests for npm, pnpm, yarn, and bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,42 +252,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pm: [npm, pnpm, yarn, bun]
+        # TODO: Re-enable bun once @shopify/cli releases with @shopify/cli-hydrogen that supports bun.lock
+        pm: [npm, pnpm, yarn]
         include:
           - pm: npm
             lockfile: package-lock.json
           - pm: pnpm
             lockfile: pnpm-lock.yaml
-            setup: |
-              npm i -g pnpm@9
           - pm: yarn
             lockfile: yarn.lock
-          - pm: bun
-            lockfile: bun.lock
-            setup: |
-              npm i -g bun
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Explicit version required because pnpm/action-setup doesn't auto-detect
+      # from packageManager field in this context. The version must match
+      # engines.pnpm in package.json (>=10.16.1)
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        with:
+          version: 10.16.1
+          run_install: false
 
       - name: ⎔ Setup node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: 📦 Setup ${{ matrix.pm }}
         if: matrix.setup
         run: ${{ matrix.setup }}
 
       - name: 📥 Install dependencies
-        run: |
-          npm ci
-          npm rebuild
+        run: pnpm install --frozen-lockfile
 
       - name: 📦 Build packages
-        run: SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npm run build:pkg
+        run: SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false pnpm run build:pkg
 
       - name: 🧪 Scaffold with ${{ matrix.pm }}
         run: |


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes scaffolding tests failing in CI. The repo only has `pnpm-lock.yaml`, but tests were trying to use `npm ci`.

### WHAT is this pull request doing?

- Use pnpm to install monorepo deps (matching all other CI jobs)
- Add explicit pnpm version 10.16.1 (pnpm/action-setup doesn't auto-detect in this context)
- Remove conflicting `npm i -g pnpm@9` from matrix setup
- Skip bun test (requires unreleased @shopify/cli with bun.lock support)

### HOW to test your changes?

Tested locally - npm, pnpm, and yarn scaffolding all work and build successfully.

**Note on bun**: Skipped until @shopify/cli releases with updated @shopify/cli-hydrogen that includes bun.lock support.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes

**Note:** No changeset needed - CI-only fix with no user-facing changes.