### PR TITLE
docs: reorganize Hydrogen documentation into focused skills

### DIFF
--- a/.claude/commands/shopify-cli-update.md
+++ b/.claude/commands/shopify-cli-update.md
@@ -359,7 +359,9 @@ skeleton template's devDependencies
 @shopify/cli-hydrogen (circular!)
 ```
 
-This may require a second cli-hydrogen release after the Shopify CLI is updated to bundle the correct skeleton version.
+Whether a second cli-hydrogen release is required depends on what the cli-hydrogen changes contained:
+- **If cli-hydrogen had actual code changes** (beyond just adding a changeset to bundle a new skeleton): manually update skeleton's `@shopify/cli` to the new Shopify CLI version and create changesets for `@shopify/cli-hydrogen` AND `@shopify/create-hydrogen` to trigger another release cycle
+- **If cli-hydrogen changes were ONLY a changeset to re-bundle the skeleton**: no further action required after Shopify CLI releases
 
 ## Exit Conditions
 

--- a/.claude/skills/hydrogen-dev-workflow/SKILL.md
+++ b/.claude/skills/hydrogen-dev-workflow/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: hydrogen-dev-workflow
+description: >
+  Development workflow guide for Shopify's Hydrogen
+  framework. Covers testing, upgrading, recipes, PR conventions, analytics architecture,
+  CLI tooling, and project scaffolding.
+  Use when developing the Hydrogen framework. Also activates when someone mentions "recipes",
+  "patch files", "customer account testing", "hydrogen upgrade", "skeleton template",
+  "hydrogen CLI", "create-hydrogen", "hydrogen init", or "shopify-cli-update" in the headless context.
+---
+
+# Hydrogen Development Workflow
+
+Development practices and workflow guide for engineers working on Shopify's headless storefront ecosystem. The Hydrogen framework repo is [`Shopify/hydrogen`](https://github.com/Shopify/hydrogen). For domain context, see the `headless-storefronts-context` skill. For repo locations, see the `shopify-repos` skill.
+
+## Testing Customer Accounts Locally
+
+To test anything in Hydrogen that requires a customer login (order history, account page, etc.):
+
+1. **Start the dev server with the customer account push flag:**
+   ```bash
+   # Using npm
+   npm run dev -- --customer-account-push
+
+   # Using Hydrogen CLI directly (h2 is the Hydrogen CLI binary)
+   h2 dev --customer-account-push
+   ```
+   Note the `--` separator when using `npm run dev`.
+
+2. **Place a test order** using the [bogus gateway test payment details](https://help.shopify.com/en/manual/checkout-settings/test-orders/payments-test-mode#bogus-gateway-test-payment-details).
+
+3. **Create a customer account** using any email and password.
+
+4. After placing an order, you can log in and view orders in the customer account section.
+
+## Hydrogen Recipes
+
+Recipes are documented cookbook entries for adding features to a Hydrogen storefront. They exist as [markdown files in the dev docs](https://shopify.dev/docs/storefronts/headless/hydrogen/cookbook/bundles). The "apply" command and related tooling are purely for **internal use** to test or update the recipes -- merchants cannot programmatically apply recipes to their storefronts.
+
+### Cookbook Architecture: Ingredients and Generated Docs
+
+Each recipe has two layers that need to stay in sync:
+
+**Ingredient files** (`cookbook/recipes/{name}/ingredients/templates/skeleton/app/routes/*.tsx`): These are **real, standalone `.tsx` route implementations** — not patches or diffs. They are applied when a merchant follows the recipe. When the skeleton has a bug (e.g., a missing `await`), the corresponding cookbook ingredient files may have the **same bug independently** and need to be fixed separately.
+
+**Generated documentation** (`cookbook/recipes/{name}/README.md` and `cookbook/llms/{name}.prompt.md`): These files are **auto-generated** from the ingredient source files. They inline the full route source code, so if you fix the ingredient `.tsx` files, you MUST also regenerate the docs:
+
+```bash
+npm run cookbook -- render --recipe {name}
+npm run cookbook -- validate --recipe {name}
+```
+
+Both the `README.md` and `llms/{name}.prompt.md` must be committed as part of the same fix. Failing to regenerate means the docs teach the wrong pattern even after the ingredient files are correct.
+
+**Example**: The `markets` recipe has `($locale).account.$.tsx`, `($locale).account.addresses.tsx`, and `($locale).account.profile.tsx` as ingredient files. These are independent of the skeleton and don't automatically inherit skeleton fixes.
+
+### Fixing Broken Recipes (Patch Files)
+
+Recipe patch files can break when the skeleton template changes. Two approaches:
+
+**For trivial 1-line changes:** Edit the patch files directly.
+
+**For nontrivial changes:**
+1. Create a new branch locally
+2. Hard reset to the latest commit where the recipes DID apply cleanly
+3. For each recipe:
+   a. Apply the recipe
+   b. Use Claude/LLM to apply all changes from that commit to latest `main` on the skeleton template with recipe applied
+   c. Generate new patch files
+   d. Un-apply the recipe and repeat for the next one
+
+## Upgrading Hydrogen
+
+The best way to upgrade a Hydrogen storefront is the [`upgrade` CLI command](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-upgrade):
+
+```bash
+npx shopify hydrogen upgrade
+```
+
+This command:
+- Automatically bumps and installs all necessary dependencies
+- For manual changes, generates a **markdown file** containing all required changes
+- The markdown file is excellent for feeding to Claude or other LLMs to apply changes
+
+**Best practice**: When upgrading across multiple major versions, upgrade **one major version at a time** and verify everything works between each bump. This is smoother than attempting multiple major version bumps at once.
+
+## Skeleton Template
+
+The skeleton template serves two purposes:
+
+1. **Internal testing**: It is the single Hydrogen storefront we use to test and validate changes to Hydrogen. Located at `templates/skeleton` in the Hydrogen repo.
+2. **New project scaffolding**: When a user scaffolds a new Hydrogen project (via `shopify hydrogen init` or `npm create @shopify/hydrogen`), they get a copy of the skeleton template.
+
+Key facts:
+
+- Lives in the Hydrogen monorepo at `templates/skeleton`
+- Uses **built versions** of Hydrogen packages from the monorepo (not from npm)
+- Bundled and released with the Hydrogen CLI
+- Should always be up to date before a Hydrogen CLI release
+- Can be updated before a release even if the Hydrogen CLI version isn't being bumped
+
+Any change to the skeleton template requires a changeset — see the Changeset Rules in CLAUDE.md for details.
+
+## PR Conventions
+
+### Link Issues to PRs
+
+Always include a link to the GitHub issue in your PR. Use `Closes <issue>` or `Fixes <issue>` so the issue automatically closes when the PR merges.
+
+## Hydrogen Analytics Architecture
+
+The analytics system in `packages/hydrogen/src/analytics-manager/` has several non-obvious design constraints worth knowing before debugging.
+
+### Module-scoped singletons
+
+`subscribers`, `registers`, and `waitForReadyQueue` are module-scoped (not instance-scoped). This means:
+- They persist across React renders and React tree unmounts/remounts
+- In tests, they accumulate state across test cases — a test that calls `register()` without `ready()` will block all subsequent tests
+- There is exactly one analytics bus per JS context; multiple `<Analytics.Provider>` instances share state
+
+### Consent enforcement is in the subscriber, not the publisher
+
+`publish()` always enqueues events regardless of consent state. Consent is enforced at three downstream layers:
+1. `ShopifyAnalytics` only calls `shopifyAnalyticsReady()` after `privacyReady` is true (privacy SDK loaded)
+2. `prepareBasePageViewPayload` evaluates `customerPrivacy.analyticsProcessingAllowed()` at handler invocation time
+3. `sendShopifyAnalytics` (in `hydrogen-react`) drops the event if `payload.hasUserConsent` is false
+
+Do NOT add consent gating to `publish()` — it causes events to be dropped (not queued) before consent resolves, creating a race condition where events fired during initialization are permanently lost.
+
+## Hydrogen CLI
+
+The Hydrogen CLI source code lives at `packages/cli-hydrogen` in the Hydrogen repo. It is released to npm as its own package.
+
+**Bundling in Shopify CLI**: Merchants typically do not use the Hydrogen CLI directly. Instead, it is bundled inside the Shopify CLI (in the `Shopify/cli` repo). After releasing a new version of the Hydrogen CLI to npm, you must also bump its version in the Shopify CLI.
+
+**Timing**: The Shopify CLI releases a new minor version on a regular cadence. Hydrogen CLI bumps should NOT wait for the next Shopify CLI minor — release the bump as a **patch** of the current Shopify CLI minor version to get it out sooner.
+
+**How to update**: A `shopify-cli-update` command exists in the Hydrogen repo at `.claude/commands/shopify-cli-update.md`. This is a Claude Code command — invoke it with `/shopify-cli-update` when working in the Hydrogen repo. It documents the full, nuanced, multi-step process. Always reference this command when performing the update — do not try to wing it from memory.
+
+## Project Scaffolding
+
+There are two ways to scaffold a new Hydrogen project:
+
+1. **`shopify hydrogen init`** — via the Shopify CLI (which bundles the Hydrogen CLI)
+2. **`npm create @shopify/hydrogen`** — via the `create-hydrogen` package
+
+Both ultimately use the skeleton template. The `create-hydrogen` package uses the Hydrogen CLI's init function under the hood.
+
+### Version Tags
+
+- **`@latest`**: The most recent official release
+- **`@next`**: Contains all Hydrogen changes that have been merged to main (with changesets), even before they have been officially released. A new `next` version is auto-published every time code is pushed to main.
+
+The `next` tag is useful for merchant bug-fix validation: after merging a fix to main, the merchant can test with `npm create @shopify/hydrogen@next` to confirm the fix resolves their issue — before waiting for an official release.
+
+### Scaffolding a Specific Version
+
+`create-hydrogen` uses SemVer while Hydrogen uses CalVer — see the `hydrogen-versioning` skill for details on the relationship. Scaffolding a specific historical Hydrogen version requires a lookup step to find which `create-hydrogen` SemVer version includes the desired Hydrogen CalVer skeleton.
+
+## Related Skills
+
+- `hydrogen-release-process` — Release process, back-fixes, changelog.json, release failure recovery
+- `hydrogen-versioning` — CalVer formats, version support policies, release cadence
+- `CLAUDE.md` — Changeset rules (apply to every PR), skeleton/CLI bundling chain

--- a/.claude/skills/hydrogen-release-process/SKILL.md
+++ b/.claude/skills/hydrogen-release-process/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: hydrogen-release-process
+description: >
+  Release process guide for Shopify's Hydrogen framework. Covers the full release flow
+  (standard, back-fix, snapshot), manual vs automatic steps, changelog.json updates,
+  h2 upgrade enablement, and release failure recovery.
+  Use when performing or debugging a Hydrogen release. Also activates when someone mentions
+  "release", "release process", "back-fix", "snapit", "changelog.json", "h2 upgrade enablement",
+  "release failure", "version PR", "release PR", or "hydrogen release".
+---
+
+# Hydrogen Release Process
+
+Hydrogen uses an automated release system built on Changesets, GitHub Actions (`release.yml`), and npm workspaces. For changeset rules that apply to every PR, see `CLAUDE.md`. For versioning semantics (CalVer, API versions), see the `hydrogen-versioning` skill.
+
+## Release Flow: From PR to Production
+
+1. **Developer creates PR with changes**
+   - If changes affect `packages/*/src/**` or `packages/*/package.json`, a changeset is required
+   - Run `npm run changeset add` to create a changeset file **(MANUAL)**
+   - Changeset specifies which packages are affected and version bump type (patch/minor/major)
+
+2. **On merge to main, TWO parallel processes occur:**
+
+   a) **Next Release (immediate)** **(AUTOMATIC)**
+      - Every push to main (except release commits) triggers the `next-release` job in `release.yml`
+      - Creates snapshot version: `0.0.0-next-{SHA}-{timestamp}`
+      - ALL packages are published with `next` tag
+      - Available immediately for testing latest changes
+
+   b) **Version PR Creation (if changesets exist)** **(AUTOMATIC)**
+      - The `release` job in `release.yml` runs
+      - If changesets are found, creates OR updates an open CI release PR
+      - PR title: `[ci] release {latestVersion}` (where `latestVersion` is the computed next version — see below)
+      - **Important**: This PR accumulates ALL changesets from merged PRs
+      - Multiple PRs can be merged before a release (e.g., 10 PRs = 10 changesets in one Version PR)
+      - The Version PR automatically updates as new changesets are merged
+
+3. **Production Release — Batched (manual step)**
+   - **Releases are batched**: Maintainers decide when to release (could be after 1 PR or 10 PRs)
+   - The Version PR accumulates all pending changesets since last release
+   - Maintainer reviews accumulated changes and merges the Version PR when ready **(MANUAL)**
+   - On merge, `release.yml` publishes to npm with `latest` tag **(AUTOMATIC)**
+   - Only packages with changesets get new versions **(AUTOMATIC)**
+   - Internal dependencies updated with patch versions **(AUTOMATIC)**
+   - Post-release actions:
+     - Compiles templates to `dist` branch **(AUTOMATIC)**
+
+4. **Post-Release: Enabling Upgrades (manual step)**
+   - After npm publication, `docs/changelog.json` must be updated **(MANUAL)**
+   - This enables the `h2 upgrade` command to detect the new version
+   - Without this step, developers cannot upgrade using the CLI
+   - Process:
+     - Update `docs/changelog.json` with release information **(MANUAL)**
+     - Include version, dependencies, features, fixes, and upgrade steps **(MANUAL)**
+     - Commit and push to main branch **(MANUAL)**
+     - Changes are served via https://hydrogen.shopify.dev/changelog.json **(AUTOMATIC)**
+
+   **How `h2 upgrade` works:**
+   - Fetches changelog.json from hydrogen.shopify.dev (proxies to the raw content of this file on the `main` branch in the Hydrogen repo)
+   - Compares user's current version against available versions
+   - Shows features, fixes, and breaking changes for upgrade path
+   - Generates local upgrade instructions file in `.hydrogen/` directory
+   - Updates package.json dependencies based on changelog specifications
+
+## Understanding Batched Releases
+
+**Key Point**: Not every merged PR triggers a release!
+
+- When you merge a PR with a changeset, it does NOT immediately release to npm
+- Instead, your changeset is added to the open CI release PR
+- This PR accumulates changesets from ALL merged PRs since the last release
+- Maintainers decide when to merge this PR to trigger an actual release
+- This allows batching multiple features/fixes into a single release
+
+**Example Timeline**:
+- Monday: 3 PRs merged with changesets → Version PR has 3 changesets
+- Tuesday: 2 more PRs merged → Version PR now has 5 changesets
+- Wednesday: 4 more PRs merged → Version PR now has 9 changesets
+- Thursday: Maintainer merges Version PR → All 9 changes released together
+
+## Multi-Package Releases
+
+- Each package versions independently (no fixed/linked packages in changesets config)
+- Single changeset can specify multiple packages
+- Example: PR changes both `@shopify/hydrogen` and `@shopify/cli-hydrogen`
+  - Both packages listed in changeset
+  - Each gets appropriate version bump
+  - Published together when Version PR merged
+
+## Other Release Types
+
+### Snapshot Testing (`/snapit`)
+
+- Comment `/snapit` on any PR
+- Creates snapshot version for testing
+- Publishes specific packages for PR validation
+
+### Back-fix Releases
+
+- Push to calver branches (e.g., `2025-01`) triggers the `backfix-release` job in `release.yml`
+- Publishes with branch name as npm tag
+- Used for patching previous versions
+- See the detailed step-by-step below
+
+## Manual vs Automatic Steps
+
+### Manual Steps (Human Intervention Required)
+
+1. **Developer Actions**
+   - **Create changesets**: Run `npm run changeset add` for any PR with code changes
+   - **Skeleton changes**: MUST include all three packages in changeset: `skeleton`, `@shopify/cli-hydrogen`, AND `@shopify/create-hydrogen` — see changeset rules in CLAUDE.md
+   - **Write PR descriptions**: Include clear explanations of changes
+   - **Request snapshot builds**: Comment `/snapit` on PR to test changes
+
+2. **Maintainer Actions — Regular Releases**
+   - **Merge Version PR**: Review and merge the auto-generated open CI release PR to trigger npm publication
+   - **Update changelog.json**: After npm release, manually update this file to enable `h2 upgrade` command
+   - **Monitor releases**: Verify packages published correctly and Slack notifications sent
+
+3. **Maintainer Actions — CLI Releases**
+   - When cli-hydrogen has updates, create a PR in the Shopify CLI repo and coordinate with Shopify CLI team to request patch release
+   - **Post-release actions**: Whether to update skeleton's `@shopify/cli` and trigger a second cli-hydrogen release depends on the nature of the cli-hydrogen changes — see the circular dependency section in CLAUDE.md
+
+4. **Maintainer Actions — Major Version Changes**
+   - **`latestBranch` detection**: `latestBranch` is computed dynamically by `calver-shared.js` + `get-calver-version-branch.js` in `release.yml`. No manual editing of `latestBranch` is needed for standard releases.
+   - **Configure back-fix branches**: To enable back-fix releases for a previous CalVer branch, add it to the `on.push.branches` array in `.github/workflows/release.yml`. Never add the current CalVer branch.
+
+### Automatic Steps (CI/CD Handles)
+
+1. **On Every Push to Main**
+   - Next release publishes immediately with tag `next`
+   - Version: `0.0.0-next-{SHA}-{timestamp}`
+   - All packages published regardless of changesets
+
+2. **When Changesets Exist on Main**
+   - Version PR automatically created
+   - Title: `[ci] release {latestVersion}`
+   - Contains version bumps and CHANGELOG updates
+
+3. **When Version PR is Merged**
+   - Packages publish to npm with `latest` tag
+   - Only packages with changesets get new versions
+   - Templates compile and push to `dist` branch
+   - Slack notification sent (if Hydrogen package included)
+   - GitHub releases created with changelogs
+
+4. **When `/snapit` is Commented**
+   - `snapit.yml` workflow runs
+   - Snapshot version created for PR
+   - Packages published with unique tag
+   - PR comment updated with installation instructions
+
+5. **On Push to Calver Branches**
+   - `backfix-release` job in `release.yml` runs
+   - Back-fix version PR created
+   - Publishes with branch name as npm tag when merged
+
+## Standard Release (from main)
+
+1. PRs with changesets are merged to main
+2. The changesets automation opens or updates a **release PR**
+3. **IMPORTANT: Validate BOTH the title AND the description** of the release PR. Bugs can happen where the title may show the correct version (e.g., `2025.7.2` — a patch bump) but the description incorrectly says a different version (e.g., `2025.10.0`). Do not trust one without checking the other.
+4. Approve and merge the release PR — this automatically publishes the packages to npm
+5. **Monitor the GitHub Actions** that run after merge to confirm they succeed. Example release PR: [#3468](https://github.com/Shopify/hydrogen/pull/3468)
+6. Double check that you now see the new release(s) on npm
+
+It is expected that for ~1 hr after doing a new release, scaffolding new Hydrogen projects may continue to be scaffolded using the stale version due to npm caching.
+
+## Back-Fix Releases (detailed)
+
+Sometimes you need to release a patch/minor for a version that is not the latest major, or `main` already has unreleased code for a future version. In these cases, use a back-fix branch.
+
+**If this is your first back-fix, pair with an experienced team member.** The process involves branch naming conventions and force-push scenarios that can silently break things if done wrong.
+
+**CRITICAL — Branch naming**: The back-fix branch **must** be named to match the major version, e.g., `2024-10`. Do NOT use arbitrary branch names. The dev docs automation for updating API documentation depends on this exact naming pattern. If the branch name is wrong, docs will not update and there will be **no error** — it fails silently.
+
+**Step-by-step workflow**:
+
+1. Create branch from the latest patch of the target major:
+   ```bash
+   git checkout -b 2024-10 @shopify/hydrogen@2024.10.1
+   ```
+2. Add your back-fix branch to the `on.push.branches` array in `.github/workflows/release.yml`. This change is only made on back-fix branches, never on main.
+3. Commit and push:
+   ```bash
+   git push origin 2024-10
+   ```
+4. Make your code changes and create a changeset
+5. Push changes directly to the back-fix branch (or create a PR targeting it)
+6. A GitHub Action will automatically create a back-fix release PR (example: [#3360](https://github.com/Shopify/hydrogen/pull/3360))
+7. Get reviews on the release PR
+8. Merge the release PR and monitor GitHub Actions for release success
+
+## Release Failure Recovery
+
+**If this is your first release failure, pair with an experienced team member before attempting recovery.**
+
+1. **Investigate** the error message from the failed GitHub Action
+2. If the issue appears to be a Shopify/npm configuration issue (NOT a Hydrogen-specific issue), get help in `#help-eng-infrastructure` (Slack ID: `C01MXHNTT4Z`)
+3. After fixing the underlying issue, **revert the release PR** to re-trigger a release attempt. Use the "Revert" button on the PR's GitHub page.
+4. If the revert button does not work (common for back-fix branches):
+   - **First, save the current branch state**: `git branch backup-2024-10` (so you can restore if needed)
+   - Check out the branch locally
+   - Drop the release PR commit(s) via rebase
+   - Force push
+
+**WARNING**: The force-push recovery path requires advanced git confidence. If you are not extremely comfortable with `git rebase` and `git push --force`, do not attempt this alone. Verify you are not deleting other commits before force pushing.
+
+## Related Skills
+
+- `CLAUDE.md` — Changeset rules (apply to every PR), skeleton/CLI bundling chain, circular dependency
+- `hydrogen-versioning` — CalVer formats, version support policies, release cadence
+- `hydrogen-dev-workflow` — Day-to-day development workflow, testing, recipes, PR conventions

--- a/.claude/skills/hydrogen-versioning/SKILL.md
+++ b/.claude/skills/hydrogen-versioning/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: hydrogen-versioning
+description: >
+  Versioning reference for Hydrogen and Shopify's GraphQL APIs. Covers CalVer formats,
+  quarterly release schedules, version support policies, and release cadence expectations.
+  Use when discussing hydrogen calver, calver, SFAPI version, API version support,
+  hydrogen release cadence, version support window, unstable API version, storefront API
+  version, or customer account API version. Also activates when planning a Hydrogen major
+  release, answering merchant questions about API version compatibility, or determining
+  which versions are currently supported.
+---
+
+# Hydrogen & Shopify API Versioning
+
+Reference for all versioning schemes in the Hydrogen ecosystem. For release *process* (how to actually ship a release), see `hydrogen-release-process`. For domain architecture context, see `headless-storefronts-context`.
+
+## Shopify GraphQL API Versioning
+
+Shopify's GraphQL APIs (Storefront API, Customer Account API, Admin API) all use the same calendar versioning scheme.
+
+### Format: `YYYY-MM`
+
+- Uses **hyphens**, not dots
+- No trailing `.0` — the version is just `YYYY-MM`
+- Examples: `2025-01`, `2025-04`, `2025-07`, `2025-10`
+
+### Quarterly Release Schedule
+
+Four versions are released per year, always on the **1st of the release month**:
+
+| Quarter | Version | Release Date |
+|---------|---------|--------------|
+| Q1 | `YYYY-01` | January 1 |
+| Q2 | `YYYY-04` | April 1 |
+| Q3 | `YYYY-07` | July 1 |
+| Q4 | `YYYY-10` | October 1 |
+
+### The `unstable` Version
+
+An `unstable` version always exists alongside the CalVer versions. It is the bleeding edge:
+
+- New features land in `unstable` first, then in a specific CalVer version once verified
+- Breaking changes can happen at any time in `unstable`
+- **Not for production use** — only for previewing upcoming features
+
+### Release Candidates
+
+The upcoming CalVer version's release candidate becomes available ~3 months before its official release (it ships on the same day as the current quarter's stable release).
+
+Example timeline for `2026-04`:
+- **January 1, 2026**: `2026-01` is officially released. Simultaneously, the `2026-04` release candidate becomes available.
+- **~March 18, 2026**: Breaking changes to the `2026-04` RC are generally frozen.
+- **April 1, 2026**: `2026-04` is officially released.
+
+**Note on the RC freeze**: The ~2-week freeze before release is **internal policy, not publicly documented**. In rare cases, breaking changes to the RC may still be permitted with SLT approval. Do not cite this freeze window as an official guarantee to merchants or external parties.
+
+### Developer Changelog
+
+API changes in each new version are posted in the [Shopify developer changelog](https://shopify.dev/changelog). Check this when planning Hydrogen upgrades to understand what changed.
+
+## Hydrogen CalVer Versioning
+
+Hydrogen uses a **different** CalVer format than Shopify's GraphQL APIs.
+
+### Format: `YYYY.MAJOR.MINOR`
+
+- Uses **dots**, not hyphens (unlike Storefront API (SF API) versions)
+- **YYYY** = calendar year
+- **MAJOR** = the Storefront API release month (`1`, `4`, `7`, `10`) — NOT a sequential counter
+- **MINOR** = minor/patch number within that major release
+
+Examples:
+- `2025.7.0` = year 2025, aligned with SF API `2025-07`, first release of that major
+- `2025.7.3` = third patch of the `2025.7.x` line
+- `2026.1.0` = year 2026, aligned with SF API `2026-01`
+
+**Historical anomaly: `2025.5.x`**: Hydrogen versions `2025.5.0` and `2025.5.1` are the first and (so far) only releases outside the standard quarterly pattern. These were released to ship breaking/major changes between SF API version updates. There are no current plans to do this again — in general, breaking/major changes are timed to coincide with SF API version updates. However, an off-cycle major release could be warranted in the future if significant breaking changes need to ship between quarterly API updates.
+
+### Tied to Storefront API / Customer Account API (CA API)
+
+- Hydrogen releases a **new major version** with every SF API/CA API version update, regardless of whether there are breaking changes in the APIs
+- Breaking changes in Hydrogen are possible every 3 months with these API updates
+
+### Deriving Hydrogen Versions (Formula)
+
+SF API releases quarterly as `YYYY-MM`. Each SF API release triggers a corresponding Hydrogen major:
+
+```
+SF API YYYY-MM  →  Hydrogen YYYY.M.0
+```
+
+Where `M` is the month number without zero-padding: `01` → `1`, `04` → `4`, `07` → `7`, `10` → `10`.
+
+## Version Support Policy
+
+Both Hydrogen packages and Shopify GraphQL APIs follow the same support policy:
+
+- **365-day minimum support window** from release date (Shopify-wide standard)
+- After 365 days, a version may be sunset — but Shopify must provide at least 365 days of notice before any breaking change or sunset takes effect
+
+### Fall-Forward for Expired SF API Versions
+
+When a requested SF API version is >365 days old, requests are **not rejected**. Instead, they are automatically served by the **oldest currently-supported version** (which is a *newer* version than what was requested). This is called "fall-forward."
+
+**Example**: In May 2026, the valid SF API versions are:
+
+| Version | Released | Still Valid? |
+|---------|----------|-------------|
+| `2025-07` | Jul 1, 2025 | Yes (oldest valid) |
+| `2025-10` | Oct 1, 2025 | Yes |
+| `2026-01` | Jan 1, 2026 | Yes |
+| `2026-04` | Apr 1, 2026 | Yes (newest) |
+
+A request for `2024-10` (expired) would be served by `2025-07` (the oldest valid version). The merchant would silently get newer API behavior, which could include breaking changes.
+
+Currently 4 valid versions exist at any time (not counting `unstable`). This is a natural consequence of quarterly releases + 365-day support window.
+
+### Practical Implications
+
+- If no breaking changes or sunsets affect a merchant's specific API operations, they may not need to take action even after their version expires — but upgrading is still recommended
+- When a merchant reports "my storefront broke and I didn't change anything," check whether their requested API version recently fell forward to a newer one that may have breaking changes for their use case
+
+## Release Cadence Expectations
+
+Hydrogen aims to support new SF API versions promptly after release.
+
+### create-hydrogen Versioning
+
+The package is **`@shopify/create-hydrogen`** (scoped) — not the legacy unscoped `create-hydrogen` which stopped at 4.3.14 in mid-2024. It uses **SemVer**, not Hydrogen CalVer, so `npm create @shopify/hydrogen@2025.7.0` will not work as-is. There is no direct version correspondence — a lookup step is required.
+
+**How npm `create` resolves the package**: `npm create @shopify/hydrogen@VERSION` invokes `@shopify/create-hydrogen@VERSION` under the hood — npm prepends `create-` to scoped packages.
+
+**Lookup technique** — find which `@shopify/create-hydrogen` SemVer maps to a target Hydrogen CalVer:
+
+```bash
+gh api repos/Shopify/hydrogen/releases --paginate \
+  --jq '.[] | select(.tag_name | test("create-hydrogen|@shopify/hydrogen@TARGET")) | {tag: .tag_name, date: .published_at}'
+```
+
+Replace `TARGET` with the Hydrogen CalVer (e.g., `2025.7.0`). The `create-hydrogen` release published within seconds of the Hydrogen release is the correct match.
+
+**Known version mappings** (confirmed from GitHub release timestamps):
+
+| Hydrogen CalVer | `@shopify/create-hydrogen` | Released |
+|-----------------|---------------------------|----------|
+| `2025.7.0` | `5.0.25` | 2025-09-30 |
+
+**Scaffold command for a specific version**:
+```bash
+npm create @shopify/hydrogen@5.0.25  # scaffolds Hydrogen 2025.7.0 skeleton
+```
+
+## Related Skills
+
+- `hydrogen-release-process` — Release process, back-fixes, changelog.json, release failure recovery
+- `hydrogen-dev-workflow` — Day-to-day development workflow, testing, recipes, CLI tooling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,168 +2,27 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Hydrogen Release Process
+## Changeset Rules
 
-### Overview
-Hydrogen uses a sophisticated automated release system built on Changesets, GitHub Actions, and npm workspaces. Understanding this flow is critical for contributing effectively.
+Changesets track what packages need new releases and at what version bump level. They can be added via `npx changeset add` or by manually creating a markdown file with proper YAML frontmatter (either method is fine).
 
-### Release Flow: From PR to Production
+If changes affect `packages/*/src/**` or `packages/*/package.json`, a changeset is required.
 
-1. **Developer creates PR with changes**
-   - If changes affect `packages/*/src/**` or `packages/*/package.json`, a changeset is required
-   - Run `npm run changeset add` to create a changeset file **(MANUAL)**
-   - Changeset specifies which packages are affected and version bump type (patch/minor/major)
-   - These changesets go into Hydrogen's changelog, and are also used to generate upgrade instructions. **Write the changeset as if the audience is a merchant building with Hydrogen.**
+These changesets go into Hydrogen's changelog, and are also used to generate upgrade instructions. **Write the changeset as if the audience is a merchant building with Hydrogen.**
 
-2. **On merge to main, TWO parallel processes occur:**
+### Rule 1: Skeleton Template Changes
 
-   a) **Next Release (immediate)** **(AUTOMATIC)**
-      - Every push to main (except release commits) triggers `next-release.yml`
-      - Creates snapshot version: `0.0.0-next-{SHA}-{timestamp}`
-      - ALL packages are published with `next` tag
-      - Available immediately for testing latest changes
+Any change to `templates/skeleton` must include a changeset specifying a **patch** bump for **both** `@shopify/cli-hydrogen` and `@shopify/create-hydrogen` (in addition to `skeleton` itself). See the [Quick Reference](#quick-reference-contributing-to-skeleton-or-cli) below for details.
 
-   b) **Version PR Creation (if changesets exist)** **(AUTOMATIC)**
-      - `changesets.yml` workflow runs
-      - If changesets are found, creates OR updates open CI release PR
-      - PR title: `[ci] release 2025-05` (current latest branch)
-      - **Important**: This PR accumulates ALL changesets from merged PRs
-      - Multiple PRs can be merged before a release (e.g., 10 PRs = 10 changesets in one Version PR)
-      - The Version PR automatically updates as new changesets are merged
+If forgotten: new scaffolded projects will use a stale template until someone catches the gap.
 
-3. **Production Release - Batched (manual step)**
-   - **Releases are batched**: Maintainers decide when to release (could be after 1 PR or 10 PRs)
-   - The Version PR accumulates all pending changesets since last release
-   - Maintainer reviews accumulated changes and merges the Version PR when ready **(MANUAL)**
-   - On merge, `changesets.yml` publishes to npm with `latest` tag **(AUTOMATIC)**
-   - Only packages with changesets get new versions **(AUTOMATIC)**
-   - Internal dependencies updated with patch versions **(AUTOMATIC)**
-   - Post-release actions:
-     - Compiles templates to `dist` branch **(AUTOMATIC)**
-     - Sends Slack notification (if Hydrogen package included) **(AUTOMATIC)**
+### Rule 2: hydrogen-react Changes
 
-4. **Post-Release: Enabling Upgrades (manual step)**
-   - After npm publication, `docs/changelog.json` must be updated **(MANUAL)**
-   - This enables the `h2 upgrade` command to detect the new version
-   - Without this step, developers cannot upgrade using the CLI
-   - Process:
-     - Update `docs/changelog.json` with release information **(MANUAL)**
-     - Include version, dependencies, features, fixes, and upgrade steps **(MANUAL)**
-     - Commit and push to main branch **(MANUAL)**
-     - Changes are served via https://hydrogen.shopify.dev/changelog.json **(AUTOMATIC)**
+The entire contents of `hydrogen-react` are re-exported in Hydrogen. Any changeset for `hydrogen-react` must also specify a corresponding bump for `hydrogen`.
 
-   **How `h2 upgrade` works:**
-   - Fetches changelog.json from hydrogen.shopify.dev (proxies to the raw content of this file on the `main` branch in the Hydrogen repo)
-   - Compares user's current version against available versions
-   - Shows features, fixes, and breaking changes for upgrade path
-   - Generates local upgrade instructions file in `.hydrogen/` directory
-   - Updates package.json dependencies based on changelog specifications
+If forgotten: Hydrogen consumers will not get the `hydrogen-react` update until a separate Hydrogen release happens to include it.
 
-### Understanding Batched Releases
-
-**Key Point**: Not every merged PR triggers a release!
-
-- When you merge a PR with a changeset, it does NOT immediately release to npm
-- Instead, your changeset is added to the open CI release PR
-- This PR accumulates changesets from ALL merged PRs since the last release
-- Maintainers decide when to merge this PR to trigger an actual release
-- This allows batching multiple features/fixes into a single release
-
-**Example Timeline**:
-- Monday: 3 PRs merged with changesets → Version PR has 3 changesets
-- Tuesday: 2 more PRs merged → Version PR now has 5 changesets
-- Wednesday: 4 more PRs merged → Version PR now has 9 changesets
-- Thursday: Maintainer merges Version PR → All 9 changes released together
-
-### Multi-Package Releases
-- Each package versions independently (no fixed/linked packages in changesets config)
-- Single changeset can specify multiple packages
-- Example: PR changes both `@shopify/hydrogen` and `@shopify/cli-hydrogen`
-  - Both packages listed in changeset
-  - Each gets appropriate version bump
-  - Published together when Version PR merged
-
-### Other Release Types
-
-**Snapshot Testing (`/snapit`)**
-- Comment `/snapit` on any PR
-- Creates snapshot version for testing
-- Publishes specific packages for PR validation
-
-**Back-fix Releases**
-- Push to calver branches (e.g., `2025-01`)
-- Publishes with branch name as npm tag
-- Used for patching previous versions
-
-### Manual vs Automatic Steps
-
-#### Manual Steps (Human Intervention Required)
-
-1. **Developer Actions**
-   - **Create changesets**: Run `npm run changeset add` for any PR with code changes
-   - **Skeleton changes**: MUST include `@shopify/cli-hydrogen` in the changeset
-     - This ensures the CLI bundles the latest skeleton template
-     - Without this, new projects will scaffold with outdated templates
-   - **Write PR descriptions**: Include clear explanations of changes
-   - **Request snapshot builds**: Comment `/snapit` on PR to test changes
-
-2. **Maintainer Actions - Regular Releases**
-   - **Merge Version PR**: Review and merge the auto-generated open CI release PR to trigger npm publication
-   - **Update changelog.json**: After npm release, manually update this file to enable `h2 upgrade` command
-   - **Monitor releases**: Verify packages published correctly and Slack notifications sent
-
-3. **Maintainer Actions - CLI Releases**
-   - When cli-hydrogen has updates, create a PR in the Shopify CLI repo and coordinate with Shopify CLI team to request patch release
-   - **Update skeleton after CLI release**: Once @shopify/cli releases, update skeleton's package.json
-   - **Second cli-hydrogen release**: Often required to bundle the updated skeleton
-
-4. **Maintainer Actions - Major Version Changes**
-   - **Update latestBranch**: Edit `.github/workflows/changesets.yml` line 32 when moving to new major version
-     - Example: Change `echo "latestBranch=2025-01"` to `echo "latestBranch=2025-05"`
-     - Required quarterly with new Storefront API versions
-   - **Configure back-fix branches**: Add old calver branches to `.github/workflows/changesets-back-fix.yml`
-     - Enables continued patches to previous versions
-     - Never add the current calver branch
-
-#### Automatic Steps (CI/CD Handles)
-
-1. **On Every Push to Main**
-   - Next release publishes immediately with tag `next`
-   - Version: `0.0.0-next-{SHA}-{timestamp}`
-   - All packages published regardless of changesets
-
-2. **When Changesets Exist on Main**
-   - Version PR automatically created
-   - Title: `[ci] release {latestBranch}`
-   - Contains version bumps and CHANGELOG updates
-
-3. **When Version PR is Merged**
-   - Packages publish to npm with `latest` tag
-   - Only packages with changesets get new versions
-   - Templates compile and push to `dist` branch
-   - Slack notification sent (if Hydrogen package included)
-   - GitHub releases created with changelogs
-
-4. **When `/snapit` is Commented**
-   - Snapshot version created for PR
-   - Packages published with unique tag
-   - PR comment updated with installation instructions
-
-5. **On Push to Calver Branches**
-   - Back-fix version PR created
-   - Publishes with branch name as npm tag when merged
-
-### Version Strategy
-- Hydrogen versions follow calendar versioning (calver)
-- Format: `YYYY.MAJOR.MINOR/PATCH`
-- Example: `2025.5.0` means:
-  - `2025` - year
-  - `5` - major release cycle (tied to Storefront API versions)
-  - `0` - minor/patch number
-- Tied to Shopify Storefront API versions
-- Breaking changes possible every 3 months with API updates
-- Hydrogen releases a new "major" version with **every** Storefront API version update, regardless of whether or not there are breaking changes between the Storefront API versions
-
+For the full release process (standard, back-fix, snapshot, failure recovery), see the `hydrogen-release-process` skill. For versioning semantics, see the `hydrogen-versioning` skill.
 
 ### CLI Dependency Graph
 The Hydrogen CLI system works through a plugin architecture:
@@ -172,7 +31,7 @@ The Hydrogen CLI system works through a plugin architecture:
 Developer's Project (e.g., skeleton template)
     ├── package.json
     │   └── devDependencies
-    │       └── @shopify/cli (~3.80.4)
+    │       └── @shopify/cli
     │
     └── npm scripts
         └── "shopify hydrogen dev" commands
@@ -209,37 +68,97 @@ The skeleton template is the default starter template for new Hydrogen projects:
 
 When developers run `npm create @shopify/hydrogen@latest`:
 
-1. **Package Resolution**
-   - npm resolves `@shopify/create-hydrogen` package
-   - This package calls the `hydrogen init` command from `@shopify/cli-hydrogen`
+1. **Default behavior**: Uses the skeleton template bundled inside `@shopify/create-hydrogen`
+   - No network fetch required—the template is pre-bundled at build time
+   - This is why `create-hydrogen` must be bumped when skeleton changes
 
-2. **Template Fetching**
-   - Downloads the latest Hydrogen release tarball from GitHub
-   - Uses GitHub API: `https://api.github.com/repos/shopify/hydrogen/releases/latest`
-   - Extracts the skeleton template from the tarball
-   - Falls back to local template if running within Hydrogen monorepo
+2. **Custom templates** (`--template` flag): Downloads from GitHub
+   - Uses GitHub API to fetch the specified template
+   - Supports community templates and alternative starters
 
-3. **Template Compilation** (during release)
-   - On production releases, templates are compiled to the `dist` branch
-   - Creates both TypeScript (`skeleton-ts`) and JavaScript (`skeleton-js`) versions
-   - The `dist` branch serves as a stable source for templates
+<details>
+<summary>Technical Details: The Bundling Chain</summary>
 
-### Critical: Skeleton Changes Require CLI Updates
+During a Hydrogen release, templates are bundled through this chain:
 
-**When modifying the skeleton template, you MUST**:
-1. Create a changeset that includes BOTH:
-   - The skeleton template changes
-   - A version bump for `@shopify/cli-hydrogen`
-2. This ensures the CLI contains a snapshot of the latest skeleton in its `dist/assets/templates` directory
-3. Without this, newly scaffolded projects will use an outdated skeleton template
+```
+templates/skeleton/
+    ↓ bundled into
+@shopify/cli-hydrogen (dist/assets/templates/)
+    ↓ bundled into
+@shopify/create-hydrogen (bundles cli-hydrogen at build time)
+    ↓ published to npm
+npm create @shopify/hydrogen@latest
+```
 
-**Why this matters**: The `@shopify/cli-hydrogen` package bundles the skeleton template. If you don't bump its version when changing the skeleton, the CLI will continue distributing the old template version.
+The `dist` branch also receives compiled templates for alternative distribution methods.
 
-### CLI Release Coordination (Circular Dependency)
+</details>
 
-The CLI system has an inherent circular dependency that requires careful coordination:
+### Quick Reference: Contributing to Skeleton or CLI
 
-**The Circular Dependency Problem**:
+#### I'm Updating the Skeleton Template
+
+**Required changeset packages:**
+- `skeleton` — the source you changed
+- `@shopify/cli-hydrogen` — bundles skeleton into its dist
+- `@shopify/create-hydrogen` — bundles cli-hydrogen into its dist
+
+⚠️ **Important**: When you run `npm run changeset add`, it only shows packages with
+actual code changes. You must **manually select** cli-hydrogen and create-hydrogen
+even though you didn't change their code. Alternatively, manually add those lines
+to the changeset file after creation.
+
+**Example changeset:**
+```md
+---
+"skeleton": patch
+"@shopify/cli-hydrogen": patch
+"@shopify/create-hydrogen": patch
+---
+
+Update skeleton template with [description of your changes]
+```
+
+**Canonical example**: See [PR #3232](https://github.com/Shopify/hydrogen/pull/3232) for a complete skeleton update with proper changeset.
+
+<details>
+<summary>Why all three packages?</summary>
+
+See the "Technical Details: The Bundling Chain" section above. If you only bump `skeleton`, the npm packages won't rebuild with your changes. If you only bump `cli-hydrogen`, the `create-hydrogen` package won't include the updated CLI. All three must be bumped to ensure `npm create @shopify/hydrogen@latest` gets your changes.
+
+</details>
+
+#### I'm Updating the CLI (cli-hydrogen)
+
+**Scenario A: CLI-only change (no init/scaffolding impact)**
+- Just bump `@shopify/cli-hydrogen`
+- Examples: bug fixes in non-init commands such as `dev`, `build`, or `check`; new flags for existing commands
+
+**Scenario B: Change affects the `init` command, scaffolding process, or CLI assets**
+- Bump both `@shopify/cli-hydrogen` and `@shopify/create-hydrogen`
+- Examples: changes to how `hydrogen init` (which powers `npm create @shopify/hydrogen`) works; changes to virtual-route templates or other files in `packages/cli/assets/`
+
+<details>
+<summary>When does a CLI change affect scaffolding?</summary>
+
+`create-hydrogen` bundles two things from `@shopify/cli-hydrogen`:
+1. **The `init` command code** — tree-shaken from the `init` entry point and its transitive dependencies only
+2. **The full `dist/assets` directory** — templates, virtual routes, tailwind configs, and other shared assets
+
+**"Does this change affect the `init` command, or any files in `packages/cli/assets/`?"**
+
+- **Yes** → bump both `cli-hydrogen` and `create-hydrogen`
+- **No** → just bump `cli-hydrogen`
+
+For non-init command changes (bug fixes to commands such as `dev`/`build`/`check`, new non-init commands): these reach newly scaffolded projects through the skeleton's `@shopify/cli` version. If those changes need to be in new scaffolds quickly, follow the circular dependency release cycle described in **Skeleton's CLI Version (Post-Release Action)** under *Understanding the Circular Dependency* below.
+
+</details>
+
+### Understanding the Circular Dependency
+
+The CLI system has an inherent circular dependency, but it's manageable:
+
 ```
 @shopify/cli-hydrogen (bundles skeleton)
     ↓ is included in
@@ -250,29 +169,27 @@ skeleton template's devDependencies
 @shopify/cli-hydrogen (circular!)
 ```
 
-**Release Process to Handle This**:
+**The circular dependency exists but is manageable:**
 
-1. **First Release**:
-   - Release `@shopify/cli-hydrogen` with new features/fixes
-   - Trigger `@shopify/cli` release to include updated `cli-hydrogen`
-   - Problem: The skeleton bundled in `cli-hydrogen` still references the OLD `@shopify/cli` version
+We break the cycle with a simple rule: skeleton changes → bump all three packages (skeleton, cli-hydrogen, create-hydrogen). This ensures the release includes everything needed.
 
-2. **Second Release Required**:
-   - Update skeleton's `package.json` to use new `@shopify/cli` version
-   - Create another changeset bumping `@shopify/cli-hydrogen`
-   - Release again so future `cli-hydrogen` bundles the updated skeleton
+**Skeleton's CLI Version (Post-Release Action):**
 
-**Example Timeline**:
-- Day 1: Release `@shopify/cli-hydrogen@8.1.0` with new command
-- Day 2: `@shopify/cli@3.80.0` released with updated hydrogen plugin
-- Day 3: Update skeleton to use `@shopify/cli@~3.80.0`
-- Day 4: Release `@shopify/cli-hydrogen@8.1.1` with updated skeleton
-- Result: New projects now have access to the new command
+After Shopify CLI releases a new version containing updated `@shopify/cli-hydrogen`, whether further action is required depends on what the cli-hydrogen changes contained:
 
-**Key Takeaways**:
-- This process often requires TWO cli-hydrogen releases for complete updates
-- The circular dependency makes the process complex but is currently unavoidable
-- Always check that skeleton's CLI version matches the features available in cli-hydrogen
+**If cli-hydrogen had actual changes** (any code changes: bug fixes, new commands, refactors — anything beyond just adding a changeset to bundle a new skeleton template):
+- Manually update skeleton's `@shopify/cli` dependency to the new Shopify CLI version
+- Create changesets for the skeleton template AND `@shopify/cli-hydrogen` AND `@shopify/create-hydrogen`
+- This triggers another cli-hydrogen release (now bundling the updated skeleton) and another Shopify CLI release
+- Required so new Hydrogen storefronts are created with the latest cli-hydrogen changes
+
+**If cli-hydrogen changes were ONLY a changeset to re-bundle the skeleton** (no actual code changes to cli-hydrogen itself):
+- No further action required after Shopify CLI releases
+- The skeleton's `@shopify/cli` version does not need to be updated
+
+**The key question**: "Were there actual code changes to cli-hydrogen, beyond just adding a changeset to bundle an updated skeleton?"
+- **Yes** → Manually update skeleton's CLI version and release another cli-hydrogen cycle
+- **No** → Done
 
 ## Security concerns
 


### PR DESCRIPTION
## Summary

Part of https://github.com/Shopify/developer-tools-team/issues/1052.

- **Create** `hydrogen-release-process` skill — dedicated on-demand runbook for the full release flow (standard, back-fix, snapshot), manual vs automatic steps, changelog.json updates, h2 upgrade enablement, failure recovery, and Dependabot review guidance
- **Slim** `CLAUDE.md` from ~340 to ~195 lines — keeps only changeset rules (now 3 rules, adding hydrogen-react and CI blind-spot rules), skeleton/CLI quick reference, and circular dependency explanation
- **Clean** `hydrogen-dev-workflow` skill — removes release process and changeset sections that now live elsewhere; fixes dangling cross-references
- **Update** `hydrogen-versioning` skill — cross-references now point to the new release skill

### Stale reference fixes
- `changesets.yml` → `release.yml` (unified workflow)
- `next-release.yml` → `next-release` job in `release.yml`
- `changesets-back-fix.yml` → `backfix-release` job in `release.yml`
- `latestBranch` → `latestVersion` in PR title documentation
- Hardcoded `~3.80.4` CLI version removed from diagram
- Fragile line-number references removed
- `latestBranch` described as dynamically computed (not hardcoded)

### Why
CLAUDE.md loads into every Claude Code session. ~145 lines of release process detail were loading even for tasks like fixing a typo or reviewing a bug fix. Moving this content to an on-demand skill means it only loads when triggered by keywords like "release", "back-fix", or "changelog.json".

### Out of scope
`docs/CALVER.md` has 6 stale references to `changesets.yml` that should be `release.yml` — noted for a separate cleanup.
