### PR TITLE
fix: resolve e2e cookie test failures in git worktrees

### DIFF
--- a/e2e/fixtures/storefront.ts
+++ b/e2e/fixtures/storefront.ts
@@ -1,4 +1,4 @@
-import type {Page, BrowserContext, Locator} from '@playwright/test';
+import type {Page, BrowserContext, Locator, Route} from '@playwright/test';
 import {expect} from '@playwright/test';
 
 // Privacy Banner element IDs
@@ -985,8 +985,7 @@ export class StorefrontPage {
    * @param enable - Whether to enable (true) or disable (false) the privacy banner
    */
   async setWithPrivacyBanner(enable: boolean) {
-    // Intercept the Hydrogen development bundle
-    await this.page.route('**/@fs/**/hydrogen/dist/**/*.js', async (route) => {
+    const injectConsentFlag = async (route: Route) => {
       const response = await route.fetch();
       let body = await response.text();
 
@@ -1003,7 +1002,17 @@ export class StorefrontPage {
         headers: response.headers(),
         body,
       });
-    });
+    };
+
+    // Intercept the Hydrogen bundle in BOTH Vite serving modes:
+    // 1. Direct filesystem serving (monorepo — hydrogen not in optimizeDeps)
+    await this.page.route('**/@fs/**/hydrogen/dist/**/*.js', injectConsentFlag);
+    // 2. Vite pre-bundled deps (production-like — hydrogen in optimizeDeps).
+    //    Trailing * after .js matches Vite's cache-busting query strings (?v=abc123).
+    await this.page.route(
+      '**/.vite/deps/@shopify_hydrogen*.js*',
+      injectConsentFlag,
+    );
   }
 
   async getCartId() {

--- a/packages/hydrogen/src/vite/plugin.ts
+++ b/packages/hydrogen/src/vite/plugin.ts
@@ -40,21 +40,20 @@ export type HydrogenPlugin = Plugin<{
 export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
   let middlewareOptions: HydrogenMiddlewareOptions = {};
 
-  const isHydrogenMonorepo = new URL(
-    '../../..',
-    import.meta.url,
-  ).pathname.endsWith('/hydrogen/packages/');
-
   return [
     {
       name: 'hydrogen:main',
       config(_, env) {
         sharedOptions.command = env.command;
 
+        // Detect monorepo: in monorepo the parent of 'hydrogen/' is 'packages/',
+        // while in production installs it's '@shopify/' (inside node_modules).
+        // Using '/packages/' instead of '/hydrogen/packages/' so this works in
+        // git worktrees and forks where the repo root isn't named 'hydrogen'.
         const isHydrogenMonorepo = new URL(
           '../../..',
           import.meta.url,
-        ).pathname.endsWith('/hydrogen/packages/');
+        ).pathname.endsWith('/packages/');
 
         return {
           build: {


### PR DESCRIPTION
## Summary

- Fix monorepo detection in hydrogen's Vite plugin that fails in git worktrees, causing `@shopify/hydrogen` to be incorrectly pre-bundled by Vite
- Broaden e2e test route interception to handle both pre-bundled and non-pre-bundled Hydrogen URLs

## Root Cause

The `isHydrogenMonorepo` check in `packages/hydrogen/src/vite/plugin.ts` used `pathname.endsWith('/hydrogen/packages/')`, hardcoding the assumption that the repo root is named `hydrogen`. In git worktrees (e.g. `hydrogen/main/`, `hydrogen/kd-cookie-verification/`), the path ends with `/<worktree-name>/packages/` instead, so the check fails.

When monorepo detection fails, the plugin tells Vite to pre-bundle `@shopify/hydrogen` into `.vite/deps/@shopify_hydrogen.js`. The e2e cookie test's JS bundle interception (`**/@fs/**/hydrogen/dist/**/*.js`) only matches direct `@fs` URLs — not pre-bundled ones — so the privacy banner injection silently fails, causing 8 of 12 cookie tests to fail.

## Changes

**`packages/hydrogen/src/vite/plugin.ts`** — Changed monorepo detection from `.endsWith('/hydrogen/packages/')` to `.endsWith('/packages/')`. In monorepo, the parent of `hydrogen/` is always `packages/`; in production installs it's `@shopify/`. This works regardless of repo root name.

**`e2e/fixtures/storefront.ts`** — Added a second route interception pattern for `.vite/deps/@shopify_hydrogen*.js*` as defense-in-depth.


Co-Authored-By: Claude <noreply@anthropic.com>