### PR TITLE
Fix(test): Migrate e2e tests from mock.shop to hydrogen preview store

### DIFF
--- a/e2e/specs/skeleton/cart.spec.ts
+++ b/e2e/specs/skeleton/cart.spec.ts
@@ -1,12 +1,12 @@
 import {setTestStore, test, expect} from '../../fixtures';
 import {CartUtil} from '../../fixtures/cart-utils';
 
-setTestStore('mockShop');
+setTestStore('hydrogenPreviewStorefront');
 
-const PRODUCT_NAME = "Women's T-shirt";
-const PRODUCT_HANDLE = 'women-t-shirt';
-const UNIT_PRICE = '$30.00';
-const TWO_ITEMS_PRICE = '$60.00';
+const PRODUCT_NAME = 'The Element';
+const PRODUCT_HANDLE = 'the-element';
+const UNIT_PRICE = '$749.95';
+const TWO_ITEMS_PRICE = '$1,499.90';
 
 test.describe('Cart', () => {
   test.describe('Line Items', () => {
@@ -254,12 +254,12 @@ test.describe('Cart', () => {
     test('Supports nested line items', async ({page, request}) => {
       const cart = new CartUtil(page);
       const PARENT_PRODUCT = {
-        title: 'Slides',
-        variantId: 'gid://shopify/ProductVariant/43695710371862',
+        title: 'The Element',
+        variantId: 'gid://shopify/ProductVariant/43567673344056',
       };
       const CHILD_PRODUCT = {
-        title: 'Sweatpants',
-        variantId: 'gid://shopify/ProductVariant/43696926949398',
+        title: 'The Elemental',
+        variantId: 'gid://shopify/ProductVariant/43567673442360',
       };
 
       const addedLines = await request
@@ -325,12 +325,13 @@ test.describe('Cart', () => {
       const lineItems = cart.getLineItems();
       const parentProductLink = lineItems
         .first()
-        .getByRole('link', {name: PARENT_PRODUCT.title});
+        .getByRole('link', {name: PARENT_PRODUCT.title, exact: true});
       const nestedList = lineItems.first().getByRole('list', {
         name: `Line items with ${PARENT_PRODUCT.title}`,
       });
       const childProductLink = nestedList.getByRole('link', {
         name: CHILD_PRODUCT.title,
+        exact: true,
       });
 
       await expect(parentProductLink).toBeVisible();

--- a/e2e/specs/smoke/cart.spec.ts
+++ b/e2e/specs/smoke/cart.spec.ts
@@ -1,14 +1,14 @@
 import {setTestStore, test, CartUtil} from '../../fixtures';
 
-setTestStore('mockShop');
+setTestStore('hydrogenPreviewStorefront');
 
 test.describe('Cart Functionality', () => {
   test('When adding a product to cart, it should update the cart', async ({
     page,
   }) => {
     const cart = new CartUtil(page);
-    const productName = "Women's T-shirt";
-    const productHandle = 'women-t-shirt';
+    const productName = 'The Element';
+    const productHandle = 'the-element';
 
     await page.goto('/');
     await cart.assertTotalItems(0);
@@ -18,6 +18,6 @@ test.describe('Cart Functionality', () => {
 
     await cart.assertTotalItems(1);
     await cart.assertInCart(productName);
-    await cart.assertSubtotal('$30.00');
+    await cart.assertSubtotal('$749.95');
   });
 });

--- a/e2e/specs/smoke/home.spec.ts
+++ b/e2e/specs/smoke/home.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect, setTestStore} from '../../fixtures';
 
-setTestStore('mockShop');
+setTestStore('hydrogenPreviewStorefront');
 
 test.describe('Home Page', () => {
   test('should display hero image, product grid, and no console errors', async ({
@@ -24,7 +24,7 @@ test.describe('Home Page', () => {
 
     const productGridImage = page
       .getByRole('region', {name: 'Recommended Products'})
-      .getByRole('link', {name: "Women's T-shirt"})
+      .getByRole('link', {name: 'The Hydrogen Snowboard'})
       .getByRole('img');
 
     await expect(heroImage).toBeVisible();

--- a/e2e/specs/smoke/pages.spec.ts
+++ b/e2e/specs/smoke/pages.spec.ts
@@ -1,16 +1,16 @@
 import {test, expect, setTestStore} from '../../fixtures';
 
-setTestStore('mockShop');
+setTestStore('hydrogenPreviewStorefront');
 
 test.describe('Pages', () => {
   test('When visiting static pages, each should display its heading', async ({
     page,
   }) => {
     const pages = [
-      {url: '/pages/contact', heading: 'Contact'},
+      {url: '/pages/about', heading: 'About'},
       {url: '/collections', heading: 'Collections'},
-      {url: '/collections/men', heading: 'Men'},
-      {url: '/blogs/news', heading: 'News'},
+      {url: '/collections/all', heading: 'Products'},
+      {url: '/blogs/journal', heading: 'Journal'},
       {url: '/search', heading: 'Search'},
       {url: '/cart', heading: 'Cart'},
       {url: '/policies', heading: 'Policies'},


### PR DESCRIPTION
### WHY are these changes introduced?

Consolidates e2e test infrastructure by migrating all tests to use the hydrogen preview store (`hydrogenPreviewStorefront`) instead of mock.shop. This ensures consistency across the test suite, as gift card and discount tests already use the hydrogen preview store.

### WHAT is this pull request doing?

Updates 4 e2e test files to use `hydrogenPreviewStorefront` instead of `mockShop`:

**Smoke tests:**
- Updated product references from "Women's T-shirt" to "The Element" (matching available products)
- Updated home page test to reference "The Hydrogen Snowboard" in recommended products
- Updated page routes to match hydrogen preview store structure (`/pages/about`, `/collections/all`, `/blogs/journal`)

**Skeleton tests:**
- Updated cart tests to use "The Element" product with correct pricing ($749.95)
- Updated nested line items test with valid variant IDs from hydrogen preview store:
  - Parent: "The Element" (`gid://shopify/ProductVariant/43567673344056`)
  - Child: "The Elemental" (`gid://shopify/ProductVariant/43567673442360`)
- Added `exact: true` to role selectors to prevent ambiguous matches between similar product names

### HOW to test your changes?

Run the updated e2e tests:

```bash
# Smoke tests (3 tests)
pnpm playwright test --project=smoke e2e/specs/smoke/

# Skeleton cart tests (18 tests)
pnpm playwright test --project=skeleton e2e/specs/skeleton/cart.spec.ts
```

All 21 tests should pass.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation