### PR TITLE
fix: allow non-tunnel HTTPS local environments

### DIFF
--- a/.changeset/strict-taxes-invite.md
+++ b/.changeset/strict-taxes-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+allow non-tunnel HTTPS local environments

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -126,7 +126,7 @@ describe('customer', () => {
         expect(params.get('code_challenge_method')).toBe('S256');
       });
 
-      it('Throws guidance error in development when request origin is not a tunnel', async () => {
+      it('Throws guidance error in development when request origin is not secure', async () => {
         expect.assertions(3);
         process.env.NODE_ENV = 'development';
 
@@ -167,6 +167,27 @@ describe('customer', () => {
         expect(url.origin).toBe('https://shopify.com');
         expect(url.searchParams.get('redirect_uri')).toBe(
           'https://my-shop.tryhydrogen.dev/account/authorize',
+        );
+      });
+
+      it('Redirects in development when request origin uses a valid HTTPS host', async () => {
+        process.env.NODE_ENV = 'development';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://my-shop.dev'),
+          waitUntil: vi.fn(),
+        });
+
+        const response = await customer.login();
+        const url = new URL(response.headers.get('location')!);
+
+        expect(response.status).toBe(302);
+        expect(url.origin).toBe('https://shopify.com');
+        expect(url.searchParams.get('redirect_uri')).toBe(
+          'https://my-shop.dev/account/authorize',
         );
       });
 
@@ -1302,7 +1323,7 @@ describe('customer', () => {
   });
 
   describe('handleAuthStatus()', async () => {
-    it('Throws guidance error in development when request origin is not a tunnel', async () => {
+    it('Throws guidance error in development when request origin is not secure', async () => {
       expect.assertions(3);
       process.env.NODE_ENV = 'development';
 

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -54,13 +54,13 @@ import {LanguageCode} from '@shopify/hydrogen-react/customer-account-api-types';
 
 const HYDROGEN_TUNNEL_DOMAIN_SUFFIX = '.tryhydrogen.dev';
 
-function throwIfNotTunnelled(hostname: string) {
+function throwIfNotSecureOrigin(protocol: string, hostname: string) {
   if (process.env.NODE_ENV === 'development') {
     // Keep this suffix in sync with the domain used by --customer-account-push.
-    if (!hostname.endsWith(HYDROGEN_TUNNEL_DOMAIN_SUFFIX)) {
+    if (protocol !== 'https:' || hostname === 'localhost') {
       throw new Response(
         [
-          'Customer Account API OAuth requires a Hydrogen tunnel in local development.',
+          'Customer Account API OAuth requires HTTPS in local development.',
           'Run the development server with the `--customer-account-push` flag,',
           `then open the tunnel URL shown in your terminal (\`https://*${HYDROGEN_TUNNEL_DOMAIN_SUFFIX}\`) instead of localhost.`,
         ].join('\n\n'),
@@ -81,8 +81,8 @@ function defaultAuthStatusHandler(
 ) {
   if (!request.url) return defaultLoginUrl;
 
-  const {hostname, pathname} = new URL(request.url);
-  throwIfNotTunnelled(hostname);
+  const {hostname, protocol, pathname} = new URL(request.url);
+  throwIfNotSecureOrigin(protocol, hostname);
 
   /**
    * Remix (single-fetch) request objects have different url
@@ -318,7 +318,7 @@ export function createCustomerAccountClient({
     mutation: Parameters<CustomerAccount['mutate']>[0],
     options?: Parameters<CustomerAccount['mutate']>[1],
   ) {
-    throwIfNotTunnelled(requestUrl.hostname);
+    throwIfNotSecureOrigin(requestUrl.protocol, requestUrl.hostname);
     ifInvalidCredentialThrowError();
 
     mutation = minifyQuery(mutation);
@@ -334,7 +334,7 @@ export function createCustomerAccountClient({
     query: Parameters<CustomerAccount['query']>[0],
     options?: Parameters<CustomerAccount['query']>[1],
   ) {
-    throwIfNotTunnelled(requestUrl.hostname);
+    throwIfNotSecureOrigin(requestUrl.protocol, requestUrl.hostname);
     ifInvalidCredentialThrowError();
 
     query = minifyQuery(query);
@@ -366,7 +366,7 @@ export function createCustomerAccountClient({
   return {
     i18n: {language: language ?? ('EN' as LanguageCode)},
     login: async (options?: LoginOptions) => {
-      throwIfNotTunnelled(requestUrl.hostname);
+      throwIfNotSecureOrigin(requestUrl.protocol, requestUrl.hostname);
       ifInvalidCredentialThrowError();
 
       const loginUrl = new URL(getCustomerAccountUrl(URL_TYPE.AUTH));
@@ -435,7 +435,7 @@ export function createCustomerAccountClient({
     },
 
     logout: async (options?: LogoutOptions) => {
-      throwIfNotTunnelled(requestUrl.hostname);
+      throwIfNotSecureOrigin(requestUrl.protocol, requestUrl.hostname);
       ifInvalidCredentialThrowError();
 
       const idToken = session.get(CUSTOMER_ACCOUNT_SESSION_KEY)?.idToken;
@@ -482,7 +482,7 @@ export function createCustomerAccountClient({
     mutate: mutate as CustomerAccount['mutate'],
     query: query as CustomerAccount['query'],
     authorize: async () => {
-      throwIfNotTunnelled(requestUrl.hostname);
+      throwIfNotSecureOrigin(requestUrl.protocol, requestUrl.hostname);
       ifInvalidCredentialThrowError();
 
       const code = requestUrl.searchParams.get('code');


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Since Hydrogen 2026.1.2 (latest as of now), non-tunnel HTTPS local environments don't work anymore.

The https://github.com/Shopify/hydrogen/pull/3504 forces the dev environment to use a tunnel for CAAPI to work, while other HTTPS environments (such as the [proxied HTTPS environment](https://github.com/Shopify/hydrogen/discussions/2976)) works just as well, and serve as alternative for those who aren't allowed to use tunnel in their companies.

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

Modified the `throwIfNotTunnelled` function to thrown when the host is either HTTP or `localhost`, as this is the condition mentioned in the [official Headless CAAPI documentation](https://shopify.dev/docs/storefronts/headless/building-with-the-customer-account-api/getting-started#:~:text=the%20use%20of-,localhost,-or%20any%20http).

#### Checklist

- [X] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [X] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [X] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [X] ~I've added or updated the documentation~ (non-breaking change)

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
