### PR TITLE
fix: correct misleading comments, stale references, and magic numbers

### DIFF
--- a/e2e/specs/recipes/metaobjects.spec.ts
+++ b/e2e/specs/recipes/metaobjects.spec.ts
@@ -11,7 +11,7 @@ setRecipeFixture({
  *
  * Tests cover:
  * - RouteContent component renders metaobject sections
- * - Section type switching logic (hero, products, collections, stores, store profile)
+ * - Section type switching logic (hero, stores grid, store profile)
  * - Dynamic route handling for store listings and individual stores
  * - Fallback behavior when routes have no sections
  * - EditRoute component for development/preview environments

--- a/e2e/specs/recipes/third-party-api.spec.ts
+++ b/e2e/specs/recipes/third-party-api.spec.ts
@@ -20,7 +20,8 @@ setRecipeFixture({
 const RECIPE_HEADING_TEXT = 'Rick & Morty Characters (Third-Party API Example)';
 
 // The skeleton queries the most recently updated collection, which may change over time.
-// If this collection is removed or renamed in hydrogenPreviewStorefront, update this constant.
+// If this collection is removed or renamed in hydrogenPreviewStorefront, or if another
+// collection becomes more recently updated than this one, update this constant.
 const KNOWN_FEATURED_COLLECTION = {
   title: 'Winter Collection',
 } as const;
@@ -63,7 +64,7 @@ test.describe('Third-party API Recipe', () => {
     await expect(characters.first()).toContainText(/[A-Za-z]/);
   });
 
-  test('preserves existing homepage sections alongside third-party content', async ({
+  test('shows Featured Collection and Recommended Products on homepage', async ({
     page,
   }) => {
     const featuredCollectionHeading = page.getByRole('heading', {

--- a/e2e/specs/recipes/third-party-api.spec.ts
+++ b/e2e/specs/recipes/third-party-api.spec.ts
@@ -57,10 +57,7 @@ test.describe('Third-party API Recipe', () => {
     await expect(characters.first()).toContainText(/[A-Za-z]/);
   });
 
-  test('shows Featured Collection and Recommended Products on homepage', async ({
-    page,
-  }) => {
-
+  test('shows Recommended Products on homepage', async ({page}) => {
     const recommendedProductsSection = page.getByRole('region', {
       name: 'Recommended Products',
     });

--- a/e2e/specs/recipes/verify-metaobjects-data.graphql
+++ b/e2e/specs/recipes/verify-metaobjects-data.graphql
@@ -59,7 +59,6 @@ query VerifyMetaobjectsData {
   # ============================================================================
   # Tests require: Homepage should render with at least one section
   # Test: "Homepage > renders route content with metaobject sections"
-  # Test: "Homepage > renders multiple section types via type switching"
 
   routeHome: metaobject(handle: {type: "route", handle: "route-home"}) {
     id
@@ -146,12 +145,12 @@ query VerifyMetaobjectsData {
               type
               handle
 
-              # Store heading (required by tests at line 123)
+              # Store heading (required by "renders store grid" and "renders store profile details")
               heading: field(key: "heading") {
                 value
               }
 
-              # Store address (required by tests at line 126, 229)
+              # Store address (required by "renders store grid" and "renders store profile details")
               address: field(key: "address") {
                 value
               }

--- a/packages/cli/src/commands/hydrogen/upgrade-e2e.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade-e2e.test.ts
@@ -72,7 +72,9 @@ vi.mock('../../lib/shell.js', () => ({getCliCommand: vi.fn(() => 'h2')}));
 
 const commitCache = new Map<string, string | null>();
 const DEFAULT_LOOKBACK_PERIOD_IN_DAYS = 365;
-// Cap git log lookback to avoid scanning the entire commit history
+// Cap git log lookback to avoid scanning the entire commit history.
+// 200 comfortably exceeds the total Hydrogen release count, so this
+// captures every release without an unbounded scan.
 const MAX_RELEASE_LOOKBACK_COUNT = 200;
 
 beforeEach(() => {

--- a/packages/cli/src/commands/hydrogen/upgrade-e2e.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade-e2e.test.ts
@@ -72,6 +72,8 @@ vi.mock('../../lib/shell.js', () => ({getCliCommand: vi.fn(() => 'h2')}));
 
 const commitCache = new Map<string, string | null>();
 const DEFAULT_LOOKBACK_PERIOD_IN_DAYS = 365;
+// Cap git log lookback to avoid scanning the entire commit history
+const MAX_RELEASE_LOOKBACK_COUNT = 200;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -689,7 +691,11 @@ async function findCommitByPackageJsonHistory(
       ['log', '--format=%H', '--all', '--', 'templates/skeleton/package.json'],
       {cwd: repoRoot},
     );
-    allCommits = stdout.trim().split('\n').filter(Boolean).slice(0, 200);
+    allCommits = stdout
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .slice(0, MAX_RELEASE_LOOKBACK_COUNT);
   } catch {
     /* git unavailable or unexpected failure */
     return null;

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -631,8 +631,8 @@ export function getCumulativeRelease({
   const removedDepsAt = new Map<string, number>();
   const removedDevDepsAt = new Map<string, number>();
 
-  // Last-write-wins: If a dep is removed in multiple releases, the map stores the *last* removal index.
-  // This ensures that a re-addition between two removal occurrences won't suppress the later removal.
+  // Last-write-wins: the map stores the index of the final removal for each dep.
+  // A re-addition only suppresses a removal if it occurs at or after that final removal index.
   releasesByVersion.forEach((release, i) => {
     release.removeDependencies?.forEach((dep) => {
       removedDepsAt.set(dep, i);
@@ -1003,8 +1003,7 @@ export async function upgradeNodeModules({
 }) {
   const tasks: Array<{title: string; task: () => Promise<void>}> = [];
 
-  // Cumulative removals cover intermediate releases (multi-version jumps).
-  // Defaults to the target release's own removals when not upgrading across multiple versions.
+  // Cumulative removals cover all intermediate releases when upgrading across multiple versions.
   const depsToRemove = [
     ...cumulativeRemoveDependencies,
     ...cumulativeRemoveDevDependencies,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/1112
Fixes https://github.com/Shopify/developer-tools-team/issues/1137
Fixes https://github.com/Shopify/developer-tools-team/issues/1117
Fixes https://github.com/Shopify/developer-tools-team/issues/1119

Comments, doc references, and a magic number in the upgrade command were misleading or stale, creating risk of confusion during future maintenance.

### WHAT is this pull request doing?

- **#1112**: Fix two misleading comments in `upgrade.ts` — one falsely claimed defaults for required params, the other mischaracterized last-write-wins semantics
- **#1137**: Extract `.slice(0, 200)` magic number into `MAX_RELEASE_LOOKBACK_COUNT` named constant
- **#1117**: Remove stale test name reference and hardcoded line numbers in metaobjects graphql/spec files
- **#1119**: Add missing failure mode to `KNOWN_FEATURED_COLLECTION` comment; rename test to match its actual assertions

### HOW to test your changes?

All changes are comment/doc/constant-name only — no behavioral changes.

- Verify `MAX_RELEASE_LOOKBACK_COUNT` is used at the `.slice()` call site
- Verify graphql comments reference test names that exist in metaobjects.spec.ts
- Verify renamed test name matches what the test body asserts

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation