### PR TITLE
revert: scaffold 2025-10 back-fix branch from main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       # To do a back-fix of a past CalVer branch, update this to the relevant branch
       # Example: If we are currently on 2025-07, add 2025-01 here to do a back-fix
       # release for the 2025-01 CalVer branch
-      - 2025-10
+      - 2025-01
 
 concurrency:
   group: release-${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- Reverts #3590 — the 2025-10 scaffold commit landed on `main` by mistake
- The release.yml branch-list change belongs on the `2025-10` calver branch, not `main`
- The `2025-10` branch has been created separately with the correct release.yml config

## What happened

The scaffold commit changed `release.yml` to replace `2025-01` with `2025-10` in the push trigger branch list. This change should have been the *starting commit* of the `2025-10` back-fix branch, not a commit on `main`.

## Test plan

- [ ] Verify `release.yml` on `main` reverts back to `2025-01`
- [ ] Verify `2025-10` branch exists and has `2025-10` in its release.yml