### PR TITLE
feat: option to use `react-router build` in `h2 build` commands

### DIFF
--- a/.changeset/fuzzy-bulldogs-tie.md
+++ b/.changeset/fuzzy-bulldogs-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Added a new `shopify hydrogen build --native-build` flag to run React Router's native build pipeline while preserving Hydrogen build checks and warnings where possible. This gives you an opt-in path to test native React Router build behavior before making it the default.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -79,6 +79,13 @@
           "name": "force-client-sourcemap",
           "allowNo": false,
           "type": "boolean"
+        },
+        "native-build": {
+          "description": "Use `react-router build` instead of the Hydrogen Vite build pipeline.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_NATIVE_BUILD",
+          "name": "native-build",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/cli/src/commands/hydrogen/build.test.ts
+++ b/packages/cli/src/commands/hydrogen/build.test.ts
@@ -1,10 +1,5 @@
 import '../../lib/onboarding/setup-template.mocks.js';
-import {
-  readFile,
-  fileExists,
-  inTemporaryDirectory,
-  removeFile,
-} from '@shopify/cli-kit/node/fs';
+import {readFile, fileExists, removeFile} from '@shopify/cli-kit/node/fs';
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {joinPath} from '@shopify/cli-kit/node/path';
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output';
@@ -13,6 +8,7 @@ import {setupTemplate} from '../../lib/onboarding/index.js';
 import {BUNDLE_ANALYZER_HTML_FILE} from '../../lib/bundle/analyzer.js';
 import path from 'node:path';
 import {mkdirSync} from 'node:fs';
+import {readdir} from 'node:fs/promises';
 
 describe('build', () => {
   const outputMock = mockAndCaptureOutput();
@@ -28,13 +24,7 @@ describe('build', () => {
       `test-project-build-${Date.now()}-${Math.random().toString(36).substring(7)}`,
     );
     mkdirSync(tmpDir);
-  });
 
-  afterAll(async () => {
-    await removeFile(tmpDir);
-  });
-
-  it('builds a Vite project', async () => {
     await setupTemplate({
       path: tmpDir,
       git: true,
@@ -42,7 +32,13 @@ describe('build', () => {
       i18n: 'subfolders',
       installDeps: true,
     });
+  });
 
+  afterAll(async () => {
+    await removeFile(tmpDir);
+  });
+
+  it('builds a Vite project', async () => {
     outputMock.clear();
     vi.stubEnv('NODE_ENV', 'production');
 
@@ -84,4 +80,60 @@ describe('build', () => {
     // Close build result resources.
     await runBuildResult.close();
   }, 60000); // 60 second timeout for build
+
+  it('builds equivalent dist outputs with native build', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    await runBuild({
+      directory: tmpDir,
+      bundleStats: false,
+    });
+    const viteBuildFiles = await listNormalizedDistFiles(tmpDir);
+
+    await runBuild({
+      directory: tmpDir,
+      bundleStats: false,
+      nativeBuild: true,
+    });
+    const nativeBuildFiles = await listNormalizedDistFiles(tmpDir);
+
+    expect(nativeBuildFiles).toEqual(viteBuildFiles);
+    await expect(
+      fileExists(joinPath(tmpDir, 'dist/server/index.js')),
+    ).resolves.toBe(true);
+  }, 60000);
 });
+
+async function listNormalizedDistFiles(root: string) {
+  const files: string[] = [];
+  await walk(joinPath(root, 'dist'));
+
+  return files
+    .filter((filepath) => {
+      const normalized = filepath.replaceAll('\\', '/');
+      if (normalized.endsWith('.map')) return false;
+      if (normalized === 'server/metafile.server.json') return false;
+      if (/^server\/server-[A-Za-z0-9_-]+\.html$/.test(normalized)) {
+        return false;
+      }
+      return true;
+    })
+    .map((filepath) =>
+      filepath
+        .replaceAll('\\', '/')
+        .replace(/([-.])[A-Za-z0-9_-]{8,}(?=\.[^.\/]+$)/g, '$1HASH'),
+    )
+    .sort();
+
+  async function walk(directory: string) {
+    for (const entry of await readdir(directory, {withFileTypes: true})) {
+      const fullPath = joinPath(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else {
+        files.push(path.relative(joinPath(root, 'dist'), fullPath));
+      }
+    }
+  }
+}

--- a/packages/cli/src/commands/hydrogen/build.test.ts
+++ b/packages/cli/src/commands/hydrogen/build.test.ts
@@ -89,6 +89,7 @@ describe('build', () => {
       bundleStats: false,
     });
     const viteBuildFiles = await listNormalizedDistFiles(tmpDir);
+    const viteSourcemaps = await listNormalizedSourcemaps(tmpDir);
 
     await runBuild({
       directory: tmpDir,
@@ -96,8 +97,10 @@ describe('build', () => {
       nativeBuild: true,
     });
     const nativeBuildFiles = await listNormalizedDistFiles(tmpDir);
+    const nativeSourcemaps = await listNormalizedSourcemaps(tmpDir);
 
     expect(nativeBuildFiles).toEqual(viteBuildFiles);
+    expect(nativeSourcemaps).toEqual(viteSourcemaps);
     await expect(
       fileExists(joinPath(tmpDir, 'dist/server/index.js')),
     ).resolves.toBe(true);
@@ -136,4 +139,55 @@ async function listNormalizedDistFiles(root: string) {
       }
     }
   }
+}
+
+async function listNormalizedSourcemaps(root: string) {
+  const mapFiles: string[] = [];
+  await walk(joinPath(root, 'dist'));
+
+  const rootNormalized = root.replaceAll('\\', '/');
+
+  const summaries = await Promise.all(
+    mapFiles.map(async (filepath) => {
+      const absolutePath = joinPath(root, 'dist', filepath);
+      const map = JSON.parse(await readFile(absolutePath));
+
+      const normalizedSources = Array.isArray(map.sources)
+        ? map.sources
+            .map((source: string) => normalizeMapValue(source, rootNormalized))
+            .sort()
+        : [];
+
+      return {
+        file: normalizeMapValue(filepath, rootNormalized),
+        generatedFile: normalizeMapValue(
+          String(map.file ?? ''),
+          rootNormalized,
+        ),
+        sourceCount: normalizedSources.length,
+        sources: normalizedSources,
+      };
+    }),
+  );
+
+  return summaries.sort((a, b) => a.file.localeCompare(b.file));
+
+  async function walk(directory: string) {
+    for (const entry of await readdir(directory, {withFileTypes: true})) {
+      const fullPath = joinPath(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.name.endsWith('.map')) {
+        mapFiles.push(path.relative(joinPath(root, 'dist'), fullPath));
+      }
+    }
+  }
+}
+
+function normalizeMapValue(value: string, rootNormalized: string) {
+  return value
+    .replaceAll('\\', '/')
+    .replaceAll(rootNormalized, '<ROOT>')
+    .replace(/([-.])[A-Za-z0-9_-]{8,}(?=\.[^.\/]+$)/g, '$1HASH');
 }

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -457,16 +457,15 @@ async function runNativeBuild({
     forceClientSourcemap ??
     (process.env.NODE_ENV !== 'production' && sourcemap);
 
-  const buildArgs = [
-    'react-router',
-    'build',
-    '--mode',
-    mode,
-    '--sourcemapServer',
-    String(sourcemap),
-    '--sourcemapClient',
-    String(clientSourcemap),
-  ];
+  const buildArgs = ['react-router', 'build', '--mode', mode];
+
+  if (sourcemap) {
+    buildArgs.push('--sourcemapServer');
+  }
+
+  if (clientSourcemap) {
+    buildArgs.push('--sourcemapClient');
+  }
 
   await onServerBuildStart?.();
 

--- a/packages/cli/src/commands/hydrogen/build.ts
+++ b/packages/cli/src/commands/hydrogen/build.ts
@@ -33,6 +33,8 @@ import {importVite} from '../../lib/import-utils.js';
 import {deferPromise, type DeferredPromise} from '../../lib/defer.js';
 import {setupResourceCleanup} from '../../lib/resource-cleanup.js';
 import {AbortError} from '@shopify/cli-kit/node/error';
+import {spawnSync} from 'node:child_process';
+import {readdir} from 'node:fs/promises';
 
 export default class Build extends Command {
   static descriptionWithMarkdown = `Builds a Hydrogen storefront for production. The client and app worker files are compiled to a \`/dist\` folder in your Hydrogen project directory.`;
@@ -59,6 +61,11 @@ export default class Build extends Command {
       description:
         'Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.',
       env: 'SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP',
+    }),
+    'native-build': Flags.boolean({
+      description:
+        'Use `react-router build` instead of the Hydrogen Vite build pipeline.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_NATIVE_BUILD',
     }),
   };
 
@@ -108,6 +115,7 @@ type RunBuildOptions = {
   bundleStats?: boolean;
   lockfileCheck?: boolean;
   watch?: boolean;
+  nativeBuild?: boolean;
   onServerBuildStart?: () => void | Promise<void>;
   onServerBuildFinish?: () => void | Promise<void>;
 };
@@ -124,6 +132,7 @@ export async function runBuild({
   assetPath,
   bundleStats = !isCI(),
   watch = false,
+  nativeBuild = false,
   onServerBuildStart,
   onServerBuildFinish,
 }: RunBuildOptions) {
@@ -139,140 +148,181 @@ export async function runBuild({
     await checkLockfileStatus(root, isCI());
   }
 
-  const [
-    vite,
-    {userViteConfig, remixConfig, clientOutDir, serverOutDir, serverOutFile},
-  ] = await Promise.all([
-    // Avoid static imports because this file is imported by `deploy` command,
-    // which must have a hard dependency on 'vite'.
-    importVite(root),
-    getViteConfig(root, ssrEntry),
-  ]);
-
-  const customLogger = vite.createLogger(watch ? 'warn' : undefined);
-  if (process.env.SHOPIFY_UNIT_TEST) {
-    // Make logs from Vite visible in tests
-    customLogger.info = (msg) => collectLog('info', msg);
-    customLogger.warn = (msg) => collectLog('warn', msg);
-    customLogger.error = (msg) => collectLog('error', msg);
-  }
+  const {
+    userViteConfig,
+    remixConfig,
+    clientOutDir,
+    serverOutDir,
+    serverOutFile,
+  } = await getViteConfig(root, ssrEntry);
 
   const serverMinify = userViteConfig.build?.minify ?? true;
-  const commonConfig = {
-    root,
-    mode: process.env.NODE_ENV,
-    base: assetPath,
-    customLogger,
-  };
 
-  let clientBuildStatus: DeferredPromise;
+  if (nativeBuild && watch) {
+    throw new AbortError(
+      'The `--watch` flag is not supported with `--native-build`.',
+      'Use `shopify hydrogen dev` for automatic rebuilds.',
+    );
+  }
 
-  // Client build first
-  const clientBuild = await vite.build({
-    ...commonConfig,
-    build: {
-      emptyOutDir: true,
-      copyPublicDir: true,
-      // Disable client sourcemaps in production by default
-      sourcemap:
-        forceClientSourcemap ??
-        (process.env.NODE_ENV !== 'production' && sourcemap),
-      watch: watch ? {} : null,
-    },
-    server: {
-      watch: watch ? {} : null,
-    },
-    plugins: [
-      {
-        name: 'hydrogen:cli:client',
-        buildStart() {
-          clientBuildStatus?.resolve();
-          clientBuildStatus = deferPromise();
-        },
-        buildEnd(error) {
-          if (error) clientBuildStatus.reject(error);
-        },
-        writeBundle() {
-          clientBuildStatus.resolve();
-        },
-        closeWatcher() {
-          // End build process if watcher is closed
-          this.error(new Error('Process exited before client build finished.'));
-        },
-      },
-    ],
-  });
+  if (nativeBuild && ssrEntry) {
+    throw new AbortError(
+      'The `--entry` flag is not supported with `--native-build`.',
+      'Use the React Router config file to customize your server entrypoint.',
+    );
+  }
 
-  console.log('');
-
-  let serverBuildStatus: DeferredPromise;
-
-  // Server/SSR build
-  const serverBuild = await vite.build({
-    ...commonConfig,
-    build: {
+  if (nativeBuild) {
+    await runNativeBuild({
+      root,
       sourcemap,
-      ssr: ssrEntry ?? true,
-      emptyOutDir: false,
-      copyPublicDir: false,
-      minify: serverMinify,
-      // Ensure the server rebuild start after the client one
-      watch: watch ? {buildDelay: 100} : null,
-    },
-    server: {
-      watch: watch ? {} : null,
-    },
-    plugins: [
-      {
-        name: 'hydrogen:cli:server',
-        async buildStart() {
-          // Wait for the client build to finish in watch mode
-          // before starting the server build to access the
-          // Remix manifest from file disk.
-          await clientBuildStatus.promise;
+      forceClientSourcemap,
+      mode: process.env.NODE_ENV,
+      onServerBuildStart,
+      onServerBuildFinish,
+    });
+  }
 
-          // Keep track of server builds to wait for them to finish
-          // before cleaning up resources in watch mode. Otherwise,
-          // it might complain about missing files and loop infinitely.
-          serverBuildStatus?.resolve();
-          serverBuildStatus = deferPromise();
-          await onServerBuildStart?.();
-        },
-        async writeBundle() {
-          if (serverBuildStatus?.state !== 'rejected') {
-            await onServerBuildFinish?.();
-          }
+  const vite = nativeBuild ? undefined : await importVite(root);
 
-          serverBuildStatus.resolve();
-        },
-        closeWatcher() {
-          // End build process if watcher is closed
-          this.error(new Error('Process exited before server build finished.'));
-        },
+  let clientBuild: {close: () => Promise<void>} | undefined;
+  let serverBuild: {close: () => Promise<void>} | undefined;
+  let clientBuildStatus: DeferredPromise | undefined;
+  let serverBuildStatus: DeferredPromise | undefined;
+
+  if (vite) {
+    const customLogger = vite.createLogger(watch ? 'warn' : undefined);
+    if (process.env.SHOPIFY_UNIT_TEST) {
+      // Make logs from Vite visible in tests
+      customLogger.info = (msg) => collectLog('info', msg);
+      customLogger.warn = (msg) => collectLog('warn', msg);
+      customLogger.error = (msg) => collectLog('error', msg);
+    }
+
+    const commonConfig = {
+      root,
+      mode: process.env.NODE_ENV,
+      base: assetPath,
+      customLogger,
+    };
+
+    // Client build first
+    const maybeClientBuild = await vite.build({
+      ...commonConfig,
+      build: {
+        emptyOutDir: true,
+        copyPublicDir: true,
+        // Disable client sourcemaps in production by default
+        sourcemap:
+          forceClientSourcemap ??
+          (process.env.NODE_ENV !== 'production' && sourcemap),
+        watch: watch ? {} : null,
       },
-      ...(bundleStats
-        ? [
-            hydrogenBundleAnalyzer({
-              minify: serverMinify
-                ? (code, filepath) =>
-                    vite
-                      .transformWithEsbuild(code, filepath, {
-                        minify: true,
-                        minifyWhitespace: true,
-                        minifySyntax: true,
-                        minifyIdentifiers: true,
-                        sourcemap: false,
-                        treeShaking: false, // Tree-shaking would drop most exports in routes
-                        legalComments: 'none',
-                        target: 'esnext',
-                      })
-                      .then((result) => result.code)
-                : undefined,
-            }),
-          ]
-        : []),
-    ],
-  });
+      server: {
+        watch: watch ? {} : null,
+      },
+      plugins: [
+        {
+          name: 'hydrogen:cli:client',
+          buildStart() {
+            clientBuildStatus?.resolve();
+            clientBuildStatus = deferPromise();
+          },
+          buildEnd(error) {
+            if (error) clientBuildStatus?.reject(error);
+          },
+          writeBundle() {
+            clientBuildStatus?.resolve();
+          },
+          closeWatcher() {
+            // End build process if watcher is closed
+            this.error(
+              new Error('Process exited before client build finished.'),
+            );
+          },
+        },
+      ],
+    });
+
+    if ('close' in maybeClientBuild) {
+      clientBuild = maybeClientBuild;
+    }
+
+    console.log('');
+
+    // Server/SSR build
+    const maybeServerBuild = await vite.build({
+      ...commonConfig,
+      build: {
+        sourcemap,
+        ssr: ssrEntry ?? true,
+        emptyOutDir: false,
+        copyPublicDir: false,
+        minify: serverMinify,
+        // Ensure the server rebuild start after the client one
+        watch: watch ? {buildDelay: 100} : null,
+      },
+      server: {
+        watch: watch ? {} : null,
+      },
+      plugins: [
+        {
+          name: 'hydrogen:cli:server',
+          async buildStart() {
+            // Wait for the client build to finish in watch mode
+            // before starting the server build to access the
+            // Remix manifest from file disk.
+            await clientBuildStatus?.promise;
+
+            // Keep track of server builds to wait for them to finish
+            // before cleaning up resources in watch mode. Otherwise,
+            // it might complain about missing files and loop infinitely.
+            serverBuildStatus?.resolve();
+            serverBuildStatus = deferPromise();
+            await onServerBuildStart?.();
+          },
+          async writeBundle() {
+            if (serverBuildStatus?.state !== 'rejected') {
+              await onServerBuildFinish?.();
+            }
+
+            serverBuildStatus?.resolve();
+          },
+          closeWatcher() {
+            // End build process if watcher is closed
+            this.error(
+              new Error('Process exited before server build finished.'),
+            );
+          },
+        },
+        ...(bundleStats
+          ? [
+              hydrogenBundleAnalyzer({
+                minify: serverMinify
+                  ? (code, filepath) =>
+                      vite
+                        .transformWithEsbuild(code, filepath, {
+                          minify: true,
+                          minifyWhitespace: true,
+                          minifySyntax: true,
+                          minifyIdentifiers: true,
+                          sourcemap: false,
+                          treeShaking: false, // Tree-shaking would drop most exports in routes
+                          legalComments: 'none',
+                          target: 'esnext',
+                        })
+                        .then((result) => result.code)
+                  : undefined,
+              }),
+            ]
+          : []),
+      ],
+    });
+
+    if ('close' in maybeServerBuild) {
+      serverBuild = maybeServerBuild;
+    }
+  }
 
   if (!watch) {
     await Promise.all([
@@ -280,6 +330,16 @@ export async function runBuild({
       removeFile(joinPath(serverOutDir, '.vite')),
       removeFile(joinPath(serverOutDir, 'assets')),
     ]);
+
+    if (nativeBuild) {
+      await cleanupNativeBuildArtifacts({
+        clientOutDir,
+        serverOutDir,
+        clientSourcemap:
+          forceClientSourcemap ??
+          (process.env.NODE_ENV !== 'production' && sourcemap),
+      });
+    }
   }
 
   const codegenOptions = {
@@ -295,7 +355,7 @@ export async function runBuild({
     : undefined;
 
   if (!watch && process.env.NODE_ENV !== 'development') {
-    if (bundleStats) {
+    if (bundleStats && !nativeBuild) {
       const bundleAnalysisPath =
         'file://' + joinPath(serverOutDir, BUNDLE_ANALYZER_HTML_FILE);
 
@@ -306,6 +366,12 @@ export async function runBuild({
           'Complete analysis: ' + bundleAnalysisPath,
           bundleAnalysisPath,
         )}\n\n`,
+      );
+    }
+
+    if (bundleStats && nativeBuild) {
+      outputInfo(
+        'Bundle stats are not currently available with `--native-build`.',
       );
     }
 
@@ -348,8 +414,8 @@ export async function runBuild({
       codegenProcess?.kill('SIGINT');
 
       const promises: Array<Promise<void>> = [];
-      if ('close' in clientBuild) promises.push(clientBuild.close());
-      if ('close' in serverBuild) promises.push(serverBuild.close());
+      if (clientBuild) promises.push(clientBuild.close());
+      if (serverBuild) promises.push(serverBuild.close());
 
       await Promise.allSettled(promises);
 
@@ -367,4 +433,88 @@ export async function runBuild({
       }
     },
   };
+}
+
+type NativeBuildOptions = {
+  root: string;
+  mode: string;
+  sourcemap: boolean;
+  forceClientSourcemap?: boolean;
+  onServerBuildStart?: () => void | Promise<void>;
+  onServerBuildFinish?: () => void | Promise<void>;
+};
+
+async function runNativeBuild({
+  root,
+  mode,
+  sourcemap,
+  forceClientSourcemap,
+  onServerBuildStart,
+  onServerBuildFinish,
+}: NativeBuildOptions) {
+  const packageManager = await getPackageManager(root);
+  const clientSourcemap =
+    forceClientSourcemap ??
+    (process.env.NODE_ENV !== 'production' && sourcemap);
+
+  const buildArgs = [
+    'react-router',
+    'build',
+    '--mode',
+    mode,
+    '--sourcemapServer',
+    String(sourcemap),
+    '--sourcemapClient',
+    String(clientSourcemap),
+  ];
+
+  await onServerBuildStart?.();
+
+  const result = spawnSync('npx', buildArgs, {
+    cwd: root,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.error || result.status !== 0) {
+    throw new AbortError(
+      'Native build failed while running `react-router build`.',
+      'Fix the build error shown above and try again.',
+    );
+  }
+
+  await onServerBuildFinish?.();
+}
+
+async function cleanupNativeBuildArtifacts({
+  clientOutDir,
+  serverOutDir,
+  clientSourcemap,
+}: {
+  clientOutDir: string;
+  serverOutDir: string;
+  clientSourcemap: boolean;
+}) {
+  const serverFiles = await readdir(serverOutDir).catch(() => []);
+
+  const cleanupPromises = serverFiles
+    .filter(
+      (filename) =>
+        filename === 'metafile.server.json' ||
+        (filename.startsWith('server-') && filename.endsWith('.html')),
+    )
+    .map((filename) => removeFile(joinPath(serverOutDir, filename)));
+
+  if (!clientSourcemap) {
+    const clientAssetDir = joinPath(clientOutDir, 'assets');
+    const clientAssetFiles = await readdir(clientAssetDir).catch(() => []);
+
+    cleanupPromises.push(
+      ...clientAssetFiles
+        .filter((filename) => filename.endsWith('.map'))
+        .map((filename) => removeFile(joinPath(clientAssetDir, filename))),
+    );
+  }
+
+  await Promise.allSettled(cleanupPromises);
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Hydrogen currently runs a custom two-step Vite build pipeline (`client` then `server`) in `hydrogen build`. That diverges from React Router's native build orchestration and blocks parity with newer React Router build capabilities (notably future `serverBundles`).

This PR introduces an opt-in path to run `react-router build` from `hydrogen build` so we can validate parity and incrementally move toward native React Router build behavior without removing existing Hydrogen build features.

### WHAT is this pull request doing?

- Adds a new `--native-build` flag to `shopify hydrogen build`.
- When enabled, `hydrogen build` runs `react-router build` (via the active package manager) instead of Hydrogen's custom two-step Vite build path.
- Keeps existing Hydrogen build features where possible:
  - lockfile checks
  - optional codegen flow
  - route validation/warnings
  - worker size warnings
- Adds native-mode guardrails for currently unsupported combinations:
  - `--native-build --watch` is rejected
  - `--native-build --entry` is rejected
- Keeps output parity by cleaning RR-specific extra artifacts that are not part of Hydrogen's expected dist shape.
- Improves sourcemap flag handling for native mode:
  - only passes `--sourcemapServer` / `--sourcemapClient` when enabled
  - avoids accidentally enabling sourcemaps with string boolean values
- Expands test coverage:
  - adds an equivalence test that runs both build paths and compares normalized dist outputs
  - now also compares normalized sourcemap metadata equivalence

Known non-equivalent behavior in native mode:

- `--bundle-stats` HTML analysis is not available with `--native-build` (an explicit informational message is shown).
- `--watch` and `--entry` remain unsupported with `--native-build` in this PR.

### HOW to test your changes?

1. Run targeted tests and typecheck:

```bash
SHOPIFY_UNIT_TEST=1 LANG=en-US.UTF-8 pnpm --dir "packages/cli" exec vitest run src/commands/hydrogen/build.test.ts --test-timeout=60000
pnpm --dir "packages/cli" run typecheck
```

2. Manual check in skeleton using local built CLI code:

```bash
pnpm --dir "packages/cli" run build
```

Legacy Hydrogen build path:

```bash
node -e "import('./packages/cli/dist/commands/hydrogen/build.js').then(async ({runBuild}) => { await runBuild({ directory: './templates/skeleton', nativeBuild: false, bundleStats: false }); });"
```

Native React Router build path:

```bash
node -e "import('./packages/cli/dist/commands/hydrogen/build.js').then(async ({runBuild}) => { await runBuild({ directory: './templates/skeleton', nativeBuild: true, bundleStats: false }); });"
```

3. Verify both produce equivalent `dist` outputs (allowing expected hash/name differences) and equivalent sourcemap source metadata; this is covered by the new unit test.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation
