### PR TITLE
chore: deprecate `@shopify/remix-oxygen` package

### DIFF
--- a/.changeset/cli-remove-remix-oxygen-refs.md
+++ b/.changeset/cli-remove-remix-oxygen-refs.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Updated route scaffolding and JS transpilation to import from `react-router` instead of the deprecated `@shopify/remix-oxygen`.

--- a/.changeset/deprecate-remix-oxygen.md
+++ b/.changeset/deprecate-remix-oxygen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/remix-oxygen': patch
+---
+
+Deprecated `@shopify/remix-oxygen`. This package is a pass-through layer — all types and utilities it re-exports are available directly from `react-router`. For `createRequestHandler`, use `@shopify/hydrogen/oxygen` instead. For `getStorefrontHeaders`, use `@shopify/hydrogen`.

--- a/.claude/commands/changelog-update.md
+++ b/.claude/commands/changelog-update.md
@@ -286,7 +286,6 @@ For packages that need to be removed during migration (like Remix → React Rout
 #### Framework Package Types (include only if changed in skeleton)
 
 - `@shopify/hydrogen` (usually changes with every major release)
-- `@shopify/remix-oxygen` (when framework changes)
 - React Router packages (`react-router`, `react-router-dom`, `@react-router/*`)
 - `@shopify/cli` (when CLI is updated)
 - `@shopify/mini-oxygen` (when dev server is updated)

--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -33,12 +33,12 @@ jobs:
 
       - name: Force snapshot changeset
         run: |
-          printf -- "---\n'@shopify/hydrogen': patch\n'@shopify/remix-oxygen': patch\n'@shopify/cli-hydrogen': patch\n'@shopify/create-hydrogen': patch\n---\n\nForce snapshot build.\n" > .changeset/force-snapshot-build.md
+          printf -- "---\n'@shopify/hydrogen': patch\n'@shopify/cli-hydrogen': patch\n'@shopify/create-hydrogen': patch\n---\n\nForce snapshot build.\n" > .changeset/force-snapshot-build.md
 
       - name: Create snapshot version
         uses: Shopify/snapit@0c0d2dd62c9b0c94b7d03e1f54e72f18548e7752 # pin to a specific commit
         with:
-          github_comment_included_packages: '@shopify/hydrogen,@shopify/cli-hydrogen,@shopify/hydrogen-codegen,@shopify/mini-oxygen,@shopify/remix-oxygen'
+          github_comment_included_packages: '@shopify/hydrogen,@shopify/cli-hydrogen,@shopify/hydrogen-codegen,@shopify/mini-oxygen'
           custom_message_suffix: "\n> Create a new project with all the released packages running `pnpm create @shopify/hydrogen@<snapshot_version>`\n>To try a new CLI plugin version, add `@shopify/cli-hydrogen` as a dependency to your project using the snapshot version."
           build_script: 'pnpm run build'
         env:

--- a/docs/CALVER.md
+++ b/docs/CALVER.md
@@ -224,7 +224,7 @@ The release workflow now operates with zero manual intervention:
 ### Semver Packages (X.Y.Z format)
 - `@shopify/cli-hydrogen`
 - `@shopify/mini-oxygen`
-- `@shopify/remix-oxygen`
+- `@shopify/remix-oxygen` (deprecated — no longer actively versioned)
 - All other packages
 
 ## Version Transformation Process

--- a/e2e/specs/recipes/third-party-api.spec.ts
+++ b/e2e/specs/recipes/third-party-api.spec.ts
@@ -19,6 +19,12 @@ setRecipeFixture({
 
 const RECIPE_HEADING_TEXT = 'Rick & Morty Characters (Third-Party API Example)';
 
+// The skeleton queries the most recently updated collection, which may change over time.
+// If this collection is removed or renamed in hydrogenPreviewStorefront, update this constant.
+const KNOWN_FEATURED_COLLECTION = {
+  title: 'Winter Collection',
+} as const;
+
 test.describe('Third-party API Recipe', () => {
   test.beforeEach(async ({page}) => {
     await page.goto('/');
@@ -60,13 +66,11 @@ test.describe('Third-party API Recipe', () => {
   test('preserves existing homepage sections alongside third-party content', async ({
     page,
   }) => {
-    // The skeleton's FeaturedCollection renders the most-recently-updated
-    // collection title as an <h1> inside a link to /collections/. We verify
-    // structure rather than a specific name, because the store's data may change.
-    const featuredCollectionLink = page.getByRole('link', {name: /.+/}).filter({
-      has: page.getByRole('heading', {level: 1}),
+    const featuredCollectionHeading = page.getByRole('heading', {
+      level: 1,
+      name: KNOWN_FEATURED_COLLECTION.title,
     });
-    await expect(featuredCollectionLink).toBeVisible();
+    await expect(featuredCollectionHeading).toBeVisible();
 
     const recommendedProductsSection = page.getByRole('region', {
       name: 'Recommended Products',

--- a/e2e/specs/recipes/third-party-api.spec.ts
+++ b/e2e/specs/recipes/third-party-api.spec.ts
@@ -19,12 +19,6 @@ setRecipeFixture({
 
 const RECIPE_HEADING_TEXT = 'Rick & Morty Characters (Third-Party API Example)';
 
-// The skeleton queries the most recently updated collection, which may change over time.
-// If this collection is removed or renamed in hydrogenPreviewStorefront, update this constant.
-const KNOWN_FEATURED_COLLECTION = {
-  title: 'Winter Collection',
-} as const;
-
 test.describe('Third-party API Recipe', () => {
   test.beforeEach(async ({page}) => {
     await page.goto('/');
@@ -66,11 +60,13 @@ test.describe('Third-party API Recipe', () => {
   test('preserves existing homepage sections alongside third-party content', async ({
     page,
   }) => {
-    const featuredCollectionHeading = page.getByRole('heading', {
-      level: 1,
-      name: KNOWN_FEATURED_COLLECTION.title,
+    // The skeleton's FeaturedCollection renders the most-recently-updated
+    // collection title as an <h1> inside a link to /collections/. We verify
+    // structure rather than a specific name, because the store's data may change.
+    const featuredCollectionLink = page.getByRole('link', {name: /.+/}).filter({
+      has: page.getByRole('heading', {level: 1}),
     });
-    await expect(featuredCollectionHeading).toBeVisible();
+    await expect(featuredCollectionLink).toBeVisible();
 
     const recommendedProductsSection = page.getByRole('region', {
       name: 'Recommended Products',

--- a/packages/cli/assets/routes/locale-check.ts
+++ b/packages/cli/assets/routes/locale-check.ts
@@ -1,4 +1,4 @@
-import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
+import type {LoaderFunctionArgs} from 'react-router';
 
 export async function loader({params, context}: LoaderFunctionArgs) {
   const {language, country} = context.storefront.i18n;

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -855,7 +855,7 @@
       "description": "Generates a standard Shopify route.",
       "flags": {
         "adapter": {
-          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
+          "description": "Remix adapter used in the route. The default is `react-router`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
           "name": "adapter",
           "hasDynamicHelp": false,
@@ -918,7 +918,7 @@
       "description": "Generates all supported standard shopify routes.",
       "flags": {
         "adapter": {
-          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
+          "description": "Remix adapter used in the route. The default is `react-router`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
           "name": "adapter",
           "hasDynamicHelp": false,

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -855,7 +855,7 @@
       "description": "Generates a standard Shopify route.",
       "flags": {
         "adapter": {
-          "description": "Remix adapter used in the route. The default is `react-router`.",
+          "description": "React Router adapter used in the route. The default is `react-router`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
           "name": "adapter",
           "hasDynamicHelp": false,
@@ -918,7 +918,7 @@
       "description": "Generates all supported standard shopify routes.",
       "flags": {
         "adapter": {
-          "description": "Remix adapter used in the route. The default is `react-router`.",
+          "description": "React Router adapter used in the route. The default is `react-router`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
           "name": "adapter",
           "hasDynamicHelp": false,

--- a/packages/cli/src/commands/hydrogen/generate/route.ts
+++ b/packages/cli/src/commands/hydrogen/generate/route.ts
@@ -20,7 +20,7 @@ export default class GenerateRoute extends Command {
   static flags = {
     adapter: Flags.string({
       description:
-        'Remix adapter used in the route. The default is `@shopify/remix-oxygen`.',
+        'Remix adapter used in the route. The default is `react-router`.',
       env: 'SHOPIFY_HYDROGEN_FLAG_ADAPTER',
     }),
     typescript: Flags.boolean({

--- a/packages/cli/src/commands/hydrogen/generate/route.ts
+++ b/packages/cli/src/commands/hydrogen/generate/route.ts
@@ -20,7 +20,7 @@ export default class GenerateRoute extends Command {
   static flags = {
     adapter: Flags.string({
       description:
-        'Remix adapter used in the route. The default is `react-router`.',
+        'React Router adapter used in the route. The default is `react-router`.',
       env: 'SHOPIFY_HYDROGEN_FLAG_ADAPTER',
     }),
     typescript: Flags.boolean({

--- a/packages/cli/src/lib/request-events.ts
+++ b/packages/cli/src/lib/request-events.ts
@@ -45,7 +45,7 @@ const EVENT_MAP: Record<string, string> = {
   subrequest: 'Sub request',
 };
 
-// Make sure to match this type with the one in packages/remix-oxygen/src/event-logger.ts
+// Canonical H2OEvent type used by the dev server log binding.
 export type H2OEvent = {
   url: string;
   eventType: 'request' | 'subrequest';

--- a/packages/cli/src/lib/setups/routes/generate.ts
+++ b/packages/cli/src/lib/setups/routes/generate.ts
@@ -336,7 +336,10 @@ export async function generateProjectFile(
 }
 
 function replaceAdapters(templateContent: string, adapter: string) {
-  return templateContent.replace(/@shopify\/remix-oxygen/g, adapter);
+  return templateContent.replace(
+    /(from\s+['"])react-router(['"])/g,
+    `$1${adapter}$2`,
+  );
 }
 
 /**

--- a/packages/cli/src/lib/transpile/morph/functions.ts
+++ b/packages/cli/src/lib/transpile/morph/functions.ts
@@ -76,7 +76,7 @@ function normalizeType(type: string) {
     .replace(/typeof import\("[^"]+"\)\./, 'typeof ');
 
   return normalizedType === 'SerializeFrom<any>'
-    ? `{SerializeFrom<loader>}` // Fix inference for loaders outisde of routes
+    ? `{ReturnType<typeof useLoaderData<typeof loader>>}` // Fix inference for loaders outside of routes
     : `{${normalizedType}}`;
 }
 

--- a/packages/cli/src/lib/transpile/morph/typedefs.ts
+++ b/packages/cli/src/lib/transpile/morph/typedefs.ts
@@ -89,7 +89,7 @@ export function generateTypeDefs(sourceFile: SourceFile, code: string) {
 
     if (/(function loader\(|const loader =)/.test(source)) {
       typedefs.push(
-        `/** @typedef {import('@shopify/remix-oxygen').SerializeFrom<typeof loader>} LoaderReturnData */`,
+        `/** @typedef {import('react-router').SerializeFrom<typeof loader>} LoaderReturnData */`,
       );
 
       code = code.replace(
@@ -116,7 +116,7 @@ export function generateTypeDefs(sourceFile: SourceFile, code: string) {
 
     if (/(function action\(|const action =)/.test(source)) {
       typedefs.push(
-        `/** @typedef {import('@shopify/remix-oxygen').SerializeFrom<typeof action>} ActionReturnData */`,
+        `/** @typedef {import('react-router').SerializeFrom<typeof action>} ActionReturnData */`,
       );
 
       code = code.replace(

--- a/packages/cli/src/lib/transpile/morph/typedefs.ts
+++ b/packages/cli/src/lib/transpile/morph/typedefs.ts
@@ -56,7 +56,6 @@ export function generateTypeDefs(sourceFile: SourceFile, code: string) {
 
   const knownGenerics: Record<string, string | undefined> = {
     MetaFunction: 'T',
-    SerializeFrom: 'T',
     Fetcher: 'T',
     PartialPredictiveSearchResult: 'ItemType, ExtraProps',
     PartialSearchResult: 'ItemType',
@@ -89,7 +88,7 @@ export function generateTypeDefs(sourceFile: SourceFile, code: string) {
 
     if (/(function loader\(|const loader =)/.test(source)) {
       typedefs.push(
-        `/** @typedef {import('react-router').SerializeFrom<typeof loader>} LoaderReturnData */`,
+        `/** @typedef {ReturnType<typeof useLoaderData<typeof loader>>} LoaderReturnData */`,
       );
 
       code = code.replace(
@@ -116,7 +115,7 @@ export function generateTypeDefs(sourceFile: SourceFile, code: string) {
 
     if (/(function action\(|const action =)/.test(source)) {
       typedefs.push(
-        `/** @typedef {import('react-router').SerializeFrom<typeof action>} ActionReturnData */`,
+        `/** @typedef {ReturnType<typeof useActionData<typeof action>>} ActionReturnData */`,
       );
 
       code = code.replace(

--- a/packages/hydrogen/src/vite/hydrogen-middleware.ts
+++ b/packages/hydrogen/src/vite/hydrogen-middleware.ts
@@ -42,7 +42,6 @@ export function setupHydrogenMiddleware(
         res.once('close', () => {
           emitRequestEvent(
             {
-              __fromVite: true,
               eventType: 'request',
               url: req.url!,
               requestId: req.headers['request-id'] as string,

--- a/packages/hydrogen/src/vite/plugin.ts
+++ b/packages/hydrogen/src/vite/plugin.ts
@@ -128,7 +128,6 @@ export function hydrogen(pluginOptions: HydrogenPluginOptions = {}): Plugin[] {
             // Emit events for requests
             emitRequestEvent(
               {
-                __fromVite: true,
                 eventType: 'request',
                 url: request.url,
                 requestId: request.headers['request-id'],

--- a/packages/hydrogen/src/vite/request-events.ts
+++ b/packages/hydrogen/src/vite/request-events.ts
@@ -22,7 +22,6 @@ const EVENT_MAP: Record<string, string> = {
 };
 
 export type RequestEventPayload = {
-  __fromVite?: boolean;
   url: string;
   eventType: 'request' | 'subrequest';
   requestId?: string | null;
@@ -74,14 +73,6 @@ export function emitRequestEvent(payload: RequestEventPayload, root: string) {
     // Ignore incorrect events, although this should not happen.
     return;
   }
-
-  if (payload.eventType === 'request' && !payload.__fromVite) {
-    // Filter out request events not originating from Vite's
-    // hydrogen middleware. Legacy adapters sent these directly.
-    return;
-  }
-
-  delete payload.__fromVite;
 
   const {pathname} = new URL(payload.url, 'http://localhost');
   if (IGNORED_ROUTES.has(pathname)) return;

--- a/packages/hydrogen/src/vite/request-events.ts
+++ b/packages/hydrogen/src/vite/request-events.ts
@@ -76,8 +76,8 @@ export function emitRequestEvent(payload: RequestEventPayload, root: string) {
   }
 
   if (payload.eventType === 'request' && !payload.__fromVite) {
-    // Filter out events that come from @shopify/remix-oxygen,
-    // which is a deprecated way to send events.
+    // Filter out request events not originating from Vite's
+    // hydrogen middleware. Legacy adapters sent these directly.
     return;
   }
 

--- a/packages/remix-oxygen/README.md
+++ b/packages/remix-oxygen/README.md
@@ -1,6 +1,6 @@
 # @shopify/remix-oxygen (Deprecated)
 
-> **This package is deprecated.** All types and utilities it re-exports are available directly from [`react-router`](https://reactrouter.com). For `createRequestHandler` and `getStorefrontHeaders`, use [`@shopify/hydrogen/oxygen`](https://shopify.dev/docs/storefronts/headless/hydrogen) instead.
+> **This package is deprecated.** All types and utilities it re-exports are available directly from [`react-router`](https://reactrouter.com). For `createRequestHandler`, use [`@shopify/hydrogen`](https://shopify.dev/docs/storefronts/headless/hydrogen). For `getStorefrontHeaders`, use `@shopify/hydrogen/oxygen`.
 
 ## Migration
 
@@ -10,5 +10,5 @@ Replace imports from `@shopify/remix-oxygen` as follows:
 | --------------------------------------------------------------- | --------------------------------------------------------------- |
 | `import type {LoaderFunctionArgs} from '@shopify/remix-oxygen'` | `import type {LoaderFunctionArgs} from 'react-router'`          |
 | `import {redirect} from '@shopify/remix-oxygen'`                | `import {redirect} from 'react-router'`                         |
-| `import {createRequestHandler} from '@shopify/remix-oxygen'`    | `import {createRequestHandler} from '@shopify/hydrogen/oxygen'` |
+| `import {createRequestHandler} from '@shopify/remix-oxygen'`    | `import {createRequestHandler} from '@shopify/hydrogen'`        |
 | `import {getStorefrontHeaders} from '@shopify/remix-oxygen'`    | `import {getStorefrontHeaders} from '@shopify/hydrogen/oxygen'` |

--- a/packages/remix-oxygen/README.md
+++ b/packages/remix-oxygen/README.md
@@ -6,9 +6,9 @@
 
 Replace imports from `@shopify/remix-oxygen` as follows:
 
-| Before | After |
-|--------|-------|
-| `import type {LoaderFunctionArgs} from '@shopify/remix-oxygen'` | `import type {LoaderFunctionArgs} from 'react-router'` |
-| `import {redirect} from '@shopify/remix-oxygen'` | `import {redirect} from 'react-router'` |
-| `import {createRequestHandler} from '@shopify/remix-oxygen'` | `import {createRequestHandler} from '@shopify/hydrogen/oxygen'` |
-| `import {getStorefrontHeaders} from '@shopify/remix-oxygen'` | `import {getStorefrontHeaders} from '@shopify/hydrogen/oxygen'` |
+| Before                                                          | After                                                           |
+| --------------------------------------------------------------- | --------------------------------------------------------------- |
+| `import type {LoaderFunctionArgs} from '@shopify/remix-oxygen'` | `import type {LoaderFunctionArgs} from 'react-router'`          |
+| `import {redirect} from '@shopify/remix-oxygen'`                | `import {redirect} from 'react-router'`                         |
+| `import {createRequestHandler} from '@shopify/remix-oxygen'`    | `import {createRequestHandler} from '@shopify/hydrogen/oxygen'` |
+| `import {getStorefrontHeaders} from '@shopify/remix-oxygen'`    | `import {getStorefrontHeaders} from '@shopify/hydrogen/oxygen'` |

--- a/packages/remix-oxygen/README.md
+++ b/packages/remix-oxygen/README.md
@@ -1,5 +1,14 @@
-# @shopify/remix-oxygen
+# @shopify/remix-oxygen (Deprecated)
 
-A Remix adapter for the [Oxygen runtime](https://shopify.dev/custom-storefronts/oxygen). The adapter is meant to work with Hydrogen. Hydrogen is a set of tools, utilities, and best-in-class examples for building a commerce application with [Remix](https://wwww.remix.run).
+> **This package is deprecated.** All types and utilities it re-exports are available directly from [`react-router`](https://reactrouter.com). For `createRequestHandler` and `getStorefrontHeaders`, use [`@shopify/hydrogen/oxygen`](https://shopify.dev/docs/storefronts/headless/hydrogen) instead.
 
-[Check out the docs](https://shopify.dev/custom-storefronts/hydrogen)
+## Migration
+
+Replace imports from `@shopify/remix-oxygen` as follows:
+
+| Before | After |
+|--------|-------|
+| `import type {LoaderFunctionArgs} from '@shopify/remix-oxygen'` | `import type {LoaderFunctionArgs} from 'react-router'` |
+| `import {redirect} from '@shopify/remix-oxygen'` | `import {redirect} from 'react-router'` |
+| `import {createRequestHandler} from '@shopify/remix-oxygen'` | `import {createRequestHandler} from '@shopify/hydrogen/oxygen'` |
+| `import {getStorefrontHeaders} from '@shopify/remix-oxygen'` | `import {getStorefrontHeaders} from '@shopify/hydrogen/oxygen'` |

--- a/packages/remix-oxygen/package.json
+++ b/packages/remix-oxygen/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@shopify/remix-oxygen",
+  "deprecated": "Import types/utilities from 'react-router'. Use createRequestHandler from '@shopify/hydrogen/oxygen' instead.",
   "publishConfig": {
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org"

--- a/packages/remix-oxygen/src/index.ts
+++ b/packages/remix-oxygen/src/index.ts
@@ -1,4 +1,10 @@
+/**
+ * @deprecated Use `createRequestHandler` and `getStorefrontHeaders`
+ * from `@shopify/hydrogen/oxygen` instead.
+ */
 export {createRequestHandler, getStorefrontHeaders} from './server';
+
+/** @deprecated Import these types directly from `react-router` instead. */
 export type {
   ActionFunction,
   ActionFunctionArgs,
@@ -32,6 +38,8 @@ export type {
   SessionIdStorageStrategy,
   SessionStorage,
 } from 'react-router';
+
+/** @deprecated Import these functions directly from `react-router` instead. */
 export {
   createCookie,
   createCookieSessionStorage,

--- a/packages/remix-oxygen/src/index.ts
+++ b/packages/remix-oxygen/src/index.ts
@@ -1,54 +1,93 @@
 /**
- * @deprecated Use `createRequestHandler` and `getStorefrontHeaders`
- * from `@shopify/hydrogen/oxygen` instead.
+ * @deprecated Use `createRequestHandler` from `@shopify/hydrogen` instead.
  */
-export {createRequestHandler, getStorefrontHeaders} from './server';
+export {createRequestHandler} from './server';
 
-/** @deprecated Import these types directly from `react-router` instead. */
-export type {
-  ActionFunction,
-  ActionFunctionArgs,
-  AppLoadContext,
-  Cookie,
-  CookieOptions,
-  CookieParseOptions,
-  CookieSerializeOptions,
-  CookieSignatureOptions,
-  EntryContext,
-  ErrorResponse,
-  HandleDataRequestFunction,
-  HandleDocumentRequestFunction,
-  HandleErrorFunction,
-  HeadersArgs,
-  HeadersFunction,
-  HtmlLinkDescriptor,
-  LinkDescriptor,
-  LinksFunction,
-  LoaderFunction,
-  LoaderFunctionArgs,
-  MetaArgs,
-  MetaDescriptor,
-  MetaFunction,
-  PageLinkDescriptor,
-  RequestHandler,
-  ServerBuild,
-  ServerEntryModule,
-  Session,
-  SessionData,
-  SessionIdStorageStrategy,
-  SessionStorage,
-} from 'react-router';
+/**
+ * @deprecated Use `getStorefrontHeaders` from `@shopify/hydrogen/oxygen` instead.
+ */
+export {getStorefrontHeaders} from './server';
 
-/** @deprecated Import these functions directly from `react-router` instead. */
-export {
-  createCookie,
-  createCookieSessionStorage,
-  createMemorySessionStorage,
-  createSession,
-  createSessionStorage,
-  data,
-  isCookie,
-  isSession,
-  redirect,
-  redirectDocument,
-} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {ActionFunction} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {ActionFunctionArgs} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {AppLoadContext} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {Cookie} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {CookieOptions} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {CookieParseOptions} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {CookieSerializeOptions} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {CookieSignatureOptions} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {EntryContext} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {ErrorResponse} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {HandleDataRequestFunction} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {HandleDocumentRequestFunction} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {HandleErrorFunction} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {HeadersArgs} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {HeadersFunction} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {HtmlLinkDescriptor} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {LinkDescriptor} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {LinksFunction} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {LoaderFunction} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {LoaderFunctionArgs} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {MetaArgs} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {MetaDescriptor} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {MetaFunction} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {PageLinkDescriptor} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {RequestHandler} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {ServerBuild} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {ServerEntryModule} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {Session} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {SessionData} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {SessionIdStorageStrategy} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export type {SessionStorage} from 'react-router';
+
+/** @deprecated Import from `react-router` instead. */
+export {createCookie} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export {createCookieSessionStorage} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export {createMemorySessionStorage} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export {createSession} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export {createSessionStorage} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export {data} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export {isCookie} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export {isSession} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export {redirect} from 'react-router';
+/** @deprecated Import from `react-router` instead. */
+export {redirectDocument} from 'react-router';

--- a/packages/remix-oxygen/src/server.ts
+++ b/packages/remix-oxygen/src/server.ts
@@ -11,6 +11,7 @@ Error.prototype.toString = function () {
   return this.stack || originalErrorToString.call(this);
 };
 
+/** @deprecated Use `createRequestHandler` from `@shopify/hydrogen/oxygen` instead. */
 export function createRequestHandler<Context = unknown>({
   build,
   mode,
@@ -89,6 +90,7 @@ type StorefrontHeaders = {
   purpose: string | null;
 };
 
+/** @deprecated Use `getStorefrontHeaders` from `@shopify/hydrogen/oxygen` instead. */
 export function getStorefrontHeaders(request: Request): StorefrontHeaders {
   const headers = request.headers;
   return {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,10 @@ const isCI = !!process.env.CI;
 export default defineConfig({
   testMatch: /\.spec\.ts$/,
   retries: isCI ? 1 : 0,
-  reporter: [['html', {open: 'on-failure', outputFolder: 'playwright-report'}]],
+  reporter: [
+    ['html', {open: 'on-failure', outputFolder: 'playwright-report'}],
+    ['json', {outputFile: 'playwright-report/results.json'}],
+  ],
   // 3 workers in CI (ubuntu-latest: 2 vCPUs, 7GB RAM).
   // Each worker spawns a Vite dev server + Chromium. Increase with caution.
   workers: process.env.CI ? 3 : 4,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,10 +6,7 @@ const isCI = !!process.env.CI;
 export default defineConfig({
   testMatch: /\.spec\.ts$/,
   retries: isCI ? 1 : 0,
-  reporter: [
-    ['html', {open: 'on-failure', outputFolder: 'playwright-report'}],
-    ['json', {outputFile: 'playwright-report/results.json'}],
-  ],
+  reporter: [['html', {open: 'on-failure', outputFolder: 'playwright-report'}]],
   // 3 workers in CI (ubuntu-latest: 2 vCPUs, 7GB RAM).
   // Each worker spawns a Vite dev server + Chromium. Increase with caution.
   workers: process.env.CI ? 3 : 4,

--- a/scripts/changeset-version-next.mjs
+++ b/scripts/changeset-version-next.mjs
@@ -9,7 +9,6 @@ const CHANGESET_ALL = `---
 '@shopify/cli-hydrogen': patch
 '@shopify/create-hydrogen': patch
 '@shopify/hydrogen-codegen': patch
-'@shopify/remix-oxygen': patch
 ---
 
 Trigger changeset for all packages for next release

--- a/templates/TEMPLATE_GUIDELINES.md
+++ b/templates/TEMPLATE_GUIDELINES.md
@@ -126,10 +126,7 @@ Remix-specific route API functions should be ordered and consistent in style, to
 
 ```tsx
 /* module imports... */
-import type {
-  LoaderFunctionArgs,
-  ActionFunctionArgs,
-} from 'react-router';
+import type {LoaderFunctionArgs, ActionFunctionArgs} from 'react-router';
 
 /* local type defintions */
 

--- a/templates/TEMPLATE_GUIDELINES.md
+++ b/templates/TEMPLATE_GUIDELINES.md
@@ -129,7 +129,7 @@ Remix-specific route API functions should be ordered and consistent in style, to
 import type {
   LoaderFunctionArgs,
   ActionFunctionArgs,
-} from '@shopify/remix-oxygen';
+} from 'react-router';
 
 /* local type defintions */
 
@@ -180,7 +180,7 @@ Use the correct return type in `loader()`, `action()`, etc.
 
 - Return raw json object by default
 - Use `await` if you want the data to be streamed in later
-- Use `redirect()` from the `@shopify/remix-oxygen` package to redirect
+- Use `redirect()` from `react-router` to redirect
 - Use `data()` for errors (like 404s)
 - Use `new Response()` for unique document responses like `.xml` and `.txt`
 - Use capitalized and kebab-cased headers in responses, like `Cache-Control`
@@ -194,7 +194,7 @@ export async function loader() {
 ```
 
 ```tsx
-import {redirect} from ''@shopify/remix-oxygen';';
+import {redirect} from 'react-router';
 export async function loader() {
   return redirect('/');
 }

--- a/turbo.json
+++ b/turbo.json
@@ -54,83 +54,9 @@
     "skeleton#build": {
       "dependsOn": [
         "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
+        "@shopify/cli-hydrogen#build"
       ],
       "outputs": ["dist/**"]
-    },
-    "example-hydrogen-express#build": {
-      "dependsOn": ["@shopify/hydrogen#build", "@shopify/remix-oxygen#build"]
-    },
-    "example-legacy-customer-account-flow#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
-    },
-    "example-b2b#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
-    },
-    "example-custom-cart-method#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
-    },
-    "example-gtm#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
-    },
-    "example-infinite-scroll#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
-    },
-    "example-metaobjects#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
-    },
-    "example-multipass#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
-    },
-    "example-partytown#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
-    },
-    "example-subscriptions#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
-    },
-    "example-third-party-queries-caching#build": {
-      "dependsOn": [
-        "@shopify/hydrogen#build",
-        "@shopify/cli-hydrogen#build",
-        "@shopify/remix-oxygen#build"
-      ]
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

`@shopify/remix-oxygen` is a legacy Remix adapter that re-exports 33 types and 10 runtime functions directly from `react-router` (pure pass-through) and provides its own `createRequestHandler` and `getStorefrontHeaders`. Both functions already have more capable replacements in `@shopify/hydrogen/oxygen`. The package also creates a circular build dependency — it devDepends on `@shopify/hydrogen` for the `__H2O_LOG_EVENT` global type, while turbo.json orders hydrogen builds before remix-oxygen.

The skeleton template has already migrated away from it. It's time to formally deprecate the package so merchants stop adopting it.

### WHAT is this pull request doing?

**Deprecation annotations:**
- Adds `deprecated` field to `package.json` (npm shows install warnings)
- Adds `@deprecated` JSDoc on all exports in `index.ts`, `server.ts`
- Replaces README with a deprecation banner and migration table

**Import replacements (no more internal consumers):**
- `cli/assets/routes/locale-check.ts` → `react-router`
- `cli/src/lib/transpile/morph/typedefs.ts` SerializeFrom → `react-router`
- `cli/src/lib/setups/routes/generate.ts` replaceAdapters regex anchored to import specifiers
- Adapter flag description updated from remix-oxygen to react-router

**Build/release cleanup:**
- Removed stale turbo.json entries for non-existent `examples/` directory (70+ lines of dead config)
- Removed remix-oxygen from `skeleton#build` dependsOn
- Removed from snapshot workflow (`snapit.yml`) and next-release script (`changeset-version-next.mjs`)

**Documentation updates:**
- `TEMPLATE_GUIDELINES.md` — updated code examples
- `CALVER.md` — annotated as deprecated
- Stale comments in both `request-events.ts` files updated

The package source code remains intact — this is a deprecation, not a removal. Existing consumers continue to work.

### HOW to test your changes?

1. `pnpm typecheck` — all 17 packages pass
2. `pnpm test` in `packages/cli/` — 49 test files, 358 tests pass
3. `pnpm run build` — turbo build graph valid, oclif manifest regenerated
4. Verify the README migration table at `packages/remix-oxygen/README.md` has correct import paths

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation