### PR TITLE
chore: scaffold 2025-10 back-fix branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
       # To do a back-fix of a past CalVer branch, update this to the relevant branch
       # Example: If we are currently on 2025-07, add 2025-01 here to do a back-fix
       # release for the 2025-01 CalVer branch
-      - 2025-01
       - 2025-10
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
       # Example: If we are currently on 2025-07, add 2025-01 here to do a back-fix
       # release for the 2025-01 CalVer branch
       - 2025-01
+      - 2025-10
 
 concurrency:
   group: release-${{ github.ref_name }}


### PR DESCRIPTION
Add 2025-10 to the release workflow's branch list so that changesets merged into this branch trigger back-fix releases.
