### PR TITLE
fix(test): improve flaky home page smoke test

### DIFF
--- a/e2e/specs/skeleton/cart.spec.ts
+++ b/e2e/specs/skeleton/cart.spec.ts
@@ -213,6 +213,7 @@ test.describe('Cart', () => {
           .getByText(/Looks like you haven.t added anything yet/);
 
         await cartLink.click();
+        await expect(page.getByRole('dialog', {name: 'Cart'})).toBeVisible();
 
         await expect(emptyCartMessage).toBeVisible();
       });

--- a/e2e/specs/smoke/home.spec.ts
+++ b/e2e/specs/smoke/home.spec.ts
@@ -24,7 +24,8 @@ test.describe('Home Page', () => {
 
     const productGridImage = page
       .getByRole('region', {name: 'Recommended Products'})
-      .getByRole('link', {name: 'The Hydrogen Snowboard'})
+      .getByRole('link')
+      .first()
       .getByRole('img');
 
     await expect(heroImage).toBeVisible();


### PR DESCRIPTION
### WHY are these changes introduced?

The home page smoke test is flaky because it hardcodes `'The Hydrogen Snowboard'` as the product to check in the Recommended Products grid. Recommended products are sorted by `UPDATED_AT desc`, so any product edit in the store reshuffles the order and breaks the test.

### WHAT is this pull request doing?

**`e2e/specs/smoke/home.spec.ts`**: Replaces the hardcoded product name selector with `.getByRole('link').first()`. The test doesn't require any specific product — it only verifies that a product image renders in the grid.

**`e2e/specs/skeleton/cart.spec.ts`**: Adds an intermediate visibility check on the cart dialog before asserting on the empty cart message. This prevents a race condition between clicking the cart link and the dialog opening.

### HOW to test your changes?

```bash
# Run the smoke test
npx playwright test e2e/specs/smoke/home.spec.ts

# Run the cart tests
npx playwright test e2e/specs/skeleton/cart.spec.ts
```

Both pass: smoke (1/1), cart (18/18).

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation