### PR TITLE
fix(e2e): replace fragile collection name assertion with structural check

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -17,6 +17,27 @@
 ❌ `page.waitForResponse(...)` - Implementation detail
 ❌ `page.locator('.css-class')` - Fragile selectors
 ❌ Adding test IDs when accessibility markup would work
+❌ Hardcoding dynamic store data names (e.g., collection titles from `sortKey: UPDATED_AT` queries)
+
+### Dynamic Store Data
+
+When testing homepage sections that query dynamic store data (e.g., "most recently updated collection"),
+assert **structure** rather than specific names:
+
+```typescript
+// GOOD: Assert that a featured collection heading exists (any h1)
+const featuredCollectionHeading = page.getByRole('heading', {level: 1});
+await expect(featuredCollectionHeading).toBeVisible();
+
+// AVOID: Hardcoding a collection name that depends on store state
+const featuredCollectionHeading = page.getByRole('heading', {
+  level: 1,
+  name: 'Winter Collection', // ❌ Breaks when a different collection is most recently updated
+});
+```
+
+Only assert specific entity names when navigating to a known entity by **handle** (a stable identifier),
+e.g., `/products/${KNOWN_PRODUCT.handle}`.
 
 ## Test Isolation
 

--- a/e2e/specs/recipes/third-party-api.spec.ts
+++ b/e2e/specs/recipes/third-party-api.spec.ts
@@ -60,8 +60,6 @@ test.describe('Third-party API Recipe', () => {
   test('preserves existing homepage sections alongside third-party content', async ({
     page,
   }) => {
-    const featuredCollectionHeading = page.getByRole('heading', {level: 1});
-    await expect(featuredCollectionHeading).toBeVisible();
 
     const recommendedProductsSection = page.getByRole('region', {
       name: 'Recommended Products',

--- a/e2e/specs/recipes/third-party-api.spec.ts
+++ b/e2e/specs/recipes/third-party-api.spec.ts
@@ -19,12 +19,6 @@ setRecipeFixture({
 
 const RECIPE_HEADING_TEXT = 'Rick & Morty Characters (Third-Party API Example)';
 
-// The skeleton queries the most recently updated collection, which may change over time.
-// If this collection is removed or renamed in hydrogenPreviewStorefront, update this constant.
-const KNOWN_FEATURED_COLLECTION = {
-  title: 'Winter Collection',
-} as const;
-
 test.describe('Third-party API Recipe', () => {
   test.beforeEach(async ({page}) => {
     await page.goto('/');
@@ -66,10 +60,7 @@ test.describe('Third-party API Recipe', () => {
   test('preserves existing homepage sections alongside third-party content', async ({
     page,
   }) => {
-    const featuredCollectionHeading = page.getByRole('heading', {
-      level: 1,
-      name: KNOWN_FEATURED_COLLECTION.title,
-    });
+    const featuredCollectionHeading = page.getByRole('heading', {level: 1});
     await expect(featuredCollectionHeading).toBeVisible();
 
     const recommendedProductsSection = page.getByRole('region', {


### PR DESCRIPTION
### WHY are these changes introduced?

The `third-party-api.spec.ts` E2E test hardcodes `'Winter Collection'` as the expected featured collection title, but the skeleton homepage queries `collections(first: 1, sortKey: UPDATED_AT, reverse: true)` — the result changes whenever any collection is updated in the preview store. This caused the test to fail in CI when a different collection became the most recently updated.

### WHAT is this pull request doing?

- Removes the fragile `KNOWN_FEATURED_COLLECTION` constant and replaces the specific name assertion with a structural `getByRole('heading', {level: 1})` check. This matches the pattern already used by `home.spec.ts`, `b2b.spec.ts`, `metaobjects.spec.ts`, and `infinite-scroll.spec.ts`.
- Adds a "Dynamic Store Data" guideline to `e2e/CLAUDE.md` to prevent this anti-pattern in future tests: assert structure rather than specific names when testing dynamically-queried store data.

### HOW to test your changes?

```bash
npx playwright test --project=recipes e2e/specs/recipes/third-party-api.spec.ts
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)