### PR TITLE
refactor: abstract proxy handler

### DIFF
--- a/.changeset/green-kings-flow.md
+++ b/.changeset/green-kings-flow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Added a public `handleProxyStandardRoutes()` export so custom server runtimes like Next.js can reuse Hydrogen's built-in Storefront API proxy handling for `/api/.../graphql.json` requests.

--- a/.changeset/green-kings-flow.md
+++ b/.changeset/green-kings-flow.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Added a public `handleProxyStandardRoutes()` export so custom server runtimes like Next.js can reuse Hydrogen's built-in Storefront API proxy handling for `/api/.../graphql.json` requests.
+Extracted `handleProxyStandardRoutes()` for use outside React Router contexts. Requires a `Storefront` client instance to proxy `/api/.../graphql.json` requests.

--- a/packages/hydrogen/src/createRequestHandler.ts
+++ b/packages/hydrogen/src/createRequestHandler.ts
@@ -6,6 +6,7 @@ import {
 } from 'react-router';
 import {storefrontContext} from './context-keys';
 import {HYDROGEN_SFAPI_PROXY_KEY} from './constants';
+import {handleProxyStandardRoutes} from './handleProxyStandardRoutes';
 import {appendServerTimingHeader} from './utils/server-timing';
 import {warnOnce} from './utils/warning';
 
@@ -93,10 +94,16 @@ export function createRequestHandler<Context = unknown>({
         );
       }
 
-      if (storefront?.isStorefrontApiUrl(request)) {
-        const response = await storefront.forward(request);
-        appendPoweredByHeader?.(response);
-        return response;
+      if (storefront) {
+        const proxyResponsePromise = handleProxyStandardRoutes({
+          request,
+          storefront,
+        });
+        if (proxyResponsePromise) {
+          const proxyResponse = await proxyResponsePromise;
+          appendPoweredByHeader?.(proxyResponse);
+          return proxyResponse;
+        }
       }
     }
 

--- a/packages/hydrogen/src/handleProxyStandardRoutes.doc.ts
+++ b/packages/hydrogen/src/handleProxyStandardRoutes.doc.ts
@@ -1,0 +1,42 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'handleProxyStandardRoutes',
+  category: 'utilities',
+  isVisualComponent: false,
+  related: [
+    {
+      name: 'createStorefrontClient',
+      type: 'utilities',
+      url: '/docs/api/hydrogen/utilities/createstorefrontclient',
+    },
+    {
+      name: 'createRequestHandler',
+      type: 'utilities',
+      url: '/docs/api/hydrogen/utilities/createrequesthandler',
+    },
+  ],
+  description: `Proxies Hydrogen's standard Storefront API routes outside React Router. Pass a Request together with a Storefront client, and return the proxied Response directly when this function returns one. When it returns \`undefined\`, continue with your app's normal request handling.`,
+  type: 'utility',
+  defaultExample: {
+    description: 'I am the default example',
+    codeblock: {
+      tabs: [
+        {
+          title: 'JavaScript',
+          code: './handleProxyStandardRoutes.example.js',
+          language: 'js',
+        },
+        {
+          title: 'TypeScript',
+          code: './handleProxyStandardRoutes.example.ts',
+          language: 'ts',
+        },
+      ],
+      title: 'Example code',
+    },
+  },
+  definitions: [],
+};
+
+export default data;

--- a/packages/hydrogen/src/handleProxyStandardRoutes.example.js
+++ b/packages/hydrogen/src/handleProxyStandardRoutes.example.js
@@ -1,0 +1,26 @@
+import {
+  createStorefrontClient,
+  handleProxyStandardRoutes,
+} from '@shopify/hydrogen';
+import {getStorefrontHeaders} from '@shopify/hydrogen/oxygen';
+
+export default {
+  async fetch(request, env, executionContext) {
+    const {storefront} = createStorefrontClient({
+      cache: await caches.open('hydrogen'),
+      waitUntil: executionContext.waitUntil.bind(executionContext),
+      privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
+      publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
+      storeDomain: env.PUBLIC_STORE_DOMAIN,
+      storefrontHeaders: getStorefrontHeaders(request),
+    });
+
+    const proxyResponse = handleProxyStandardRoutes({request, storefront});
+
+    if (proxyResponse) {
+      return proxyResponse;
+    }
+
+    return new Response('Handle the rest of your app here.');
+  },
+};

--- a/packages/hydrogen/src/handleProxyStandardRoutes.example.ts
+++ b/packages/hydrogen/src/handleProxyStandardRoutes.example.ts
@@ -1,0 +1,30 @@
+import {
+  createStorefrontClient,
+  handleProxyStandardRoutes,
+} from '@shopify/hydrogen';
+import {getStorefrontHeaders} from '@shopify/hydrogen/oxygen';
+
+export default {
+  async fetch(
+    request: Request,
+    env: Record<string, string>,
+    executionContext: ExecutionContext,
+  ) {
+    const {storefront} = createStorefrontClient({
+      cache: await caches.open('hydrogen'),
+      waitUntil: executionContext.waitUntil.bind(executionContext),
+      privateStorefrontToken: env.PRIVATE_STOREFRONT_API_TOKEN,
+      publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
+      storeDomain: env.PUBLIC_STORE_DOMAIN,
+      storefrontHeaders: getStorefrontHeaders(request),
+    });
+
+    const proxyResponse = handleProxyStandardRoutes({request, storefront});
+
+    if (proxyResponse) {
+      return proxyResponse;
+    }
+
+    return new Response('Handle the rest of your app here.');
+  },
+};

--- a/packages/hydrogen/src/handleProxyStandardRoutes.test.ts
+++ b/packages/hydrogen/src/handleProxyStandardRoutes.test.ts
@@ -2,7 +2,7 @@ import {describe, it, expect, vi} from 'vitest';
 import {handleProxyStandardRoutes} from './handleProxyStandardRoutes';
 
 describe('handleProxyStandardRoutes', () => {
-  it('proxies dated Storefront API routes', async () => {
+  it('returns the proxied response when the storefront marks the request as proxied', async () => {
     const response = new Response('proxied');
     const storefront = {
       isStorefrontApiUrl: vi.fn(() => true),
@@ -20,39 +20,20 @@ describe('handleProxyStandardRoutes', () => {
     expect(storefront.forward).toHaveBeenCalledWith(request);
   });
 
-  it('proxies unstable Storefront API routes', async () => {
-    const response = new Response('proxied');
-    const storefront = {
-      isStorefrontApiUrl: vi.fn(() => true),
-      forward: vi.fn(async () => response),
-    };
-    const request = new Request(
-      'https://example.com/api/unstable/graphql.json',
-    );
-
-    const proxyResponse = await handleProxyStandardRoutes({
-      request,
-      storefront,
-    });
-
-    expect(proxyResponse).toBe(response);
-    expect(storefront.isStorefrontApiUrl).toHaveBeenCalledWith(request);
-    expect(storefront.forward).toHaveBeenCalledWith(request);
-  });
-
-  it('returns undefined when the route is not proxied', async () => {
+  it('returns undefined when the route is not proxied', () => {
     const storefront = {
       isStorefrontApiUrl: vi.fn(() => false),
       forward: vi.fn(),
     };
     const request = new Request('https://example.com/products/widget');
 
-    const proxyResponse = await handleProxyStandardRoutes({
+    const proxyResponse = handleProxyStandardRoutes({
       request,
       storefront,
     });
 
     expect(proxyResponse).toBeUndefined();
+    expect(storefront.isStorefrontApiUrl).toHaveBeenCalledWith(request);
     expect(storefront.forward).not.toHaveBeenCalled();
   });
 });

--- a/packages/hydrogen/src/handleProxyStandardRoutes.test.ts
+++ b/packages/hydrogen/src/handleProxyStandardRoutes.test.ts
@@ -1,0 +1,58 @@
+import {describe, it, expect, vi} from 'vitest';
+import {handleProxyStandardRoutes} from './handleProxyStandardRoutes';
+
+describe('handleProxyStandardRoutes', () => {
+  it('proxies dated Storefront API routes', async () => {
+    const response = new Response('proxied');
+    const storefront = {
+      isStorefrontApiUrl: vi.fn(() => true),
+      forward: vi.fn(async () => response),
+    };
+    const request = new Request('https://example.com/api/2026-01/graphql.json');
+
+    const proxyResponse = await handleProxyStandardRoutes({
+      request,
+      storefront,
+    });
+
+    expect(proxyResponse).toBe(response);
+    expect(storefront.isStorefrontApiUrl).toHaveBeenCalledWith(request);
+    expect(storefront.forward).toHaveBeenCalledWith(request);
+  });
+
+  it('proxies unstable Storefront API routes', async () => {
+    const response = new Response('proxied');
+    const storefront = {
+      isStorefrontApiUrl: vi.fn(() => true),
+      forward: vi.fn(async () => response),
+    };
+    const request = new Request(
+      'https://example.com/api/unstable/graphql.json',
+    );
+
+    const proxyResponse = await handleProxyStandardRoutes({
+      request,
+      storefront,
+    });
+
+    expect(proxyResponse).toBe(response);
+    expect(storefront.isStorefrontApiUrl).toHaveBeenCalledWith(request);
+    expect(storefront.forward).toHaveBeenCalledWith(request);
+  });
+
+  it('returns undefined when the route is not proxied', async () => {
+    const storefront = {
+      isStorefrontApiUrl: vi.fn(() => false),
+      forward: vi.fn(),
+    };
+    const request = new Request('https://example.com/products/widget');
+
+    const proxyResponse = await handleProxyStandardRoutes({
+      request,
+      storefront,
+    });
+
+    expect(proxyResponse).toBeUndefined();
+    expect(storefront.forward).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hydrogen/src/handleProxyStandardRoutes.ts
+++ b/packages/hydrogen/src/handleProxyStandardRoutes.ts
@@ -1,0 +1,15 @@
+import type {Storefront} from './storefront';
+
+export function handleProxyStandardRoutes({
+  request,
+  storefront,
+}: {
+  request: Request;
+  storefront: Storefront;
+}): Promise<Response> | undefined {
+  if (!storefront.isStorefrontApiUrl(request)) {
+    return undefined;
+  }
+
+  return storefront.forward(request);
+}

--- a/packages/hydrogen/src/handleProxyStandardRoutes.ts
+++ b/packages/hydrogen/src/handleProxyStandardRoutes.ts
@@ -1,5 +1,13 @@
 import type {Storefront} from './storefront';
 
+/**
+ * Proxies Hydrogen's standard Storefront API routes for non-React-Router
+ * runtimes.
+ *
+ * Returns `undefined` when the request is not a proxied route so normal
+ * request handling can continue. Returns a `Promise<Response>` when the
+ * request is proxied and the response should be returned directly.
+ */
 export function handleProxyStandardRoutes({
   request,
   storefront,

--- a/packages/hydrogen/src/handleProxyStandardRoutes.ts
+++ b/packages/hydrogen/src/handleProxyStandardRoutes.ts
@@ -5,7 +5,7 @@ export function handleProxyStandardRoutes({
   storefront,
 }: {
   request: Request;
-  storefront: Storefront;
+  storefront: Pick<Storefront, 'isStorefrontApiUrl' | 'forward'>;
 }): Promise<Response> | undefined {
   if (!storefront.isStorefrontApiUrl(request)) {
     return undefined;

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -96,6 +96,7 @@ export {
   type VisitorConsentCollected,
 } from './customer-privacy/ShopifyCustomerPrivacy';
 export {hydrogenRoutes} from './dev/hydrogen-routes';
+export {handleProxyStandardRoutes} from './handleProxyStandardRoutes';
 export {
   OptimisticInput,
   useOptimisticData,

--- a/templates/skeleton/storefrontapi.generated.d.ts
+++ b/templates/skeleton/storefrontapi.generated.d.ts
@@ -377,13 +377,6 @@ export type FooterQuery = {
   >;
 };
 
-export type StoreRobotsQueryVariables = StorefrontAPI.Exact<{
-  country?: StorefrontAPI.InputMaybe<StorefrontAPI.CountryCode>;
-  language?: StorefrontAPI.InputMaybe<StorefrontAPI.LanguageCode>;
-}>;
-
-export type StoreRobotsQuery = {shop: Pick<StorefrontAPI.Shop, 'id'>};
-
 export type FeaturedCollectionFragment = Pick<
   StorefrontAPI.Collection,
   'id' | 'title' | 'handle'
@@ -1282,10 +1275,6 @@ interface GeneratedQueryTypes {
   '#graphql\n  query Footer(\n    $country: CountryCode\n    $footerMenuHandle: String!\n    $language: LanguageCode\n  ) @inContext(language: $language, country: $country) {\n    menu(handle: $footerMenuHandle) {\n      ...Menu\n    }\n  }\n  #graphql\n  fragment MenuItem on MenuItem {\n    id\n    resourceId\n    tags\n    title\n    type\n    url\n  }\n  fragment ChildMenuItem on MenuItem {\n    ...MenuItem\n  }\n  fragment ParentMenuItem on MenuItem {\n    ...MenuItem\n    items {\n      ...ChildMenuItem\n    }\n  }\n  fragment Menu on Menu {\n    id\n    items {\n      ...ParentMenuItem\n    }\n  }\n\n': {
     return: FooterQuery;
     variables: FooterQueryVariables;
-  };
-  '#graphql\n  query StoreRobots($country: CountryCode, $language: LanguageCode)\n   @inContext(country: $country, language: $language) {\n    shop {\n      id\n    }\n  }\n': {
-    return: StoreRobotsQuery;
-    variables: StoreRobotsQueryVariables;
   };
   '#graphql\n  fragment FeaturedCollection on Collection {\n    id\n    title\n    image {\n      id\n      url\n      altText\n      width\n      height\n    }\n    handle\n  }\n  query FeaturedCollection($country: CountryCode, $language: LanguageCode)\n    @inContext(country: $country, language: $language) {\n    collections(first: 1, sortKey: UPDATED_AT, reverse: true) {\n      nodes {\n        ...FeaturedCollection\n      }\n    }\n  }\n': {
     return: FeaturedCollectionQuery;


### PR DESCRIPTION
### WHY are these changes introduced?

We want to start separating the server-side analytics and SFAPI proxy behavior from React Router-specific request handling.

This change extracts the standard route proxy logic behind `createRequestHandler` into a small standalone helper so we can begin reusing that behavior in non-React-Router environments without changing the current Hydrogen request flow.

### WHAT is this pull request doing?

- extracts the `proxyStandardRoutes` forwarding branch from `createRequestHandler` into `packages/hydrogen/src/handleProxyStandardRoutes.ts`
- keeps `createRequestHandler` responsible for deciding when to call the helper and for appending the `powered-by` header to proxied responses
- preserves the existing behavior of the proxy path:
  - returns `undefined` when the incoming request is not a proxied SFAPI route
  - returns the forwarded `Response` when the incoming request matches a proxied SFAPI route
- leaves the existing subrequest tracking / `Server-Timing` response logic in `createRequestHandler` unchanged

This is intended to be a behavior-preserving refactor and a first step toward making the server-side SFAPI proxy path easier to reuse in other frameworks.

### HOW to test your changes?

1. Run:

```bash
pnpm exec eslint packages/hydrogen/src/createRequestHandler.ts packages/hydrogen/src/handleProxyStandardRoutes.ts
```

2. Exercise a request that matches `/api/{version}/graphql.json` and confirm it is still forwarded through the storefront proxy.
3. Exercise a non-SFAPI route and confirm it still falls through to the normal React Router request handler.
4. Confirm proxied responses still receive the `powered-by: Shopify, Hydrogen` header when `poweredByHeader` is enabled.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
