### PR TITLE
test(e2e): add subscriptions recipe e2e tests

### DIFF
--- a/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx
+++ b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/routes/account.subscriptions.tsx
@@ -3,12 +3,7 @@ import type {
   SubscriptionDiscountFragmentFragment,
   SubscriptionsContractsQueryQuery,
 } from 'customer-accountapi.generated';
-import {
-  data,
-  useActionData,
-  useFetcher,
-  useLoaderData,
-} from 'react-router';
+import {data, useActionData, useFetcher, useLoaderData} from 'react-router';
 import type {Route} from './+types/account.subscriptions';
 import {SUBSCRIPTIONS_CONTRACTS_QUERY} from '../graphql/customer-account/CustomerSubscriptionsQuery';
 import {SUBSCRIPTION_CANCEL_MUTATION} from '../graphql/customer-account/CustomerSubscriptionsMutations';
@@ -91,14 +86,14 @@ export default function AccountProfile() {
           </mark>
         </p>
       ) : null}
-      <div className="account-subscriptions">
+      <ul className="account-subscriptions" aria-label="Subscriptions">
         {subscriptions?.customer?.subscriptionContracts.nodes.map(
           (subscription) => {
             const isBeingCancelled =
               fetcher.state !== 'idle' &&
               fetcher.formData?.get('subId') === subscription.id;
             return (
-              <div key={subscription.id} className="subscription-row">
+              <li key={subscription.id} className="subscription-row">
                 <div className="subscription-row-content">
                   <div>
                     {subscription.lines.nodes.map((line) => (
@@ -149,11 +144,11 @@ export default function AccountProfile() {
                     </fetcher.Form>
                   )}
                 </div>
-              </div>
+              </li>
             );
           },
         )}
-      </div>
+      </ul>
     </div>
   );
 }

--- a/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css
+++ b/cookbook/recipes/subscriptions/ingredients/templates/skeleton/app/styles/account-subscriptions.css
@@ -2,6 +2,9 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 .account-subscriptions .subscription-row {

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -30,6 +30,7 @@ export {DiscountUtil} from './discount-utils';
 export {GiftCardUtil} from './gift-card-utils';
 export {CustomerAccountUtil} from './customer-account-utils';
 export {DeliveryAddressUtil} from './delivery-address-utils';
+export {SubscriptionsUtil} from './subscriptions-utils';
 
 export const CUSTOMER_ACCOUNT_STORAGE_STATE_PATH = path.resolve(
   __dirname,

--- a/e2e/fixtures/msw/handlers.ts
+++ b/e2e/fixtures/msw/handlers.ts
@@ -318,6 +318,104 @@ scenarios.set('b2b-logged-in', {
   mocksCustomerAccountApi: true,
 });
 
+/**
+ * Subscriptions scenario: simulates a logged-in customer with active
+ * subscription contracts. The SubscriptionsContractsQuery and cancel
+ * mutation are introduced by the subscriptions recipe and have no
+ * generated types, so we use raw graphql handlers matched by operation name.
+ */
+const subscriptionsContractsMock = {
+  customer: {
+    subscriptionContracts: {
+      nodes: [
+        {
+          id: 'gid://shopify/SubscriptionContract/1',
+          status: 'ACTIVE',
+          createdAt: '2025-06-01T00:00:00.000Z',
+          billingPolicy: {
+            interval: 'MONTH',
+            intervalCount: {
+              count: 1,
+              precision: 'EXACT',
+            },
+          },
+          discounts: {
+            nodes: [
+              {
+                id: 'gid://shopify/SubscriptionDiscount/1',
+                title: 'Subscriber Savings',
+                recurringCycleLimit: null,
+                value: {
+                  __typename: 'SubscriptionDiscountPercentageValue',
+                  percentage: 10,
+                },
+              },
+            ],
+          },
+          lines: {
+            nodes: [
+              {
+                id: 'gid://shopify/SubscriptionLine/1',
+                name: 'Shopify Wax - Monthly',
+              },
+            ],
+          },
+        },
+        {
+          id: 'gid://shopify/SubscriptionContract/2',
+          status: 'CANCELLED',
+          createdAt: '2025-01-15T00:00:00.000Z',
+          billingPolicy: {
+            interval: 'WEEK',
+            intervalCount: {
+              count: 2,
+              precision: 'EXACT',
+            },
+          },
+          discounts: {
+            nodes: [],
+          },
+          lines: {
+            nodes: [
+              {
+                id: 'gid://shopify/SubscriptionLine/2',
+                name: 'Premium Polish - Bi-Weekly',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+};
+
+scenarios.set('subscriptions-logged-in', {
+  handlers: [
+    mockCustomerAccountOperation(CUSTOMER_DETAILS_QUERY, () => {
+      return customerDetailsMock;
+    }),
+    mockCustomerAccountOperation(CUSTOMER_ORDERS_QUERY, () => {
+      return customerOrdersMock;
+    }),
+    graphql.query('SubscriptionsContractsQuery', () => {
+      return HttpResponse.json({data: subscriptionsContractsMock});
+    }),
+    graphql.mutation('subscriptionContractCancel', ({variables}) => {
+      return HttpResponse.json({
+        data: {
+          subscriptionContractCancel: {
+            contract: {
+              id: variables.subscriptionContractId,
+            },
+            userErrors: [],
+          },
+        },
+      });
+    }),
+  ],
+  mocksCustomerAccountApi: true,
+});
+
 function isMswScenario(scenario: string): scenario is MswScenario {
   return scenarios.has(scenario);
 }

--- a/e2e/fixtures/msw/scenarios.ts
+++ b/e2e/fixtures/msw/scenarios.ts
@@ -2,6 +2,7 @@ export const MSW_SCENARIOS = {
   customerAccountLoggedIn: 'customer-account-logged-in',
   deliveryAddresses: 'delivery-addresses',
   b2bLoggedIn: 'b2b-logged-in',
+  subscriptionsLoggedIn: 'subscriptions-logged-in',
 } as const;
 
 export type MswScenario = (typeof MSW_SCENARIOS)[keyof typeof MSW_SCENARIOS];

--- a/e2e/fixtures/subscriptions-utils.ts
+++ b/e2e/fixtures/subscriptions-utils.ts
@@ -1,0 +1,55 @@
+import {expect, Locator, Page} from '@playwright/test';
+
+/**
+ * Subscriptions-specific test utilities for the Subscriptions recipe.
+ * Covers the account subscriptions management page (auth-required flows).
+ */
+export class SubscriptionsUtil {
+  constructor(private page: Page) {}
+
+  // -- Account: Subscriptions management page --
+
+  async navigateToSubscriptions() {
+    await this.page.goto('/account/subscriptions');
+  }
+
+  getSubscriptionsHeading(): Locator {
+    return this.page.getByRole('heading', {name: 'My subscriptions'});
+  }
+
+  getSubscriptionRows(): Locator {
+    return this.page
+      .getByRole('list', {name: 'Subscriptions'})
+      .getByRole('listitem');
+  }
+
+  getStatusBadgeByText(status: string): Locator {
+    return this.page.getByText(status, {exact: true});
+  }
+
+  getCancelButton(subscriptionRow: Locator): Locator {
+    return subscriptionRow.getByRole('button', {name: 'Cancel subscription'});
+  }
+
+  getCancellingButton(subscriptionRow: Locator): Locator {
+    return subscriptionRow.getByRole('button', {name: 'Canceling'});
+  }
+
+  getDiscountLabels(subscriptionRow: Locator): Locator {
+    return subscriptionRow.getByText(/\d+% off|\$[\d.]+ off/);
+  }
+
+  async assertSubscriptionsPageLoaded() {
+    await expect(this.getSubscriptionsHeading()).toBeVisible();
+  }
+
+  // -- Account navigation --
+
+  getSubscriptionsNavLink(): Locator {
+    return this.page.getByRole('link', {name: 'Subscriptions'});
+  }
+
+  async assertSubscriptionsLinkInAccountMenu() {
+    await expect(this.getSubscriptionsNavLink()).toBeVisible();
+  }
+}

--- a/e2e/specs/recipes/subscriptions-auth.spec.ts
+++ b/e2e/specs/recipes/subscriptions-auth.spec.ts
@@ -1,0 +1,120 @@
+import {test, expect, setRecipeFixture, MSW_SCENARIOS} from '../../fixtures';
+import {SubscriptionsUtil} from '../../fixtures/subscriptions-utils';
+
+setRecipeFixture({
+  recipeName: 'subscriptions',
+  storeKey: 'hydrogenPreviewStorefront',
+  mock: {
+    scenario: MSW_SCENARIOS.subscriptionsLoggedIn,
+  },
+});
+
+/**
+ * Subscriptions Recipe E2E Tests — Auth-Required Flows
+ *
+ * Tests cover the customer-account-authenticated areas of the recipe:
+ * - Account subscriptions management page (list, status, billing, discounts)
+ * - Subscription cancellation flow
+ * - Account navigation (Subscriptions link in menu)
+ *
+ * Storefront-facing features (selling plan selector on product pages, cart
+ * subscription info) are covered in subscriptions.spec.ts.
+ */
+
+test.describe('Subscriptions Recipe', () => {
+  test.describe('Account Subscriptions Page', () => {
+    test.beforeEach(async ({page}) => {
+      const subscriptions = new SubscriptionsUtil(page);
+      await subscriptions.navigateToSubscriptions();
+      await subscriptions.assertSubscriptionsPageLoaded();
+    });
+
+    test('renders subscription list with correct count', async ({page}) => {
+      const subscriptions = new SubscriptionsUtil(page);
+      const rows = subscriptions.getSubscriptionRows();
+      await expect(rows).toHaveCount(2);
+    });
+
+    test('displays subscription line item names', async ({page}) => {
+      await expect(page.getByText('Shopify Wax - Monthly')).toBeVisible();
+      await expect(page.getByText('Premium Polish - Bi-Weekly')).toBeVisible();
+    });
+
+    test('shows active and cancelled status badges', async ({page}) => {
+      const subscriptions = new SubscriptionsUtil(page);
+
+      await expect(subscriptions.getStatusBadgeByText('ACTIVE')).toBeVisible();
+      await expect(
+        subscriptions.getStatusBadgeByText('CANCELLED'),
+      ).toBeVisible();
+    });
+
+    test('displays billing interval for subscriptions', async ({page}) => {
+      const subscriptions = new SubscriptionsUtil(page);
+
+      const firstRow = subscriptions.getSubscriptionRows().first();
+      const secondRow = subscriptions.getSubscriptionRows().nth(1);
+
+      await expect(firstRow.getByText('1 month')).toBeVisible();
+      await expect(secondRow.getByText('2 weeks')).toBeVisible();
+    });
+
+    test('shows discount information on subscriptions', async ({page}) => {
+      const subscriptions = new SubscriptionsUtil(page);
+
+      const firstRow = subscriptions.getSubscriptionRows().first();
+      const discountLabels = subscriptions.getDiscountLabels(firstRow);
+      await expect(discountLabels).toHaveCount(1);
+      await expect(discountLabels.first()).toHaveText('10% off');
+    });
+
+    test('shows cancel button only for active subscriptions', async ({
+      page,
+    }) => {
+      const subscriptions = new SubscriptionsUtil(page);
+
+      const activeRow = subscriptions.getSubscriptionRows().first();
+      const cancelledRow = subscriptions.getSubscriptionRows().nth(1);
+
+      await expect(subscriptions.getCancelButton(activeRow)).toBeVisible();
+      await expect(
+        subscriptions.getCancelButton(cancelledRow),
+      ).not.toBeVisible();
+    });
+
+    test('cancel button submits and shows cancelling state', async ({page}) => {
+      const subscriptions = new SubscriptionsUtil(page);
+
+      const activeRow = subscriptions.getSubscriptionRows().first();
+      const cancelButton = subscriptions.getCancelButton(activeRow);
+
+      await cancelButton.click();
+
+      // The button text changes to 'Canceling' while the mutation is in flight,
+      // then the page re-renders after the response. We wait for either state.
+      await expect(
+        subscriptions.getCancellingButton(activeRow).or(cancelButton),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe('Account Navigation', () => {
+    test('account menu includes Subscriptions link', async ({page}) => {
+      const subscriptions = new SubscriptionsUtil(page);
+      await page.goto('/account');
+
+      await subscriptions.assertSubscriptionsLinkInAccountMenu();
+    });
+
+    test('Subscriptions link navigates to subscriptions page', async ({
+      page,
+    }) => {
+      const subscriptions = new SubscriptionsUtil(page);
+      await page.goto('/account');
+
+      await subscriptions.getSubscriptionsNavLink().click();
+      await expect(page).toHaveURL(/\/account\/subscriptions/);
+      await subscriptions.assertSubscriptionsPageLoaded();
+    });
+  });
+});

--- a/e2e/specs/recipes/subscriptions.spec.ts
+++ b/e2e/specs/recipes/subscriptions.spec.ts
@@ -10,7 +10,8 @@ setRecipeFixture({
  * Validates the Subscriptions recipe, which enables selling subscription-based
  * products using selling plan groups from the Shopify Subscriptions app.
  *
- * TODO: Add tests for /account/subscriptions management page (requires customer authentication).
+ * Auth-required flows (account subscriptions management, cancellation) are
+ * covered in subscriptions-auth.spec.ts.
  */
 
 const KNOWN_SUBSCRIPTION_PRODUCT = {


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/developer-tools-team/issues/1057

The subscriptions cookbook recipe template (`account.subscriptions.tsx`) had no e2e test coverage for its auth-required flows, and used plain `<div>` elements where semantic HTML would better serve screen readers and test selectors.

The consensus review (Sheldon + John, Round 2) flagged `.subscription-row` as a CSS class selector that could be eliminated with proper HTML semantics.

### WHAT is this pull request doing?

**E2E tests (9 tests):**
- Subscription list rendering with correct count
- Line item names, billing intervals, discount labels
- Active/cancelled status badges
- Cancel button visibility (active-only) and cancellation flow
- Account navigation (Subscriptions link in menu)

Uses `subscriptions-logged-in` MSW scenario with two mock subscription contracts (1 active with 10% discount, 1 cancelled).

**ARIA template improvements:**
- `<div className="account-subscriptions">` → `<ul className="account-subscriptions" aria-label="Subscriptions">`
- `<div className="subscription-row">` → `<li className="subscription-row">`
- CSS reset (`list-style: none; padding: 0; margin: 0;`) to preserve visual appearance
- Test selector: `getByRole('list', {name: 'Subscriptions'}).getByRole('listitem')` — zero CSS class selectors in the test util

### HOW to test your changes?

```bash
# Clear cached fixture (required after template changes)
rm -rf .tmp/recipe-fixtures/subscriptions

# Run subscriptions tests
npx playwright test e2e/specs/recipes/subscriptions.spec.ts --project=recipes
# Expected: 9/9 passed

# Verify no regression on legacy customer account tests
npx playwright test e2e/specs/recipes/legacy-customer-account-flow.spec.ts --project=recipes
# Expected: 17/17 passed
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation