### PR TITLE
test(e2e): legacy customer account flow e2e tests

### DIFF
--- a/cookbook/CLAUDE.md
+++ b/cookbook/CLAUDE.md
@@ -22,7 +22,7 @@ npm run cookbook -- validate --recipe {name}
 ```
 
 **Recipe requirements:**
-- Step numbers are numeric: `step: 1` not `step: "1"`
+- Step values are quoted strings: `step: "1"` not `step: 1` (YAML coerces unquoted integers to numbers, but the Zod schema expects strings)
 - Every step has a description (non-null, non-empty)
 - Step names are unique within the same step number
 - All referenced patch/ingredient files exist
@@ -36,14 +36,14 @@ npm run cookbook -- render --recipe {name}
 
 ## Common Errors
 
-### String Step Numbers
+### Unquoted Step Numbers
 ```
-❌ recipe.yaml:52  steps.0.step  RecipeSchema: Expected number, received string (actual value: "1")
+❌ recipe.yaml:52  steps.0.step  RecipeSchema: Invalid input: expected string, received number (actual value: 1)
 ```
-**Fix**: Remove quotes from step numbers:
+**Fix**: Quote step numbers so YAML preserves them as strings:
 ```diff
-- step: "1"
-+ step: 1
+- step: 1
++ step: "1"
 ```
 
 ### Outdated README
@@ -69,7 +69,7 @@ npm run cookbook -- render --recipe {name}
 
 ## Code Style
 
-- Step numbers: Numeric values only (`step: 1`)
+- Step values: Quoted strings (`step: "1"`) — unquoted integers fail Zod validation
 - Step names: Unique within same step number, kebab-case for file paths
 - Descriptions: Non-null, non-empty strings explaining what the step does
 - Comments: Use `@description` in code to explain why, not what
@@ -194,7 +194,7 @@ npm run cookbook -- validate --recipe my-recipe --hydrogenPackagesVersion 2025.1
 ```
 ❌ Recipe 'gtm' - 5 error(s):
 
-recipe.yaml:52      steps.0.step                  RecipeSchema: Expected number, received string (actual value: "1")
+recipe.yaml:52      steps.0.step                  RecipeSchema: Invalid input: expected string, received number (actual value: 1)
                     README.md                     validateReadmeExists: README.md not found. Run: npm run cookbook render gtm
 ```
 
@@ -320,7 +320,7 @@ ingredients:
   - path: 'templates/skeleton/app/components/NewFile.tsx'
     description: 'Component description'
 steps:
-  - step: 1  # IMPORTANT: Numeric, not string
+  - step: "1"  # IMPORTANT: Quoted string, not bare integer
     type: PATCH
     name: 'app/root.tsx'
     description: 'What this step does'  # IMPORTANT: Required, non-null

--- a/cookbook/recipes/legacy-customer-account-flow/patches/account.addresses.tsx.f3bb60.patch
+++ b/cookbook/recipes/legacy-customer-account-flow/patches/account.addresses.tsx.f3bb60.patch
@@ -428,7 +428,7 @@ index 3e04bc72..e95f252f 100644
 -        <label htmlFor="territoryCode">Country Code*</label>
 +        <label htmlFor="country">Country*</label>
          <input
--          aria-label="territoryCode"
+-          aria-label="Country code"
 -          autoComplete="country"
 -          defaultValue={address?.territoryCode ?? ''}
 -          id="territoryCode"

--- a/cookbook/recipes/legacy-customer-account-flow/patches/account.profile.tsx.8e4050.patch
+++ b/cookbook/recipes/legacy-customer-account-flow/patches/account.profile.tsx.8e4050.patch
@@ -18,7 +18,7 @@ index 6f10065f..7b8c77d3 100644
  } from 'react-router';
  import type {Route} from './+types/account.profile';
  
-@@ -20,62 +20,79 @@ export const meta: Route.MetaFunction = () => {
+@@ -20,62 +20,80 @@ export const meta: Route.MetaFunction = () => {
  };
  
  export async function loader({context}: Route.LoaderArgs) {
@@ -49,20 +49,21 @@ index 6f10065f..7b8c77d3 100644
 +    const password = getPassword(form);
      const customer: CustomerUpdateInput = {};
 -    const validInputKeys = ['firstName', 'lastName'] as const;
++    const acceptsMarketing = form.get('acceptsMarketing');
++    if (acceptsMarketing !== null) {
++      customer.acceptsMarketing = acceptsMarketing === 'on';
++    }
++
 +    const validInputKeys = [
 +      'firstName',
 +      'lastName',
 +      'email',
-+      'password',
 +      'phone',
 +    ] as const;
      for (const [key, value] of form.entries()) {
        if (!validInputKeys.includes(key as any)) {
          continue;
        }
-+      if (key === 'acceptsMarketing') {
-+        customer.acceptsMarketing = value === 'on';
-+      }
        if (typeof value === 'string' && value.length) {
          customer[key as (typeof validInputKeys)[number]] = value;
        }
@@ -189,31 +190,24 @@ index 6f10065f..7b8c77d3 100644
          </fieldset>
          {action?.error ? (
            <p>
-@@ -131,3 +206,55 @@ export default function AccountProfile() {
+@@ -131,3 +207,48 @@ export default function AccountProfile() {
      </div>
    );
  }
 +
 +function getPassword(form: FormData): string | undefined {
-+  let password;
 +  const newPassword = form.get('newPassword');
 +  const newPasswordConfirm = form.get('newPasswordConfirm');
 +
-+  let passwordError;
-+
-+  if (newPassword && newPassword !== newPasswordConfirm) {
-+    passwordError = new Error('New passwords must match.');
++  if (!newPassword) {
++    return undefined;
 +  }
 +
-+  if (passwordError) {
-+    throw passwordError;
++  if (newPassword !== newPasswordConfirm) {
++    throw new Error('New passwords must match.');
 +  }
 +
-+  if (newPassword) {
-+    password = newPassword;
-+  }
-+
-+  return String(password);
++  return String(newPassword);
 +}
 +
 +const CUSTOMER_UPDATE_MUTATION = `#graphql

--- a/cookbook/recipes/legacy-customer-account-flow/patches/account.tsx.30f6e3.patch
+++ b/cookbook/recipes/legacy-customer-account-flow/patches/account.tsx.30f6e3.patch
@@ -1,7 +1,7 @@
 index 0429e7eb..c5e01b28 100644
 --- a/templates/skeleton/app/routes/account.tsx
 +++ b/templates/skeleton/app/routes/account.tsx
-@@ -1,42 +1,106 @@
+@@ -1,42 +1,109 @@
  import {
 -  data as remixData,
    Form,
@@ -42,24 +42,23 @@ index 0429e7eb..c5e01b28 100644
 +      pathname,
 +    );
 +
++  if (!isLoggedIn && (isPrivateRoute || isAccountHome)) {
++    session.unset('customerAccessToken');
++    return redirect('/account/login');
++  }
++
 +  if (!isLoggedIn) {
-+    if (isPrivateRoute || isAccountHome) {
-+      session.unset('customerAccessToken');
-+      return redirect('/account/login');
-+    } else {
-+      // public subroute such as /account/login...
-+      return {
-+        isLoggedIn: false,
-+        isAccountHome,
-+        isPrivateRoute,
-+        customer: null,
-+      };
-+    }
-+  } else {
-+    // loggedIn, default redirect to the orders page
-+    if (isAccountHome) {
-+      return redirect('/account/orders');
-+    }
++    // public subroute such as /account/login...
++    return {
++      isLoggedIn: false,
++      isAccountHome,
++      isPrivateRoute,
++      customer: null,
++    };
++  }
++
++  if (isAccountHome) {
++    return redirect('/account/orders');
    }
  
 -  return remixData(
@@ -106,8 +105,12 @@ index 0429e7eb..c5e01b28 100644
 +    return <Outlet context={{customer}} />;
 +  }
 +
++  if (!customer) {
++    return null;
++  }
++
 +  return (
-+    <AccountLayout customer={customer as CustomerFragment}>
++    <AccountLayout customer={customer}>
 +      <br />
 +      <br />
 +      <Outlet context={{customer}} />
@@ -128,7 +131,7 @@ index 0429e7eb..c5e01b28 100644
    const heading = customer
      ? customer.firstName
        ? `Welcome, ${customer.firstName}`
-@@ -48,9 +112,7 @@ export default function AccountLayout() {
+@@ -48,9 +115,7 @@ export default function AccountLayout() {
        <h1>{heading}</h1>
        <br />
        <AccountMenu />
@@ -139,7 +142,7 @@ index 0429e7eb..c5e01b28 100644
      </div>
    );
  }
-@@ -95,3 +157,50 @@ function Logout() {
+@@ -95,3 +160,50 @@ function Logout() {
      </Form>
    );
  }

--- a/cookbook/recipes/legacy-customer-account-flow/recipe.yaml
+++ b/cookbook/recipes/legacy-customer-account-flow/recipe.yaml
@@ -46,108 +46,108 @@ ingredients:
 deletedFiles: []
 steps:
   - type: PATCH
-    step: 1
+    step: "1"
     name: Document legacy customer accounts in the README
     description: Update the README file to document the legacy customer account flow.
     diffs:
       - file: README.md
         patchFile: README.md.a0354d.patch
   - type: PATCH
-    step: 2
+    step: "2"
     name: Add account link to header navigation
     description: Add an account link to the header navigation.
     diffs:
       - file: app/components/Header.tsx
         patchFile: Header.tsx.994c25.patch
   - type: NEW_FILE
-    step: 3
+    step: "3"
     name: Create account activation flow
     description: Add an account activation route for email verification.
     ingredients:
       - path: templates/skeleton/app/routes/account_.activate.$id.$activationToken.tsx
   - type: PATCH
-    step: 4
+    step: "4"
     name: Update PageLayout for legacy auth
     description: Update PageLayout to handle account routes.
     diffs:
       - file: app/components/PageLayout.tsx
         patchFile: PageLayout.tsx.145dab.patch
   - type: NEW_FILE
-    step: 5
+    step: "5"
     name: Build password recovery flow
     description: Add a password recovery form.
     ingredients:
       - path: templates/skeleton/app/routes/account_.recover.tsx
   - type: PATCH
-    step: 6
+    step: "6"
     name: Validate customer access tokens
     description: Add customer access token validation to the root loader.
     diffs:
       - file: app/root.tsx
         patchFile: root.tsx.8c60e9.patch
   - type: NEW_FILE
-    step: 7
+    step: "7"
     name: Create customer registration flow
     description: Add a customer registration form.
     ingredients:
       - path: templates/skeleton/app/routes/account_.register.tsx
   - type: PATCH
-    step: 8
+    step: "8"
     name: Handle unauthenticated account routes
     description: Convert the catch-all route to use Storefront API authentication.
     diffs:
       - file: app/routes/account.$.tsx
         patchFile: account.$.tsx.5ed838.patch
   - type: NEW_FILE
-    step: 9
+    step: "9"
     name: Build password reset flow
     description: Add a password reset form with token validation.
     ingredients:
       - path: templates/skeleton/app/routes/account_.reset.$id.$resetToken.tsx
   - type: PATCH
-    step: 10
+    step: "10"
     name: Add address management
     description: Convert address management to use Storefront API mutations.
     diffs:
       - file: app/routes/account.addresses.tsx
         patchFile: account.addresses.tsx.f3bb60.patch
   - type: PATCH
-    step: 11
+    step: "11"
     name: Show order details
     description: Convert the order details page to use Storefront API queries.
     diffs:
       - file: app/routes/account.orders.$id.tsx
         patchFile: account.orders.$id.tsx.56d9c4.patch
   - type: PATCH
-    step: 12
+    step: "12"
     name: Display order history
     description: Convert the orders list to use the Storefront API with pagination.
     diffs:
       - file: app/routes/account.orders._index.tsx
         patchFile: account.orders._index.tsx.8942cc.patch
   - type: PATCH
-    step: 13
+    step: "13"
     name: Build customer profile page
     description: Convert the customer profile page to use Storefront API queries.
     diffs:
       - file: app/routes/account.profile.tsx
         patchFile: account.profile.tsx.8e4050.patch
   - type: PATCH
-    step: 14
+    step: "14"
     name: Update account layout for session auth
     description: Convert the account layout to use session-based authentication.
     diffs:
       - file: app/routes/account.tsx
         patchFile: account.tsx.30f6e3.patch
   - type: PATCH
-    step: 15
+    step: "15"
     name: Create login page
     description: Replace the Customer Account API login with the Storefront API form.
     diffs:
       - file: app/routes/account_.login.tsx
         patchFile: account_.login.tsx.d75928.patch
   - type: PATCH
-    step: 16
+    step: "16"
     name: Handle logout and session cleanup
     description: Replace the Customer Account API logout with a session cleanup.
     diffs:

--- a/cookbook/recipes/legacy-customer-account-flow/recipe.yaml
+++ b/cookbook/recipes/legacy-customer-account-flow/recipe.yaml
@@ -46,108 +46,108 @@ ingredients:
 deletedFiles: []
 steps:
   - type: PATCH
-    step: "1"
+    step: 1
     name: Document legacy customer accounts in the README
     description: Update the README file to document the legacy customer account flow.
     diffs:
       - file: README.md
         patchFile: README.md.a0354d.patch
   - type: PATCH
-    step: "2"
+    step: 2
     name: Add account link to header navigation
     description: Add an account link to the header navigation.
     diffs:
       - file: app/components/Header.tsx
         patchFile: Header.tsx.994c25.patch
   - type: NEW_FILE
-    step: "3"
+    step: 3
     name: Create account activation flow
     description: Add an account activation route for email verification.
     ingredients:
       - path: templates/skeleton/app/routes/account_.activate.$id.$activationToken.tsx
   - type: PATCH
-    step: "4"
+    step: 4
     name: Update PageLayout for legacy auth
     description: Update PageLayout to handle account routes.
     diffs:
       - file: app/components/PageLayout.tsx
         patchFile: PageLayout.tsx.145dab.patch
   - type: NEW_FILE
-    step: "5"
+    step: 5
     name: Build password recovery flow
     description: Add a password recovery form.
     ingredients:
       - path: templates/skeleton/app/routes/account_.recover.tsx
   - type: PATCH
-    step: "6"
+    step: 6
     name: Validate customer access tokens
     description: Add customer access token validation to the root loader.
     diffs:
       - file: app/root.tsx
         patchFile: root.tsx.8c60e9.patch
   - type: NEW_FILE
-    step: "7"
+    step: 7
     name: Create customer registration flow
     description: Add a customer registration form.
     ingredients:
       - path: templates/skeleton/app/routes/account_.register.tsx
   - type: PATCH
-    step: "8"
+    step: 8
     name: Handle unauthenticated account routes
     description: Convert the catch-all route to use Storefront API authentication.
     diffs:
       - file: app/routes/account.$.tsx
         patchFile: account.$.tsx.5ed838.patch
   - type: NEW_FILE
-    step: "9"
+    step: 9
     name: Build password reset flow
     description: Add a password reset form with token validation.
     ingredients:
       - path: templates/skeleton/app/routes/account_.reset.$id.$resetToken.tsx
   - type: PATCH
-    step: "10"
+    step: 10
     name: Add address management
     description: Convert address management to use Storefront API mutations.
     diffs:
       - file: app/routes/account.addresses.tsx
         patchFile: account.addresses.tsx.f3bb60.patch
   - type: PATCH
-    step: "11"
+    step: 11
     name: Show order details
     description: Convert the order details page to use Storefront API queries.
     diffs:
       - file: app/routes/account.orders.$id.tsx
         patchFile: account.orders.$id.tsx.56d9c4.patch
   - type: PATCH
-    step: "12"
+    step: 12
     name: Display order history
     description: Convert the orders list to use the Storefront API with pagination.
     diffs:
       - file: app/routes/account.orders._index.tsx
         patchFile: account.orders._index.tsx.8942cc.patch
   - type: PATCH
-    step: "13"
+    step: 13
     name: Build customer profile page
     description: Convert the customer profile page to use Storefront API queries.
     diffs:
       - file: app/routes/account.profile.tsx
         patchFile: account.profile.tsx.8e4050.patch
   - type: PATCH
-    step: "14"
+    step: 14
     name: Update account layout for session auth
     description: Convert the account layout to use session-based authentication.
     diffs:
       - file: app/routes/account.tsx
         patchFile: account.tsx.30f6e3.patch
   - type: PATCH
-    step: "15"
+    step: 15
     name: Create login page
     description: Replace the Customer Account API login with the Storefront API form.
     diffs:
       - file: app/routes/account_.login.tsx
         patchFile: account_.login.tsx.d75928.patch
   - type: PATCH
-    step: "16"
+    step: 16
     name: Handle logout and session cleanup
     description: Replace the Customer Account API logout with a session cleanup.
     diffs:

--- a/cookbook/recipes/multipass/patches/account.addresses.tsx.f3bb60.patch
+++ b/cookbook/recipes/multipass/patches/account.addresses.tsx.f3bb60.patch
@@ -399,7 +399,7 @@ index 3e04bc72..d36d1d91 100644
 -        <label htmlFor="territoryCode">Country Code*</label>
 +        <label htmlFor="country">Country*</label>
          <input
--          aria-label="territoryCode"
+-          aria-label="Country code"
 -          autoComplete="country"
 -          defaultValue={address?.territoryCode ?? ''}
 -          id="territoryCode"

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -55,6 +55,7 @@ export {B2BUtil} from './b2b-utils';
 export {mockCustomerAccountOperation} from './msw/graphql';
 export {MSW_SCENARIOS} from './msw/scenarios';
 export {B2B_COMPANY_NAME} from './msw/handlers';
+export {LEGACY_CUSTOMER_FIRST_NAME} from './msw/handlers';
 
 export const test = base.extend<
   {

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -55,7 +55,7 @@ export {B2BUtil} from './b2b-utils';
 export {mockCustomerAccountOperation} from './msw/graphql';
 export {MSW_SCENARIOS} from './msw/scenarios';
 export {B2B_COMPANY_NAME} from './msw/handlers';
-export {LEGACY_CUSTOMER_FIRST_NAME} from './msw/handlers';
+export {LEGACY_CUSTOMER_MOCK} from './msw/handlers';
 
 export const test = base.extend<
   {

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -31,6 +31,7 @@ export {GiftCardUtil} from './gift-card-utils';
 export {CustomerAccountUtil} from './customer-account-utils';
 export {DeliveryAddressUtil} from './delivery-address-utils';
 export {SubscriptionsUtil} from './subscriptions-utils';
+export {LegacyCustomerAccountUtil} from './legacy-customer-account-utils';
 
 export const CUSTOMER_ACCOUNT_STORAGE_STATE_PATH = path.resolve(
   __dirname,

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -14,6 +14,7 @@ import {GiftCardUtil} from './gift-card-utils';
 import {CustomerAccountUtil} from './customer-account-utils';
 import {DeliveryAddressUtil} from './delivery-address-utils';
 import {B2BUtil} from './b2b-utils';
+import {LegacyCustomerAccountUtil} from './legacy-customer-account-utils';
 import type {MswScenario} from './msw/scenarios';
 import {getHandlersForScenario} from './msw/handlers';
 
@@ -66,6 +67,7 @@ export const test = base.extend<
     customerAccount: CustomerAccountUtil;
     addresses: DeliveryAddressUtil;
     b2b: B2BUtil;
+    legacyCustomerAccount: LegacyCustomerAccountUtil;
   },
   {forEachWorker: void}
 >({
@@ -96,6 +98,10 @@ export const test = base.extend<
   b2b: async ({page}, use) => {
     const b2b = new B2BUtil(page);
     await use(b2b);
+  },
+  legacyCustomerAccount: async ({page}, use) => {
+    const legacyCustomerAccount = new LegacyCustomerAccountUtil(page);
+    await use(legacyCustomerAccount);
   },
 });
 

--- a/e2e/fixtures/legacy-customer-account-utils.ts
+++ b/e2e/fixtures/legacy-customer-account-utils.ts
@@ -95,6 +95,10 @@ export class LegacyCustomerAccountUtil {
     return this.page.getByRole('textbox', {name: /last name/i});
   }
 
+  getCityInput(): Locator {
+    return this.page.getByRole('textbox', {name: /city/i});
+  }
+
   getPhoneInput(): Locator {
     return this.page.getByLabel(/mobile/i);
   }
@@ -172,15 +176,6 @@ export class LegacyCustomerAccountUtil {
   }
 
   // ── Authenticated page assertions ───────────────────────
-
-  async assertOrdersPageRendered(firstName: string) {
-    await expect(this.getWelcomeHeading(firstName)).toBeVisible();
-    await expect(
-      this.getEmptyOrdersMessage().or(
-        this.page.getByRole('link', {name: /view order/i}),
-      ),
-    ).toBeVisible();
-  }
 
   async assertEmptyOrders() {
     await expect(this.getEmptyOrdersMessage()).toBeVisible();

--- a/e2e/fixtures/legacy-customer-account-utils.ts
+++ b/e2e/fixtures/legacy-customer-account-utils.ts
@@ -25,6 +25,21 @@ export class LegacyCustomerAccountUtil {
     await expect(this.page).toHaveURL(/\/account\/recover/);
   }
 
+  async navigateToOrders() {
+    await this.page.goto('/account/orders');
+    await expect(this.page).toHaveURL(/\/account\/orders/);
+  }
+
+  async navigateToProfile() {
+    await this.page.goto('/account/profile');
+    await expect(this.page).toHaveURL(/\/account\/profile/);
+  }
+
+  async navigateToAddresses() {
+    await this.page.goto('/account/addresses');
+    await expect(this.page).toHaveURL(/\/account\/addresses/);
+  }
+
   // ── Page element locators ───────────────────────────────
 
   getPageHeading(): Locator {
@@ -49,6 +64,59 @@ export class LegacyCustomerAccountUtil {
 
   getLink(name: string | RegExp): Locator {
     return this.page.getByRole('link', {name});
+  }
+
+  // ── Authenticated page locators ─────────────────────────
+
+  getWelcomeHeading(firstName: string): Locator {
+    return this.page.getByRole('heading', {
+      name: new RegExp('Welcome, ' + firstName),
+      level: 1,
+    });
+  }
+
+  getAccountMenuLink(name: string | RegExp): Locator {
+    return this.page.getByRole('link', {name});
+  }
+
+  getEmptyOrdersMessage(): Locator {
+    return this.page.getByText("You haven't placed any orders yet.");
+  }
+
+  getStartShoppingLink(): Locator {
+    return this.page.getByRole('link', {name: /start shopping/i});
+  }
+
+  getFirstNameInput(): Locator {
+    return this.page.getByRole('textbox', {name: /first name/i});
+  }
+
+  getLastNameInput(): Locator {
+    return this.page.getByRole('textbox', {name: /last name/i});
+  }
+
+  getPhoneInput(): Locator {
+    return this.page.getByLabel(/mobile/i);
+  }
+
+  getProfileEmailInput(): Locator {
+    return this.page.locator('#email');
+  }
+
+  getMarketingCheckbox(): Locator {
+    return this.page.getByLabel(/subscribed to marketing/i);
+  }
+
+  getNewPasswordInput(): Locator {
+    return this.page.getByLabel('New password', {exact: true});
+  }
+
+  getNewPasswordConfirmInput(): Locator {
+    return this.page.getByLabel(/new password \(confirm\)/i);
+  }
+
+  getLogoutButton(): Locator {
+    return this.page.getByRole('button', {name: /logout|sign out/i});
   }
 
   // ── Login page assertions ───────────────────────────────
@@ -101,5 +169,41 @@ export class LegacyCustomerAccountUtil {
 
   async assertHeaderHasAccountLink() {
     await expect(this.getHeaderAccountLink()).toBeVisible();
+  }
+
+  // ── Authenticated page assertions ───────────────────────
+
+  async assertOrdersPageRendered(firstName: string) {
+    await expect(this.getWelcomeHeading(firstName)).toBeVisible();
+    await expect(this.page.locator('.orders')).toBeVisible();
+  }
+
+  async assertEmptyOrders() {
+    await expect(this.getEmptyOrdersMessage()).toBeVisible();
+    await expect(this.getStartShoppingLink()).toBeVisible();
+  }
+
+  async assertProfilePageRendered(customer: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string;
+  }) {
+    await expect(this.getFirstNameInput()).toHaveValue(customer.firstName);
+    await expect(this.getLastNameInput()).toHaveValue(customer.lastName);
+    await expect(this.getProfileEmailInput()).toHaveValue(customer.email);
+    await expect(this.getPhoneInput()).toHaveValue(customer.phone);
+  }
+
+  async assertAddressesPageRendered() {
+    await expect(
+      this.page.getByRole('heading', {name: /addresses/i}),
+    ).toBeVisible();
+  }
+
+  async assertAccountMenuLinks() {
+    await expect(this.getAccountMenuLink(/orders/i)).toBeVisible();
+    await expect(this.getAccountMenuLink(/profile/i)).toBeVisible();
+    await expect(this.getAccountMenuLink(/addresses/i)).toBeVisible();
   }
 }

--- a/e2e/fixtures/legacy-customer-account-utils.ts
+++ b/e2e/fixtures/legacy-customer-account-utils.ts
@@ -112,7 +112,7 @@ export class LegacyCustomerAccountUtil {
   }
 
   getNewPasswordConfirmInput(): Locator {
-    return this.page.getByLabel(/new password \(confirm\)/i);
+    return this.page.getByLabel(/new password confirm/i);
   }
 
   getLogoutButton(): Locator {

--- a/e2e/fixtures/legacy-customer-account-utils.ts
+++ b/e2e/fixtures/legacy-customer-account-utils.ts
@@ -76,7 +76,7 @@ export class LegacyCustomerAccountUtil {
   }
 
   getAccountMenuLink(name: string | RegExp): Locator {
-    return this.page.getByRole('link', {name});
+    return this.page.getByRole('navigation').getByRole('link', {name});
   }
 
   getEmptyOrdersMessage(): Locator {
@@ -100,7 +100,7 @@ export class LegacyCustomerAccountUtil {
   }
 
   getProfileEmailInput(): Locator {
-    return this.page.locator('#email');
+    return this.page.getByLabel(/email address/i);
   }
 
   getMarketingCheckbox(): Locator {
@@ -175,7 +175,11 @@ export class LegacyCustomerAccountUtil {
 
   async assertOrdersPageRendered(firstName: string) {
     await expect(this.getWelcomeHeading(firstName)).toBeVisible();
-    await expect(this.page.locator('.orders')).toBeVisible();
+    await expect(
+      this.getEmptyOrdersMessage().or(
+        this.page.getByRole('link', {name: /view order/i}),
+      ),
+    ).toBeVisible();
   }
 
   async assertEmptyOrders() {

--- a/e2e/fixtures/legacy-customer-account-utils.ts
+++ b/e2e/fixtures/legacy-customer-account-utils.ts
@@ -58,14 +58,6 @@ export class LegacyCustomerAccountUtil {
     return this.page.getByLabel(/re-enter password/i);
   }
 
-  getSubmitButton(name: string | RegExp): Locator {
-    return this.page.getByRole('button', {name});
-  }
-
-  getLink(name: string | RegExp): Locator {
-    return this.page.getByRole('link', {name});
-  }
-
   // ── Authenticated page locators ─────────────────────────
 
   getWelcomeHeading(firstName: string): Locator {
@@ -129,12 +121,18 @@ export class LegacyCustomerAccountUtil {
     await expect(this.getPageHeading()).toHaveText('Sign in.');
     await expect(this.getEmailInput()).toBeVisible();
     await expect(this.getPasswordInput()).toBeVisible();
-    await expect(this.getSubmitButton('Sign in')).toBeVisible();
+    await expect(
+      this.page.getByRole('button', {name: 'Sign in'}),
+    ).toBeVisible();
   }
 
   async assertLoginPageLinks() {
-    await expect(this.getLink(/forgot password/i)).toBeVisible();
-    await expect(this.getLink(/register/i)).toBeVisible();
+    await expect(
+      this.page.getByRole('link', {name: /forgot password/i}),
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole('link', {name: /register/i}),
+    ).toBeVisible();
   }
 
   // ── Register page assertions ────────────────────────────
@@ -144,11 +142,13 @@ export class LegacyCustomerAccountUtil {
     await expect(this.getEmailInput()).toBeVisible();
     await expect(this.getPasswordInput()).toBeVisible();
     await expect(this.getPasswordConfirmInput()).toBeVisible();
-    await expect(this.getSubmitButton('Register')).toBeVisible();
+    await expect(
+      this.page.getByRole('button', {name: 'Register'}),
+    ).toBeVisible();
   }
 
   async assertRegisterPageLinks() {
-    await expect(this.getLink(/login/i)).toBeVisible();
+    await expect(this.page.getByRole('link', {name: /login/i})).toBeVisible();
   }
 
   // ── Recover page assertions ─────────────────────────────
@@ -156,11 +156,13 @@ export class LegacyCustomerAccountUtil {
   async assertRecoverPageRendered() {
     await expect(this.getPageHeading()).toHaveText('Forgot Password.');
     await expect(this.getEmailInput()).toBeVisible();
-    await expect(this.getSubmitButton(/request reset link/i)).toBeVisible();
+    await expect(
+      this.page.getByRole('button', {name: /request reset link/i}),
+    ).toBeVisible();
   }
 
   async assertRecoverPageLinks() {
-    await expect(this.getLink(/login/i)).toBeVisible();
+    await expect(this.page.getByRole('link', {name: /login/i})).toBeVisible();
   }
 
   // ── Header assertions ──────────────────────────────────

--- a/e2e/fixtures/legacy-customer-account-utils.ts
+++ b/e2e/fixtures/legacy-customer-account-utils.ts
@@ -1,0 +1,105 @@
+import {expect, type Locator, type Page} from '@playwright/test';
+
+/**
+ * Test utilities for the legacy-customer-account-flow recipe.
+ * Provides helpers for navigating auth pages and asserting page structure
+ * in the legacy Storefront API auth flow.
+ */
+export class LegacyCustomerAccountUtil {
+  constructor(private page: Page) {}
+
+  // ── Navigation ──────────────────────────────────────────
+
+  async navigateToLogin() {
+    await this.page.goto('/account/login');
+    await expect(this.page).toHaveURL(/\/account\/login/);
+  }
+
+  async navigateToRegister() {
+    await this.page.goto('/account/register');
+    await expect(this.page).toHaveURL(/\/account\/register/);
+  }
+
+  async navigateToRecover() {
+    await this.page.goto('/account/recover');
+    await expect(this.page).toHaveURL(/\/account\/recover/);
+  }
+
+  // ── Page element locators ───────────────────────────────
+
+  getPageHeading(): Locator {
+    return this.page.getByRole('heading', {level: 1});
+  }
+
+  getEmailInput(): Locator {
+    return this.page.getByRole('textbox', {name: /email address/i});
+  }
+
+  getPasswordInput(): Locator {
+    return this.page.getByLabel('Password', {exact: true});
+  }
+
+  getPasswordConfirmInput(): Locator {
+    return this.page.getByLabel(/re-enter password/i);
+  }
+
+  getSubmitButton(name: string | RegExp): Locator {
+    return this.page.getByRole('button', {name});
+  }
+
+  getLink(name: string | RegExp): Locator {
+    return this.page.getByRole('link', {name});
+  }
+
+  // ── Login page assertions ───────────────────────────────
+
+  async assertLoginPageRendered() {
+    await expect(this.getPageHeading()).toHaveText('Sign in.');
+    await expect(this.getEmailInput()).toBeVisible();
+    await expect(this.getPasswordInput()).toBeVisible();
+    await expect(this.getSubmitButton('Sign in')).toBeVisible();
+  }
+
+  async assertLoginPageLinks() {
+    await expect(this.getLink(/forgot password/i)).toBeVisible();
+    await expect(this.getLink(/register/i)).toBeVisible();
+  }
+
+  // ── Register page assertions ────────────────────────────
+
+  async assertRegisterPageRendered() {
+    await expect(this.getPageHeading()).toHaveText('Register.');
+    await expect(this.getEmailInput()).toBeVisible();
+    await expect(this.getPasswordInput()).toBeVisible();
+    await expect(this.getPasswordConfirmInput()).toBeVisible();
+    await expect(this.getSubmitButton('Register')).toBeVisible();
+  }
+
+  async assertRegisterPageLinks() {
+    await expect(this.getLink(/login/i)).toBeVisible();
+  }
+
+  // ── Recover page assertions ─────────────────────────────
+
+  async assertRecoverPageRendered() {
+    await expect(this.getPageHeading()).toHaveText('Forgot Password.');
+    await expect(this.getEmailInput()).toBeVisible();
+    await expect(this.getSubmitButton(/request reset link/i)).toBeVisible();
+  }
+
+  async assertRecoverPageLinks() {
+    await expect(this.getLink(/login/i)).toBeVisible();
+  }
+
+  // ── Header assertions ──────────────────────────────────
+
+  getHeaderAccountLink(): Locator {
+    return this.page
+      .getByRole('banner')
+      .getByRole('link', {name: /sign in|account/i});
+  }
+
+  async assertHeaderHasAccountLink() {
+    await expect(this.getHeaderAccountLink()).toBeVisible();
+  }
+}

--- a/e2e/fixtures/legacy-customer-account-utils.ts
+++ b/e2e/fixtures/legacy-customer-account-utils.ts
@@ -104,11 +104,11 @@ export class LegacyCustomerAccountUtil {
   }
 
   getMarketingCheckbox(): Locator {
-    return this.page.getByLabel(/subscribed to marketing/i);
+    return this.page.getByLabel(/accept marketing/i);
   }
 
   getNewPasswordInput(): Locator {
-    return this.page.getByLabel('New password', {exact: true});
+    return this.page.getByLabel(/^new password$/i);
   }
 
   getNewPasswordConfirmInput(): Locator {

--- a/e2e/fixtures/msw/entry.ts
+++ b/e2e/fixtures/msw/entry.ts
@@ -4,6 +4,9 @@ import {MswScenarioMeta} from './handlers';
 const installedKey = Symbol.for('hydrogen.e2e.msw.installed');
 const LOCAL_STORAGE_TEST_KEY = '__hydrogen_e2e_local_storage_test__';
 
+// Cookie-based session storage derives cookie attributes from the request URL.
+// localhost wouldn't produce cookies valid for the CAAPI auth flow, so we
+// rewrite requests to a tunnel hostname that matches the expected cookie domain.
 const E2E_TUNNEL_HOSTNAME = 'e2e.tryhydrogen.dev';
 
 const SESSION_TTL_IN_MS = 60 * 60 * 1000;
@@ -137,6 +140,9 @@ ensureNodeProcessForMsw();
 const {getResponse} = await import('msw');
 const {getHandlersForScenario} = await import('./handlers');
 
+// The fetch interceptor is installed once as a closure and cannot receive
+// parameters per-request. Module-level state is the only way to communicate
+// the current scenario to the interceptor. Safe because workerd is single-threaded.
 let currentMswScenarioMeta: MswScenarioMeta | undefined = undefined;
 
 function toRequest(input: RequestInfo | URL, init?: RequestInit) {

--- a/e2e/fixtures/msw/entry.ts
+++ b/e2e/fixtures/msw/entry.ts
@@ -4,9 +4,6 @@ import {MswScenarioMeta} from './handlers';
 const installedKey = Symbol.for('hydrogen.e2e.msw.installed');
 const LOCAL_STORAGE_TEST_KEY = '__hydrogen_e2e_local_storage_test__';
 
-// Cookie-based session storage derives cookie attributes from the request URL.
-// localhost wouldn't produce cookies valid for the CAAPI auth flow, so we
-// rewrite requests to a tunnel hostname that matches the expected cookie domain.
 const E2E_TUNNEL_HOSTNAME = 'e2e.tryhydrogen.dev';
 
 const SESSION_TTL_IN_MS = 60 * 60 * 1000;
@@ -105,9 +102,9 @@ function ensureBroadcastChannel() {
 }
 
 /**
- * MSW needs `process.versions.node` set so it uses its Node.js programmatic
- * interception strategy (not Service Worker). `NODE_ENV: 'production'`
- * suppresses MSW's verbose dev-mode diagnostics that pollute test logs.
+ * MSW needs process.versions.node set so it uses its Node.js programmatic
+ * interception strategy (not Service Worker). NODE_ENV: 'production'
+ * suppresses MSW verbose dev-mode diagnostics that pollute test logs.
  */
 function ensureNodeProcessForMsw() {
   const currentProcess = (globalThis as MswGlobal).process;
@@ -140,9 +137,6 @@ ensureNodeProcessForMsw();
 const {getResponse} = await import('msw');
 const {getHandlersForScenario} = await import('./handlers');
 
-// The fetch interceptor is installed once as a closure and cannot receive
-// parameters per-request. Module-level state is the only way to communicate
-// the current scenario to the interceptor. Safe because workerd is single-threaded.
 let currentMswScenarioMeta: MswScenarioMeta | undefined = undefined;
 
 function toRequest(input: RequestInfo | URL, init?: RequestInit) {
@@ -190,7 +184,8 @@ function getMswScenario(env: Env): string | undefined {
 function shouldInjectCustomerSession() {
   return (
     currentMswScenarioMeta &&
-    currentMswScenarioMeta.mocksCustomerAccountApi &&
+    (currentMswScenarioMeta.mocksCustomerAccountApi ||
+      currentMswScenarioMeta.mocksLegacyCustomerAuth) &&
     currentMswScenarioMeta.handlers.length > 0
   );
 }
@@ -237,6 +232,47 @@ function getSessionStorage(secret: string) {
   return cachedSessionStorage;
 }
 
+type SessionLike = Awaited<
+  ReturnType<ReturnType<typeof createCookieSessionStorage>['getSession']>
+>;
+
+function injectCustomerAccountSession(session: SessionLike) {
+  const current =
+    session.get('customerAccount') ??
+    ({} as {
+      accessToken?: string;
+      refreshToken?: string;
+      expiresAt?: string;
+    });
+
+  session.set('customerAccount', {
+    ...current,
+    accessToken: current.accessToken ?? 'e2e-customer-access-token',
+    refreshToken: current.refreshToken ?? 'e2e-customer-refresh-token',
+    expiresAt: current.expiresAt ?? String(Date.now() + SESSION_TTL_IN_MS),
+  });
+}
+
+/**
+ * The legacy customer account recipe uses the Storefront API for auth,
+ * storing customerAccessToken (with shape {accessToken, expiresAt})
+ * instead of customerAccount (which also has refreshToken).
+ * expiresAt is an ISO date string parsed with new Date(expiresAt).
+ */
+function injectLegacyCustomerSession(session: SessionLike) {
+  const current =
+    session.get('customerAccessToken') ??
+    ({} as {accessToken?: string; expiresAt?: string});
+
+  session.set('customerAccessToken', {
+    ...current,
+    accessToken: current.accessToken ?? 'e2e-legacy-customer-access-token',
+    expiresAt:
+      current.expiresAt ??
+      new Date(Date.now() + SESSION_TTL_IN_MS).toISOString(),
+  });
+}
+
 async function addMockCustomerSessionCookieIfNeeded(
   request: Request,
   env: Env,
@@ -256,25 +292,11 @@ async function addMockCustomerSessionCookieIfNeeded(
     requestWithTunnelHostname.headers.get('Cookie') ?? '',
   );
 
-  const currentCustomerAccountSession =
-    session.get('customerAccount') ??
-    ({} as {
-      accessToken?: string;
-      refreshToken?: string;
-      expiresAt?: string;
-    });
-
-  session.set('customerAccount', {
-    ...currentCustomerAccountSession,
-    accessToken:
-      currentCustomerAccountSession.accessToken ?? 'e2e-customer-access-token',
-    refreshToken:
-      currentCustomerAccountSession.refreshToken ??
-      'e2e-customer-refresh-token',
-    expiresAt:
-      currentCustomerAccountSession.expiresAt ??
-      String(Date.now() + SESSION_TTL_IN_MS),
-  });
+  if (currentMswScenarioMeta?.mocksLegacyCustomerAuth) {
+    injectLegacyCustomerSession(session);
+  } else {
+    injectCustomerAccountSession(session);
+  }
 
   const sessionCookiePair = (await storage.commitSession(session)).split(
     ';',

--- a/e2e/fixtures/msw/entry.ts
+++ b/e2e/fixtures/msw/entry.ts
@@ -105,8 +105,8 @@ function ensureBroadcastChannel() {
 }
 
 /**
- * MSW needs process.versions.node set so it uses its Node.js programmatic
- * interception strategy (not Service Worker). NODE_ENV: 'production'
+ * MSW needs `process.versions.node` set so it uses its Node.js programmatic
+ * interception strategy (not Service Worker). `NODE_ENV: 'production'`
  * suppresses MSW verbose dev-mode diagnostics that pollute test logs.
  */
 function ensureNodeProcessForMsw() {

--- a/e2e/fixtures/msw/handlers.ts
+++ b/e2e/fixtures/msw/handlers.ts
@@ -130,7 +130,7 @@ const legacyCustomerOrdersMock = {
   },
 };
 
-scenarios.set('legacy-customer-account-logged-in', {
+scenarios.set(MSW_SCENARIOS.legacyCustomerAccountLoggedIn, {
   handlers: [
     graphql.query('Customer', () => {
       return HttpResponse.json({data: {customer: LEGACY_CUSTOMER_MOCK}});

--- a/e2e/fixtures/msw/handlers.ts
+++ b/e2e/fixtures/msw/handlers.ts
@@ -44,6 +44,7 @@ const customerOrdersMock: CustomerOrdersQuery = {
 export interface MswScenarioMeta {
   handlers: RequestHandler[];
   mocksCustomerAccountApi: boolean;
+  mocksLegacyCustomerAuth: boolean;
 }
 
 const scenarios = new Map<MswScenario, MswScenarioMeta>();
@@ -96,6 +97,52 @@ scenarios.set(MSW_SCENARIOS.customerAccountLoggedIn, {
     }),
   ],
   mocksCustomerAccountApi: true,
+  mocksLegacyCustomerAuth: false,
+});
+
+/**
+ * Legacy customer account scenario: simulates a logged-in customer using
+ * Storefront API auth (not Customer Account API). The legacy recipe stores
+ * customerAccessToken in the session instead of customerAccount.
+ * GraphQL queries are matched by operation name against the Storefront API.
+ */
+export const LEGACY_CUSTOMER_FIRST_NAME = 'Taylor';
+
+const legacyCustomerMock = {
+  acceptsMarketing: false,
+  addresses: {nodes: []},
+  defaultAddress: null,
+  email: 'taylor@example.com',
+  firstName: LEGACY_CUSTOMER_FIRST_NAME,
+  lastName: 'E2E',
+  numberOfOrders: 0,
+  phone: '+15551234567',
+};
+
+const legacyCustomerOrdersMock = {
+  numberOfOrders: 0,
+  orders: {
+    nodes: [],
+    pageInfo: {
+      hasPreviousPage: false,
+      hasNextPage: false,
+      endCursor: null,
+      startCursor: null,
+    },
+  },
+};
+
+scenarios.set('legacy-customer-account-logged-in', {
+  handlers: [
+    graphql.query('Customer', () => {
+      return HttpResponse.json({data: {customer: legacyCustomerMock}});
+    }),
+    graphql.query('CustomerOrders', () => {
+      return HttpResponse.json({data: {customer: legacyCustomerOrdersMock}});
+    }),
+  ],
+  mocksCustomerAccountApi: false,
+  mocksLegacyCustomerAuth: true,
 });
 
 /**
@@ -424,17 +471,21 @@ export function getHandlersForScenario(
   scenario: string | undefined,
 ): MswScenarioMeta {
   if (!scenario) {
-    return {handlers: [], mocksCustomerAccountApi: false};
+    return {
+      handlers: [],
+      mocksCustomerAccountApi: false,
+      mocksLegacyCustomerAuth: false,
+    };
   }
 
   if (!isMswScenario(scenario)) {
-    throw new Error(`[e2e-msw] Unknown scenario: "${scenario}"`);
+    throw new Error('[e2e-msw] Unknown scenario: "' + scenario + '"');
   }
 
   const meta = scenarios.get(scenario);
   if (!meta) {
     throw new Error(
-      `[e2e-msw] Scenario "${scenario}" registered but metadata missing`,
+      '[e2e-msw] Scenario "' + scenario + '" registered but metadata missing',
     );
   }
 

--- a/e2e/fixtures/msw/handlers.ts
+++ b/e2e/fixtures/msw/handlers.ts
@@ -279,6 +279,7 @@ function createDeliveryAddressesScenario(): MswScenarioMeta {
       }),
     ],
     mocksCustomerAccountApi: true,
+    mocksLegacyCustomerAuth: false,
   };
 }
 
@@ -477,13 +478,13 @@ export function getHandlersForScenario(
   }
 
   if (!isMswScenario(scenario)) {
-    throw new Error('[e2e-msw] Unknown scenario: "' + scenario + '"');
+    throw new Error(`[e2e-msw] Unknown scenario: "${scenario}"`);
   }
 
   const meta = scenarios.get(scenario);
   if (!meta) {
     throw new Error(
-      '[e2e-msw] Scenario "' + scenario + '" registered but metadata missing',
+      `[e2e-msw] Scenario "${scenario}" registered but metadata missing`,
     );
   }
 

--- a/e2e/fixtures/msw/handlers.ts
+++ b/e2e/fixtures/msw/handlers.ts
@@ -106,14 +106,12 @@ scenarios.set(MSW_SCENARIOS.customerAccountLoggedIn, {
  * customerAccessToken in the session instead of customerAccount.
  * GraphQL queries are matched by operation name against the Storefront API.
  */
-export const LEGACY_CUSTOMER_FIRST_NAME = 'Taylor';
-
-const legacyCustomerMock = {
+export const LEGACY_CUSTOMER_MOCK = {
   acceptsMarketing: false,
   addresses: {nodes: []},
   defaultAddress: null,
   email: 'taylor@example.com',
-  firstName: LEGACY_CUSTOMER_FIRST_NAME,
+  firstName: 'Taylor',
   lastName: 'E2E',
   numberOfOrders: 0,
   phone: '+15551234567',
@@ -135,7 +133,7 @@ const legacyCustomerOrdersMock = {
 scenarios.set('legacy-customer-account-logged-in', {
   handlers: [
     graphql.query('Customer', () => {
-      return HttpResponse.json({data: {customer: legacyCustomerMock}});
+      return HttpResponse.json({data: {customer: LEGACY_CUSTOMER_MOCK}});
     }),
     graphql.query('CustomerOrders', () => {
       return HttpResponse.json({data: {customer: legacyCustomerOrdersMock}});

--- a/e2e/fixtures/msw/scenarios.ts
+++ b/e2e/fixtures/msw/scenarios.ts
@@ -3,6 +3,7 @@ export const MSW_SCENARIOS = {
   deliveryAddresses: 'delivery-addresses',
   b2bLoggedIn: 'b2b-logged-in',
   subscriptionsLoggedIn: 'subscriptions-logged-in',
+  legacyCustomerAccountLoggedIn: 'legacy-customer-account-logged-in',
 } as const;
 
 export type MswScenario = (typeof MSW_SCENARIOS)[keyof typeof MSW_SCENARIOS];

--- a/e2e/fixtures/recipe.ts
+++ b/e2e/fixtures/recipe.ts
@@ -69,10 +69,10 @@ export const setRecipeFixture = (options: RecipeFixtureOptions) => {
 
   const isLocal = !storeKey.startsWith('https://');
   const tmpRoot = path.resolve(__dirname, '../../.tmp/recipe-fixtures');
-  // Each recipe fixture directory is owned by exactly one test file's beforeAll.
-  // Two test files MUST NOT share the same recipeName — doing so would cause
-  // parallel workers to race on the same directory. Enforced by convention:
-  // each recipe has its own dedicated spec file.
+  // Multiple spec files MAY share the same recipeName (e.g. subscriptions.spec.ts
+  // and subscriptions-auth.spec.ts both use 'subscriptions'). The lock-and-wait
+  // mechanism (acquireLock/waitForFixture) ensures only one worker generates
+  // the fixture while others wait for it to complete.
   const recipeFixturePath = path.join(tmpRoot, recipeName);
   const skeletonPath = path.resolve(__dirname, '../../templates/skeleton');
   const repoRoot = path.resolve(__dirname, '../..');

--- a/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
@@ -67,11 +67,11 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
       await expect(page).not.toHaveURL(/\/account\/recover/);
     });
 
-    test('redirects unknown account sub-route to /account when authenticated', async ({
+    test('redirects unknown account sub-route to /account/orders when authenticated', async ({
       page,
     }) => {
       await page.goto('/account/nonexistent');
-      await expect(page).toHaveURL(/\/account/);
+      await expect(page).toHaveURL(/\/account\/orders/);
     });
   });
 
@@ -143,13 +143,10 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
     });
 
     test('shows new address form with required fields', async ({page}) => {
-      await expect(
-        page.getByRole('textbox', {name: /first name/i}),
-      ).toBeVisible();
-      await expect(
-        page.getByRole('textbox', {name: /last name/i}),
-      ).toBeVisible();
-      await expect(page.getByRole('textbox', {name: /city/i})).toBeVisible();
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await expect(recipe.getFirstNameInput()).toBeVisible();
+      await expect(recipe.getLastNameInput()).toBeVisible();
+      await expect(recipe.getCityInput()).toBeVisible();
     });
   });
 

--- a/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
@@ -76,41 +76,37 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
   });
 
   test.describe('Orders Page', () => {
+    let recipe: LegacyCustomerAccountUtil;
+
     test.beforeEach(async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+      recipe = new LegacyCustomerAccountUtil(page);
       await recipe.navigateToOrders();
     });
 
-    test('renders welcome heading with customer first name', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('renders welcome heading with customer first name', async () => {
       await expect(
         recipe.getWelcomeHeading(LEGACY_CUSTOMER_MOCK.firstName),
       ).toBeVisible();
     });
 
-    test('shows empty orders message with start shopping link', async ({
-      page,
-    }) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('shows empty orders message with start shopping link', async () => {
       await recipe.assertEmptyOrders();
     });
 
-    test('displays account navigation menu', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('displays account navigation menu', async () => {
       await recipe.assertAccountMenuLinks();
     });
   });
 
   test.describe('Profile Page', () => {
+    let recipe: LegacyCustomerAccountUtil;
+
     test.beforeEach(async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+      recipe = new LegacyCustomerAccountUtil(page);
       await recipe.navigateToProfile();
     });
 
-    test('renders profile form pre-filled with customer data', async ({
-      page,
-    }) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('renders profile form pre-filled with customer data', async () => {
       await recipe.assertProfilePageRendered({
         firstName: LEGACY_CUSTOMER_MOCK.firstName,
         lastName: LEGACY_CUSTOMER_MOCK.lastName,
@@ -119,31 +115,29 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
       });
     });
 
-    test('shows marketing preferences checkbox', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('shows marketing preferences checkbox', async () => {
       await expect(recipe.getMarketingCheckbox()).toBeVisible();
     });
 
-    test('shows password change section', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('shows password change section', async () => {
       await expect(recipe.getNewPasswordInput()).toBeVisible();
       await expect(recipe.getNewPasswordConfirmInput()).toBeVisible();
     });
   });
 
   test.describe('Addresses Page', () => {
+    let recipe: LegacyCustomerAccountUtil;
+
     test.beforeEach(async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+      recipe = new LegacyCustomerAccountUtil(page);
       await recipe.navigateToAddresses();
     });
 
-    test('renders addresses page with heading', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('renders addresses page with heading', async () => {
       await recipe.assertAddressesPageRendered();
     });
 
-    test('shows new address form with required fields', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('shows new address form with required fields', async () => {
       await expect(recipe.getFirstNameInput()).toBeVisible();
       await expect(recipe.getLastNameInput()).toBeVisible();
       await expect(recipe.getCityInput()).toBeVisible();
@@ -151,13 +145,14 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
   });
 
   test.describe('Account Navigation', () => {
+    let recipe: LegacyCustomerAccountUtil;
+
     test.beforeEach(async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+      recipe = new LegacyCustomerAccountUtil(page);
       await recipe.navigateToOrders();
     });
 
     test('clicking Profile link navigates to profile page', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
       await recipe.getAccountMenuLink(/profile/i).click();
       await expect(page).toHaveURL(/\/account\/profile/);
     });
@@ -165,7 +160,6 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
     test('clicking Addresses link navigates to addresses page', async ({
       page,
     }) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
       await recipe.getAccountMenuLink(/addresses/i).click();
       await expect(page).toHaveURL(/\/account\/addresses/);
     });

--- a/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
@@ -3,7 +3,7 @@ import {
   expect,
   setRecipeFixture,
   MSW_SCENARIOS,
-  LEGACY_CUSTOMER_FIRST_NAME,
+  LEGACY_CUSTOMER_MOCK,
 } from '../../fixtures';
 import {LegacyCustomerAccountUtil} from '../../fixtures/legacy-customer-account-utils';
 
@@ -32,13 +32,6 @@ setRecipeFixture({
  * to /account (the login loader checks session.customerAccessToken).
  */
 
-const legacyCustomerMock = {
-  firstName: LEGACY_CUSTOMER_FIRST_NAME,
-  lastName: 'E2E',
-  email: 'taylor@example.com',
-  phone: '+15551234567',
-};
-
 test.describe('Legacy Customer Account Flow — Authenticated', () => {
   test.describe('Account Home Redirect', () => {
     test('redirects /account to /account/orders when logged in', async ({
@@ -46,6 +39,39 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
     }) => {
       await page.goto('/account');
       await expect(page).toHaveURL(/\/account\/orders/);
+    });
+  });
+
+  test.describe('Authenticated Redirects on Public Routes', () => {
+    test('redirects /account/login to /account when already authenticated', async ({
+      page,
+    }) => {
+      await page.goto('/account/login');
+      await expect(page).toHaveURL(/\/account/);
+      await expect(page).not.toHaveURL(/\/account\/login/);
+    });
+
+    test('redirects /account/register to /account when already authenticated', async ({
+      page,
+    }) => {
+      await page.goto('/account/register');
+      await expect(page).toHaveURL(/\/account/);
+      await expect(page).not.toHaveURL(/\/account\/register/);
+    });
+
+    test('redirects /account/recover to /account when already authenticated', async ({
+      page,
+    }) => {
+      await page.goto('/account/recover');
+      await expect(page).toHaveURL(/\/account/);
+      await expect(page).not.toHaveURL(/\/account\/recover/);
+    });
+
+    test('redirects unknown account sub-route to /account when authenticated', async ({
+      page,
+    }) => {
+      await page.goto('/account/nonexistent');
+      await expect(page).toHaveURL(/\/account/);
     });
   });
 
@@ -57,7 +83,9 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
 
     test('renders welcome heading with customer first name', async ({page}) => {
       const recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.assertOrdersPageRendered(legacyCustomerMock.firstName);
+      await expect(
+        recipe.getWelcomeHeading(LEGACY_CUSTOMER_MOCK.firstName),
+      ).toBeVisible();
     });
 
     test('shows empty orders message with start shopping link', async ({
@@ -83,7 +111,12 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
       page,
     }) => {
       const recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.assertProfilePageRendered(legacyCustomerMock);
+      await recipe.assertProfilePageRendered({
+        firstName: LEGACY_CUSTOMER_MOCK.firstName,
+        lastName: LEGACY_CUSTOMER_MOCK.lastName,
+        email: LEGACY_CUSTOMER_MOCK.email,
+        phone: LEGACY_CUSTOMER_MOCK.phone,
+      });
     });
 
     test('shows marketing preferences checkbox', async ({page}) => {

--- a/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
@@ -6,8 +6,11 @@ import {
   LEGACY_CUSTOMER_MOCK,
 } from '../../fixtures';
 
+// Uses a distinct recipeName so parallel workers don't race on the same
+// fixture directory as the unauthenticated spec file. Both apply the same
+// recipe but from independent fixture copies.
 setRecipeFixture({
-  recipeName: 'legacy-customer-account-flow',
+  recipeName: 'legacy-customer-account-flow-auth',
   storeKey: 'hydrogenPreviewStorefront',
   mock: {
     scenario: MSW_SCENARIOS.legacyCustomerAccountLoggedIn,

--- a/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
@@ -6,11 +6,11 @@ import {
   LEGACY_CUSTOMER_MOCK,
 } from '../../fixtures';
 
-// Uses a distinct recipeName so parallel workers don't race on the same
-// fixture directory as the unauthenticated spec file. Both apply the same
-// recipe but from independent fixture copies.
+// Shares recipeName with the unauthenticated spec — the lock-and-wait
+// mechanism in recipe.ts safely handles parallel workers generating the
+// same fixture (see acquireLock/waitForFixture).
 setRecipeFixture({
-  recipeName: 'legacy-customer-account-flow-auth',
+  recipeName: 'legacy-customer-account-flow',
   storeKey: 'hydrogenPreviewStorefront',
   mock: {
     scenario: MSW_SCENARIOS.legacyCustomerAccountLoggedIn,

--- a/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
@@ -1,0 +1,152 @@
+import {
+  test,
+  expect,
+  setRecipeFixture,
+  MSW_SCENARIOS,
+  LEGACY_CUSTOMER_FIRST_NAME,
+} from '../../fixtures';
+import {LegacyCustomerAccountUtil} from '../../fixtures/legacy-customer-account-utils';
+
+setRecipeFixture({
+  recipeName: 'legacy-customer-account-flow',
+  storeKey: 'hydrogenPreviewStorefront',
+  mock: {
+    scenario: MSW_SCENARIOS.legacyCustomerAccountLoggedIn,
+  },
+});
+
+/**
+ * Legacy Customer Account Flow — Authenticated E2E Tests
+ *
+ * These tests run with MSW session injection that writes a
+ * customerAccessToken into the cookie session, simulating a
+ * customer logged in via the Storefront API auth flow.
+ *
+ * Storefront API GraphQL queries (Customer, CustomerOrders) are
+ * intercepted by MSW and return mock data. Non-customer queries
+ * (products, collections, header/footer) fall through to the real store.
+ *
+ * NOTE: This is a separate file from the unauthenticated tests because
+ * setRecipeFixture configures the dev server globally per-file. With MSW
+ * session injection active, public routes like /account/login redirect
+ * to /account (the login loader checks session.customerAccessToken).
+ */
+
+const legacyCustomerMock = {
+  firstName: LEGACY_CUSTOMER_FIRST_NAME,
+  lastName: 'E2E',
+  email: 'taylor@example.com',
+  phone: '+15551234567',
+};
+
+test.describe('Legacy Customer Account Flow — Authenticated', () => {
+  test.describe('Account Home Redirect', () => {
+    test('redirects /account to /account/orders when logged in', async ({
+      page,
+    }) => {
+      await page.goto('/account');
+      await expect(page).toHaveURL(/\/account\/orders/);
+    });
+  });
+
+  test.describe('Orders Page', () => {
+    test.beforeEach(async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.navigateToOrders();
+    });
+
+    test('renders welcome heading with customer first name', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertOrdersPageRendered(legacyCustomerMock.firstName);
+    });
+
+    test('shows empty orders message with start shopping link', async ({
+      page,
+    }) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertEmptyOrders();
+    });
+
+    test('displays account navigation menu', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertAccountMenuLinks();
+    });
+  });
+
+  test.describe('Profile Page', () => {
+    test.beforeEach(async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.navigateToProfile();
+    });
+
+    test('renders profile form pre-filled with customer data', async ({
+      page,
+    }) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertProfilePageRendered(legacyCustomerMock);
+    });
+
+    test('shows marketing preferences checkbox', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await expect(recipe.getMarketingCheckbox()).toBeVisible();
+    });
+
+    test('shows password change section', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await expect(recipe.getNewPasswordInput()).toBeVisible();
+      await expect(recipe.getNewPasswordConfirmInput()).toBeVisible();
+    });
+  });
+
+  test.describe('Addresses Page', () => {
+    test.beforeEach(async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.navigateToAddresses();
+    });
+
+    test('renders addresses page with heading', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertAddressesPageRendered();
+    });
+
+    test('shows new address form with required fields', async ({page}) => {
+      await expect(
+        page.getByRole('textbox', {name: /first name/i}),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('textbox', {name: /last name/i}),
+      ).toBeVisible();
+      await expect(page.getByRole('textbox', {name: /city/i})).toBeVisible();
+    });
+  });
+
+  test.describe('Account Navigation', () => {
+    test.beforeEach(async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.navigateToOrders();
+    });
+
+    test('clicking Profile link navigates to profile page', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.getAccountMenuLink(/profile/i).click();
+      await expect(page).toHaveURL(/\/account\/profile/);
+    });
+
+    test('clicking Addresses link navigates to addresses page', async ({
+      page,
+    }) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.getAccountMenuLink(/addresses/i).click();
+      await expect(page).toHaveURL(/\/account\/addresses/);
+    });
+  });
+
+  test.describe('Logout', () => {
+    test('logout button submits form and redirects to home', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.navigateToOrders();
+      await recipe.getLogoutButton().click();
+      await expect(page).toHaveURL(/^https?:\/\/[^/]+\/$/);
+    });
+  });
+});

--- a/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow-auth.spec.ts
@@ -5,7 +5,6 @@ import {
   MSW_SCENARIOS,
   LEGACY_CUSTOMER_MOCK,
 } from '../../fixtures';
-import {LegacyCustomerAccountUtil} from '../../fixtures/legacy-customer-account-utils';
 
 setRecipeFixture({
   recipeName: 'legacy-customer-account-flow',
@@ -76,38 +75,40 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
   });
 
   test.describe('Orders Page', () => {
-    let recipe: LegacyCustomerAccountUtil;
-
-    test.beforeEach(async ({page}) => {
-      recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.navigateToOrders();
+    test.beforeEach(async ({legacyCustomerAccount}) => {
+      await legacyCustomerAccount.navigateToOrders();
     });
 
-    test('renders welcome heading with customer first name', async () => {
+    test('renders welcome heading with customer first name', async ({
+      legacyCustomerAccount,
+    }) => {
       await expect(
-        recipe.getWelcomeHeading(LEGACY_CUSTOMER_MOCK.firstName),
+        legacyCustomerAccount.getWelcomeHeading(LEGACY_CUSTOMER_MOCK.firstName),
       ).toBeVisible();
     });
 
-    test('shows empty orders message with start shopping link', async () => {
-      await recipe.assertEmptyOrders();
+    test('shows empty orders message with start shopping link', async ({
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.assertEmptyOrders();
     });
 
-    test('displays account navigation menu', async () => {
-      await recipe.assertAccountMenuLinks();
+    test('displays account navigation menu', async ({
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.assertAccountMenuLinks();
     });
   });
 
   test.describe('Profile Page', () => {
-    let recipe: LegacyCustomerAccountUtil;
-
-    test.beforeEach(async ({page}) => {
-      recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.navigateToProfile();
+    test.beforeEach(async ({legacyCustomerAccount}) => {
+      await legacyCustomerAccount.navigateToProfile();
     });
 
-    test('renders profile form pre-filled with customer data', async () => {
-      await recipe.assertProfilePageRendered({
+    test('renders profile form pre-filled with customer data', async ({
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.assertProfilePageRendered({
         firstName: LEGACY_CUSTOMER_MOCK.firstName,
         lastName: LEGACY_CUSTOMER_MOCK.lastName,
         email: LEGACY_CUSTOMER_MOCK.email,
@@ -115,61 +116,69 @@ test.describe('Legacy Customer Account Flow — Authenticated', () => {
       });
     });
 
-    test('shows marketing preferences checkbox', async () => {
-      await expect(recipe.getMarketingCheckbox()).toBeVisible();
+    test('shows marketing preferences checkbox', async ({
+      legacyCustomerAccount,
+    }) => {
+      await expect(legacyCustomerAccount.getMarketingCheckbox()).toBeVisible();
     });
 
-    test('shows password change section', async () => {
-      await expect(recipe.getNewPasswordInput()).toBeVisible();
-      await expect(recipe.getNewPasswordConfirmInput()).toBeVisible();
+    test('shows password change section', async ({legacyCustomerAccount}) => {
+      await expect(legacyCustomerAccount.getNewPasswordInput()).toBeVisible();
+      await expect(
+        legacyCustomerAccount.getNewPasswordConfirmInput(),
+      ).toBeVisible();
     });
   });
 
   test.describe('Addresses Page', () => {
-    let recipe: LegacyCustomerAccountUtil;
-
-    test.beforeEach(async ({page}) => {
-      recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.navigateToAddresses();
+    test.beforeEach(async ({legacyCustomerAccount}) => {
+      await legacyCustomerAccount.navigateToAddresses();
     });
 
-    test('renders addresses page with heading', async () => {
-      await recipe.assertAddressesPageRendered();
+    test('renders addresses page with heading', async ({
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.assertAddressesPageRendered();
     });
 
-    test('shows new address form with required fields', async () => {
-      await expect(recipe.getFirstNameInput()).toBeVisible();
-      await expect(recipe.getLastNameInput()).toBeVisible();
-      await expect(recipe.getCityInput()).toBeVisible();
+    test('shows new address form with required fields', async ({
+      legacyCustomerAccount,
+    }) => {
+      await expect(legacyCustomerAccount.getFirstNameInput()).toBeVisible();
+      await expect(legacyCustomerAccount.getLastNameInput()).toBeVisible();
+      await expect(legacyCustomerAccount.getCityInput()).toBeVisible();
     });
   });
 
   test.describe('Account Navigation', () => {
-    let recipe: LegacyCustomerAccountUtil;
-
-    test.beforeEach(async ({page}) => {
-      recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.navigateToOrders();
+    test.beforeEach(async ({legacyCustomerAccount}) => {
+      await legacyCustomerAccount.navigateToOrders();
     });
 
-    test('clicking Profile link navigates to profile page', async ({page}) => {
-      await recipe.getAccountMenuLink(/profile/i).click();
+    test('clicking Profile link navigates to profile page', async ({
+      page,
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.getAccountMenuLink(/profile/i).click();
       await expect(page).toHaveURL(/\/account\/profile/);
     });
 
     test('clicking Addresses link navigates to addresses page', async ({
       page,
+      legacyCustomerAccount,
     }) => {
-      await recipe.getAccountMenuLink(/addresses/i).click();
+      await legacyCustomerAccount.getAccountMenuLink(/addresses/i).click();
       await expect(page).toHaveURL(/\/account\/addresses/);
     });
   });
 
   test.describe('Logout', () => {
-    test('logout button submits form and redirects to home', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.navigateToOrders();
-      await recipe.getLogoutButton().click();
+    test('logout button submits form and redirects to home', async ({
+      page,
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.navigateToOrders();
+      await legacyCustomerAccount.getLogoutButton().click();
       await expect(page).toHaveURL(/^https?:\/\/[^/]+\/$/);
     });
   });

--- a/e2e/specs/recipes/legacy-customer-account-flow.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow.spec.ts
@@ -1,5 +1,4 @@
 import {test, expect, setRecipeFixture} from '../../fixtures';
-import {LegacyCustomerAccountUtil} from '../../fixtures/legacy-customer-account-utils';
 
 setRecipeFixture({
   recipeName: 'legacy-customer-account-flow',
@@ -20,79 +19,88 @@ setRecipeFixture({
 
 test.describe('Legacy Customer Account Flow Recipe', () => {
   test.describe('Login Page', () => {
-    let recipe: LegacyCustomerAccountUtil;
-
-    test.beforeEach(async ({page}) => {
-      recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.navigateToLogin();
+    test.beforeEach(async ({legacyCustomerAccount}) => {
+      await legacyCustomerAccount.navigateToLogin();
     });
 
-    test('renders login form with email and password fields', async () => {
-      await recipe.assertLoginPageRendered();
+    test('renders login form with email and password fields', async ({
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.assertLoginPageRendered();
     });
 
-    test('shows links to register and forgot password', async () => {
-      await recipe.assertLoginPageLinks();
+    test('shows links to register and forgot password', async ({
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.assertLoginPageLinks();
     });
 
-    test('navigates to register page via link', async ({page}) => {
-      await recipe.getLink(/register/i).click();
+    test('navigates to register page via link', async ({
+      page,
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.getLink(/register/i).click();
       await expect(page).toHaveURL(/\/account\/register/);
-      await recipe.assertRegisterPageRendered();
+      await legacyCustomerAccount.assertRegisterPageRendered();
     });
 
     test('navigates to recover page via forgot password link', async ({
       page,
+      legacyCustomerAccount,
     }) => {
-      await recipe.getLink(/forgot password/i).click();
+      await legacyCustomerAccount.getLink(/forgot password/i).click();
       await expect(page).toHaveURL(/\/account\/recover/);
-      await recipe.assertRecoverPageRendered();
+      await legacyCustomerAccount.assertRecoverPageRendered();
     });
   });
 
   test.describe('Register Page', () => {
-    let recipe: LegacyCustomerAccountUtil;
-
-    test.beforeEach(async ({page}) => {
-      recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.navigateToRegister();
+    test.beforeEach(async ({legacyCustomerAccount}) => {
+      await legacyCustomerAccount.navigateToRegister();
     });
 
-    test('renders registration form with email, password, and confirm fields', async () => {
-      await recipe.assertRegisterPageRendered();
+    test('renders registration form with email, password, and confirm fields', async ({
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.assertRegisterPageRendered();
     });
 
-    test('shows link to login page', async () => {
-      await recipe.assertRegisterPageLinks();
+    test('shows link to login page', async ({legacyCustomerAccount}) => {
+      await legacyCustomerAccount.assertRegisterPageLinks();
     });
 
-    test('navigates to login page via link', async ({page}) => {
-      await recipe.getLink(/login/i).click();
+    test('navigates to login page via link', async ({
+      page,
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.getLink(/login/i).click();
       await expect(page).toHaveURL(/\/account\/login/);
-      await recipe.assertLoginPageRendered();
+      await legacyCustomerAccount.assertLoginPageRendered();
     });
   });
 
   test.describe('Password Recovery Page', () => {
-    let recipe: LegacyCustomerAccountUtil;
-
-    test.beforeEach(async ({page}) => {
-      recipe = new LegacyCustomerAccountUtil(page);
-      await recipe.navigateToRecover();
+    test.beforeEach(async ({legacyCustomerAccount}) => {
+      await legacyCustomerAccount.navigateToRecover();
     });
 
-    test('renders recovery form with email field', async () => {
-      await recipe.assertRecoverPageRendered();
+    test('renders recovery form with email field', async ({
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.assertRecoverPageRendered();
     });
 
-    test('shows link to login page', async () => {
-      await recipe.assertRecoverPageLinks();
+    test('shows link to login page', async ({legacyCustomerAccount}) => {
+      await legacyCustomerAccount.assertRecoverPageLinks();
     });
 
-    test('navigates to login page via link', async ({page}) => {
-      await recipe.getLink(/login/i).click();
+    test('navigates to login page via link', async ({
+      page,
+      legacyCustomerAccount,
+    }) => {
+      await legacyCustomerAccount.getLink(/login/i).click();
       await expect(page).toHaveURL(/\/account\/login/);
-      await recipe.assertLoginPageRendered();
+      await legacyCustomerAccount.assertLoginPageRendered();
     });
   });
 
@@ -132,18 +140,20 @@ test.describe('Legacy Customer Account Flow Recipe', () => {
   });
 
   test.describe('Header Navigation', () => {
-    test('header contains an account link', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('header contains an account link', async ({
+      page,
+      legacyCustomerAccount,
+    }) => {
       await page.goto('/');
-      await recipe.assertHeaderHasAccountLink();
+      await legacyCustomerAccount.assertHeaderHasAccountLink();
     });
 
     test('account link navigates to login page when not authenticated', async ({
       page,
+      legacyCustomerAccount,
     }) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
       await page.goto('/');
-      await recipe.getHeaderAccountLink().click();
+      await legacyCustomerAccount.getHeaderAccountLink().click();
       await expect(page).toHaveURL(/\/account\/login/);
     });
   });

--- a/e2e/specs/recipes/legacy-customer-account-flow.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow.spec.ts
@@ -20,25 +20,22 @@ setRecipeFixture({
 
 test.describe('Legacy Customer Account Flow Recipe', () => {
   test.describe('Login Page', () => {
+    let recipe: LegacyCustomerAccountUtil;
+
     test.beforeEach(async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+      recipe = new LegacyCustomerAccountUtil(page);
       await recipe.navigateToLogin();
     });
 
-    test('renders login form with email and password fields', async ({
-      page,
-    }) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('renders login form with email and password fields', async () => {
       await recipe.assertLoginPageRendered();
     });
 
-    test('shows links to register and forgot password', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('shows links to register and forgot password', async () => {
       await recipe.assertLoginPageLinks();
     });
 
     test('navigates to register page via link', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
       await recipe.getLink(/register/i).click();
       await expect(page).toHaveURL(/\/account\/register/);
       await recipe.assertRegisterPageRendered();
@@ -47,7 +44,6 @@ test.describe('Legacy Customer Account Flow Recipe', () => {
     test('navigates to recover page via forgot password link', async ({
       page,
     }) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
       await recipe.getLink(/forgot password/i).click();
       await expect(page).toHaveURL(/\/account\/recover/);
       await recipe.assertRecoverPageRendered();
@@ -55,25 +51,22 @@ test.describe('Legacy Customer Account Flow Recipe', () => {
   });
 
   test.describe('Register Page', () => {
+    let recipe: LegacyCustomerAccountUtil;
+
     test.beforeEach(async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+      recipe = new LegacyCustomerAccountUtil(page);
       await recipe.navigateToRegister();
     });
 
-    test('renders registration form with email, password, and confirm fields', async ({
-      page,
-    }) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('renders registration form with email, password, and confirm fields', async () => {
       await recipe.assertRegisterPageRendered();
     });
 
-    test('shows link to login page', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('shows link to login page', async () => {
       await recipe.assertRegisterPageLinks();
     });
 
     test('navigates to login page via link', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
       await recipe.getLink(/login/i).click();
       await expect(page).toHaveURL(/\/account\/login/);
       await recipe.assertLoginPageRendered();
@@ -81,23 +74,22 @@ test.describe('Legacy Customer Account Flow Recipe', () => {
   });
 
   test.describe('Password Recovery Page', () => {
+    let recipe: LegacyCustomerAccountUtil;
+
     test.beforeEach(async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+      recipe = new LegacyCustomerAccountUtil(page);
       await recipe.navigateToRecover();
     });
 
-    test('renders recovery form with email field', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('renders recovery form with email field', async () => {
       await recipe.assertRecoverPageRendered();
     });
 
-    test('shows link to login page', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
+    test('shows link to login page', async () => {
       await recipe.assertRecoverPageLinks();
     });
 
     test('navigates to login page via link', async ({page}) => {
-      const recipe = new LegacyCustomerAccountUtil(page);
       await recipe.getLink(/login/i).click();
       await expect(page).toHaveURL(/\/account\/login/);
       await recipe.assertLoginPageRendered();

--- a/e2e/specs/recipes/legacy-customer-account-flow.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow.spec.ts
@@ -1,0 +1,158 @@
+import {test, expect, setRecipeFixture} from '../../fixtures';
+import {LegacyCustomerAccountUtil} from '../../fixtures/legacy-customer-account-utils';
+
+setRecipeFixture({
+  recipeName: 'legacy-customer-account-flow',
+  storeKey: 'hydrogenPreviewStorefront',
+});
+
+/**
+ * Legacy Customer Account Flow Recipe E2E Tests
+ *
+ * This recipe replaces the Customer Account API with Storefront API-based
+ * authentication using form-based login, registration, and password recovery.
+ * Session-based auth stores customer access tokens in cookies.
+ *
+ * Since these tests run against a real Storefront API without mocked auth,
+ * they focus on unauthenticated flows: page rendering, form structure,
+ * navigation between auth routes, and redirect behavior.
+ */
+
+test.describe('Legacy Customer Account Flow Recipe', () => {
+  test.describe('Login Page', () => {
+    test.beforeEach(async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.navigateToLogin();
+    });
+
+    test('renders login form with email and password fields', async ({
+      page,
+    }) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertLoginPageRendered();
+    });
+
+    test('shows links to register and forgot password', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertLoginPageLinks();
+    });
+
+    test('navigates to register page via link', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.getLink(/register/i).click();
+      await expect(page).toHaveURL(/\/account\/register/);
+      await recipe.assertRegisterPageRendered();
+    });
+
+    test('navigates to recover page via forgot password link', async ({
+      page,
+    }) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.getLink(/forgot password/i).click();
+      await expect(page).toHaveURL(/\/account\/recover/);
+      await recipe.assertRecoverPageRendered();
+    });
+  });
+
+  test.describe('Register Page', () => {
+    test.beforeEach(async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.navigateToRegister();
+    });
+
+    test('renders registration form with email, password, and confirm fields', async ({
+      page,
+    }) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertRegisterPageRendered();
+    });
+
+    test('shows link to login page', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertRegisterPageLinks();
+    });
+
+    test('navigates to login page via link', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.getLink(/login/i).click();
+      await expect(page).toHaveURL(/\/account\/login/);
+      await recipe.assertLoginPageRendered();
+    });
+  });
+
+  test.describe('Password Recovery Page', () => {
+    test.beforeEach(async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.navigateToRecover();
+    });
+
+    test('renders recovery form with email field', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertRecoverPageRendered();
+    });
+
+    test('shows link to login page', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.assertRecoverPageLinks();
+    });
+
+    test('navigates to login page via link', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await recipe.getLink(/login/i).click();
+      await expect(page).toHaveURL(/\/account\/login/);
+      await recipe.assertLoginPageRendered();
+    });
+  });
+
+  test.describe('Unauthenticated Redirects', () => {
+    test('redirects /account to /account/login when not logged in', async ({
+      page,
+    }) => {
+      await page.goto('/account');
+      await expect(page).toHaveURL(/\/account\/login/);
+    });
+
+    test('redirects /account/orders to /account/login when not logged in', async ({
+      page,
+    }) => {
+      await page.goto('/account/orders');
+      await expect(page).toHaveURL(/\/account\/login/);
+    });
+
+    test('redirects /account/profile to /account/login when not logged in', async ({
+      page,
+    }) => {
+      await page.goto('/account/profile');
+      await expect(page).toHaveURL(/\/account\/login/);
+    });
+
+    test('redirects /account/addresses to /account/login when not logged in', async ({
+      page,
+    }) => {
+      await page.goto('/account/addresses');
+      await expect(page).toHaveURL(/\/account\/login/);
+    });
+
+    test('logout route redirects to /account/login', async ({page}) => {
+      await page.goto('/account/logout');
+      await expect(page).toHaveURL(/\/account\/login/);
+    });
+  });
+
+  test.describe('Header Navigation', () => {
+    test('header contains an account link', async ({page}) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await page.goto('/');
+      await recipe.assertHeaderHasAccountLink();
+    });
+
+    test('account link navigates to login page when not authenticated', async ({
+      page,
+    }) => {
+      const recipe = new LegacyCustomerAccountUtil(page);
+      await page.goto('/');
+      await recipe.getHeaderAccountLink().click();
+      await expect(page).toHaveURL(/\/account\/login/);
+    });
+  });
+});

--- a/e2e/specs/recipes/legacy-customer-account-flow.spec.ts
+++ b/e2e/specs/recipes/legacy-customer-account-flow.spec.ts
@@ -39,7 +39,7 @@ test.describe('Legacy Customer Account Flow Recipe', () => {
       page,
       legacyCustomerAccount,
     }) => {
-      await legacyCustomerAccount.getLink(/register/i).click();
+      await page.getByRole('link', {name: /register/i}).click();
       await expect(page).toHaveURL(/\/account\/register/);
       await legacyCustomerAccount.assertRegisterPageRendered();
     });
@@ -48,7 +48,7 @@ test.describe('Legacy Customer Account Flow Recipe', () => {
       page,
       legacyCustomerAccount,
     }) => {
-      await legacyCustomerAccount.getLink(/forgot password/i).click();
+      await page.getByRole('link', {name: /forgot password/i}).click();
       await expect(page).toHaveURL(/\/account\/recover/);
       await legacyCustomerAccount.assertRecoverPageRendered();
     });
@@ -73,7 +73,7 @@ test.describe('Legacy Customer Account Flow Recipe', () => {
       page,
       legacyCustomerAccount,
     }) => {
-      await legacyCustomerAccount.getLink(/login/i).click();
+      await page.getByRole('link', {name: /login/i}).click();
       await expect(page).toHaveURL(/\/account\/login/);
       await legacyCustomerAccount.assertLoginPageRendered();
     });
@@ -98,7 +98,7 @@ test.describe('Legacy Customer Account Flow Recipe', () => {
       page,
       legacyCustomerAccount,
     }) => {
-      await legacyCustomerAccount.getLink(/login/i).click();
+      await page.getByRole('link', {name: /login/i}).click();
       await expect(page).toHaveURL(/\/account\/login/);
       await legacyCustomerAccount.assertLoginPageRendered();
     });


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/developer-tools-team/issues/1057

The legacy customer account flow recipe had zero e2e test coverage. This recipe replaces the Customer Account API with Storefront API-based authentication — a fundamentally different auth mechanism that stores `customerAccessToken` in the session instead of `customerAccount`. Without tests, regressions from skeleton template updates or recipe regeneration would go undetected.

### WHAT is this pull request doing?

Adds 33 e2e tests (17 unauthenticated + 16 authenticated) covering the legacy customer account flow recipe:

**Unauthenticated tests (no MSW):**
- Login, register, and password recovery page rendering and form structure
- Cross-page navigation between auth routes
- Auth guard redirects for all protected routes
- Header account link behavior

**Authenticated tests (MSW-mocked):**
- Account home redirect (`/account` → `/account/orders` when logged in)
- Authenticated redirects on public routes (login/register/recover → `/account`)
- Catch-all route redirect for unknown account sub-routes
- Orders page: welcome heading with customer name, empty state, navigation menu
- Profile page: pre-filled form fields from Customer query, marketing checkbox, password section
- Addresses page: heading and new address form fields
- Account navigation between Orders/Profile/Addresses
- Logout via POST form submission

**MSW infrastructure extensions:**
- New `legacyCustomerAccountLoggedIn` scenario with `Customer` and `CustomerOrders` Storefront API handlers
- `mocksLegacyCustomerAuth` boolean on `MswScenarioMeta` to branch session injection
- Legacy session injection writes `customerAccessToken` with ISO `expiresAt` (vs CAAPI's `customerAccount` with Unix timestamp)
- `LEGACY_CUSTOMER_MOCK` exported as single source of truth for test assertions

### HOW to test your changes?

```bash
# Run all legacy customer account tests (use 1 worker for stability)
npx playwright test --project=recipes -g "Legacy Customer" --workers=1

# Run just authenticated tests
npx playwright test --project=recipes -g "Authenticated" --workers=1

# Run just unauthenticated tests
npx playwright test --project=recipes -g "Legacy Customer Account Flow Recipe" --workers=1
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation