### PR TITLE
test(cookbook): add unit tests for 6 recipes and extract shared test utility

### DIFF
--- a/cookbook/recipes/__test-utils__/index.ts
+++ b/cookbook/recipes/__test-utils__/index.ts
@@ -1,0 +1,21 @@
+import {readFile, readdir} from 'node:fs/promises';
+import {join} from 'node:path';
+
+/**
+ * Loads the content of a recipe patch file by prefix match.
+ * Patch filenames include a hash suffix (e.g. `vite.config.ts.abc123.patch`),
+ * so callers match by the stable prefix (e.g. `vite.config.ts`).
+ */
+export async function loadRecipePatch(
+  recipeDir: string,
+  filePrefix: string,
+): Promise<string> {
+  const files = await readdir(join(recipeDir, 'patches'));
+  const match = files.find((f) => f.startsWith(filePrefix));
+  if (!match) {
+    throw new Error(
+      `Expected ${filePrefix} patch file in patches/. Found: [${files.join(', ')}]`,
+    );
+  }
+  return readFile(join(recipeDir, 'patches', match), 'utf8');
+}

--- a/cookbook/recipes/combined-listings/__tests__/combined-listings.test.ts
+++ b/cookbook/recipes/combined-listings/__tests__/combined-listings.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from 'vitest';
+import {
+  isCombinedListing,
+  combinedListingsSettings,
+  maybeFilterOutCombinedListingsQuery,
+} from '../ingredients/templates/skeleton/app/lib/combined-listings';
+
+describe('combined-listings recipe', () => {
+  describe('combinedListingsSettings', () => {
+    it('has expected default configuration', () => {
+      expect(combinedListingsSettings).toEqual({
+        redirectToFirstVariant: false,
+        combinedListingTag: 'combined',
+        hideCombinedListingsFromProductList: true,
+      });
+    });
+  });
+
+  describe('maybeFilterOutCombinedListingsQuery', () => {
+    it('produces a filter query that excludes the combined tag', () => {
+      expect(maybeFilterOutCombinedListingsQuery).toContain('NOT tag:');
+      expect(maybeFilterOutCombinedListingsQuery).toContain(
+        combinedListingsSettings.combinedListingTag,
+      );
+    });
+  });
+
+  describe('isCombinedListing', () => {
+    it('returns true for a product with the combined tag', () => {
+      const product = {tags: ['sale', 'combined', 'featured']};
+      expect(isCombinedListing(product)).toBe(true);
+    });
+
+    it('returns false for a product without the combined tag', () => {
+      const product = {tags: ['sale', 'featured']};
+      expect(isCombinedListing(product)).toBe(false);
+    });
+
+    it('returns false for a product with an empty tags array', () => {
+      const product = {tags: []};
+      expect(isCombinedListing(product)).toBe(false);
+    });
+
+    it('returns false for null input', () => {
+      expect(isCombinedListing(null)).toBe(false);
+    });
+
+    it('returns false for undefined input', () => {
+      expect(isCombinedListing(undefined)).toBe(false);
+    });
+
+    it('returns false for an object without tags', () => {
+      expect(isCombinedListing({title: 'Widget'})).toBe(false);
+    });
+
+    it('returns false for non-object input', () => {
+      expect(isCombinedListing('combined')).toBe(false);
+    });
+  });
+});

--- a/cookbook/recipes/express/__tests__/express.test.ts
+++ b/cookbook/recipes/express/__tests__/express.test.ts
@@ -76,6 +76,10 @@ describe('express recipe', () => {
     });
 
     it('AppSession implements required session methods', () => {
+      const classMatch = serverContent.match(/class AppSession[\s\S]*?^}/m);
+      expect(classMatch).not.toBeNull();
+      const classBody = classMatch![0];
+
       const requiredMethods = [
         'get(',
         'set(',
@@ -85,7 +89,7 @@ describe('express recipe', () => {
         'commit(',
       ];
       for (const method of requiredMethods) {
-        expect(serverContent).toContain(method);
+        expect(classBody).toContain(method);
       }
     });
   });

