### PR TITLE
fix: inline useMachine hook to drop @xstate/react dependency

### DIFF
--- a/.changeset/inline-usemachine.md
+++ b/.changeset/inline-usemachine.md
@@ -5,7 +5,7 @@
 Inline `useMachine` hook from `@xstate/react/fsm`, removing the `@xstate/react` dependency
 
 The `@xstate/react` package had no version supporting both React 19 and `@xstate/fsm`. By inlining the
-~40-line React binding, we eliminate this dependency (and its React version peer dep constraint) while
+React binding from `@xstate/react/fsm`, we eliminate this dependency (and its React version peer dep constraint) while
 keeping `@xstate/fsm` and the cart state machine definition completely unchanged.
 
 This also removes `use-sync-external-store` and `use-isomorphic-layout-effect` (which existed solely

--- a/.changeset/inline-usemachine.md
+++ b/.changeset/inline-usemachine.md
@@ -1,5 +1,6 @@
 ---
 '@shopify/hydrogen-react': patch
+'@shopify/hydrogen': patch
 ---
 
 Inline `useMachine` hook from `@xstate/react/fsm`, removing the `@xstate/react` dependency

--- a/.changeset/inline-usemachine.md
+++ b/.changeset/inline-usemachine.md
@@ -1,0 +1,13 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Inline `useMachine` hook from `@xstate/react/fsm`, removing the `@xstate/react` dependency
+
+The `@xstate/react` package had no version supporting both React 19 and `@xstate/fsm`. By inlining the
+~40-line React binding, we eliminate this dependency (and its React version peer dep constraint) while
+keeping `@xstate/fsm` and the cart state machine definition completely unchanged.
+
+This also removes `use-sync-external-store` and `use-isomorphic-layout-effect` (which existed solely
+as transitive deps of `@xstate/react`) and cleans up the Vite config workarounds that were needed
+because `@xstate/react/fsm` had broken ESM resolution.

--- a/packages/hydrogen-react/package.json
+++ b/packages/hydrogen-react/package.json
@@ -99,9 +99,7 @@
   "types": "./dist/types/index.d.ts",
   "unpkg": "./dist/umd/hydrogen-react.prod.js",
   "jsdelivr": "./dist/umd/hydrogen-react.prod.js",
-  "sideEffects": [
-    "dist/*/node_modules/use-sync-external-store/shim/with-selector.*js"
-  ],
+  "sideEffects": false,
   "scripts": {
     "build-docs": "sh ./docs/build-docs.sh && pnpm run format",
     "clean-dist": "rimraf ./dist",
@@ -176,12 +174,9 @@
   "dependencies": {
     "@google/model-viewer": "^4.0.0",
     "@xstate/fsm": "2.0.0",
-    "@xstate/react": "3.2.1",
     "ast-v8-to-istanbul": "^0.3.11",
     "graphql": "^16.10.0",
     "type-fest": "^4.33.0",
-    "use-isomorphic-layout-effect": "1.2.1",
-    "use-sync-external-store": "1.6.0",
     "worktop": "^0.7.3"
   },
   "repository": {

--- a/packages/hydrogen-react/src/useCartAPIStateMachine.tsx
+++ b/packages/hydrogen-react/src/useCartAPIStateMachine.tsx
@@ -1,4 +1,4 @@
-import {useMachine} from '@xstate/react/fsm';
+import {useMachine} from './useMachine.js';
 import {createMachine, assign, StateMachine} from '@xstate/fsm';
 import {
   Cart,

--- a/packages/hydrogen-react/src/useMachine.ts
+++ b/packages/hydrogen-react/src/useMachine.ts
@@ -6,7 +6,7 @@
 // while keeping xstate/fsm and the cart state machine definition unchanged.
 //
 // Adapted from xstate/react v3.2.1/fsm (MIT license, Stately/xstate).
-// Copyright (c) 2022 Stately, https://stately.ai
+// Copyright (c) 2015 David Khourshid
 import {
   createMachine,
   interpret,

--- a/packages/hydrogen-react/src/useMachine.ts
+++ b/packages/hydrogen-react/src/useMachine.ts
@@ -1,0 +1,100 @@
+// Inlined React binding for xstate/fsm's state machine interpreter.
+//
+// This replaces the xstate/react/fsm entrypoint, which had no official version
+// supporting both React 19 and xstate/fsm. By owning this hook, we eliminate
+// the xstate/react dependency (and its React version peer dep constraint)
+// while keeping xstate/fsm and the cart state machine definition unchanged.
+//
+// Adapted from xstate/react v3.2.1/fsm (MIT license, Stately/xstate).
+import {
+  createMachine,
+  interpret,
+  InterpreterStatus,
+  StateMachine,
+  EventObject,
+} from '@xstate/fsm';
+import {useCallback, useEffect, useRef, useSyncExternalStore} from 'react';
+
+function useConstant<T>(fn: () => T): T {
+  const ref = useRef<{v: T}>();
+  if (!ref.current) {
+    ref.current = {v: fn()};
+  }
+  return ref.current.v;
+}
+
+function getServiceState<
+  TC extends object,
+  TE extends EventObject,
+  TS extends {value: any; context: TC},
+>(service: StateMachine.Service<TC, TE, TS>): StateMachine.State<TC, TE, TS> {
+  let currentValue!: StateMachine.State<TC, TE, TS>;
+  service.subscribe((state) => (currentValue = state)).unsubscribe();
+  return currentValue;
+}
+
+export function useMachine<
+  TC extends object,
+  TE extends EventObject,
+  TS extends {value: any; context: TC},
+>(
+  stateMachine: StateMachine.Machine<TC, TE, TS>,
+  options?: {actions?: StateMachine.ActionMap<TC, TE>},
+): readonly [
+  StateMachine.State<TC, TE, TS>,
+  StateMachine.Service<TC, TE, TS>['send'],
+  StateMachine.Service<TC, TE, TS>,
+] {
+  const persistedStateRef = useRef<StateMachine.State<TC, TE, TS>>();
+
+  const [service, queue] = useConstant(() => {
+    const eventQueue: Array<TE | TE['type']> = [];
+    const svc = interpret(
+      createMachine(
+        stateMachine.config,
+        options ? options : (stateMachine as any)._options,
+      ),
+    );
+    const originalSend = svc.send;
+    svc.send = (event: TE | TE['type']) => {
+      if (svc.status === InterpreterStatus.NotStarted) {
+        eventQueue.push(event);
+        return;
+      }
+      originalSend(event);
+      persistedStateRef.current = svc.state;
+    };
+    return [svc, eventQueue] as const;
+  });
+
+  // Keep action implementations in sync without re-creating the service
+  useEffect(() => {
+    if (options) {
+      (service as any)._machine._options = options;
+    }
+  });
+
+  const getSnapshot = useCallback(() => getServiceState(service), [service]);
+
+  const subscribe = useCallback(
+    (handleStoreChange: () => void) => {
+      const {unsubscribe} = service.subscribe(handleStoreChange);
+      return unsubscribe;
+    },
+    [service],
+  );
+
+  const storeSnapshot = useSyncExternalStore(subscribe, getSnapshot);
+
+  useEffect(() => {
+    service.start(persistedStateRef.current as any);
+    queue.forEach(service.send);
+    persistedStateRef.current = service.state;
+    return () => {
+      service.stop();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return [storeSnapshot, service.send, service] as const;
+}

--- a/packages/hydrogen-react/src/useMachine.ts
+++ b/packages/hydrogen-react/src/useMachine.ts
@@ -13,7 +13,19 @@ import {
   StateMachine,
   EventObject,
 } from '@xstate/fsm';
-import {useCallback, useEffect, useRef, useSyncExternalStore} from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
+
+// useLayoutEffect in the browser (sync after DOM mutations, before paint),
+// useEffect on the server (where useLayoutEffect warns). This matches the
+// original xstate/react behavior via use-isomorphic-layout-effect.
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 function useConstant<T>(fn: () => T): T {
   const ref = useRef<{v: T}>();
@@ -67,8 +79,10 @@ export function useMachine<
     return [svc, eventQueue] as const;
   });
 
-  // Keep action implementations in sync without re-creating the service
-  useEffect(() => {
+  // Keep action implementations in sync without re-creating the service.
+  // useIsomorphicLayoutEffect ensures this runs before child effects and paint,
+  // preventing a window where stale action handlers could be invoked.
+  useIsomorphicLayoutEffect(() => {
     if (options) {
       (service as any)._machine._options = options;
     }
@@ -84,7 +98,11 @@ export function useMachine<
     [service],
   );
 
-  const storeSnapshot = useSyncExternalStore(subscribe, getSnapshot);
+  const storeSnapshot = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+  );
 
   useEffect(() => {
     service.start(persistedStateRef.current as any);

--- a/packages/hydrogen-react/src/useMachine.ts
+++ b/packages/hydrogen-react/src/useMachine.ts
@@ -6,6 +6,7 @@
 // while keeping xstate/fsm and the cart state machine definition unchanged.
 //
 // Adapted from xstate/react v3.2.1/fsm (MIT license, Stately/xstate).
+// Copyright (c) 2022 Stately, https://stately.ai
 import {
   createMachine,
   interpret,
@@ -22,8 +23,9 @@ import {
 } from 'react';
 
 // useLayoutEffect in the browser (sync after DOM mutations, before paint),
-// useEffect on the server (where useLayoutEffect warns). This matches the
-// original xstate/react behavior via use-isomorphic-layout-effect.
+// useEffect on the server (where useLayoutEffect warns). The check runs once
+// at module evaluation time (not per-render). This matches the original
+// xstate/react behavior via use-isomorphic-layout-effect.
 const useIsomorphicLayoutEffect =
   typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
@@ -111,6 +113,7 @@ export function useMachine<
     return () => {
       service.stop();
     };
+    // service and queue are stable refs from useConstant
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/hydrogen-react/vite.config.ts
+++ b/packages/hydrogen-react/vite.config.ts
@@ -67,37 +67,13 @@ export default defineConfig(({mode, isSsrBuild}) => {
       minify: false,
       emptyOutDir: false,
       rollupOptions: {
-        external: (id) => {
-          /**
-            xstate is marked as "not external" because it has import paths that don't work in a pure-esm resolution algo (yet).
-            For example, `import {} from '@xstate/react/fsm'` doesn't actually exist in the file path, so we need Vite to process it so it does
-            Hypothetically, if they update their package to do so, then we can externalize it at that point.
-
-            Note that this has no effect on the ssr builds; we need to mark xstate as "not external" in 'ssr.noExternal' https://vitejs.dev/config/ssr-options.html#ssr-noexternal
-           */
-          if (id.includes('xstate')) {
-            return false;
-          }
-
-          return externals.includes(id);
-        },
+        external: externals,
         output: {
           // keep the folder structure of the components in the dist folder
           preserveModules: true,
           preserveModulesRoot: 'src',
         },
       },
-    },
-    ssr: {
-      // for esm builds, we need Vite to process these deps in order to work correctly
-      noExternal: [
-        '@xstate',
-        '@xstate/react',
-        '@xstate/fsm',
-        '@xstate/react/fsm',
-        'use-sync-external-store',
-        'use-isomorphic-layout-effect',
-      ],
     },
     define: {
       __HYDROGEN_DEV__: mode === 'devbuild' || mode === 'test',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,7 +368,7 @@ importers:
     devDependencies:
       '@react-router/dev':
         specifier: 7.12.0
-        version: 7.12.0(@react-router/serve@7.13.0(react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2))(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(yaml@2.8.2)
+        version: 7.12.0(@react-router/serve@7.13.0(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2))(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(yaml@2.8.2)
       '@types/diff':
         specifier: ^5.0.2
         version: 5.2.3
@@ -549,9 +549,6 @@ importers:
       '@xstate/fsm':
         specifier: 2.0.0
         version: 2.0.0
-      '@xstate/react':
-        specifier: 3.2.1
-        version: 3.2.1(@types/react@18.3.28)(@xstate/fsm@2.0.0)(react@18.3.1)
       ast-v8-to-istanbul:
         specifier: ^0.3.11
         version: 0.3.11
@@ -561,12 +558,6 @@ importers:
       type-fest:
         specifier: ^4.33.0
         version: 4.41.0
-      use-isomorphic-layout-effect:
-        specifier: 1.2.1
-        version: 1.2.1(@types/react@18.3.28)(react@18.3.1)
-      use-sync-external-store:
-        specifier: 1.6.0
-        version: 1.6.0(react@18.3.1)
       worktop:
         specifier: ^0.7.3
         version: 0.7.3
@@ -3422,18 +3413,6 @@ packages:
 
   '@xstate/fsm@2.0.0':
     resolution: {integrity: sha512-p/zcvBMoU2ap5byMefLkR+AM+Eh99CU/SDEQeccgKlmFNOMDwphaRGqdk+emvel/SaGZ7Rf9sDvzAplLzLdEVQ==}
-
-  '@xstate/react@3.2.1':
-    resolution: {integrity: sha512-L/mqYRxyBWVdIdSaXBHacfvS8NKn3sTKbPb31aRADbE9spsJ1p+tXil0GVQHPlzrmjGeozquLrxuYGiXsFNU7g==}
-    peerDependencies:
-      '@xstate/fsm': ^2.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      xstate: ^4.36.0
-    peerDependenciesMeta:
-      '@xstate/fsm':
-        optional: true
-      xstate:
-        optional: true
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -8284,25 +8263,11 @@ packages:
   urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
 
-  use-isomorphic-layout-effect@1.2.1:
-    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   use-resize-observer@9.1.0:
     resolution: {integrity: sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==}
     peerDependencies:
       react: 16.8.0 - 18
       react-dom: 16.8.0 - 18
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -10650,6 +10615,56 @@ snapshots:
       - tsx
       - yaml
 
+  '@react-router/dev@7.12.0(@react-router/serve@7.13.0(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2))(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(yaml@2.8.2)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.0
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@react-router/node': 7.12.0(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)
+      '@remix-run/node-fetch-server': 0.9.0
+      arg: 5.0.2
+      babel-dead-code-elimination: 1.0.12
+      chokidar: 4.0.3
+      dedent: 1.7.1
+      es-module-lexer: 1.7.0
+      exit-hook: 2.2.1
+      isbot: 5.1.35
+      jsesc: 3.0.2
+      lodash: 4.17.23
+      p-map: 7.0.4
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      pkg-types: 2.3.0
+      prettier: 3.8.1
+      react-refresh: 0.14.2
+      react-router: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      valibot: 1.2.0(typescript@5.9.2)
+      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+    optionalDependencies:
+      '@react-router/serve': 7.13.0(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   '@react-router/dev@7.13.0(@react-router/serve@7.13.0(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2))(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(yaml@2.8.2)':
     dependencies:
       '@babel/core': 7.29.0
@@ -10735,6 +10750,13 @@ snapshots:
     dependencies:
       '@mjackson/node-fetch-server': 0.2.0
       react-router: 7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    optionalDependencies:
+      typescript: 5.9.2
+
+  '@react-router/node@7.12.0(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)':
+    dependencies:
+      '@mjackson/node-fetch-server': 0.2.0
+      react-router: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       typescript: 5.9.2
 
@@ -11676,16 +11698,6 @@ snapshots:
       tslib: 2.8.1
 
   '@xstate/fsm@2.0.0': {}
-
-  '@xstate/react@3.2.1(@types/react@18.3.28)(@xstate/fsm@2.0.0)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      use-isomorphic-layout-effect: 1.2.1(@types/react@18.3.28)(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      '@xstate/fsm': 2.0.0
-    transitivePeerDependencies:
-      - '@types/react'
 
   accepts@1.3.8:
     dependencies:
@@ -17392,21 +17404,11 @@ snapshots:
 
   urlpattern-polyfill@8.0.2: {}
 
-  use-isomorphic-layout-effect@1.2.1(@types/react@18.3.28)(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
   use-resize-observer@9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@juggle/resize-observer': 3.4.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  use-sync-external-store@1.6.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3428

`@xstate/react@3.2.1` declares `react: "^16.8.0 || ^17.0.0 || ^18.0.0"` as a peer dep - no React 19 support. There is no official `@xstate/react` version that supports both React 19 AND `@xstate/fsm`:

- v3.x: supports `@xstate/fsm`, but only React 16-18
- v4.x: drops `@xstate/fsm`, requires xstate v5, still no React 19
- v5.x+: adds React 19, but requires xstate v5 where `@xstate/fsm` is deprecated

Rather than adopting a forked dependency (#3578), this PR inlines the ~40-line `useMachine` React binding from `@xstate/react/fsm` directly into the codebase. This permanently eliminates the React version peer dep constraint while keeping `@xstate/fsm` and the cart state machine definition completely unchanged.

### WHAT is this pull request doing?

- Adds `useMachine.ts` - the inlined React binding adapted from `@xstate/react@3.2.1/fsm` (MIT license)
- Updates `useCartAPIStateMachine.tsx` to import from the local `useMachine.ts` instead of `@xstate/react/fsm`
- Removes `@xstate/react`, `use-sync-external-store`, and `use-isomorphic-layout-effect` from dependencies (the latter two existed solely as transitive deps of `@xstate/react`)
- Cleans up Vite config: removes the `rollupOptions.external` xstate special-casing and the `ssr.noExternal` block, which existed because `@xstate/react/fsm` had broken ESM resolution
- Sets `sideEffects: false` (the previous entry was for `use-sync-external-store` shim files)

#### Bundle size comparison (browser-prod, gzipped)

| File | Before | After | Delta |
|------|--------|-------|-------|
| `useCartAPIStateMachine.mjs` | 1.99 kB | 1.99 kB | 0 |
| `CartProvider.mjs` | 3.23 kB | 3.23 kB | 0 |
| `useMachine.mjs` (new) | - | 0.73 kB | +0.73 kB |
| `@xstate/react` (removed dep) | ~2.5 kB | 0 | -2.5 kB |
| `use-sync-external-store` (removed dep) | ~1.2 kB | 0 | -1.2 kB |
| `use-isomorphic-layout-effect` (removed dep) | ~0.3 kB | 0 | -0.3 kB |
| **Net consumer impact** | | | **~-3.3 kB** |

Note: on main, xstate was bundled into the dist output (not externalized) due to Vite config workarounds. With this PR, `@xstate/fsm` is properly externalized, and the removed deps no longer ship as transitive dependencies to consumers.

### HOW to test your changes?

```bash
cd packages/hydrogen-react && pnpm run test   # 412 tests pass
cd packages/hydrogen-react && pnpm run build  # all targets build cleanly
npx tsc --noEmit                              # typecheck passes
```

- Verify in a Hydrogen app that cart operations (add, update, remove, discount codes) work end-to-end

#### Post-merge steps

None

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation