### PR TITLE
test(e2e): add B2B recipe e2e tests and fix location session persistence

### DIFF
--- a/cookbook/recipes/b2b/patches/cart.tsx.2f79e3.patch
+++ b/cookbook/recipes/b2b/patches/cart.tsx.2f79e3.patch
@@ -1,0 +1,26 @@
+index 983f6505..0fdab3fb 100644
+--- a/templates/skeleton/app/routes/cart.tsx
++++ b/templates/skeleton/app/routes/cart.tsx
+@@ -11,7 +11,8 @@ export const meta: Route.MetaFunction = () => {
+ export const headers: HeadersFunction = ({actionHeaders}) => actionHeaders;
+
+ export async function action({request, context}: Route.ActionArgs) {
+-  const {cart} = context;
++  // @description Destructure customerAccount for B2B location session persistence
++  const {cart, customerAccount} = context;
+
+   const formData = await request.formData();
+
+@@ -64,6 +65,12 @@ export async function action({request, context}: Route.ActionArgs) {
+       break;
+     }
+     case CartForm.ACTIONS.BuyerIdentityUpdate: {
++      // @description Persist B2B company location in the customer account session
++      const companyLocationId = inputs.buyerIdentity?.companyLocationId;
++      if (companyLocationId && customerAccount) {
++        customerAccount.setBuyer({companyLocationId});
++      }
++
+       result = await cart.updateBuyerIdentity({
+         ...inputs.buyerIdentity,
+       });

--- a/cookbook/recipes/b2b/recipe.yaml
+++ b/cookbook/recipes/b2b/recipe.yaml
@@ -151,6 +151,15 @@ steps:
       - path: templates/skeleton/app/routes/b2blocations.tsx
   - type: PATCH
     step: "13"
+    name: Persist B2B company location in session when updating buyer identity
+    description: Update the cart route to call customerAccount.setBuyer() when
+      processing BuyerIdentityUpdate, so the selected company location persists
+      in the session and the b2blocations loader can read it back via getBuyer()
+    diffs:
+      - file: app/routes/cart.tsx
+        patchFile: cart.tsx.2f79e3.patch
+  - type: PATCH
+    step: "14"
     name: Clear company location and customer data from cart when logging out
     description: Update the logout process to clear B2B-specific data including
       selected company location and customer context from the cart session
@@ -158,7 +167,7 @@ steps:
       - file: app/routes/account_.logout.tsx
         patchFile: account_.logout.tsx.eec6ad.patch
   - type: PATCH
-    step: "14"
+    step: "15"
     name: Contextualize product queries with buyer information and display B2B
       pricing details
     description: Update product queries to include buyer context (company location

--- a/e2e/fixtures/b2b-utils.ts
+++ b/e2e/fixtures/b2b-utils.ts
@@ -1,0 +1,108 @@
+import {expect, type Page} from '@playwright/test';
+
+/**
+ * B2B-specific test utilities for the B2B recipe.
+ * Provides helpers for company location selection, quantity rules,
+ * and price break assertions.
+ */
+export class B2BUtil {
+  constructor(private page: Page) {}
+
+  getLocationModalHeading(companyName: string) {
+    return this.page.getByRole('heading', {
+      name: `Logged in for ${companyName}`,
+    });
+  }
+
+  getChooseLocationLegend() {
+    return this.page.getByText('Choose a location:');
+  }
+
+  getLocationButtons() {
+    return this.page.getByRole('button', {
+      name: /Select B2B location:/,
+    });
+  }
+
+  getLocationButton(locationName: string) {
+    return this.page.getByRole('button', {
+      name: `Select B2B location: ${locationName}`,
+    });
+  }
+
+  getChangeLocationButton(selectedLocationName?: string) {
+    const buttonName = selectedLocationName ?? /Select Location/;
+    return this.page
+      .getByRole('navigation')
+      .getByRole('button', {name: buttonName});
+  }
+
+  getQuantityRulesHeading() {
+    return this.page.getByRole('heading', {name: 'Quantity Rules', level: 4});
+  }
+
+  getQuantityRulesTable() {
+    return this.page
+      .getByRole('table')
+      .filter({has: this.page.getByRole('columnheader', {name: 'Increment'})});
+  }
+
+  getVolumePricingHeading() {
+    return this.page.getByRole('heading', {name: 'Volume Pricing', level: 4});
+  }
+
+  getVolumePricingTable() {
+    return this.page.getByRole('table').filter({
+      has: this.page.getByRole('columnheader', {name: 'Minimum Quantity'}),
+    });
+  }
+
+  async assertLocationModalVisible(companyName: string) {
+    await expect(this.getLocationModalHeading(companyName)).toBeVisible();
+    await expect(this.getChooseLocationLegend()).toBeVisible();
+    await expect(this.getLocationButtons().first()).toBeVisible();
+  }
+
+  async assertLocationModalHidden(companyName: string) {
+    await expect(this.getLocationModalHeading(companyName)).not.toBeVisible();
+  }
+
+  async selectLocation(companyName: string, locationName: string) {
+    const button = this.getLocationButton(locationName);
+    await expect(button).toBeVisible();
+    await button.click();
+    await this.assertLocationModalHidden(companyName);
+  }
+
+  async assertQuantityRulesVisible() {
+    await expect(this.getQuantityRulesHeading()).toBeVisible();
+    await expect(this.getQuantityRulesTable()).toBeVisible();
+  }
+
+  async assertQuantityRulesHidden() {
+    await expect(this.getQuantityRulesHeading()).not.toBeVisible();
+  }
+
+  async assertQuantityRuleValues(
+    increment: string,
+    minimum: string,
+    maximum: string,
+  ) {
+    const table = this.getQuantityRulesTable();
+    const dataRow = table.getByRole('row').nth(1);
+    const cells = dataRow.getByRole('cell');
+
+    await expect(cells.nth(0)).toHaveText(increment);
+    await expect(cells.nth(1)).toHaveText(minimum);
+    await expect(cells.nth(2)).toHaveText(maximum);
+  }
+
+  async assertVolumePricingVisible() {
+    await expect(this.getVolumePricingHeading()).toBeVisible();
+    await expect(this.getVolumePricingTable()).toBeVisible();
+  }
+
+  async assertVolumePricingHidden() {
+    await expect(this.getVolumePricingHeading()).not.toBeVisible();
+  }
+}

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -13,6 +13,7 @@ import {DiscountUtil} from './discount-utils';
 import {GiftCardUtil} from './gift-card-utils';
 import {CustomerAccountUtil} from './customer-account-utils';
 import {DeliveryAddressUtil} from './delivery-address-utils';
+import {B2BUtil} from './b2b-utils';
 import type {MswScenario} from './msw/scenarios';
 import {getHandlersForScenario} from './msw/handlers';
 
@@ -48,8 +49,10 @@ export const TUNNEL_SETUP_TIMEOUT_IN_MS =
   STARTUP_TIMEOUT_IN_MS +
   TUNNEL_READY_TIMEOUT_IN_MS +
   TUNNEL_SETUP_MARGIN_IN_MS;
+export {B2BUtil} from './b2b-utils';
 export {mockCustomerAccountOperation} from './msw/graphql';
 export {MSW_SCENARIOS} from './msw/scenarios';
+export {B2B_COMPANY_NAME} from './msw/handlers';
 
 export const test = base.extend<
   {
@@ -59,6 +62,7 @@ export const test = base.extend<
     giftCard: GiftCardUtil;
     customerAccount: CustomerAccountUtil;
     addresses: DeliveryAddressUtil;
+    b2b: B2BUtil;
   },
   {forEachWorker: void}
 >({
@@ -85,6 +89,10 @@ export const test = base.extend<
   addresses: async ({page}, use) => {
     const addresses = new DeliveryAddressUtil(page);
     await use(addresses);
+  },
+  b2b: async ({page}, use) => {
+    const b2b = new B2BUtil(page);
+    await use(b2b);
   },
 });
 

--- a/e2e/fixtures/msw/handlers.ts
+++ b/e2e/fixtures/msw/handlers.ts
@@ -1,4 +1,5 @@
 import type {RequestHandler} from 'msw';
+import {graphql, HttpResponse} from 'msw';
 import {CUSTOMER_DETAILS_QUERY} from '../../../templates/skeleton/app/graphql/customer-account/CustomerDetailsQuery';
 import {CUSTOMER_ORDERS_QUERY} from '../../../templates/skeleton/app/graphql/customer-account/CustomerOrdersQuery';
 import {
@@ -240,6 +241,82 @@ scenarios.set(
   MSW_SCENARIOS.deliveryAddresses,
   createDeliveryAddressesScenario(),
 );
+
+/**
+ * B2B scenario: simulates a logged-in customer with a B2B company
+ * that has multiple locations. The CustomerLocationsQuery is introduced
+ * by the B2B recipe and has no generated types, so we use raw graphql
+ * handlers matched by operation name.
+ */
+export const B2B_COMPANY_NAME = 'Acme Corp';
+
+const b2bCustomerLocationsMock = {
+  customer: {
+    id: 'gid://shopify/Customer/123',
+    emailAddress: {
+      emailAddress: 'taylor@acmecorp.example.com',
+    },
+    companyContacts: {
+      edges: [
+        {
+          node: {
+            company: {
+              id: 'gid://shopify/Company/1',
+              name: B2B_COMPANY_NAME,
+              locations: {
+                edges: [
+                  {
+                    node: {
+                      id: 'gid://shopify/CompanyLocation/1',
+                      name: 'Headquarters',
+                      shippingAddress: {
+                        countryCode: 'US',
+                        formattedAddress: [
+                          '123 Main St',
+                          'New York, NY 10001',
+                          'United States',
+                        ],
+                      },
+                    },
+                  },
+                  {
+                    node: {
+                      id: 'gid://shopify/CompanyLocation/2',
+                      name: 'Warehouse',
+                      shippingAddress: {
+                        countryCode: 'US',
+                        formattedAddress: [
+                          '456 Industrial Ave',
+                          'Chicago, IL 60601',
+                          'United States',
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+scenarios.set('b2b-logged-in', {
+  handlers: [
+    mockCustomerAccountOperation(CUSTOMER_DETAILS_QUERY, () => {
+      return customerDetailsMock;
+    }),
+    mockCustomerAccountOperation(CUSTOMER_ORDERS_QUERY, () => {
+      return customerOrdersMock;
+    }),
+    graphql.query('CustomerLocations', () => {
+      return HttpResponse.json({data: b2bCustomerLocationsMock});
+    }),
+  ],
+  mocksCustomerAccountApi: true,
+});
 
 function isMswScenario(scenario: string): scenario is MswScenario {
   return scenarios.has(scenario);

--- a/e2e/fixtures/msw/scenarios.ts
+++ b/e2e/fixtures/msw/scenarios.ts
@@ -1,6 +1,7 @@
 export const MSW_SCENARIOS = {
   customerAccountLoggedIn: 'customer-account-logged-in',
   deliveryAddresses: 'delivery-addresses',
+  b2bLoggedIn: 'b2b-logged-in',
 } as const;
 
 export type MswScenario = (typeof MSW_SCENARIOS)[keyof typeof MSW_SCENARIOS];

--- a/e2e/fixtures/recipe.ts
+++ b/e2e/fixtures/recipe.ts
@@ -13,6 +13,7 @@ import {
 import {exec, execFile} from 'node:child_process';
 import {promisify} from 'node:util';
 import {parse as parseYaml} from 'yaml';
+import type {MswScenario} from './msw/scenarios';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -48,6 +49,13 @@ export type RecipeFixtureOptions = {
    * These override any defaults but don't override the test store env file.
    */
   envOverrides?: Record<string, string>;
+  /**
+   * MSW mock configuration for intercepting API calls (e.g. Customer Account API).
+   * Storefront API calls still reach the real store.
+   */
+  mock?: {
+    scenario: MswScenario;
+  };
 };
 
 export const setRecipeFixture = (options: RecipeFixtureOptions) => {
@@ -56,6 +64,7 @@ export const setRecipeFixture = (options: RecipeFixtureOptions) => {
     storeKey = 'hydrogenPreviewStorefront',
     useCache = true,
     envOverrides = {},
+    mock,
   } = options;
 
   const isLocal = !storeKey.startsWith('https://');
@@ -87,6 +96,7 @@ export const setRecipeFixture = (options: RecipeFixtureOptions) => {
   configureDevServer({
     storeKey,
     projectPath: isLocal ? recipeFixturePath : undefined,
+    mock,
   });
 };
 

--- a/e2e/specs/recipes/b2b.spec.ts
+++ b/e2e/specs/recipes/b2b.spec.ts
@@ -1,0 +1,147 @@
+import {
+  test,
+  expect,
+  setRecipeFixture,
+  MSW_SCENARIOS,
+  B2B_COMPANY_NAME,
+} from '../../fixtures';
+
+setRecipeFixture({
+  recipeName: 'b2b',
+  storeKey: 'hydrogenPreviewStorefront',
+  mock: {
+    scenario: MSW_SCENARIOS.b2bLoggedIn,
+  },
+});
+
+/**
+ * B2B Recipe E2E Tests
+ *
+ * Tests the B2B commerce recipe which adds:
+ * - Company location selector modal for B2B customers
+ * - Quantity rules (min, max, increment) on product pages
+ * - Volume pricing (price breaks) on product pages
+ * - Buyer-contextualized product queries
+ *
+ * All Customer Account API calls are mocked via MSW. The mock scenario
+ * provides a B2B customer with two company locations (Headquarters, Warehouse).
+ * Storefront API calls go to the real hydrogenPreviewStorefront.
+ *
+ * NOTE: Quantity rules and volume pricing tables are only visible when
+ * products have B2B-specific data (configured in Shopify admin on a Plus plan).
+ * The hydrogenPreviewStorefront products don't have B2B attributes,
+ * so we verify the components render correctly when data is absent
+ * (conditional rendering doesn't break the page).
+ */
+
+test.describe('B2B Recipe', () => {
+  test.describe('Location Selector', () => {
+    test('shows location modal on first visit for B2B customer with multiple locations', async ({
+      page,
+      b2b,
+    }) => {
+      await page.goto('/');
+
+      await b2b.assertLocationModalVisible(B2B_COMPANY_NAME);
+    });
+
+    test('displays all company locations with addresses', async ({
+      page,
+      b2b,
+    }) => {
+      await page.goto('/');
+
+      await b2b.assertLocationModalVisible(B2B_COMPANY_NAME);
+
+      const locationButtons = b2b.getLocationButtons();
+      await expect(locationButtons).toHaveCount(2);
+
+      await expect(b2b.getLocationButton('Headquarters')).toBeVisible();
+      await expect(b2b.getLocationButton('Warehouse')).toBeVisible();
+
+      await expect(page.getByText('123 Main St')).toBeVisible();
+      await expect(page.getByText('456 Industrial Ave')).toBeVisible();
+    });
+
+    test('closes modal after selecting a location', async ({page, b2b}) => {
+      await page.goto('/');
+
+      await b2b.assertLocationModalVisible(B2B_COMPANY_NAME);
+      await b2b.selectLocation(B2B_COMPANY_NAME, 'Headquarters');
+    });
+
+    test('shows change location button in header after selection', async ({
+      page,
+      b2b,
+    }) => {
+      await page.goto('/');
+
+      await b2b.assertLocationModalVisible(B2B_COMPANY_NAME);
+      await b2b.selectLocation(B2B_COMPANY_NAME, 'Headquarters');
+
+      await expect(b2b.getChangeLocationButton('Headquarters')).toBeVisible();
+    });
+
+    test('reopens modal when change location button is clicked', async ({
+      page,
+      b2b,
+    }) => {
+      await page.goto('/');
+
+      await b2b.assertLocationModalVisible(B2B_COMPANY_NAME);
+      await b2b.selectLocation(B2B_COMPANY_NAME, 'Headquarters');
+
+      const changeButton = b2b.getChangeLocationButton('Headquarters');
+      await changeButton.click();
+
+      await b2b.assertLocationModalVisible(B2B_COMPANY_NAME);
+    });
+
+    test('switches location and updates header button', async ({page, b2b}) => {
+      await page.goto('/');
+
+      await b2b.assertLocationModalVisible(B2B_COMPANY_NAME);
+      await b2b.selectLocation(B2B_COMPANY_NAME, 'Headquarters');
+      await expect(b2b.getChangeLocationButton('Headquarters')).toBeVisible();
+
+      await b2b.getChangeLocationButton('Headquarters').click();
+      await b2b.assertLocationModalVisible(B2B_COMPANY_NAME);
+      await b2b.selectLocation(B2B_COMPANY_NAME, 'Warehouse');
+      await expect(b2b.getChangeLocationButton('Warehouse')).toBeVisible();
+    });
+  });
+
+  test.describe('Product Page with B2B Context', () => {
+    test.beforeEach(async ({page, b2b}) => {
+      await page.goto('/');
+      await b2b.assertLocationModalVisible(B2B_COMPANY_NAME);
+      await b2b.selectLocation(B2B_COMPANY_NAME, 'Headquarters');
+    });
+
+    test('product page loads and renders add-to-cart button', async ({
+      page,
+      storefront,
+    }) => {
+      await storefront.goto('/');
+      await storefront.navigateToFirstProduct();
+
+      await expect(page.getByRole('heading', {level: 1})).toBeVisible();
+      await expect(
+        page.getByRole('button', {name: 'Add to cart'}),
+      ).toBeVisible();
+    });
+
+    test('product page does not show quantity rules for standard products', async ({
+      page,
+      storefront,
+      b2b,
+    }) => {
+      await storefront.goto('/');
+      await storefront.navigateToFirstProduct();
+
+      await expect(page.getByRole('heading', {level: 1})).toBeVisible();
+      await b2b.assertQuantityRulesHidden();
+      await b2b.assertVolumePricingHidden();
+    });
+  });
+});


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/developer-tools-team/issues/1057

The B2B commerce recipe had no e2e test coverage, and a bug in the recipe prevented the selected company location from persisting in the customer account session after `BuyerIdentityUpdate`.

When a B2B customer selects a company location for the first time (no cart exists), Hydrogen's `createCartHandler` delegates to `cartCreate()` instead of `cartBuyerIdentityUpdateDefault()`. Only the latter calls `customerAccount.setBuyer()`. This means the `b2blocations` loader's `getBuyer()` returns null for `companyLocationId`, and the header's "Change Location" button never updates from "Select Location" to the selected location name.

### WHAT is this pull request doing?

**E2E tests** (`e2e/specs/recipes/b2b.spec.ts`, `e2e/fixtures/b2b-utils.ts`):
- 8 tests across 2 describe blocks covering the B2B recipe flow
- Location Selector: modal display, location listing, selection/dismissal, header button update, modal reopen, and **location switching** (Headquarters → Warehouse)
- Product Page with B2B Context: page rendering and conditional B2B component visibility
- Uses `b2b-logged-in` MSW scenario to mock Customer Account API while hitting the real Storefront API on `hydrogenPreviewStorefront`
- `B2BUtil` wired as a proper Playwright fixture (consistent with `CartUtil`, `DiscountUtil`, `GiftCardUtil`)

**Recipe bug fix** (`cookbook/recipes/b2b/patches/cart.tsx.2f79e3.patch`, `cookbook/recipes/b2b/recipe.yaml`):
- Adds a `cart.tsx` recipe patch that calls `customerAccount.setBuyer({companyLocationId})` in the `BuyerIdentityUpdate` case before `cart.updateBuyerIdentity()`
- This ensures the session persists the selected location regardless of whether a cart already exists
- New recipe step 13 added to `recipe.yaml`; existing steps 13-14 renumbered to 14-15

### HOW to test your changes?

```bash
# Run the B2B recipe e2e tests
npx playwright test --project=recipes --grep "B2B"
```

All 8 tests should pass (~30-35s). The recipe fixture is generated automatically on first run (copies skeleton, applies B2B recipe patches, installs deps).

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation