### PR TITLE
test(e2e): delivery address 

### DIFF
--- a/.changeset/fix-territory-code-aria-label.md
+++ b/.changeset/fix-territory-code-aria-label.md
@@ -1,0 +1,7 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Fix broken `aria-label` on territory code input in address form. The label was the raw developer string `"territoryCode"` instead of a human-readable `"Country code"`.

--- a/e2e/fixtures/delivery-address-utils.ts
+++ b/e2e/fixtures/delivery-address-utils.ts
@@ -82,18 +82,28 @@ export class DeliveryAddressUtil {
   }
 
   async createAddress(data: AddressFormData) {
+    const countBefore = await this.getExistingAddresses().count();
     const form = this.getCreateAddressForm();
     await this.fillAddressForm(form, data);
     const createButton = form.getByRole('button', {name: 'Create'});
     await createButton.click();
-    await this.page.waitForLoadState('networkidle');
+    // Wait for a new existing-address form to appear, proving the full
+    // create -> revalidate -> re-render cycle completed.
+    await this.assertAddressCount(countBefore + 1);
   }
 
   async updateAddress(form: Locator, data: Partial<AddressFormData>) {
     await this.fillAddressForm(form, data);
     const saveButton = form.getByRole('button', {name: 'Save'});
+    // Register response listener before clicking so we don't miss it.
+    // React Router's Form sends a real fetch to the dev server for the
+    // action. Waiting for the response proves the server-side mutation
+    // completed and MSW closure state is updated.
+    const actionResponse = this.page.waitForResponse((res) =>
+      res.url().includes('/account/addresses'),
+    );
     await saveButton.click();
-    await this.page.waitForLoadState('networkidle');
+    await actionResponse;
   }
 
   async deleteAddress(form: Locator) {

--- a/e2e/fixtures/delivery-address-utils.ts
+++ b/e2e/fixtures/delivery-address-utils.ts
@@ -99,7 +99,10 @@ export class DeliveryAddressUtil {
   async deleteAddress(form: Locator) {
     const deleteButton = form.getByRole('button', {name: 'Delete'});
     await deleteButton.click();
-    await this.page.waitForLoadState('networkidle');
+    // Wait for the form to be removed from the DOM, which proves the full
+    // delete → revalidate → re-render cycle completed. Unlike networkidle,
+    // this is a DOM-level signal that can't fire prematurely.
+    await expect(deleteButton).not.toBeVisible();
   }
 
   async assertAddressCount(count: number) {

--- a/e2e/fixtures/delivery-address-utils.ts
+++ b/e2e/fixtures/delivery-address-utils.ts
@@ -1,0 +1,154 @@
+import {expect, Locator, Page} from '@playwright/test';
+
+export const EMPTY_STATE_MESSAGE = 'You have no addresses saved.';
+const FORM_SUBMISSION_TIMEOUT_IN_MS = 10_000;
+
+export interface AddressFormData {
+  firstName: string;
+  lastName: string;
+  company?: string;
+  address1: string;
+  address2?: string;
+  city: string;
+  zoneCode: string;
+  zip: string;
+  territoryCode: string;
+  phoneNumber?: string;
+  defaultAddress?: boolean;
+}
+
+export class DeliveryAddressUtil {
+  constructor(private page: Page) {}
+
+  async navigateToAddresses() {
+    await this.page.goto('/account/addresses');
+    await expect(
+      this.page.getByRole('heading', {level: 2, name: 'Addresses'}),
+    ).toBeVisible();
+  }
+
+  /**
+   * Returns each existing address form (excluding the create form).
+   * The create form has id="NEW_ADDRESS_ID"; existing forms have GID-based ids.
+   * We select forms with Save/Delete buttons, which only appear on existing addresses.
+   */
+  getExistingAddresses(): Locator {
+    return this.page
+      .locator('form')
+      .filter({has: this.page.getByRole('button', {name: 'Save'})});
+  }
+
+  getCreateAddressForm(): Locator {
+    return this.page
+      .locator('form')
+      .filter({has: this.page.getByRole('button', {name: 'Create'})});
+  }
+
+  getEmptyState(): Locator {
+    return this.page.getByText(EMPTY_STATE_MESSAGE);
+  }
+
+  private static readonly FIELD_LABEL_MAP: Record<
+    keyof Omit<AddressFormData, 'defaultAddress'>,
+    string
+  > = {
+    firstName: 'First name',
+    lastName: 'Last name',
+    company: 'Company',
+    address1: 'Address line 1',
+    address2: 'Address line 2',
+    city: 'City',
+    zoneCode: 'State/Province',
+    zip: 'Zip',
+    territoryCode: 'Country code',
+    phoneNumber: 'Phone Number',
+  };
+
+  async fillAddressForm(form: Locator, data: Partial<AddressFormData>) {
+    for (const [field, label] of Object.entries(
+      DeliveryAddressUtil.FIELD_LABEL_MAP,
+    )) {
+      const value = data[field as keyof typeof data];
+      if (value !== undefined && typeof value === 'string') {
+        await form.getByLabel(label).fill(value);
+      }
+    }
+    if (data.defaultAddress !== undefined) {
+      const checkbox = form.getByRole('checkbox');
+      const isChecked = await checkbox.isChecked();
+      if (data.defaultAddress !== isChecked) {
+        await checkbox.click();
+      }
+    }
+  }
+
+  async createAddress(data: AddressFormData) {
+    const form = this.getCreateAddressForm();
+    await this.fillAddressForm(form, data);
+    const createButton = form.getByRole('button', {name: 'Create'});
+    await createButton.click();
+    await expect(createButton).toHaveText('Create', {
+      timeout: FORM_SUBMISSION_TIMEOUT_IN_MS,
+    });
+  }
+
+  async updateAddress(form: Locator, data: Partial<AddressFormData>) {
+    await this.fillAddressForm(form, data);
+    const saveButton = form.getByRole('button', {name: 'Save'});
+    await saveButton.click();
+    await expect(saveButton).toHaveText('Save', {
+      timeout: FORM_SUBMISSION_TIMEOUT_IN_MS,
+    });
+  }
+
+  async deleteAddress(form: Locator) {
+    const deleteButton = form.getByRole('button', {name: 'Delete'});
+    await deleteButton.click();
+    await expect(deleteButton).not.toBeVisible({
+      timeout: FORM_SUBMISSION_TIMEOUT_IN_MS,
+    });
+  }
+
+  async assertAddressCount(count: number) {
+    if (count === 0) {
+      await expect(this.getEmptyState()).toBeVisible();
+      return;
+    }
+    await expect(this.getExistingAddresses()).toHaveCount(count);
+  }
+
+  async assertAddressVisible(
+    data: Partial<Omit<AddressFormData, 'defaultAddress'>>,
+  ) {
+    const entries = Object.entries(data).map(([field, value]) => ({
+      label:
+        DeliveryAddressUtil.FIELD_LABEL_MAP[
+          field as keyof typeof DeliveryAddressUtil.FIELD_LABEL_MAP
+        ],
+      value: value as string,
+    }));
+
+    if (entries.length === 0) {
+      throw new Error('assertAddressVisible requires at least one field');
+    }
+
+    const [matchField, ...remainingFields] = entries;
+    const forms = this.getExistingAddresses();
+    const count = await forms.count();
+
+    for (let i = 0; i < count; i++) {
+      const form = forms.nth(i);
+      const actual = await form.getByLabel(matchField.label).inputValue();
+      if (actual === matchField.value) {
+        for (const field of remainingFields) {
+          await expect(form.getByLabel(field.label)).toHaveValue(field.value);
+        }
+        return;
+      }
+    }
+
+    throw new Error(
+      `No address found matching ${matchField.label}="${matchField.value}"`,
+    );
+  }
+}

--- a/e2e/fixtures/delivery-address-utils.ts
+++ b/e2e/fixtures/delivery-address-utils.ts
@@ -97,12 +97,16 @@ export class DeliveryAddressUtil {
   }
 
   async deleteAddress(form: Locator) {
+    const countBefore = await this.getExistingAddresses().count();
     const deleteButton = form.getByRole('button', {name: 'Delete'});
+    await expect(deleteButton).toBeVisible();
     await deleteButton.click();
-    // Wait for the form to be removed from the DOM, which proves the full
-    // delete → revalidate → re-render cycle completed. Unlike networkidle,
-    // this is a DOM-level signal that can't fire prematurely.
-    await expect(deleteButton).not.toBeVisible();
+    // Wait for the address count to decrease, proving the full
+    // delete -> revalidate -> re-render cycle completed. We can't use
+    // not.toBeVisible() on the delete button because Playwright locators
+    // are lazy: after the form is removed, .first()/.last() shifts to
+    // the next form whose delete button IS visible.
+    await this.assertAddressCount(countBefore - 1);
   }
 
   async assertAddressCount(count: number) {

--- a/e2e/fixtures/delivery-address-utils.ts
+++ b/e2e/fixtures/delivery-address-utils.ts
@@ -92,13 +92,16 @@ export class DeliveryAddressUtil {
     await this.assertAddressCount(countBefore + 1);
   }
 
+  // DEVIATION: waitForResponse is used here despite the e2e guideline to
+  // "wait for the visible effect rather than the underlying mechanism."
+  // The skeleton's AddressForm has no visible success feedback (no toast, no
+  // flash), and the inputs are uncontrolled (defaultValue) so user-typed values
+  // persist in the DOM regardless of mutation success. There is no user-visible
+  // effect to wait for. Tests that call updateAddress must re-navigate afterward
+  // to verify persistence via a fresh mount from MSW state.
   async updateAddress(form: Locator, data: Partial<AddressFormData>) {
     await this.fillAddressForm(form, data);
     const saveButton = form.getByRole('button', {name: 'Save'});
-    // Register response listener before clicking so we don't miss it.
-    // React Router's Form sends a real fetch to the dev server for the
-    // action. Waiting for the response proves the server-side mutation
-    // completed and MSW closure state is updated.
     const actionResponse = this.page.waitForResponse((res) =>
       res.url().includes('/account/addresses'),
     );

--- a/e2e/fixtures/delivery-address-utils.ts
+++ b/e2e/fixtures/delivery-address-utils.ts
@@ -1,7 +1,6 @@
 import {expect, Locator, Page} from '@playwright/test';
 
 export const EMPTY_STATE_MESSAGE = 'You have no addresses saved.';
-const FORM_SUBMISSION_TIMEOUT_IN_MS = 10_000;
 
 export interface AddressFormData {
   firstName: string;
@@ -87,26 +86,20 @@ export class DeliveryAddressUtil {
     await this.fillAddressForm(form, data);
     const createButton = form.getByRole('button', {name: 'Create'});
     await createButton.click();
-    await expect(createButton).toHaveText('Create', {
-      timeout: FORM_SUBMISSION_TIMEOUT_IN_MS,
-    });
+    await this.page.waitForLoadState('networkidle');
   }
 
   async updateAddress(form: Locator, data: Partial<AddressFormData>) {
     await this.fillAddressForm(form, data);
     const saveButton = form.getByRole('button', {name: 'Save'});
     await saveButton.click();
-    await expect(saveButton).toHaveText('Save', {
-      timeout: FORM_SUBMISSION_TIMEOUT_IN_MS,
-    });
+    await this.page.waitForLoadState('networkidle');
   }
 
   async deleteAddress(form: Locator) {
     const deleteButton = form.getByRole('button', {name: 'Delete'});
     await deleteButton.click();
-    await expect(deleteButton).not.toBeVisible({
-      timeout: FORM_SUBMISSION_TIMEOUT_IN_MS,
-    });
+    await this.page.waitForLoadState('networkidle');
   }
 
   async assertAddressCount(count: number) {

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -12,6 +12,7 @@ import {CartUtil} from './cart-utils';
 import {DiscountUtil} from './discount-utils';
 import {GiftCardUtil} from './gift-card-utils';
 import {CustomerAccountUtil} from './customer-account-utils';
+import {DeliveryAddressUtil} from './delivery-address-utils';
 import type {MswScenario} from './msw/scenarios';
 import {getHandlersForScenario} from './msw/handlers';
 
@@ -57,6 +58,7 @@ export const test = base.extend<
     discount: DiscountUtil;
     giftCard: GiftCardUtil;
     customerAccount: CustomerAccountUtil;
+    addresses: DeliveryAddressUtil;
   },
   {forEachWorker: void}
 >({
@@ -79,6 +81,10 @@ export const test = base.extend<
   customerAccount: async ({page}, use) => {
     const customerAccount = new CustomerAccountUtil(page);
     await use(customerAccount);
+  },
+  addresses: async ({page}, use) => {
+    const addresses = new DeliveryAddressUtil(page);
+    await use(addresses);
   },
 });
 

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -27,6 +27,7 @@ export {CartUtil} from './cart-utils';
 export {DiscountUtil} from './discount-utils';
 export {GiftCardUtil} from './gift-card-utils';
 export {CustomerAccountUtil} from './customer-account-utils';
+export {DeliveryAddressUtil} from './delivery-address-utils';
 
 export const CUSTOMER_ACCOUNT_STORAGE_STATE_PATH = path.resolve(
   __dirname,

--- a/e2e/fixtures/msw/handlers.ts
+++ b/e2e/fixtures/msw/handlers.ts
@@ -1,9 +1,15 @@
 import type {RequestHandler} from 'msw';
 import {CUSTOMER_DETAILS_QUERY} from '../../../templates/skeleton/app/graphql/customer-account/CustomerDetailsQuery';
 import {CUSTOMER_ORDERS_QUERY} from '../../../templates/skeleton/app/graphql/customer-account/CustomerOrdersQuery';
+import {
+  CREATE_ADDRESS_MUTATION,
+  UPDATE_ADDRESS_MUTATION,
+  DELETE_ADDRESS_MUTATION,
+} from '../../../templates/skeleton/app/graphql/customer-account/CustomerAddressMutations';
 import {mockCustomerAccountOperation} from './graphql';
 import {MSW_SCENARIOS, MswScenario} from './scenarios';
 import {
+  AddressFragment,
   CustomerDetailsQuery,
   CustomerOrdersQuery,
 } from '../../../templates/skeleton/customer-accountapi.generated';
@@ -90,6 +96,150 @@ scenarios.set(MSW_SCENARIOS.customerAccountLoggedIn, {
   ],
   mocksCustomerAccountApi: true,
 });
+
+/**
+ * Delivery addresses scenario with mutable state.
+ * A closure-scoped address array allows mutations to modify the list
+ * so subsequent CustomerDetailsQuery calls reflect CRUD changes.
+ */
+const DELIVERY_ADDRESS_SEED_DATA: AddressFragment[] = [
+  {
+    id: 'gid://shopify/CustomerAddress/1',
+    formatted: ['123 Main St', 'Anytown ON M5V 2H1', 'Canada'],
+    firstName: 'Taylor',
+    lastName: 'E2E',
+    company: 'Shopify',
+    address1: '123 Main St',
+    address2: '',
+    territoryCode: 'CA',
+    zoneCode: 'ON',
+    city: 'Anytown',
+    zip: 'M5V 2H1',
+    phoneNumber: '+16135551111',
+  },
+  {
+    id: 'gid://shopify/CustomerAddress/2',
+    formatted: ['456 Oak Ave', 'Springfield IL 62704', 'United States'],
+    firstName: 'Sam',
+    lastName: 'Test',
+    company: '',
+    address1: '456 Oak Ave',
+    address2: 'Apt 2B',
+    territoryCode: 'US',
+    zoneCode: 'IL',
+    city: 'Springfield',
+    zip: '62704',
+    phoneNumber: '+12175559999',
+  },
+];
+
+export const DELIVERY_ADDRESS_SEED_COUNT = DELIVERY_ADDRESS_SEED_DATA.length;
+
+function createDeliveryAddressesScenario(): MswScenarioMeta {
+  let nextAddressId = DELIVERY_ADDRESS_SEED_DATA.length + 1;
+  const addresses: AddressFragment[] = [...DELIVERY_ADDRESS_SEED_DATA];
+
+  let defaultAddressId: string | null = addresses[0].id;
+
+  function getDefaultAddress(): AddressFragment | null {
+    return addresses.find((a) => a.id === defaultAddressId) ?? null;
+  }
+
+  return {
+    handlers: [
+      mockCustomerAccountOperation(CUSTOMER_DETAILS_QUERY, () => ({
+        customer: {
+          id: 'gid://shopify/Customer/123',
+          firstName: 'Taylor',
+          lastName: 'E2E',
+          defaultAddress: getDefaultAddress(),
+          addresses: {nodes: [...addresses]},
+        },
+      })),
+      mockCustomerAccountOperation(
+        CUSTOMER_ORDERS_QUERY,
+        () => customerOrdersMock,
+      ),
+      mockCustomerAccountOperation(CREATE_ADDRESS_MUTATION, ({variables}) => {
+        const id = `gid://shopify/CustomerAddress/${nextAddressId++}`;
+        const newAddress: AddressFragment = {
+          id,
+          formatted: [
+            variables.address.address1 ?? '',
+            `${variables.address.city ?? ''} ${variables.address.zoneCode ?? ''} ${variables.address.zip ?? ''}`,
+            variables.address.territoryCode ?? '',
+          ],
+          firstName: variables.address.firstName ?? '',
+          lastName: variables.address.lastName ?? '',
+          company: variables.address.company ?? '',
+          address1: variables.address.address1 ?? '',
+          address2: variables.address.address2 ?? '',
+          territoryCode: variables.address.territoryCode ?? '',
+          zoneCode: variables.address.zoneCode ?? '',
+          city: variables.address.city ?? '',
+          zip: variables.address.zip ?? '',
+          phoneNumber: variables.address.phoneNumber ?? '',
+        };
+        addresses.push(newAddress);
+        if (variables.defaultAddress) {
+          defaultAddressId = id;
+        }
+        return {
+          customerAddressCreate: {
+            customerAddress: {id},
+            userErrors: [],
+          },
+        };
+      }),
+      mockCustomerAccountOperation(UPDATE_ADDRESS_MUTATION, ({variables}) => {
+        const index = addresses.findIndex((a) => a.id === variables.addressId);
+        if (index !== -1) {
+          addresses[index] = {
+            ...addresses[index],
+            ...variables.address,
+            formatted: [
+              variables.address.address1 ?? addresses[index].address1 ?? '',
+              `${variables.address.city ?? addresses[index].city ?? ''} ${variables.address.zoneCode ?? addresses[index].zoneCode ?? ''} ${variables.address.zip ?? addresses[index].zip ?? ''}`,
+              variables.address.territoryCode ??
+                addresses[index].territoryCode ??
+                '',
+            ],
+          };
+        }
+        if (variables.defaultAddress) {
+          defaultAddressId = variables.addressId;
+        }
+        return {
+          customerAddressUpdate: {
+            customerAddress: {id: variables.addressId},
+            userErrors: [],
+          },
+        };
+      }),
+      mockCustomerAccountOperation(DELETE_ADDRESS_MUTATION, ({variables}) => {
+        const index = addresses.findIndex((a) => a.id === variables.addressId);
+        if (index !== -1) {
+          addresses.splice(index, 1);
+        }
+        if (defaultAddressId === variables.addressId) {
+          defaultAddressId = addresses[0]?.id ?? null;
+        }
+        return {
+          customerAddressDelete: {
+            deletedAddressId: variables.addressId,
+            userErrors: [],
+          },
+        };
+      }),
+    ],
+    mocksCustomerAccountApi: true,
+  };
+}
+
+scenarios.set(
+  MSW_SCENARIOS.deliveryAddresses,
+  createDeliveryAddressesScenario(),
+);
 
 function isMswScenario(scenario: string): scenario is MswScenario {
   return scenarios.has(scenario);

--- a/e2e/fixtures/msw/scenarios.ts
+++ b/e2e/fixtures/msw/scenarios.ts
@@ -1,5 +1,6 @@
 export const MSW_SCENARIOS = {
   customerAccountLoggedIn: 'customer-account-logged-in',
+  deliveryAddresses: 'delivery-addresses',
 } as const;
 
 export type MswScenario = (typeof MSW_SCENARIOS)[keyof typeof MSW_SCENARIOS];

--- a/e2e/specs/skeleton/deliveryAddresses.spec.ts
+++ b/e2e/specs/skeleton/deliveryAddresses.spec.ts
@@ -88,7 +88,11 @@ test.describe('Delivery Addresses', () => {
       await expect(targetForm.getByLabel('City')).not.toHaveValue(updatedCity);
       await addresses.updateAddress(targetForm, {city: updatedCity});
 
-      await expect(targetForm.getByLabel('City')).toHaveValue(updatedCity);
+      // Re-navigate to verify the mutation persisted in MSW closure state.
+      // Without this, the assertion would pass from the user-typed DOM value
+      // alone, since the form uses uncontrolled inputs (defaultValue).
+      await addresses.navigateToAddresses();
+      await addresses.assertAddressVisible({city: updatedCity});
     });
   });
 
@@ -106,8 +110,17 @@ test.describe('Delivery Addresses', () => {
 
       await addresses.updateAddress(secondForm, {defaultAddress: true});
 
-      await expect(secondForm.getByRole('checkbox')).toBeChecked();
-      await expect(firstForm.getByRole('checkbox')).not.toBeChecked();
+      // Re-navigate to verify the default toggle persisted in MSW state.
+      // The checkbox uses defaultChecked (uncontrolled), and key={address.id}
+      // is stable across default-toggle updates, so React reconciles in place
+      // without resetting the checkbox DOM state. Fresh mount is needed.
+      await addresses.navigateToAddresses();
+
+      const refreshedForms = addresses.getExistingAddresses();
+      await expect(
+        refreshedForms.first().getByRole('checkbox'),
+      ).not.toBeChecked();
+      await expect(refreshedForms.nth(1).getByRole('checkbox')).toBeChecked();
     });
   });
 

--- a/e2e/specs/skeleton/deliveryAddresses.spec.ts
+++ b/e2e/specs/skeleton/deliveryAddresses.spec.ts
@@ -1,9 +1,6 @@
 import {setTestStore, test, expect, MSW_SCENARIOS} from '../../fixtures';
 import {DELIVERY_ADDRESS_SEED_COUNT} from '../../fixtures/msw/handlers';
-import {
-  DeliveryAddressUtil,
-  type AddressFormData,
-} from '../../fixtures/delivery-address-utils';
+import type {AddressFormData} from '../../fixtures/delivery-address-utils';
 
 setTestStore('mockShop', {
   mock: {scenario: MSW_SCENARIOS.deliveryAddresses},
@@ -28,18 +25,16 @@ test.describe('Delivery Addresses', () => {
   // and Delete tests then operate on).
   test.describe.configure({mode: 'serial'});
 
-  test.describe('Read', () => {
-    test('renders existing addresses', async ({page}) => {
-      const addresses = new DeliveryAddressUtil(page);
-      await addresses.navigateToAddresses();
+  test.beforeEach(async ({addresses}) => {
+    await addresses.navigateToAddresses();
+  });
 
+  test.describe('Read', () => {
+    test('renders existing addresses', async ({addresses}) => {
       await addresses.assertAddressCount(DELIVERY_ADDRESS_SEED_COUNT);
     });
 
-    test('shows the create address form', async ({page}) => {
-      const addresses = new DeliveryAddressUtil(page);
-      await addresses.navigateToAddresses();
-
+    test('shows the create address form', async ({addresses}) => {
       const createForm = addresses.getCreateAddressForm();
       await expect(createForm).toBeVisible();
       await expect(
@@ -47,10 +42,7 @@ test.describe('Delivery Addresses', () => {
       ).toBeVisible();
     });
 
-    test('displays default address checkbox state', async ({page}) => {
-      const addresses = new DeliveryAddressUtil(page);
-      await addresses.navigateToAddresses();
-
+    test('displays default address checkbox state', async ({addresses}) => {
       const existingForms = addresses.getExistingAddresses();
       const firstCheckbox = existingForms.first().getByRole('checkbox');
       await expect(firstCheckbox).toBeChecked();
@@ -61,10 +53,7 @@ test.describe('Delivery Addresses', () => {
   });
 
   test.describe('Create', () => {
-    test('creates a new address', async ({page}) => {
-      const addresses = new DeliveryAddressUtil(page);
-      await addresses.navigateToAddresses();
-
+    test('creates a new address', async ({addresses}) => {
       await addresses.assertAddressCount(DELIVERY_ADDRESS_SEED_COUNT);
       await addresses.createAddress(NEW_ADDRESS);
 
@@ -77,10 +66,7 @@ test.describe('Delivery Addresses', () => {
   });
 
   test.describe('Update', () => {
-    test('updates an existing address', async ({page}) => {
-      const addresses = new DeliveryAddressUtil(page);
-      await addresses.navigateToAddresses();
-
+    test('updates an existing address', async ({addresses}) => {
       const updatedCity = 'New Portland';
       const existingForms = addresses.getExistingAddresses();
       const targetForm = existingForms.first();
@@ -97,10 +83,9 @@ test.describe('Delivery Addresses', () => {
   });
 
   test.describe('Default Address', () => {
-    test('toggles default address to a different address', async ({page}) => {
-      const addresses = new DeliveryAddressUtil(page);
-      await addresses.navigateToAddresses();
-
+    test('toggles default address to a different address', async ({
+      addresses,
+    }) => {
       const existingForms = addresses.getExistingAddresses();
       const firstForm = existingForms.first();
       const secondForm = existingForms.nth(1);
@@ -125,10 +110,7 @@ test.describe('Delivery Addresses', () => {
   });
 
   test.describe('Delete', () => {
-    test('deletes an address and decreases count', async ({page}) => {
-      const addresses = new DeliveryAddressUtil(page);
-      await addresses.navigateToAddresses();
-
+    test('deletes an address and decreases count', async ({addresses}) => {
       const countBefore = await addresses.getExistingAddresses().count();
       expect(countBefore).toBeGreaterThan(0);
       const lastForm = addresses.getExistingAddresses().last();
@@ -137,10 +119,9 @@ test.describe('Delivery Addresses', () => {
       await addresses.assertAddressCount(countBefore - 1);
     });
 
-    test('shows empty state when all addresses are deleted', async ({page}) => {
-      const addresses = new DeliveryAddressUtil(page);
-      await addresses.navigateToAddresses();
-
+    test('shows empty state when all addresses are deleted', async ({
+      addresses,
+    }) => {
       await expect(addresses.getEmptyState()).toHaveCount(0);
       const remaining = await addresses.getExistingAddresses().count();
       for (let i = 0; i < remaining; i++) {

--- a/e2e/specs/skeleton/deliveryAddresses.spec.ts
+++ b/e2e/specs/skeleton/deliveryAddresses.spec.ts
@@ -141,6 +141,7 @@ test.describe('Delivery Addresses', () => {
       const addresses = new DeliveryAddressUtil(page);
       await addresses.navigateToAddresses();
 
+      await expect(addresses.getEmptyState()).toHaveCount(0);
       const remaining = await addresses.getExistingAddresses().count();
       for (let i = 0; i < remaining; i++) {
         const form = addresses.getExistingAddresses().first();

--- a/e2e/specs/skeleton/deliveryAddresses.spec.ts
+++ b/e2e/specs/skeleton/deliveryAddresses.spec.ts
@@ -1,0 +1,140 @@
+import {setTestStore, test, expect, MSW_SCENARIOS} from '../../fixtures';
+import {DELIVERY_ADDRESS_SEED_COUNT} from '../../fixtures/msw/handlers';
+import {
+  DeliveryAddressUtil,
+  type AddressFormData,
+} from '../../fixtures/delivery-address-utils';
+
+setTestStore('mockShop', {
+  mock: {scenario: MSW_SCENARIOS.deliveryAddresses},
+});
+
+const NEW_ADDRESS: AddressFormData = {
+  firstName: 'New',
+  lastName: 'Address',
+  company: 'TestCo',
+  address1: '789 Pine Rd',
+  address2: 'Suite 100',
+  city: 'Portland',
+  zoneCode: 'OR',
+  zip: '97201',
+  territoryCode: 'US',
+  phoneNumber: '+15035551234',
+};
+
+test.describe('Delivery Addresses', () => {
+  // Serial mode is required because MSW mutable state is shared across tests,
+  // so CRUD operations accumulate (e.g., Create adds an address that Update
+  // and Delete tests then operate on).
+  test.describe.configure({mode: 'serial'});
+
+  test.describe('Read', () => {
+    test('renders existing addresses', async ({page}) => {
+      const addresses = new DeliveryAddressUtil(page);
+      await addresses.navigateToAddresses();
+
+      await addresses.assertAddressCount(DELIVERY_ADDRESS_SEED_COUNT);
+    });
+
+    test('shows the create address form', async ({page}) => {
+      const addresses = new DeliveryAddressUtil(page);
+      await addresses.navigateToAddresses();
+
+      const createForm = addresses.getCreateAddressForm();
+      await expect(createForm).toBeVisible();
+      await expect(
+        createForm.getByRole('button', {name: 'Create'}),
+      ).toBeVisible();
+    });
+
+    test('displays default address checkbox state', async ({page}) => {
+      const addresses = new DeliveryAddressUtil(page);
+      await addresses.navigateToAddresses();
+
+      const existingForms = addresses.getExistingAddresses();
+      const firstCheckbox = existingForms.first().getByRole('checkbox');
+      await expect(firstCheckbox).toBeChecked();
+
+      const secondCheckbox = existingForms.nth(1).getByRole('checkbox');
+      await expect(secondCheckbox).not.toBeChecked();
+    });
+  });
+
+  test.describe('Create', () => {
+    test('creates a new address', async ({page}) => {
+      const addresses = new DeliveryAddressUtil(page);
+      await addresses.navigateToAddresses();
+
+      await addresses.assertAddressCount(DELIVERY_ADDRESS_SEED_COUNT);
+      await addresses.createAddress(NEW_ADDRESS);
+
+      await addresses.assertAddressCount(DELIVERY_ADDRESS_SEED_COUNT + 1);
+      await addresses.assertAddressVisible({
+        firstName: NEW_ADDRESS.firstName,
+        address1: NEW_ADDRESS.address1,
+      });
+    });
+  });
+
+  test.describe('Update', () => {
+    test('updates an existing address', async ({page}) => {
+      const addresses = new DeliveryAddressUtil(page);
+      await addresses.navigateToAddresses();
+
+      const updatedCity = 'New Portland';
+      const existingForms = addresses.getExistingAddresses();
+      const targetForm = existingForms.first();
+
+      await expect(targetForm.getByLabel('City')).not.toHaveValue(updatedCity);
+      await addresses.updateAddress(targetForm, {city: updatedCity});
+
+      await expect(targetForm.getByLabel('City')).toHaveValue(updatedCity);
+    });
+  });
+
+  test.describe('Default Address', () => {
+    test('toggles default address to a different address', async ({page}) => {
+      const addresses = new DeliveryAddressUtil(page);
+      await addresses.navigateToAddresses();
+
+      const existingForms = addresses.getExistingAddresses();
+      const firstForm = existingForms.first();
+      const secondForm = existingForms.nth(1);
+
+      await expect(firstForm.getByRole('checkbox')).toBeChecked();
+      await expect(secondForm.getByRole('checkbox')).not.toBeChecked();
+
+      await addresses.updateAddress(secondForm, {defaultAddress: true});
+
+      await expect(secondForm.getByRole('checkbox')).toBeChecked();
+      await expect(firstForm.getByRole('checkbox')).not.toBeChecked();
+    });
+  });
+
+  test.describe('Delete', () => {
+    test('deletes an address and decreases count', async ({page}) => {
+      const addresses = new DeliveryAddressUtil(page);
+      await addresses.navigateToAddresses();
+
+      const countBefore = await addresses.getExistingAddresses().count();
+      expect(countBefore).toBeGreaterThan(0);
+      const lastForm = addresses.getExistingAddresses().last();
+      await addresses.deleteAddress(lastForm);
+
+      await addresses.assertAddressCount(countBefore - 1);
+    });
+
+    test('shows empty state when all addresses are deleted', async ({page}) => {
+      const addresses = new DeliveryAddressUtil(page);
+      await addresses.navigateToAddresses();
+
+      const remaining = await addresses.getExistingAddresses().count();
+      for (let i = 0; i < remaining; i++) {
+        const form = addresses.getExistingAddresses().first();
+        await addresses.deleteAddress(form);
+      }
+
+      await expect(addresses.getEmptyState()).toBeVisible();
+    });
+  });
+});

--- a/templates/skeleton/app/routes/account.addresses.tsx
+++ b/templates/skeleton/app/routes/account.addresses.tsx
@@ -468,7 +468,7 @@ export function AddressForm({
         />
         <label htmlFor="territoryCode">Country Code*</label>
         <input
-          aria-label="territoryCode"
+          aria-label="Country code"
           autoComplete="country"
           defaultValue={address?.territoryCode ?? ''}
           id="territoryCode"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/1038

Adds E2E test coverage for delivery address CRUD in the skeleton template. This is a gap in our test suite — the `account.addresses.tsx` route had zero E2E coverage. Uses MSW to mock the Customer Account API, enabling fast, deterministic tests without a real storefront.

Depends on MSW infrastructure from PR #3537.

Related: https://github.com/Shopify/developer-tools-team/issues/1038

### WHAT is this pull request doing?

**New files:**
- `e2e/fixtures/delivery-address-utils.ts` — `DeliveryAddressUtil` fixture following the deep module pattern. Hides form-filling, button mechanics, and completion signals behind a simple action interface.
- `e2e/specs/skeleton/deliveryAddresses.spec.ts` — 8 serial tests covering all CRUD flows + default address toggling.

**Modified files:**
- `e2e/fixtures/msw/handlers.ts` — New `delivery-addresses` MSW scenario with mutable closure state. Mocks `CustomerDetailsQuery`, `CustomerOrdersQuery`, and all three address mutations. Seed data exported as `DELIVERY_ADDRESS_SEED_COUNT` for spec consumption.
- `e2e/fixtures/msw/scenarios.ts` — Added `deliveryAddresses` scenario constant.
- `e2e/fixtures/index.ts` — Removed orphaned `AccountUtil` export.
- `templates/skeleton/app/routes/account.addresses.tsx` — Fixed `aria-label="territoryCode"` → `aria-label="Country code"` (was a raw developer string, meaningless to screen readers).

**Test coverage:**
| Group | Tests |
|-------|-------|
| Read | Existing addresses render, create form visible, default checkbox state |
| Create | Fill and submit new address, verify count and data |
| Update | Modify city field, verify change |
| Default Address | Toggle default to a different address, verify checkbox states swap |
| Delete | Remove one address (count decreases), delete all (empty state) |

### HOW to test your changes?

```bash
npx playwright test --project=skeleton --workers=1 e2e/specs/skeleton/deliveryAddresses.spec.ts
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation