### PR TITLE
fix: prevent query syntax injection in storefrontRedirect

### DIFF
--- a/.changeset/fix-redirect-query-injection.md
+++ b/.changeset/fix-redirect-query-injection.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix query syntax injection in `storefrontRedirect` by wrapping the path in phrase quotes

--- a/packages/hydrogen/src/routing/redirect.test.ts
+++ b/packages/hydrogen/src/routing/redirect.test.ts
@@ -294,7 +294,25 @@ describe('storefrontRedirect', () => {
       });
     });
 
-    it('escapes percent-encoded double quotes in path', async () => {
+    it('wraps query params containing injection characters in phrase quotes with matchQueryParams', async () => {
+      queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
+      const response = new Response('Not Found', {status: 404});
+
+      await storefrontRedirect({
+        response,
+        storefront: storefrontMock,
+        request: new Request(
+          'https://domain.com/some-page?param=value*%20OR%20path:*',
+        ),
+        matchQueryParams: true,
+      });
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:"/some-page?param=value*+or+path%3a*"'},
+      });
+    });
+
+    it('wraps paths containing percent-encoded quotes in phrase quotes', async () => {
       queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
       const response = new Response('Not Found', {status: 404});
 
@@ -305,7 +323,7 @@ describe('storefrontRedirect', () => {
       });
 
       expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-        variables: {query: 'path:"/page%22breakout"'},
+        variables: {query: 'path:"/page\\"breakout"'},
       });
     });
   });

--- a/packages/hydrogen/src/routing/redirect.test.ts
+++ b/packages/hydrogen/src/routing/redirect.test.ts
@@ -46,7 +46,7 @@ describe('storefrontRedirect', () => {
     );
 
     expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      variables: {query: 'path:"/some-page"'},
     });
   });
 
@@ -67,7 +67,7 @@ describe('storefrontRedirect', () => {
       }),
     );
     expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      variables: {query: 'path:"/some-page"'},
     });
   });
 
@@ -89,7 +89,7 @@ describe('storefrontRedirect', () => {
     );
 
     expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      variables: {query: 'path:"/some-page"'},
     });
   });
 
@@ -116,7 +116,7 @@ describe('storefrontRedirect', () => {
     );
 
     expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      variables: {query: 'path:"/some-page"'},
     });
   });
 
@@ -144,7 +144,7 @@ describe('storefrontRedirect', () => {
     );
 
     expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page?test=true'},
+      variables: {query: 'path:"/some-page?test=true"'},
     });
   });
 
@@ -177,7 +177,7 @@ describe('storefrontRedirect', () => {
     );
 
     expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      variables: {query: 'path:"/some-page"'},
     });
   });
 
@@ -207,7 +207,7 @@ describe('storefrontRedirect', () => {
     );
 
     expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      variables: {query: 'path:"/some-page"'},
     });
   });
 
@@ -227,7 +227,7 @@ describe('storefrontRedirect', () => {
     ).resolves.toEqual(response);
 
     expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      variables: {query: 'path:"/some-page"'},
     });
   });
 
@@ -244,7 +244,69 @@ describe('storefrontRedirect', () => {
     ).resolves.toEqual(response);
 
     expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      variables: {query: 'path:"/some-page"'},
+    });
+  });
+
+  describe('query syntax injection prevention', () => {
+    it('wraps path in phrase quotes to prevent wildcard injection', async () => {
+      queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
+      const response = new Response('Not Found', {status: 404});
+
+      await storefrontRedirect({
+        response,
+        storefront: storefrontMock,
+        request: new Request('https://domain.com/a*'),
+      });
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:"/a*"'},
+      });
+    });
+
+    it('wraps paths containing percent-encoded operators in phrase quotes', async () => {
+      queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
+      const response = new Response('Not Found', {status: 404});
+
+      await storefrontRedirect({
+        response,
+        storefront: storefrontMock,
+        request: new Request('https://domain.com/anything%20OR%20path:*'),
+      });
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:"/anything%20or%20path:*"'},
+      });
+    });
+
+    it('wraps paths containing colons in phrase quotes', async () => {
+      queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
+      const response = new Response('Not Found', {status: 404});
+
+      await storefrontRedirect({
+        response,
+        storefront: storefrontMock,
+        request: new Request('https://domain.com/field:value*'),
+      });
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:"/field:value*"'},
+      });
+    });
+
+    it('escapes percent-encoded double quotes in path', async () => {
+      queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
+      const response = new Response('Not Found', {status: 404});
+
+      await storefrontRedirect({
+        response,
+        storefront: storefrontMock,
+        request: new Request('https://domain.com/page%22breakout'),
+      });
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:"/page%22breakout"'},
+      });
     });
   });
 

--- a/packages/hydrogen/src/routing/redirect.ts
+++ b/packages/hydrogen/src/routing/redirect.ts
@@ -64,7 +64,10 @@ export async function storefrontRedirect(
       variables: {
         query:
           'path:"' +
-          redirectFrom.replace(/\/+$/, '').replace(/"/g, '\\"') +
+          redirectFrom
+            .replace(/\/+$/, '')
+            .replace(/%22/gi, '"')
+            .replace(/"/g, '\\"') +
           '"',
       },
     });

--- a/packages/hydrogen/src/routing/redirect.ts
+++ b/packages/hydrogen/src/routing/redirect.ts
@@ -61,7 +61,12 @@ export async function storefrontRedirect(
     }>(REDIRECT_QUERY, {
       // The admin doesn't allow redirects to have a
       // trailing slash, so strip them all off
-      variables: {query: 'path:' + redirectFrom.replace(/\/+$/, '')},
+      variables: {
+        query:
+          'path:"' +
+          redirectFrom.replace(/\/+$/, '').replace(/"/g, '\\"') +
+          '"',
+      },
     });
 
     const location = urlRedirects?.edges?.[0]?.node?.target;


### PR DESCRIPTION
## Summary

Fix query syntax injection in `storefrontRedirect` by wrapping the redirect path in [Shopify phrase query](https://shopify.dev/docs/api/usage/search-syntax#phrase-queries) double quotes.

Closes #2485

## Problem

The `storefrontRedirect` utility concatenates the URL pathname directly into a Shopify query syntax string without escaping:

```javascript
variables: {query: 'path:' + redirectFrom.replace(/\/+$/, '')}
```

This allows an external attacker to inject query syntax operators. For example, visiting `/a*` generates the query `path:/a*`, which matches all redirects starting with `/a` via wildcard. Other operators like `:` (field references) can also be injected since they are valid URL path characters.

## Solution

Wrap the path value in phrase query double quotes and escape any embedded quotes:

```diff
- variables: {query: 'path:' + redirectFrom.replace(/\/+$/, '')},
+ variables: {
+   query:
+     'path:"' +
+     redirectFrom.replace(/\/+$/, '').replace(/"/g, '\\"') +
+     '"',
+ },
```

This ensures special characters in the path (wildcards, field operators) are treated as literal characters rather than query syntax operators.

## Test plan

- [x] Updated 8 existing test assertions to expect the new phrase query format
- [x] Added 4 new test cases for injection prevention:
  - Wildcard `*` is wrapped in phrase quotes
  - Percent-encoded boolean operators are properly contained
  - Colon `:` in paths is properly contained
  - Percent-encoded double quotes don't break the phrase query
- [x] All 17 tests in `redirect.test.ts` pass

Made with [Cursor](https://cursor.com)