### PR TITLE
chore: remove `engines` field from hydrogen-react `package.json`

### DIFF
--- a/.changeset/dull-papayas-cross.md
+++ b/.changeset/dull-papayas-cross.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen-react': patch
+---
+
+Remove `engines` field from package.json to avoid blocking installation on newer Node.js versions

--- a/packages/hydrogen-react/package.json
+++ b/packages/hydrogen-react/package.json
@@ -4,9 +4,6 @@
   "description": "React components, hooks, and utilities for creating custom Shopify storefronts",
   "homepage": "https://github.com/Shopify/hydrogen/tree/main/packages/hydrogen-react",
   "license": "MIT",
-  "engines": {
-    "node": "^22 || ^24"
-  },
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Ran into an issue with the dev-mcp on node 25 which depends on hydrogen-react and failed to install due to the `engines` field only allowing node 22 and 22, but nothing that's newer than this.

This was changed here: https://github.com/Shopify/hydrogen/commit/1fa96e5d47cd22217412b6279b62f1e3fa660cae#diff-d591febe7715fc9ae8d69187b166b69ee0f8a28e801ac7e01e2ab00d9ba1e482L33

Before we allowed 18 and higher. 
Now we're going back to allowing a floor (22) and anything that's higher than that.