### PR TITLE
docs: fix stale workflow file references across repo

### DIFF
--- a/.github/workflows/test-calver.yml
+++ b/.github/workflows/test-calver.yml
@@ -3,7 +3,7 @@ name: Test CalVer Scripts
 # This workflow validates the automated CalVer (Calendar Versioning) release system
 # that powers Hydrogen's quarterly release cycle aligned with Shopify Storefront API versions.
 #
-# CRITICAL: These scripts run in production changesets.yml workflow during every release.
+# CRITICAL: These scripts run in production release.yml workflow during every release.
 # Failures here indicate potential version corruption, release blocking, or incorrect
 # quarterly alignment that affects millions of Hydrogen developers.
 #
@@ -13,7 +13,7 @@ name: Test CalVer Scripts
 # 3. Patch versioning - CalVer packages increment correctly (2025.5.0 → 2025.5.1)
 # 4. Major versioning - CalVer packages align to quarters (2025.5.0 → 2025.7.0 for Q3)
 # 5. Branch detection - Automated quarter advancement logic (2025-05 → 2025-07)
-# 6. CLI utilities - Shared functions used by changesets.yml workflow
+# 6. CLI utilities - Shared functions used by release.yml workflow
 # 7. Mixed packages - CalVer vs semver package type handling and precedence logic
 #
 # Each test validates against actual package.json versions and changeset files,

--- a/docs/CALVER.md
+++ b/docs/CALVER.md
@@ -308,7 +308,7 @@ node scripts/get-latest-branch.js
 
 ### 1. Regular Release (main branch)
 - **Trigger**: Merge to main with changesets
-- **Workflow**: `.github/workflows/changesets.yml`
+- **Workflow**: `.github/workflows/release.yml` (`release` job)
 - **Branch Detection**: Automatic via `get-latest-branch.js`
 - **Version Calculation**: Automatic via `calver-shared.js` utilities
 - **Version PR Title**: `[ci] release YYYY.Q.P` (CalVer format)
@@ -316,14 +316,14 @@ node scripts/get-latest-branch.js
 
 ### 2. Back-fix Release (CalVer branches)
 - **Trigger**: Push to CalVer branch (e.g., `2025-01`)
-- **Workflow**: `.github/workflows/changesets-back-fix.yml`
+- **Workflow**: `.github/workflows/release.yml` (`backfix-release` job)
 - **Branch**: Uses branch name directly
 - **Version PR Title**: `[ci] back-fix release YYYY-MM`
 - **npm tag**: Branch name (e.g., `2025-01`)
 
 ### 3. Next Release (continuous)
 - **Trigger**: Every push to main
-- **Workflow**: `.github/workflows/next-release.yml`
+- **Workflow**: `.github/workflows/release.yml` (`next-release` job)
 - **Version Format**: `0.0.0-next-{SHA}-{timestamp}`
 - **npm tag**: `next`
 - **Purpose**: Immediate testing of latest changes
@@ -538,8 +538,8 @@ cat packages/hydrogen-react/package.json | grep version
 ### Issue: PR titles still show branch format (YYYY-MM) instead of version format (YYYY.Q.P)
 **Solution**: Ensure the workflow has been updated with dynamic version calculation
 ```bash
-# Check if latestVersion is being calculated in changesets.yml
-grep -A 10 "latestVersion" .github/workflows/changesets.yml
+# Check if latestVersion is being calculated in release.yml
+grep -A 10 "latestVersion" .github/workflows/release.yml
 ```
 
 ### Issue: CLI-only releases create misleading CalVer PR titles
@@ -581,7 +581,7 @@ rm .changeset/test-cli.md
 ## Migration Notes
 
 ### For Maintainers
-- **No more manual updates**: The `latestBranch` in changesets.yml updates automatically
+- **No more manual updates**: The `latestBranch` in release.yml is detected automatically
 - **Branch naming unchanged**: Still uses `YYYY-MM` format (e.g., `2025-05`)
 - **Changeset process unchanged**: Continue using `npm run changeset add`
 


### PR DESCRIPTION
## Why

PR #3347 (Jan 2026) consolidated three separate workflow files (`changesets.yml`, `next-release.yml`, `changesets-back-fix.yml`) into a single `release.yml` for npm OIDC Trusted Publishing. The documentation was never updated — stale references to the deleted files would mislead anyone following the release or back-fix instructions.

## Changes

| File | Stale references fixed |
|------|----------------------|
| `CLAUDE.md` | `next-release.yml` → `release.yml` (next-release job); `changesets.yml` → `release.yml` (release job); `changesets-back-fix.yml` → `release.yml` on.push.branches |
| `docs/CALVER.md` | Release workflows section (3 refs), troubleshooting grep command, migration notes |
| `.github/workflows/test-calver.yml` | 2 comments referencing `changesets.yml` |

Historical before/after comparisons in `docs/CALVER.md` (the "BEFORE (Manual)" ASCII diagram) are intentionally left intact since they describe the old process.

Also fixed the local `hydrogen-dev-workflow` skill file (not in this PR — local Claude Code config).