--- a/cookbook/recipes/express/__tests__/express.test.ts
+++ b/cookbook/recipes/express/__tests__/express.test.ts
@@ -20,7 +20,7 @@ describe('express recipe', () => {
     const match = patchFiles.find((f) => f.startsWith(prefix));
     if (!match) {
       throw new Error(
-        `Expected ${prefix} patch file to exist in patches directory`,
+        `Expected ${prefix} patch file to exist in patches directory. Found: [${patchFiles.join(', ')}]`,
       );
     }
     return match;
@@ -77,8 +77,10 @@ describe('express recipe', () => {
 
     it('AppSession implements required session methods', () => {
       const classMatch = serverContent.match(/class AppSession[\s\S]*?^}/m);
-      expect(classMatch).not.toBeNull();
-      const classBody = classMatch![0];
+      if (!classMatch) {
+        throw new Error('Expected AppSession class to be found in server.mjs');
+      }
+      const classBody = classMatch[0];
 
       const requiredMethods = [
         'get(',

--- a/cookbook/recipes/express/__tests__/express.test.ts
+++ b/cookbook/recipes/express/__tests__/express.test.ts
@@ -1,30 +1,19 @@
 import {describe, expect, it, beforeAll} from 'vitest';
-import {readFile, readdir} from 'node:fs/promises';
+import {readFile} from 'node:fs/promises';
 import {join} from 'node:path';
+import {loadRecipePatch} from '../../__test-utils__/index';
 
 const RECIPE_DIR = join(__dirname, '..');
 
 describe('express recipe', () => {
   let serverContent: string;
-  let patchFiles: string[];
 
   beforeAll(async () => {
     serverContent = await readFile(
       join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
       'utf8',
     );
-    patchFiles = await readdir(join(RECIPE_DIR, 'patches'));
   });
-
-  function findPatchFile(prefix: string): string {
-    const match = patchFiles.find((f) => f.startsWith(prefix));
-    if (!match) {
-      throw new Error(
-        `Expected ${prefix} patch file to exist in patches directory. Found: [${patchFiles.join(', ')}]`,
-      );
-    }
-    return match;
-  }
 
   describe('recipe structure', () => {
     it('has a valid recipe.yaml', async () => {
@@ -51,20 +40,12 @@ describe('express recipe', () => {
     });
 
     it('uses renderToPipeableStream for Node.js streaming', async () => {
-      const patchFile = findPatchFile('entry.server.tsx');
-      const content = await readFile(
-        join(RECIPE_DIR, 'patches', patchFile),
-        'utf8',
-      );
+      const content = await loadRecipePatch(RECIPE_DIR, 'entry.server.tsx');
       expect(content).toContain('renderToPipeableStream');
     });
 
-    it('removes oxygen plugin from vite config', async () => {
-      const patchFile = findPatchFile('vite.config.ts');
-      const content = await readFile(
-        join(RECIPE_DIR, 'patches', patchFile),
-        'utf8',
-      );
+    it('vite config patch references oxygen plugin', async () => {
+      const content = await loadRecipePatch(RECIPE_DIR, 'vite.config.ts');
       expect(content).toContain('oxygen');
     });
   });

--- a/cookbook/recipes/express/__tests__/express.test.ts
+++ b/cookbook/recipes/express/__tests__/express.test.ts
@@ -1,0 +1,116 @@
+import {describe, expect, it} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import {join} from 'node:path';
+
+const RECIPE_DIR = join(__dirname, '..');
+
+describe('express recipe', () => {
+  describe('recipe structure', () => {
+    it('has a valid recipe.yaml', async () => {
+      const content = await readFile(join(RECIPE_DIR, 'recipe.yaml'), 'utf8');
+      expect(content).toBeTruthy();
+      expect(content).toContain('title:');
+      expect(content).toContain('express');
+    });
+
+    it('includes server.mjs ingredient', async () => {
+      const content = await readFile(
+        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
+        'utf8',
+      );
+      expect(content).toBeTruthy();
+    });
+  });
+
+  describe('server configuration', () => {
+    it('creates an Express app with required middleware', async () => {
+      const content = await readFile(
+        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
+        'utf8',
+      );
+
+      // Core Express setup
+      expect(content).toContain('express()');
+      expect(content).toContain('app.listen');
+
+      // Uses express.static for serving built assets
+      expect(content).toContain('express.static');
+    });
+
+    it('handles port-in-use error with fallback', async () => {
+      const content = await readFile(
+        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
+        'utf8',
+      );
+
+      expect(content).toContain('EADDRINUSE');
+    });
+
+    it('uses renderToPipeableStream for Node.js streaming', async () => {
+      const patchFiles = await import('node:fs/promises').then((fs) =>
+        fs.readdir(join(RECIPE_DIR, 'patches')),
+      );
+      const entryServerPatch = patchFiles.find((f) =>
+        f.startsWith('entry.server.tsx'),
+      );
+      expect(entryServerPatch).toBeDefined();
+
+      const content = await readFile(
+        join(RECIPE_DIR, 'patches', entryServerPatch!),
+        'utf8',
+      );
+
+      expect(content).toContain('renderToPipeableStream');
+    });
+
+    it('removes oxygen plugin from vite config', async () => {
+      const patchFiles = await import('node:fs/promises').then((fs) =>
+        fs.readdir(join(RECIPE_DIR, 'patches')),
+      );
+      const viteConfigPatch = patchFiles.find((f) =>
+        f.startsWith('vite.config.ts'),
+      );
+      expect(viteConfigPatch).toBeDefined();
+
+      const content = await readFile(
+        join(RECIPE_DIR, 'patches', viteConfigPatch!),
+        'utf8',
+      );
+
+      // The patch should remove the oxygen plugin import
+      expect(content).toContain('-');
+      expect(content).toContain('oxygen');
+    });
+  });
+
+  describe('session management', () => {
+    it('includes AppSession class with cookie session storage', async () => {
+      const content = await readFile(
+        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
+        'utf8',
+      );
+
+      expect(content).toContain('AppSession');
+      expect(content).toContain('createCookieSessionStorage');
+    });
+
+    it('AppSession implements required session methods', async () => {
+      const content = await readFile(
+        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
+        'utf8',
+      );
+
+      const requiredMethods = [
+        'get',
+        'set',
+        'destroy',
+        'flash',
+        'unset',
+        'commit',
+      ];
+      for (const method of requiredMethods) {
+        expect(content).toContain(method);
+      }
+    });
+  });
+});

--- a/cookbook/recipes/express/__tests__/express.test.ts
+++ b/cookbook/recipes/express/__tests__/express.test.ts
@@ -1,10 +1,31 @@
-import {describe, expect, it} from 'vitest';
-import {readFile} from 'node:fs/promises';
+import {describe, expect, it, beforeAll} from 'vitest';
+import {readFile, readdir} from 'node:fs/promises';
 import {join} from 'node:path';
 
 const RECIPE_DIR = join(__dirname, '..');
 
 describe('express recipe', () => {
+  let serverContent: string;
+  let patchFiles: string[];
+
+  beforeAll(async () => {
+    serverContent = await readFile(
+      join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
+      'utf8',
+    );
+    patchFiles = await readdir(join(RECIPE_DIR, 'patches'));
+  });
+
+  function findPatchFile(prefix: string): string {
+    const match = patchFiles.find((f) => f.startsWith(prefix));
+    if (!match) {
+      throw new Error(
+        `Expected ${prefix} patch file to exist in patches directory`,
+      );
+    }
+    return match;
+  }
+
   describe('recipe structure', () => {
     it('has a valid recipe.yaml', async () => {
       const content = await readFile(join(RECIPE_DIR, 'recipe.yaml'), 'utf8');
@@ -13,103 +34,58 @@ describe('express recipe', () => {
       expect(content).toContain('express');
     });
 
-    it('includes server.mjs ingredient', async () => {
-      const content = await readFile(
-        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
-        'utf8',
-      );
-      expect(content).toBeTruthy();
+    it('includes server.mjs ingredient', () => {
+      expect(serverContent).toBeTruthy();
     });
   });
 
   describe('server configuration', () => {
-    it('creates an Express app with required middleware', async () => {
-      const content = await readFile(
-        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
-        'utf8',
-      );
-
-      // Core Express setup
-      expect(content).toContain('express()');
-      expect(content).toContain('app.listen');
-
-      // Uses express.static for serving built assets
-      expect(content).toContain('express.static');
+    it('creates an Express app with static file serving', () => {
+      expect(serverContent).toContain('express()');
+      expect(serverContent).toContain('app.listen');
+      expect(serverContent).toContain('express.static');
     });
 
-    it('handles port-in-use error with fallback', async () => {
-      const content = await readFile(
-        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
-        'utf8',
-      );
-
-      expect(content).toContain('EADDRINUSE');
+    it('handles port-in-use error with fallback', () => {
+      expect(serverContent).toContain('EADDRINUSE');
     });
 
     it('uses renderToPipeableStream for Node.js streaming', async () => {
-      const patchFiles = await import('node:fs/promises').then((fs) =>
-        fs.readdir(join(RECIPE_DIR, 'patches')),
-      );
-      const entryServerPatch = patchFiles.find((f) =>
-        f.startsWith('entry.server.tsx'),
-      );
-      expect(entryServerPatch).toBeDefined();
-
+      const patchFile = findPatchFile('entry.server.tsx');
       const content = await readFile(
-        join(RECIPE_DIR, 'patches', entryServerPatch!),
+        join(RECIPE_DIR, 'patches', patchFile),
         'utf8',
       );
-
       expect(content).toContain('renderToPipeableStream');
     });
 
     it('removes oxygen plugin from vite config', async () => {
-      const patchFiles = await import('node:fs/promises').then((fs) =>
-        fs.readdir(join(RECIPE_DIR, 'patches')),
-      );
-      const viteConfigPatch = patchFiles.find((f) =>
-        f.startsWith('vite.config.ts'),
-      );
-      expect(viteConfigPatch).toBeDefined();
-
+      const patchFile = findPatchFile('vite.config.ts');
       const content = await readFile(
-        join(RECIPE_DIR, 'patches', viteConfigPatch!),
+        join(RECIPE_DIR, 'patches', patchFile),
         'utf8',
       );
-
-      // The patch should remove the oxygen plugin import
-      expect(content).toContain('-');
       expect(content).toContain('oxygen');
     });
   });
 
   describe('session management', () => {
-    it('includes AppSession class with cookie session storage', async () => {
-      const content = await readFile(
-        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
-        'utf8',
-      );
-
-      expect(content).toContain('AppSession');
-      expect(content).toContain('createCookieSessionStorage');
+    it('includes AppSession class with cookie session storage', () => {
+      expect(serverContent).toContain('AppSession');
+      expect(serverContent).toContain('createCookieSessionStorage');
     });
 
-    it('AppSession implements required session methods', async () => {
-      const content = await readFile(
-        join(RECIPE_DIR, 'ingredients/templates/skeleton/server.mjs'),
-        'utf8',
-      );
-
+    it('AppSession implements required session methods', () => {
       const requiredMethods = [
-        'get',
-        'set',
-        'destroy',
-        'flash',
-        'unset',
-        'commit',
+        'get(',
+        'set(',
+        'destroy(',
+        'flash(',
+        'unset(',
+        'commit(',
       ];
       for (const method of requiredMethods) {
-        expect(content).toContain(method);
+        expect(serverContent).toContain(method);
       }
     });
   });

--- a/cookbook/recipes/gtm/__tests__/gtm.test.ts
+++ b/cookbook/recipes/gtm/__tests__/gtm.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import {join} from 'node:path';
+
+const RECIPE_DIR = join(__dirname, '..');
+
+describe('gtm recipe', () => {
+  describe('recipe structure', () => {
+    it('has a valid recipe.yaml', async () => {
+      const content = await readFile(join(RECIPE_DIR, 'recipe.yaml'), 'utf8');
+      expect(content).toBeTruthy();
+      expect(content).toContain('title:');
+      expect(content).toContain('Google Tag Manager');
+    });
+
+    it('includes GoogleTagManager component ingredient', async () => {
+      const componentPath = join(
+        RECIPE_DIR,
+        'ingredients/templates/skeleton/app/components/GoogleTagManager.tsx',
+      );
+      const content = await readFile(componentPath, 'utf8');
+
+      expect(content).toContain('useAnalytics');
+      expect(content).toContain('dataLayer');
+    });
+  });
+
+  describe('CSP configuration', () => {
+    it('entry.server patch includes GTM domains in CSP directives', async () => {
+      const patchFiles = await import('node:fs/promises').then((fs) =>
+        fs.readdir(join(RECIPE_DIR, 'patches')),
+      );
+      const entryServerPatch = patchFiles.find((f) =>
+        f.startsWith('entry.server.tsx'),
+      );
+      expect(entryServerPatch).toBeDefined();
+
+      const patchContent = await readFile(
+        join(RECIPE_DIR, 'patches', entryServerPatch!),
+        'utf8',
+      );
+
+      // GTM requires these domains in CSP
+      expect(patchContent).toContain('googletagmanager.com');
+      expect(patchContent).toContain('google-analytics.com');
+    });
+  });
+
+  describe('GoogleTagManager component', () => {
+    it('pushes events to window.dataLayer', async () => {
+      const content = await readFile(
+        join(
+          RECIPE_DIR,
+          'ingredients/templates/skeleton/app/components/GoogleTagManager.tsx',
+        ),
+        'utf8',
+      );
+
+      expect(content).toContain('window.dataLayer');
+      expect(content).toContain('.push(');
+    });
+
+    it('uses useAnalytics hook for Hydrogen analytics integration', async () => {
+      const content = await readFile(
+        join(
+          RECIPE_DIR,
+          'ingredients/templates/skeleton/app/components/GoogleTagManager.tsx',
+        ),
+        'utf8',
+      );
+
+      expect(content).toContain('import {useAnalytics}');
+    });
+  });
+});

--- a/cookbook/recipes/gtm/__tests__/gtm.test.ts
+++ b/cookbook/recipes/gtm/__tests__/gtm.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it, beforeAll} from 'vitest';
-import {readFile, readdir} from 'node:fs/promises';
+import {readFile} from 'node:fs/promises';
 import {join} from 'node:path';
+import {loadRecipePatch} from '../../__test-utils__/index';
 
 const RECIPE_DIR = join(__dirname, '..');
 const COMPONENT_PATH = join(
@@ -10,22 +11,10 @@ const COMPONENT_PATH = join(
 
 describe('gtm recipe', () => {
   let componentContent: string;
-  let patchFiles: string[];
 
   beforeAll(async () => {
     componentContent = await readFile(COMPONENT_PATH, 'utf8');
-    patchFiles = await readdir(join(RECIPE_DIR, 'patches'));
   });
-
-  function findPatchFile(prefix: string): string {
-    const match = patchFiles.find((f) => f.startsWith(prefix));
-    if (!match) {
-      throw new Error(
-        `Expected ${prefix} patch file to exist in patches directory. Found: [${patchFiles.join(', ')}]`,
-      );
-    }
-    return match;
-  }
 
   describe('recipe structure', () => {
     it('has a valid recipe.yaml', async () => {
@@ -43,10 +32,9 @@ describe('gtm recipe', () => {
 
   describe('CSP configuration', () => {
     it('entry.server patch includes GTM domains in CSP directives', async () => {
-      const patchFile = findPatchFile('entry.server.tsx');
-      const patchContent = await readFile(
-        join(RECIPE_DIR, 'patches', patchFile),
-        'utf8',
+      const patchContent = await loadRecipePatch(
+        RECIPE_DIR,
+        'entry.server.tsx',
       );
 
       expect(patchContent).toContain('googletagmanager.com');

--- a/cookbook/recipes/gtm/__tests__/gtm.test.ts
+++ b/cookbook/recipes/gtm/__tests__/gtm.test.ts
@@ -21,7 +21,7 @@ describe('gtm recipe', () => {
     const match = patchFiles.find((f) => f.startsWith(prefix));
     if (!match) {
       throw new Error(
-        `Expected ${prefix} patch file to exist in patches directory`,
+        `Expected ${prefix} patch file to exist in patches directory. Found: [${patchFiles.join(', ')}]`,
       );
     }
     return match;

--- a/cookbook/recipes/gtm/__tests__/gtm.test.ts
+++ b/cookbook/recipes/gtm/__tests__/gtm.test.ts
@@ -1,10 +1,20 @@
-import {describe, expect, it} from 'vitest';
-import {readFile} from 'node:fs/promises';
+import {describe, expect, it, beforeAll} from 'vitest';
+import {readFile, readdir} from 'node:fs/promises';
 import {join} from 'node:path';
 
 const RECIPE_DIR = join(__dirname, '..');
+const COMPONENT_PATH = join(
+  RECIPE_DIR,
+  'ingredients/templates/skeleton/app/components/GoogleTagManager.tsx',
+);
 
 describe('gtm recipe', () => {
+  let componentContent: string;
+
+  beforeAll(async () => {
+    componentContent = await readFile(COMPONENT_PATH, 'utf8');
+  });
+
   describe('recipe structure', () => {
     it('has a valid recipe.yaml', async () => {
       const content = await readFile(join(RECIPE_DIR, 'recipe.yaml'), 'utf8');
@@ -13,63 +23,42 @@ describe('gtm recipe', () => {
       expect(content).toContain('Google Tag Manager');
     });
 
-    it('includes GoogleTagManager component ingredient', async () => {
-      const componentPath = join(
-        RECIPE_DIR,
-        'ingredients/templates/skeleton/app/components/GoogleTagManager.tsx',
-      );
-      const content = await readFile(componentPath, 'utf8');
-
-      expect(content).toContain('useAnalytics');
-      expect(content).toContain('dataLayer');
+    it('includes GoogleTagManager component ingredient', () => {
+      expect(componentContent).toContain('useAnalytics');
+      expect(componentContent).toContain('dataLayer');
     });
   });
 
   describe('CSP configuration', () => {
     it('entry.server patch includes GTM domains in CSP directives', async () => {
-      const patchFiles = await import('node:fs/promises').then((fs) =>
-        fs.readdir(join(RECIPE_DIR, 'patches')),
-      );
+      const patchFiles = await readdir(join(RECIPE_DIR, 'patches'));
       const entryServerPatch = patchFiles.find((f) =>
         f.startsWith('entry.server.tsx'),
       );
-      expect(entryServerPatch).toBeDefined();
+      if (!entryServerPatch) {
+        throw new Error(
+          'Expected entry.server.tsx patch file to exist in patches directory',
+        );
+      }
 
       const patchContent = await readFile(
-        join(RECIPE_DIR, 'patches', entryServerPatch!),
+        join(RECIPE_DIR, 'patches', entryServerPatch),
         'utf8',
       );
 
-      // GTM requires these domains in CSP
       expect(patchContent).toContain('googletagmanager.com');
       expect(patchContent).toContain('google-analytics.com');
     });
   });
 
   describe('GoogleTagManager component', () => {
-    it('pushes events to window.dataLayer', async () => {
-      const content = await readFile(
-        join(
-          RECIPE_DIR,
-          'ingredients/templates/skeleton/app/components/GoogleTagManager.tsx',
-        ),
-        'utf8',
-      );
-
-      expect(content).toContain('window.dataLayer');
-      expect(content).toContain('.push(');
+    it('pushes events to window.dataLayer', () => {
+      expect(componentContent).toContain('window.dataLayer');
+      expect(componentContent).toContain('.push(');
     });
 
-    it('uses useAnalytics hook for Hydrogen analytics integration', async () => {
-      const content = await readFile(
-        join(
-          RECIPE_DIR,
-          'ingredients/templates/skeleton/app/components/GoogleTagManager.tsx',
-        ),
-        'utf8',
-      );
-
-      expect(content).toContain('import {useAnalytics}');
+    it('uses useAnalytics hook for Hydrogen analytics integration', () => {
+      expect(componentContent).toContain('import {useAnalytics}');
     });
   });
 });

--- a/cookbook/recipes/gtm/__tests__/gtm.test.ts
+++ b/cookbook/recipes/gtm/__tests__/gtm.test.ts
@@ -10,10 +10,22 @@ const COMPONENT_PATH = join(
 
 describe('gtm recipe', () => {
   let componentContent: string;
+  let patchFiles: string[];
 
   beforeAll(async () => {
     componentContent = await readFile(COMPONENT_PATH, 'utf8');
+    patchFiles = await readdir(join(RECIPE_DIR, 'patches'));
   });
+
+  function findPatchFile(prefix: string): string {
+    const match = patchFiles.find((f) => f.startsWith(prefix));
+    if (!match) {
+      throw new Error(
+        `Expected ${prefix} patch file to exist in patches directory`,
+      );
+    }
+    return match;
+  }
 
   describe('recipe structure', () => {
     it('has a valid recipe.yaml', async () => {
@@ -31,18 +43,9 @@ describe('gtm recipe', () => {
 
   describe('CSP configuration', () => {
     it('entry.server patch includes GTM domains in CSP directives', async () => {
-      const patchFiles = await readdir(join(RECIPE_DIR, 'patches'));
-      const entryServerPatch = patchFiles.find((f) =>
-        f.startsWith('entry.server.tsx'),
-      );
-      if (!entryServerPatch) {
-        throw new Error(
-          'Expected entry.server.tsx patch file to exist in patches directory',
-        );
-      }
-
+      const patchFile = findPatchFile('entry.server.tsx');
       const patchContent = await readFile(
-        join(RECIPE_DIR, 'patches', entryServerPatch),
+        join(RECIPE_DIR, 'patches', patchFile),
         'utf8',
       );
 

--- a/cookbook/recipes/markets/__tests__/markets.test.ts
+++ b/cookbook/recipes/markets/__tests__/markets.test.ts
@@ -1,0 +1,173 @@
+import {describe, expect, it, vi} from 'vitest';
+
+// Mock react-router since its hooks aren't callable outside a router context.
+// The pure functions we're testing don't use hooks, but the module imports them.
+vi.mock('react-router', () => ({useMatches: vi.fn(), useLocation: vi.fn()}));
+
+import {
+  getLocaleFromRequest,
+  getPathWithoutLocale,
+  localeMatchesPrefix,
+  normalizePrefix,
+  findLocaleByPrefix,
+  cleanPath,
+  DEFAULT_LOCALE,
+  SUPPORTED_LOCALES,
+} from '../ingredients/templates/skeleton/app/lib/i18n';
+
+describe('markets recipe — i18n utilities', () => {
+  describe('DEFAULT_LOCALE', () => {
+    it('defaults to US English with root prefix', () => {
+      expect(DEFAULT_LOCALE).toEqual({
+        language: 'EN',
+        country: 'US',
+        pathPrefix: '/',
+      });
+    });
+  });
+
+  describe('SUPPORTED_LOCALES', () => {
+    it('includes at least the default locale and one non-default', () => {
+      expect(SUPPORTED_LOCALES.length).toBeGreaterThan(1);
+      expect(SUPPORTED_LOCALES).toContainEqual(DEFAULT_LOCALE);
+    });
+  });
+
+  describe('getLocaleFromRequest', () => {
+    it('returns DEFAULT_LOCALE for a root URL', () => {
+      const request = new Request('http://localhost/');
+      expect(getLocaleFromRequest(request)).toEqual(DEFAULT_LOCALE);
+    });
+
+    it('returns DEFAULT_LOCALE for a non-locale path', () => {
+      const request = new Request('http://localhost/products/widget');
+      expect(getLocaleFromRequest(request)).toEqual(DEFAULT_LOCALE);
+    });
+
+    it('parses a locale prefix from the URL', () => {
+      const request = new Request('http://localhost/FR-CA/products');
+      expect(getLocaleFromRequest(request)).toEqual({
+        language: 'FR',
+        country: 'CA',
+        pathPrefix: '/FR-CA',
+      });
+    });
+
+    it('is case-insensitive — normalizes to uppercase', () => {
+      const request = new Request('http://localhost/fr-ca/products');
+      expect(getLocaleFromRequest(request)).toEqual({
+        language: 'FR',
+        country: 'CA',
+        pathPrefix: '/FR-CA',
+      });
+    });
+
+    it('strips .data suffix before parsing locale', () => {
+      const request = new Request('http://localhost/EN-CA.data/products');
+      const locale = getLocaleFromRequest(request);
+      expect(locale.pathPrefix).toBe('/EN-CA');
+    });
+  });
+
+  describe('getPathWithoutLocale', () => {
+    it('strips the locale prefix from a path', () => {
+      const locale = {
+        language: 'FR' as const,
+        country: 'CA' as const,
+        pathPrefix: '/FR-CA',
+      };
+      expect(getPathWithoutLocale('/FR-CA/products', locale)).toBe('/products');
+    });
+
+    it('returns the original path when locale is null', () => {
+      expect(getPathWithoutLocale('/products', null)).toBe('/products');
+    });
+
+    it('returns root when only the locale prefix is present', () => {
+      const locale = {
+        language: 'FR' as const,
+        country: 'CA' as const,
+        pathPrefix: '/FR-CA',
+      };
+      expect(getPathWithoutLocale('/FR-CA', locale)).toBe('/');
+    });
+
+    it('is case-insensitive', () => {
+      const locale = {
+        language: 'FR' as const,
+        country: 'CA' as const,
+        pathPrefix: '/FR-CA',
+      };
+      expect(getPathWithoutLocale('/fr-ca/about', locale)).toBe('/about');
+    });
+
+    it('returns path unchanged for DEFAULT_LOCALE (root prefix)', () => {
+      expect(getPathWithoutLocale('/products', DEFAULT_LOCALE)).toBe(
+        '/products',
+      );
+    });
+  });
+
+  describe('localeMatchesPrefix', () => {
+    it('returns true for a supported locale segment', () => {
+      expect(localeMatchesPrefix('EN-CA')).toBe(true);
+    });
+
+    it('returns false for an unsupported locale segment', () => {
+      expect(localeMatchesPrefix('XY-ZZ')).toBe(false);
+    });
+
+    it('returns true for null (matches default locale root prefix)', () => {
+      expect(localeMatchesPrefix(null)).toBe(true);
+    });
+  });
+
+  describe('normalizePrefix', () => {
+    it('strips trailing slashes', () => {
+      expect(normalizePrefix('/FR-CA/')).toBe('/FR-CA');
+    });
+
+    it('returns empty string for root prefix', () => {
+      expect(normalizePrefix('/')).toBe('');
+    });
+
+    it('preserves a prefix without trailing slash', () => {
+      expect(normalizePrefix('/EN-CA')).toBe('/EN-CA');
+    });
+  });
+
+  describe('findLocaleByPrefix', () => {
+    it('finds a locale by case-insensitive prefix', () => {
+      const locale = findLocaleByPrefix('/fr-ca/products');
+      expect(locale).toEqual(
+        expect.objectContaining({language: 'FR', country: 'CA'}),
+      );
+    });
+
+    it('returns null for the default locale prefix /', () => {
+      expect(findLocaleByPrefix('/products')).toBeNull();
+    });
+
+    it('returns null for an unknown prefix', () => {
+      expect(findLocaleByPrefix('/XY-ZZ/about')).toBeNull();
+    });
+  });
+
+  describe('cleanPath', () => {
+    it('strips a known locale prefix', () => {
+      expect(cleanPath('/FR-CA/products')).toBe('/products');
+    });
+
+    it('returns root when only a locale prefix is present', () => {
+      expect(cleanPath('/FR-CA')).toBe('/');
+    });
+
+    it('returns the path unchanged when no locale is present', () => {
+      expect(cleanPath('/products/widget')).toBe('/products/widget');
+    });
+
+    it('strips a language-only prefix that is not a valid locale', () => {
+      expect(cleanPath('/de/products')).toBe('/products');
+    });
+  });
+});

--- a/cookbook/recipes/partytown/__tests__/partytown.test.ts
+++ b/cookbook/recipes/partytown/__tests__/partytown.test.ts
@@ -1,0 +1,57 @@
+import {describe, expect, it} from 'vitest';
+import {maybeProxyRequest} from '../ingredients/templates/skeleton/app/utils/partytown/maybeProxyRequest';
+import {partytownAtomicHeaders} from '../ingredients/templates/skeleton/app/utils/partytown/partytownAtomicHeaders';
+
+describe('partytown recipe', () => {
+  describe('maybeProxyRequest', () => {
+    const location = {origin: 'https://my-store.com'} as Location;
+
+    it('proxies script requests through /reverse-proxy', () => {
+      const url = new URL('https://www.googletagmanager.com/gtm.js');
+      const result = maybeProxyRequest(url, location, 'script');
+
+      expect(result.origin).toBe('https://my-store.com');
+      expect(result.pathname).toBe('/reverse-proxy');
+      expect(result.searchParams.get('apiUrl')).toBe(
+        'https://www.googletagmanager.com/gtm.js',
+      );
+    });
+
+    it('returns the original URL for non-script types', () => {
+      const url = new URL('https://www.googletagmanager.com/image.png');
+      const result = maybeProxyRequest(url, location, 'image');
+
+      expect(result).toBe(url);
+    });
+
+    it('returns the original URL if already proxied', () => {
+      const url = new URL(
+        'https://my-store.com/reverse-proxy?apiUrl=https://example.com/script.js',
+      );
+      const result = maybeProxyRequest(url, location, 'script');
+
+      expect(result).toBe(url);
+    });
+
+    it('returns the original URL for non-proxy domains', () => {
+      // nonProxyDomains is currently empty, so all domains get proxied.
+      // This test documents the current behavior — if domains are added
+      // to nonProxyDomains, they should bypass the proxy.
+      const url = new URL('https://cdn.example.com/lib.js');
+      const result = maybeProxyRequest(url, location, 'script');
+
+      expect(result.pathname).toBe('/reverse-proxy');
+    });
+  });
+
+  describe('partytownAtomicHeaders', () => {
+    it('returns COOP and COEP headers for atomic mode', () => {
+      const headers = partytownAtomicHeaders();
+
+      expect(headers).toEqual({
+        'Cross-Origin-Embedder-Policy': 'credentialless',
+        'Cross-Origin-Opener-Policy': 'same-origin',
+      });
+    });
+  });
+});

--- a/cookbook/recipes/partytown/__tests__/partytown.test.ts
+++ b/cookbook/recipes/partytown/__tests__/partytown.test.ts
@@ -33,10 +33,9 @@ describe('partytown recipe', () => {
       expect(result).toBe(url);
     });
 
-    it('returns the original URL for non-proxy domains', () => {
+    it('proxies all domains when nonProxyDomains is empty', () => {
       // nonProxyDomains is currently empty, so all domains get proxied.
-      // This test documents the current behavior — if domains are added
-      // to nonProxyDomains, they should bypass the proxy.
+      // If domains are added to nonProxyDomains, they should bypass the proxy.
       const url = new URL('https://cdn.example.com/lib.js');
       const result = maybeProxyRequest(url, location, 'script');
 

--- a/cookbook/recipes/third-party-api/__tests__/third-party-api.test.ts
+++ b/cookbook/recipes/third-party-api/__tests__/third-party-api.test.ts
@@ -24,6 +24,9 @@ describe('third-party-api recipe', () => {
 
       const result = minifyQuery(query);
 
+      // Supplementary to the positive assertions below; the .toContain checks
+      // confirm the output still has the expected content, while this verifies
+      // no comment markers survived minification.
       expect(result).not.toContain('#');
       expect(result).toContain('query Characters');
       expect(result).toContain('results { name }');
@@ -42,6 +45,8 @@ describe('third-party-api recipe', () => {
 
       const result = minifyQuery(query);
 
+      // Supplementary to the exact .toBe() match below, which is the
+      // primary guard against whitespace collapsing regressions.
       expect(result).not.toMatch(/\s{2,}/);
       expect(result).toBe(
         'query Characters { characters { results { name } } }',
@@ -81,8 +86,11 @@ describe('third-party-api recipe', () => {
   });
 
   describe('display name extraction', () => {
-    // The createRickAndMortyClient extracts display names via this regex
-    // on the minified query string. We test the combined behavior.
+    // This regex is intentionally duplicated from createRickAndMortyClient.server.ts
+    // (line ~47). Exporting it from the source would mean adding a public API surface
+    // just for testing. The duplication is acceptable because (a) the regex is simple
+    // and stable, and (b) these tests verify the combined minifyQuery + extraction
+    // behavior rather than the regex in isolation.
     const extractDisplayName = (query: string) =>
       query.match(/^(query|mutation)\s\w+/)?.[0];
 

--- a/cookbook/recipes/third-party-api/__tests__/third-party-api.test.ts
+++ b/cookbook/recipes/third-party-api/__tests__/third-party-api.test.ts
@@ -1,0 +1,107 @@
+import {describe, expect, it} from 'vitest';
+
+// minifyQuery is not exported, so we inline-test the same logic.
+// If it becomes exported in the future, import it directly.
+function minifyQuery<T extends string>(string: T) {
+  return string
+    .replace(/\s*#.*$/gm, '')
+    .replace(/\s+/gm, ' ')
+    .trim() as T;
+}
+
+describe('third-party-api recipe', () => {
+  describe('minifyQuery', () => {
+    it('removes GraphQL comments', () => {
+      const query = `
+        # This is a comment
+        query Characters {
+          characters { # inline comment
+            results {
+              name
+            }
+          }
+        }
+      `;
+
+      const result = minifyQuery(query);
+
+      expect(result).not.toContain('#');
+      expect(result).toContain('query Characters');
+      expect(result).toContain('results { name }');
+    });
+
+    it('collapses whitespace into single spaces', () => {
+      const query = `
+        query   Characters   {
+          characters    {
+            results   {
+              name
+            }
+          }
+        }
+      `;
+
+      const result = minifyQuery(query);
+
+      expect(result).not.toMatch(/\s{2,}/);
+      expect(result).toBe(
+        'query Characters { characters { results { name } } }',
+      );
+    });
+
+    it('trims leading and trailing whitespace', () => {
+      const result = minifyQuery('  query Foo { bar }  ');
+      expect(result).toBe('query Foo { bar }');
+    });
+
+    it('handles empty queries', () => {
+      const result = minifyQuery('');
+      expect(result).toBe('');
+    });
+
+    it('preserves query structure after minification', () => {
+      const query = `#graphql:rickAndMorty
+        query Characters($page: Int) {
+          characters(page: $page) {
+            results {
+              name
+              status
+              species
+              image
+            }
+          }
+        }
+      `;
+
+      const result = minifyQuery(query);
+
+      expect(result).toBe(
+        'query Characters($page: Int) { characters(page: $page) { results { name status species image } } }',
+      );
+    });
+  });
+
+  describe('display name extraction', () => {
+    // The createRickAndMortyClient extracts display names via regex:
+    // query.match(/^(query|mutation)\s\w+/)?.[0]
+    const extractDisplayName = (query: string) =>
+      query.match(/^(query|mutation)\s\w+/)?.[0];
+
+    it('extracts query display name', () => {
+      // In real usage, #graphql:rickAndMorty is on its own line followed by the query.
+      // After minification, the comment line is stripped and the query starts with 'query'.
+      const minified = minifyQuery(`#graphql:rickAndMorty
+        query Characters { characters { results { name } } }`);
+      expect(extractDisplayName(minified)).toBe('query Characters');
+    });
+
+    it('extracts mutation display name', () => {
+      const minified = 'mutation UpdateCharacter { updateCharacter { id } }';
+      expect(extractDisplayName(minified)).toBe('mutation UpdateCharacter');
+    });
+
+    it('returns undefined for non-operation strings', () => {
+      expect(extractDisplayName('{ characters { name } }')).toBeUndefined();
+    });
+  });
+});

--- a/cookbook/recipes/third-party-api/__tests__/third-party-api.test.ts
+++ b/cookbook/recipes/third-party-api/__tests__/third-party-api.test.ts
@@ -1,12 +1,17 @@
-import {describe, expect, it, vi} from 'vitest';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
 
 // Mock @shopify/hydrogen since it's not available in the cookbook test context
+const mockFetch = vi.fn();
 vi.mock('@shopify/hydrogen', () => ({
-  createWithCache: vi.fn(),
+  createWithCache: vi.fn(() => ({fetch: mockFetch})),
   CacheLong: vi.fn(),
 }));
 
-import {minifyQuery} from '../ingredients/templates/skeleton/app/lib/createRickAndMortyClient.server';
+import {
+  minifyQuery,
+  OPERATION_NAME_PATTERN,
+  createRickAndMortyClient,
+} from '../ingredients/templates/skeleton/app/lib/createRickAndMortyClient.server';
 
 describe('third-party-api recipe', () => {
   describe('minifyQuery', () => {
@@ -86,13 +91,8 @@ describe('third-party-api recipe', () => {
   });
 
   describe('display name extraction', () => {
-    // This regex is intentionally duplicated from createRickAndMortyClient.server.ts
-    // (line ~47). Exporting it from the source would mean adding a public API surface
-    // just for testing. The duplication is acceptable because (a) the regex is simple
-    // and stable, and (b) these tests verify the combined minifyQuery + extraction
-    // behavior rather than the regex in isolation.
     const extractDisplayName = (query: string) =>
-      query.match(/^(query|mutation)\s\w+/)?.[0];
+      query.match(OPERATION_NAME_PATTERN)?.[0];
 
     it('extracts query display name from minified query', () => {
       const minified = minifyQuery(`#graphql:rickAndMorty
@@ -107,6 +107,62 @@ describe('third-party-api recipe', () => {
 
     it('returns undefined for non-operation strings', () => {
       expect(extractDisplayName('{ characters { name } }')).toBeUndefined();
+    });
+  });
+
+  describe('createRickAndMortyClient', () => {
+    const TEST_QUERY =
+      `#graphql:rickAndMorty query Characters { characters { results { name } } }` as const;
+
+    function buildClient() {
+      return createRickAndMortyClient({
+        cache: {} as Cache,
+        waitUntil: vi.fn() as unknown as ExecutionContext['waitUntil'],
+        request: new Request('http://localhost'),
+      });
+    }
+
+    beforeEach(() => {
+      mockFetch.mockReset();
+    });
+
+    it('returns data.data on a successful response', async () => {
+      const expected = {characters: {results: [{name: 'Rick'}]}};
+      mockFetch.mockResolvedValue({
+        data: {data: expected},
+        response: {ok: true},
+      });
+
+      const client = buildClient();
+      const result = await client.query(TEST_QUERY, {});
+
+      expect(result).toEqual(expected);
+    });
+
+    it('throws with data.error message when response contains an error', async () => {
+      mockFetch.mockResolvedValue({
+        data: {error: 'Rate limit exceeded'},
+        response: {ok: true},
+      });
+
+      const client = buildClient();
+
+      await expect(client.query(TEST_QUERY, {})).rejects.toThrow(
+        'Rate limit exceeded',
+      );
+    });
+
+    it('throws with statusText when response is not ok', async () => {
+      mockFetch.mockResolvedValue({
+        data: null,
+        response: {ok: false, statusText: 'Service Unavailable'},
+      });
+
+      const client = buildClient();
+
+      await expect(client.query(TEST_QUERY, {})).rejects.toThrow(
+        'Error fetching from rick and morty api: Service Unavailable',
+      );
     });
   });
 });

--- a/cookbook/recipes/third-party-api/__tests__/third-party-api.test.ts
+++ b/cookbook/recipes/third-party-api/__tests__/third-party-api.test.ts
@@ -1,13 +1,12 @@
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
-// minifyQuery is not exported, so we inline-test the same logic.
-// If it becomes exported in the future, import it directly.
-function minifyQuery<T extends string>(string: T) {
-  return string
-    .replace(/\s*#.*$/gm, '')
-    .replace(/\s+/gm, ' ')
-    .trim() as T;
-}
+// Mock @shopify/hydrogen since it's not available in the cookbook test context
+vi.mock('@shopify/hydrogen', () => ({
+  createWithCache: vi.fn(),
+  CacheLong: vi.fn(),
+}));
+
+import {minifyQuery} from '../ingredients/templates/skeleton/app/lib/createRickAndMortyClient.server';
 
 describe('third-party-api recipe', () => {
   describe('minifyQuery', () => {
@@ -82,14 +81,12 @@ describe('third-party-api recipe', () => {
   });
 
   describe('display name extraction', () => {
-    // The createRickAndMortyClient extracts display names via regex:
-    // query.match(/^(query|mutation)\s\w+/)?.[0]
+    // The createRickAndMortyClient extracts display names via this regex
+    // on the minified query string. We test the combined behavior.
     const extractDisplayName = (query: string) =>
       query.match(/^(query|mutation)\s\w+/)?.[0];
 
-    it('extracts query display name', () => {
-      // In real usage, #graphql:rickAndMorty is on its own line followed by the query.
-      // After minification, the comment line is stripped and the query starts with 'query'.
+    it('extracts query display name from minified query', () => {
       const minified = minifyQuery(`#graphql:rickAndMorty
         query Characters { characters { results { name } } }`);
       expect(extractDisplayName(minified)).toBe('query Characters');

--- a/cookbook/recipes/third-party-api/ingredients/templates/skeleton/app/lib/createRickAndMortyClient.server.ts
+++ b/cookbook/recipes/third-party-api/ingredients/templates/skeleton/app/lib/createRickAndMortyClient.server.ts
@@ -4,6 +4,8 @@ import {
   type CachingStrategy,
 } from '@shopify/hydrogen';
 
+export const OPERATION_NAME_PATTERN = /^(query|mutation)\s\w+/;
+
 export function createRickAndMortyClient({
   cache,
   waitUntil,
@@ -38,7 +40,7 @@ export function createRickAndMortyClient({
           shouldCacheResponse: (body) => !body?.error,
           cacheKey: ['r&m', body],
           displayName:
-            'Rick & Morty - ' + query.match(/^(query|mutation)\s\w+/)?.[0],
+            'Rick & Morty - ' + query.match(OPERATION_NAME_PATTERN)?.[0],
         },
       );
 

--- a/cookbook/recipes/third-party-api/ingredients/templates/skeleton/app/lib/createRickAndMortyClient.server.ts
+++ b/cookbook/recipes/third-party-api/ingredients/templates/skeleton/app/lib/createRickAndMortyClient.server.ts
@@ -54,7 +54,7 @@ export function createRickAndMortyClient({
   };
 }
 
-function minifyQuery<T extends string>(string: T) {
+export function minifyQuery<T extends string>(string: T) {
   return string
     .replace(/\s*#.*$/gm, '') // Remove GQL comments
     .replace(/\s+/gm, ' ') // Minify spaces


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/1130
Fixes https://github.com/Shopify/developer-tools-team/issues/1131
Fixes https://github.com/Shopify/developer-tools-team/issues/1132
Fixes https://github.com/Shopify/developer-tools-team/issues/1133

Six cookbook recipes had no unit tests, meaning structural regressions (broken exports, missing config, invalid CSP domains) and behavioral regressions (broken query minification, incorrect locale parsing, wrong type guards) would only be caught by slower E2E tests or in production.

### WHAT is this pull request doing?

**Recipe tests (6 recipes, 63 tests across 7 files):**

- **Express**: validate server.mjs structure, Express setup, renderToPipeableStream, vite config, and AppSession class
- **GTM**: validate recipe structure, CSP domain configuration, GoogleTagManager dataLayer/useAnalytics integration
- **Partytown**: test `maybeProxyRequest` pure function (script proxying, non-script bypass, already-proxied bypass) and `partytownAtomicHeaders` (COOP/COEP headers)
- **Third-party-api**: test `minifyQuery`, display name extraction via `OPERATION_NAME_PATTERN`, and `createRickAndMortyClient` query method error handling (success, data.error, HTTP error)
- **Combined-listings**: test `isCombinedListing` type guard with all input types (valid product, missing tag, null, undefined, non-object), settings snapshot, and filter query generation
- **Markets**: test all 6 pure i18n utilities — `getLocaleFromRequest`, `getPathWithoutLocale`, `localeMatchesPrefix`, `normalizePrefix`, `findLocaleByPrefix`, `cleanPath` — plus exported constants

**Shared infrastructure:**

- Extract `loadRecipePatch` utility into `cookbook/recipes/__test-utils__/index.ts` to replace duplicated `findPatchFile` helpers
- Export `OPERATION_NAME_PATTERN` constant from `createRickAndMortyClient.server.ts` so the test imports the real regex instead of duplicating it

**Recipes not tested (and why):**

- b2b, bundles, subscriptions — React components + GraphQL fragments only
- legacy-customer-account-flow — route files only
- custom-cart-method, infinite-scroll — patches only, no ingredient source files
- metaobjects — `parseSection` depends on `@shopify/hydrogen`'s `parseMetafield`
- multipass — `multipassify.server.ts` needs `crypto-js`; `multipass.ts` needs fetch + browser env

### HOW to test your changes?

```bash
cd cookbook && npx vitest run recipes --pool forks
# 63 passed, 7 files
```

Full cookbook suite: `npx vitest run --pool forks` — 150 passed, 13 files

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation