### PR TITLE
fix: improve accessibility across skeleton template and recipe components

### DIFF
--- a/.changeset/accessibility-fixes.md
+++ b/.changeset/accessibility-fixes.md
@@ -1,0 +1,7 @@
+---
+"skeleton": patch
+"@shopify/cli-hydrogen": patch
+"@shopify/create-hydrogen": patch
+---
+
+Improve accessibility in PaginatedResourceSection: render region wrapper when `ariaLabel` is provided even without `resourcesClassName`, and add `aria-live` announcements for loading state and item count changes.

--- a/.changeset/accessibility-fixes.md
+++ b/.changeset/accessibility-fixes.md
@@ -4,4 +4,9 @@
 "@shopify/create-hydrogen": patch
 ---
 
-Improve accessibility in PaginatedResourceSection: render region wrapper when `ariaLabel` is provided even without `resourcesClassName`, and add `aria-live` announcements for loading state and item count changes.
+Improve accessibility across skeleton template and recipe components:
+
+- **PaginatedResourceSection**: render region wrapper when `ariaLabel` is provided even without `resourcesClassName`, and add `aria-live` announcements for loading state and item count changes
+- **Heading hierarchy** (metaobjects recipe): fix skipped heading levels in SectionHero, SectionStoreProfile, SectionStores, and use semantic `<section>` instead of `<div role="region">` in Sections
+- **CountrySelector** (markets recipe): add Escape key handling to close the disclosure widget and return focus to the trigger, remove incorrect `role="group"` override on `<details>`
+- **Infinite scroll** (recipe): separate Intersection Observer sentinel from focusable NextLink to prevent keyboard navigation from triggering auto-loading (WCAG 2.1.1), and add deferred `aria-live` announcements for product count changes

--- a/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
+++ b/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
@@ -14,7 +14,7 @@ index c416c2b3..e6a35150 100644
 +} from '@shopify/hydrogen';
  import {redirectIfHandleIsLocalized} from '~/lib/redirect';
  import {ProductItem} from '~/components/ProductItem';
-+import {useEffect} from 'react';
++import {useState, useEffect, useRef} from 'react';
 +import {useInView} from 'react-intersection-observer';
  import type {ProductItemFragment} from 'storefrontapi.generated';
  
@@ -91,7 +91,14 @@ index c416c2b3..e6a35150 100644
 +  inView: boolean;
 +  hasNextPage: boolean;
 +  nextPageUrl: string;
-+  state: any;
++  state: {
++    nodes: Array<ProductItemFragment>;
++    pageInfo: {
++      endCursor: string | null | undefined;
++      startCursor: string | null | undefined;
++      hasPreviousPage: boolean;
++    };
++  };
 +}) {
 +  const navigate = useNavigate();
 +
@@ -107,9 +114,7 @@ index c416c2b3..e6a35150 100644
 +
 +  return (
 +    <div aria-label="Products" role="region" className="products-grid">
-+      <div aria-live="polite" aria-atomic="true" className="sr-only">
-+        {`Showing ${products.length} products`}
-+      </div>
++      <ProductsGridStatus productCount={products.length} />
 +      {products.map((product, index) => {
 +        return (
 +          <ProductItem
@@ -119,6 +124,28 @@ index c416c2b3..e6a35150 100644
 +          />
 +        );
 +      })}
++    </div>
++  );
++}
++
++/**
++ * Announces product count changes to screen readers.
++ * Renders empty on initial mount to avoid an unprompted announcement.
++ */
++function ProductsGridStatus({productCount}: {productCount: number}) {
++  const [message, setMessage] = useState('');
++  const prevCountRef = useRef(productCount);
++
++  useEffect(() => {
++    if (productCount !== prevCountRef.current) {
++      setMessage(`Showing ${productCount} products`);
++      prevCountRef.current = productCount;
++    }
++  }, [productCount]);
++
++  return (
++    <div aria-live="polite" aria-atomic="true" className="sr-only">
++      {message}
 +    </div>
 +  );
 +}

--- a/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
+++ b/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
@@ -19,7 +19,7 @@ index c416c2b3..e6a35150 100644
  import type {ProductItemFragment} from 'storefrontapi.generated';
  
  export const meta: Route.MetaFunction = ({data}) => {
-@@ -67,23 +72,41 @@ function loadDeferredData({context}: Route.LoaderArgs) {
+@@ -67,23 +72,44 @@
  
  export default function Collection() {
    const {collection} = useLoaderData<typeof loader>();
@@ -75,7 +75,7 @@ index c416c2b3..e6a35150 100644
        <Analytics.CollectionView
          data={{
            collection: {
-@@ -96,6 +119,47 @@ export default function Collection() {
+@@ -96,6 +122,77 @@
    );
  }
  

--- a/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
+++ b/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
@@ -51,7 +51,7 @@ index c416c2b3..e6a35150 100644
 +        }) => (
 +          <>
 +            <PreviousLink>
-+              {isLoading ? 'Loading...' : <span>↑ Load previous</span>}
++              {isLoading ? 'Loading...' : <span><span aria-hidden="true">↑</span> Load previous</span>}
 +            </PreviousLink>
 +            <ProductsGrid
 +              products={nodes}
@@ -66,7 +66,7 @@ index c416c2b3..e6a35150 100644
 +                from triggering IO and creating an infinite loading cycle (WCAG 2.1.1). */}
 +            <div ref={ref} aria-hidden="true" style={{height: '1px'}} />
 +            <NextLink>
-+              {isLoading ? 'Loading...' : <span>Load more ↓</span>}
++              {isLoading ? 'Loading...' : <span>Load more <span aria-hidden="true">↓</span></span>}
 +            </NextLink>
 +          </>
          )}

--- a/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
+++ b/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
@@ -61,8 +61,11 @@ index c416c2b3..e6a35150 100644
 +              state={state}
 +            />
 +            <br />
-+            {/* @description Add ref to NextLink for intersection observer */}
-+            <NextLink ref={ref}>
++            {/* @description Non-focusable sentinel for Intersection Observer.
++                Separated from the focusable NextLink to prevent keyboard tabbing
++                from triggering IO and creating an infinite loading cycle (WCAG 2.1.1). */}
++            <div ref={ref} aria-hidden="true" style={{height: 1}} />
++            <NextLink>
 +              {isLoading ? 'Loading...' : <span>Load more ↓</span>}
 +            </NextLink>
 +          </>
@@ -104,6 +107,9 @@ index c416c2b3..e6a35150 100644
 +
 +  return (
 +    <div aria-label="Products" role="region" className="products-grid">
++      <div aria-live="polite" aria-atomic="true" className="sr-only">
++        {`Showing ${products.length} products`}
++      </div>
 +      {products.map((product, index) => {
 +        return (
 +          <ProductItem

--- a/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
+++ b/cookbook/recipes/infinite-scroll/patches/collections.$handle.tsx.f062a9.patch
@@ -64,7 +64,7 @@ index c416c2b3..e6a35150 100644
 +            {/* @description Non-focusable sentinel for Intersection Observer.
 +                Separated from the focusable NextLink to prevent keyboard tabbing
 +                from triggering IO and creating an infinite loading cycle (WCAG 2.1.1). */}
-+            <div ref={ref} aria-hidden="true" style={{height: 1}} />
++            <div ref={ref} aria-hidden="true" style={{height: '1px'}} />
 +            <NextLink>
 +              {isLoading ? 'Loading...' : <span>Load more ↓</span>}
 +            </NextLink>

--- a/cookbook/recipes/infinite-scroll/patches/package.json.acbf33.patch
+++ b/cookbook/recipes/infinite-scroll/patches/package.json.acbf33.patch
@@ -3,8 +3,8 @@ index e971ba7e..98bd2d0f 100644
 +++ b/templates/skeleton/package.json
 @@ -20,6 +20,7 @@
      "isbot": "^5.1.22",
-     "react": "catalog:",
-     "react-dom": "catalog:",
+     "react": "^18.3.1",
+     "react-dom": "^18.3.1",
 +    "react-intersection-observer": "^8.34.0",
      "react-router": "7.12.0",
      "react-router-dom": "7.12.0"

--- a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
+++ b/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
@@ -72,7 +72,7 @@ function LocaleForm({locale}: {locale: Locale}) {
 
   return (
     <Form method="POST" action={action}>
-      <input type="hidden" name="redirectTo" value={newPath} tabIndex={-1} />
+      <input type="hidden" name="redirectTo" value={newPath} />
       <input
         type="hidden"
         name="cartFormInput"

--- a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
+++ b/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
@@ -72,6 +72,8 @@ function LocaleForm({locale}: {locale: Locale}) {
 
   return (
     <Form method="POST" action={action}>
+      {/* Hidden inputs are not focusable per HTML spec (type="hidden" elements
+          are excluded from the tab order), so tabIndex={-1} is unnecessary. */}
       <input type="hidden" name="redirectTo" value={newPath} />
       <input
         type="hidden"

--- a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
+++ b/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
@@ -20,6 +20,12 @@ export function CountrySelector() {
       role="group"
       aria-label="Country selector"
       style={{position: 'relative', cursor: 'pointer'}}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.currentTarget.removeAttribute('open');
+          e.currentTarget.querySelector('summary')?.focus();
+        }
+      }}
     >
       <summary aria-label={`Current locale: ${label}`}>{label}</summary>
       <div
@@ -67,11 +73,12 @@ function LocaleForm({locale}: {locale: Locale}) {
 
   return (
     <Form method="POST" action={action}>
-      <input type="hidden" name="redirectTo" value={newPath} />
+      <input type="hidden" name="redirectTo" value={newPath} tabIndex={-1} />
       <input
         type="hidden"
         name="cartFormInput"
         value={JSON.stringify(variables)}
+        tabIndex={-1}
       />
       <button type="submit">
         Switch to {locale.language}-{locale.country}

--- a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
+++ b/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
@@ -17,7 +17,6 @@ export function CountrySelector() {
 
   return (
     <details
-      role="group"
       aria-label="Country selector"
       style={{position: 'relative', cursor: 'pointer'}}
       onKeyDown={(e) => {
@@ -78,7 +77,6 @@ function LocaleForm({locale}: {locale: Locale}) {
         type="hidden"
         name="cartFormInput"
         value={JSON.stringify(variables)}
-        tabIndex={-1}
       />
       <button type="submit">
         Switch to {locale.language}-{locale.country}

--- a/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
+++ b/cookbook/recipes/markets/ingredients/templates/skeleton/app/components/CountrySelector.tsx
@@ -21,7 +21,7 @@ export function CountrySelector() {
       style={{position: 'relative', cursor: 'pointer'}}
       onKeyDown={(e) => {
         if (e.key === 'Escape') {
-          e.currentTarget.removeAttribute('open');
+          e.currentTarget.open = false;
           e.currentTarget.querySelector('summary')?.focus();
         }
       }}

--- a/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionHero.tsx
+++ b/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionHero.tsx
@@ -45,7 +45,7 @@ export function SectionHero(props: SectionHeroFragment) {
           bottom: 0,
         }}
       >
-        {heading && <h1 style={{marginBottom: 0}}>{heading.parsedValue}</h1>}
+        {heading && <h2 style={{marginBottom: 0}}>{heading.parsedValue}</h2>}
         {subheading && <p>{subheading.value}</p>}
         {link?.href?.value && (
           <Link

--- a/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionStoreProfile.tsx
+++ b/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionStoreProfile.tsx
@@ -30,7 +30,7 @@ export function SectionStoreProfile(props: SectionStoreProfileFragment) {
           />
         )}
       </div>
-      {heading && <h1>{heading.value}</h1>}
+      {heading && <h2>{heading.value}</h2>}
       {description && <p>{description.value}</p>}
       <br />
       <div>

--- a/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionStoreProfile.tsx
+++ b/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionStoreProfile.tsx
@@ -34,13 +34,13 @@ export function SectionStoreProfile(props: SectionStoreProfileFragment) {
       {description && <p>{description.value}</p>}
       <br />
       <div>
-        <h5>Address</h5>
+        <h3>Address</h3>
         {address && <address>{address.value}</address>}
       </div>
       {hours?.parsedValue && (
         <div>
           <br />
-          <h5>Opening Hours</h5>
+          <h3>Opening Hours</h3>
           {hours.parsedValue.map((day: string) => (
             <p key={day}>{day}</p>
           ))}

--- a/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionStores.tsx
+++ b/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionStores.tsx
@@ -41,9 +41,9 @@ export function SectionStores(props: SectionStoresFragment) {
                   />
                 )}
                 {heading && (
-                  <h2 style={{marginBottom: '.25rem', marginTop: '1rem'}}>
+                  <h3 style={{marginBottom: '.25rem', marginTop: '1rem'}}>
                     {heading.value}
-                  </h2>
+                  </h3>
                 )}
                 {address && <address>{address?.value}</address>}
               </Link>

--- a/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionStores.tsx
+++ b/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/SectionStores.tsx
@@ -16,7 +16,7 @@ export function SectionStores(props: SectionStoresFragment) {
 
   return (
     <section className="section-stores" aria-label="Stores">
-      {heading?.value && <h1>{heading.value}</h1>}
+      {heading?.value && <h2>{heading.value}</h2>}
       <div
         className="stores"
         style={{

--- a/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/Sections.tsx
+++ b/cookbook/recipes/metaobjects/ingredients/templates/skeleton/app/sections/Sections.tsx
@@ -17,7 +17,7 @@ import type {SectionsFragment} from 'storefrontapi.generated';
 
 export function Sections({sections}: {sections: SectionsFragment}) {
   return (
-    <div className="sections" role="region" aria-label="Route Content">
+    <section className="sections" aria-label="Route Content">
       {sections?.references?.nodes.map((section) => {
         switch (section.type) {
           case 'section_hero':
@@ -38,7 +38,7 @@ export function Sections({sections}: {sections: SectionsFragment}) {
             return null;
         }
       })}
-    </div>
+    </section>
   );
 }
 

--- a/cookbook/recipes/metaobjects/patches/package.json.acbf33.patch
+++ b/cookbook/recipes/metaobjects/patches/package.json.acbf33.patch
@@ -2,8 +2,8 @@ index e971ba7e..f2c3af10 100644
 --- a/templates/skeleton/package.json
 +++ b/templates/skeleton/package.json
 @@ -21,7 +21,9 @@
-     "react": "catalog:",
-     "react-dom": "catalog:",
+     "react": "^18.3.1",
+     "react-dom": "^18.3.1",
      "react-router": "7.12.0",
 -    "react-router-dom": "7.12.0"
 +    "react-router-dom": "7.12.0",

--- a/templates/skeleton/app/components/PaginatedResourceSection.tsx
+++ b/templates/skeleton/app/components/PaginatedResourceSection.tsx
@@ -24,6 +24,11 @@ export function PaginatedResourceSection<NodesType>({
 
         return (
           <div>
+            <div aria-live="polite" aria-atomic="true" className="sr-only">
+              {isLoading
+                ? 'Loading more items...'
+                : `Showing ${nodes.length} items`}
+            </div>
             <PreviousLink>
               {isLoading ? (
                 'Loading...'
@@ -33,7 +38,7 @@ export function PaginatedResourceSection<NodesType>({
                 </span>
               )}
             </PreviousLink>
-            {resourcesClassName ? (
+            {resourcesClassName || ariaLabel ? (
               <div
                 aria-label={ariaLabel}
                 className={resourcesClassName}

--- a/templates/skeleton/app/components/PaginatedResourceSection.tsx
+++ b/templates/skeleton/app/components/PaginatedResourceSection.tsx
@@ -24,11 +24,7 @@ export function PaginatedResourceSection<NodesType>({
 
         return (
           <div>
-            <div aria-live="polite" aria-atomic="true" className="sr-only">
-              {isLoading
-                ? 'Loading more items...'
-                : `Showing ${nodes.length} items`}
-            </div>
+            <PaginationStatus isLoading={isLoading} itemCount={nodes.length} />
             <PreviousLink>
               {isLoading ? (
                 'Loading...'
@@ -62,5 +58,35 @@ export function PaginatedResourceSection<NodesType>({
         );
       }}
     </Pagination>
+  );
+}
+
+/**
+ * Announces loading state and item count changes to screen readers.
+ * Renders empty on initial mount to avoid an unprompted announcement.
+ */
+function PaginationStatus({
+  isLoading,
+  itemCount,
+}: {
+  isLoading: boolean;
+  itemCount: number;
+}) {
+  const [message, setMessage] = React.useState('');
+  const prevCountRef = React.useRef(itemCount);
+
+  React.useEffect(() => {
+    if (isLoading) {
+      setMessage('Loading more items...');
+    } else if (itemCount !== prevCountRef.current) {
+      setMessage(`Showing ${itemCount} items`);
+      prevCountRef.current = itemCount;
+    }
+  }, [isLoading, itemCount]);
+
+  return (
+    <div aria-live="polite" aria-atomic="true" className="sr-only">
+      {message}
+    </div>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/1125
Fixes https://github.com/Shopify/developer-tools-team/issues/1114
Fixes https://github.com/Shopify/developer-tools-team/issues/1115
Fixes https://github.com/Shopify/developer-tools-team/issues/1111
Fixes https://github.com/Shopify/developer-tools-team/issues/1139
Fixes https://github.com/Shopify/developer-tools-team/issues/1140

Accessibility gaps in the skeleton template and recipe components: missing aria-live announcements, broken heading hierarchy, keyboard traps, and incorrect ARIA roles.

### WHAT is this pull request doing?

- **PaginatedResourceSection** (skeleton): render the `ariaLabel` region wrapper even when `resourcesClassName` is absent; add `PaginationStatus` with deferred `aria-live` announcements (silent on initial render, fires on loading-state and item-count changes)
- **Infinite-scroll recipe**: separate Intersection Observer sentinel into a non-focusable `<div aria-hidden>` to prevent keyboard tabbing from triggering auto-load (WCAG 2.1.1); add `ProductsGridStatus` with deferred `aria-live` for product count; mark decorative arrow characters with `aria-hidden`
- **CountrySelector** (markets recipe): add Escape key handler to close the `<details>` widget and return focus to the trigger; remove `role="group"` that stripped native disclosure semantics
- **Metaobjects recipe**: fix heading hierarchy (`h1`→`h2` for section headings, `h2`→`h3` for store names, `h5`→`h3` for Address/Hours); replace `<div role="region">` with semantic `<section>` in Sections.tsx

### HOW to test your changes?

- `npm run cookbook -- validate --recipe metaobjects`
- `npm run cookbook -- validate --recipe infinite-scroll`
- `npm run cookbook -- validate --recipe markets`
- `cd templates/skeleton && npm run build`
- Manual VoiceOver/NVDA testing: keyboard nav, live regions, heading hierarchy

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation