### PR TITLE
fix: redirect to login on state mismatch in authorize (fixes #3403)

### DIFF
--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -5,7 +5,7 @@ import {
   CUSTOMER_ACCOUNT_SESSION_KEY,
   BUYER_SESSION_KEY,
   USER_AGENT,
-} from './constants';
+} from './constants'
 import {
   clearSession,
   generateCodeChallenge,
@@ -500,10 +500,12 @@ export function createCustomerAccountClient({
       if (session.get(CUSTOMER_ACCOUNT_SESSION_KEY)?.state !== state) {
         clearSession(session);
 
-        throw new BadRequest(
-          'Unauthorized',
-          'The session state does not match the state parameter. Make sure that the session is configured correctly and passed to `createCustomerAccountClient`.',
-        );
+        // State mismatch can occur when:
+        // 1. User opens login in a different browser/tab (e.g. from a webview to a browser)
+        // 2. User opens the login link multiple times (e.g. cmd+click/ctrl+click twice)
+        // In these cases, if the user is already authenticated with Shopify, redirecting
+        // back to login restarts the OAuth flow and they are logged in automatically.
+        return redirect(loginPath);
       }
 
       const clientId = customerAccountId;

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -505,6 +505,9 @@ export function createCustomerAccountClient({
         // 2. User opens the login link multiple times (e.g. cmd+click/ctrl+click twice)
         // In these cases, if the user is already authenticated with Shopify, redirecting
         // back to login restarts the OAuth flow and they are logged in automatically.
+        console.warn(
+          '[hydrogen] State mismatch in authorize callback — redirecting to login. This can happen when the login link is opened in a different browser context or multiple times.',
+        );
         return redirect(loginPath);
       }
 


### PR DESCRIPTION
When the session state doesn't match the state parameter in the authorize callback, instead of throwing a BadRequest error (which shows an unfriendly error page), redirect the user back to the login page.

This handles two common cases:
1. User opens the login link in a different browser context (e.g. from a webview to a browser) - the new browser has a different cookie jar so the session state is missing
2. User opens the login link multiple times (e.g. cmd+click/ctrl+click twice) - the second tab regenerates the session state, making the first tab's state stale

In both cases, if the user is already authenticated with Shopify, the redirect to login will restart the OAuth flow and they will be logged in automatically without having to enter credentials again.

Fixes #3403

<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
