### PR TITLE
refactor: replace `@xstate/react` with a patched pkg to remove React 19 warnings

### DIFF
--- a/packages/hydrogen-react/package.json
+++ b/packages/hydrogen-react/package.json
@@ -176,7 +176,7 @@
   "dependencies": {
     "@google/model-viewer": "^4.0.0",
     "@xstate/fsm": "2.0.0",
-    "@xstate/react": "3.2.1",
+    "@nexpb/xstate-react-patched": "3.4.0",
     "ast-v8-to-istanbul": "^0.3.11",
     "graphql": "^16.10.0",
     "type-fest": "^4.33.0",

--- a/packages/hydrogen-react/src/useCartAPIStateMachine.tsx
+++ b/packages/hydrogen-react/src/useCartAPIStateMachine.tsx
@@ -1,4 +1,4 @@
-import {useMachine} from '@xstate/react/fsm';
+import {useMachine} from '@nexpb/xstate-react-patched/fsm';
 import {createMachine, assign, StateMachine} from '@xstate/fsm';
 import {
   Cart,

--- a/packages/hydrogen-react/vite.config.ts
+++ b/packages/hydrogen-react/vite.config.ts
@@ -67,37 +67,13 @@ export default defineConfig(({mode, isSsrBuild}) => {
       minify: false,
       emptyOutDir: false,
       rollupOptions: {
-        external: (id) => {
-          /**
-            xstate is marked as "not external" because it has import paths that don't work in a pure-esm resolution algo (yet).
-            For example, `import {} from '@xstate/react/fsm'` doesn't actually exist in the file path, so we need Vite to process it so it does
-            Hypothetically, if they update their package to do so, then we can externalize it at that point.
-
-            Note that this has no effect on the ssr builds; we need to mark xstate as "not external" in 'ssr.noExternal' https://vitejs.dev/config/ssr-options.html#ssr-noexternal
-           */
-          if (id.includes('xstate')) {
-            return false;
-          }
-
-          return externals.includes(id);
-        },
+        external: externals,
         output: {
           // keep the folder structure of the components in the dist folder
           preserveModules: true,
           preserveModulesRoot: 'src',
         },
       },
-    },
-    ssr: {
-      // for esm builds, we need Vite to process these deps in order to work correctly
-      noExternal: [
-        '@xstate',
-        '@xstate/react',
-        '@xstate/fsm',
-        '@xstate/react/fsm',
-        'use-sync-external-store',
-        'use-isomorphic-layout-effect',
-      ],
     },
     define: {
       __HYDROGEN_DEV__: mode === 'devbuild' || mode === 'test',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,12 +546,12 @@ importers:
       '@google/model-viewer':
         specifier: ^4.0.0
         version: 4.1.0(three@0.172.0)
+      '@nexpb/xstate-react-patched':
+        specifier: 3.4.0
+        version: 3.4.0(@types/react@18.3.28)(@xstate/fsm@2.0.0)(react@18.3.1)
       '@xstate/fsm':
         specifier: 2.0.0
         version: 2.0.0
-      '@xstate/react':
-        specifier: 3.2.1
-        version: 3.2.1(@types/react@18.3.28)(@xstate/fsm@2.0.0)(react@18.3.1)
       ast-v8-to-istanbul:
         specifier: ^0.3.11
         version: 0.3.11
@@ -2389,6 +2389,18 @@ packages:
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
 
+  '@nexpb/xstate-react-patched@3.4.0':
+    resolution: {integrity: sha512-rRLqQT077FfDeowq9Ede/I8tRzSDELtHE1PvRhd+9RO4XModrBo7Oibb2UW53KBscap2l2oKAgj8X/jJ1mUkYQ==}
+    peerDependencies:
+      '@xstate/fsm': ^2.0.0
+      react: ^18.0.0 || ^19.0.0
+      xstate: ^4.37.2
+    peerDependenciesMeta:
+      '@xstate/fsm':
+        optional: true
+      xstate:
+        optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3416,18 +3428,6 @@ packages:
 
   '@xstate/fsm@2.0.0':
     resolution: {integrity: sha512-p/zcvBMoU2ap5byMefLkR+AM+Eh99CU/SDEQeccgKlmFNOMDwphaRGqdk+emvel/SaGZ7Rf9sDvzAplLzLdEVQ==}
-
-  '@xstate/react@3.2.1':
-    resolution: {integrity: sha512-L/mqYRxyBWVdIdSaXBHacfvS8NKn3sTKbPb31aRADbE9spsJ1p+tXil0GVQHPlzrmjGeozquLrxuYGiXsFNU7g==}
-    peerDependencies:
-      '@xstate/fsm': ^2.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      xstate: ^4.36.0
-    peerDependenciesMeta:
-      '@xstate/fsm':
-        optional: true
-      xstate:
-        optional: true
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -10408,6 +10408,16 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
+  '@nexpb/xstate-react-patched@3.4.0(@types/react@18.3.28)(@xstate/fsm@2.0.0)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      use-isomorphic-layout-effect: 1.2.1(@types/react@18.3.28)(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@xstate/fsm': 2.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -11724,16 +11734,6 @@ snapshots:
       tslib: 2.8.1
 
   '@xstate/fsm@2.0.0': {}
-
-  '@xstate/react@3.2.1(@types/react@18.3.28)(@xstate/fsm@2.0.0)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      use-isomorphic-layout-effect: 1.2.1(@types/react@18.3.28)(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      '@xstate/fsm': 2.0.0
-    transitivePeerDependencies:
-      - '@types/react'
 
   accepts@1.3.8:
     dependencies:


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

(I understand having a forked dep from a random guy doesn't exactly make this mergeable but, it's mostly done to bring awareness to the outstanding issue https://github.com/Shopify/hydrogen/issues/3428)

The upstream `@xstate/react` package dropped support for `@xstate/fsm` in newer versions. This replaces it with a patched fork that preserves `@xstate/fsm` compatibility, allows react 19 and adds proper ESM support via the exports field.

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

- Replaces `@xstate/react@3.2.1` with `@nexpb/xstate-react-patched@3.4.0`
- Updates the import in `useCartAPIStateMachine.tsx`
- Removes the`ssr.noExternal` block from `vite.config.ts` — it was dead config since rollupOptions.external already externalizes all dependencies

### HOW to test your changes?

`cd packages/hydrogen-react && pnpm run test`
`cd packages/hydrogen-react && pnpm run build` 

#### Post-merge steps

None

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->

