### PR TITLE
test(e2e): add third-party-api recipe e2e tests

### DIFF
--- a/e2e/specs/recipes/third-party-api.spec.ts
+++ b/e2e/specs/recipes/third-party-api.spec.ts
@@ -22,7 +22,7 @@ const RECIPE_HEADING_TEXT = 'Rick & Morty Characters (Third-Party API Example)';
 // The skeleton queries the most recently updated collection, which may change over time.
 // If this collection is removed or renamed in hydrogenPreviewStorefront, update this constant.
 const KNOWN_FEATURED_COLLECTION = {
-  title: 'Hats and Accessories',
+  title: 'Winter Collection',
 } as const;
 
 test.describe('Third-party API Recipe', () => {

--- a/e2e/specs/recipes/third-party-api.spec.ts
+++ b/e2e/specs/recipes/third-party-api.spec.ts
@@ -1,0 +1,85 @@
+import {test, expect, setRecipeFixture} from '../../fixtures';
+
+setRecipeFixture({
+  recipeName: 'third-party-api',
+  storeKey: 'hydrogenPreviewStorefront',
+});
+
+/**
+ * Validates the Third-party API recipe, which demonstrates integrating
+ * external GraphQL APIs with Oxygen's caching system.
+ *
+ * The recipe adds a Rick & Morty characters section to the homepage that
+ * displays data fetched server-side from rickandmortyapi.com GraphQL API in the loader.
+ *
+ * ⚠️  Note: These tests depend on rickandmortyapi.com being available.
+ * If the external API is down, slow, or rate-limited, tests may fail.
+ * This is expected behavior as the recipe is designed to call this live API.
+ */
+
+const RECIPE_HEADING_TEXT = 'Rick & Morty Characters (Third-Party API Example)';
+
+// The skeleton queries the most recently updated collection, which may change over time.
+// If this collection is removed or renamed in hydrogenPreviewStorefront, update this constant.
+const KNOWN_FEATURED_COLLECTION = {
+  title: 'Hats and Accessories',
+} as const;
+
+test.describe('Third-party API Recipe', () => {
+  test.beforeEach(async ({page}) => {
+    await page.goto('/');
+  });
+
+  test('displays Rick and Morty characters section with heading', async ({
+    page,
+  }) => {
+    const heading = page.getByRole('heading', {
+      name: RECIPE_HEADING_TEXT,
+    });
+    await expect(heading).toBeVisible();
+
+    const description = page.getByText(
+      /This data is fetched from rickandmortyapi\.com GraphQL API/i,
+    );
+    await expect(description).toBeVisible();
+  });
+
+  test('renders character list from third-party API', async ({page}) => {
+    const recipeHeading = page.getByRole('heading', {
+      name: RECIPE_HEADING_TEXT,
+    });
+    const recipeSection = page.locator('section').filter({has: recipeHeading});
+    const characterList = recipeSection.getByRole('list');
+
+    await expect(recipeSection).toBeVisible();
+    await expect(characterList).toHaveCount(1);
+    await expect(characterList).toBeVisible();
+
+    const characters = characterList.getByRole('listitem');
+    await expect(characters.first()).toBeVisible();
+    await expect(characters.nth(1)).toBeVisible();
+    await expect.poll(() => characters.count()).toBeGreaterThan(1);
+    await expect(characters.first()).not.toHaveText(/^\s*$/);
+    await expect(characters.first()).toContainText(/[A-Za-z]/);
+  });
+
+  test('preserves existing homepage sections alongside third-party content', async ({
+    page,
+  }) => {
+    const featuredCollectionHeading = page.getByRole('heading', {
+      level: 1,
+      name: KNOWN_FEATURED_COLLECTION.title,
+    });
+    await expect(featuredCollectionHeading).toBeVisible();
+
+    const recommendedProductsSection = page.getByRole('region', {
+      name: 'Recommended Products',
+    });
+    await expect(recommendedProductsSection).toBeVisible();
+
+    const recommendedProductLinks =
+      recommendedProductsSection.getByRole('link');
+    await expect(recommendedProductLinks.first()).toBeVisible();
+    await expect.poll(() => recommendedProductLinks.count()).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Part of https://github.com/Shopify/developer-tools-team/issues/1057

### WHY are these changes introduced?

Adds e2e test coverage for the third-party-api recipe, which demonstrates integrating external GraphQL APIs (Rick & Morty API) with Oxygen's caching system. This continues the systematic testing of recipes to ensure user-facing recipe behavior is validated.

This PR is stacked on #3548 (metaobjects tests).

### WHAT is this pull request doing?

Adds `e2e/specs/recipes/third-party-api.spec.ts` with 3 tests covering:
- Rick & Morty characters section heading and description visibility
- Character list rendering from the third-party API with non-empty item content
- Existing homepage sections still rendering alongside third-party recipe content

Tests verify that the recipe successfully:
- Adds a new section to the homepage with the expected heading text
- Displays character data from rickandmortyapi.com in a structured list
- Preserves existing homepage UX (for example, Recommended Products)
- Uses resilient, user-facing assertions and semantic locator patterns

### HOW to test your changes?

```bash
# Run third-party-api recipe tests only
npx playwright test --project=recipes third-party-api

# Run all recipe tests
npx playwright test --project=recipes
```

#### Checklist

- [x] I've read the Contributing Guidelines
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a changeset if this PR contains user-facing or noteworthy changes
- [x] I've added tests to cover my changes
- [ ] I've added or updated the documentation