### PR TITLE
chore: update changelog.json for 2026.1.3

### DIFF
--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -3,6 +3,192 @@
   "version": "1",
   "releases": [
     {
+      "title": "Accessibility improvements, CLI fixes, and dependency updates",
+      "version": "2026.1.3",
+      "date": "2026-03-27",
+      "hash": "fcfbcaa299f46788d2fbabf24d021b8a8dcaadae",
+      "commit": "https://github.com/Shopify/hydrogen/pull/3584/commits/fcfbcaa299f46788d2fbabf24d021b8a8dcaadae",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3584",
+      "dependencies": {
+        "@shopify/hydrogen": "2026.1.3"
+      },
+      "devDependencies": {},
+      "removeDependencies": [
+        "@shopify/hydrogen"
+      ],
+      "fixes": [
+        {
+          "title": "Improve screen reader experience in paginated product grids",
+          "info": "Hide decorative arrow characters from screen readers by adding aria-hidden attributes to improve accessibility for users of assistive technology.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3557",
+          "id": "3557"
+        },
+        {
+          "title": "Fix hydrogen dev --port 0 with --customer-account-push tunnel",
+          "info": "Resolved issue where using port 0 (OS-assigned) with --customer-account-push caused cloudflared to target the wrong origin. The port is now resolved upfront so both cloudflared and Vite bind to the same address.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3532",
+          "id": "3532"
+        },
+        {
+          "title": "Fix broken aria-label on territory code input in address form",
+          "info": "The territory code input was displaying the raw developer string 'territoryCode' instead of the human-readable label 'Country code'.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3607",
+          "id": "3607"
+        },
+        {
+          "title": "Fix h2 upgrade failing with yarn and pnpm",
+          "info": "The hydrogen upgrade command now uses the correct package-specific install subcommand: 'add' for yarn/pnpm and 'install' for npm/bun when upgrading dependencies.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3462",
+          "id": "3462"
+        },
+        {
+          "title": "Fix h2 upgrade to correctly handle dependency removals across versions",
+          "info": "When upgrading across multiple versions, dependencies removed in intermediate releases are now properly removed even when jumping versions.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3527",
+          "id": "3527"
+        },
+        {
+          "title": "Add aria-label to ProductPrice for improved screen reader accessibility",
+          "info": "The ProductPrice component now includes an aria-label to better describe price information to users of assistive technology.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3558",
+          "id": "3558"
+        },
+        {
+          "title": "Fix multi-version upgrades to accumulate intermediate dependency bumps",
+          "info": "When upgrading across multiple Hydrogen versions, dependency version bumps from intermediate releases are now properly accumulated. Also applies --legacy-peer-deps for npm to resolve ERESOLVE conflicts during upgrade.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3507",
+          "id": "3507"
+        },
+        {
+          "title": "Inline useMachine hook and remove @xstate/react dependency",
+          "info": "The useMachine hook from @xstate/react/fsm is now inlined directly in @shopify/hydrogen-react, eliminating the @xstate/react dependency which had no version supporting both React 19 and @xstate/fsm. This also removes transitive dependencies use-sync-external-store and use-isomorphic-layout-effect, and cleans up Vite config workarounds.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3594",
+          "id": "3594"
+        },
+        {
+          "title": "Remove engines field from @shopify/hydrogen-react",
+          "info": "Removed the engines field from package.json to avoid blocking installation on newer Node.js versions.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3596",
+          "id": "3596"
+        },
+        {
+          "title": "Security: Bump undici from 7.21.0 to 7.24.0",
+          "info": "Updated undici dependency to address known security vulnerabilities.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3581",
+          "id": "3581"
+        }
+      ],
+      "features": []
+    },
+    {
+      "title": "Accessibility, CLI, and template improvements",
+      "version": "2026.1.2",
+      "date": "2026-03-13",
+      "hash": "f3b9b4fef8ea1bc60544132051f97346f29c6b2d",
+      "commit": "https://github.com/Shopify/hydrogen/pull/3524/commits/f3b9b4fef8ea1bc60544132051f97346f29c6b2d",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3524",
+      "dependencies": {
+        "@shopify/hydrogen": "2026.1.2"
+      },
+      "devDependencies": {},
+      "removeDependencies": [
+        "@shopify/hydrogen"
+      ],
+      "fixes": [
+        {
+          "title": "Improve gift card accessibility in skeleton template",
+          "info": "Enhanced accessibility of gift card components in the default skeleton template for better screen reader support.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3518",
+          "id": "3518"
+        },
+        {
+          "title": "Improved local Customer Account OAuth errors",
+          "info": "In development, if you are not on a *.tryhydrogen.dev tunnel URL, Hydrogen now shows clear guidance to run shopify hydrogen dev --customer-account-push and continue from the tunnel URL.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3504",
+          "id": "3504"
+        },
+        {
+          "title": "Update robots.txt defaults in skeleton template",
+          "info": "Removed disallow rules specific to Shopify themes that are not part of a new Hydrogen app by default, reducing confusion when reviewing or customizing robots rules.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3526",
+          "id": "3526"
+        },
+        {
+          "title": "Fix --package-manager flag being ignored",
+          "info": "Projects now correctly use the specified package manager when --install-deps is explicitly passed.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3458",
+          "id": "3458"
+        },
+        {
+          "title": "Fix customer account auth status typing",
+          "info": "customerAccount.handleAuthStatus() is now correctly typed as async (Promise<void>) and callers must await it.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3523",
+          "id": "3523"
+        }
+      ],
+      "features": []
+    },
+    {
+      "title": "Security, vulnerability, and template improvements",
+      "version": "2026.1.1",
+      "date": "2026-02-26",
+      "hash": "6c966328355bde1301cdfe6117a088213e3a442f",
+      "commit": "https://github.com/Shopify/hydrogen/pull/3468/commits/6c966328355bde1301cdfe6117a088213e3a442f",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3468",
+      "dependencies": {
+        "@shopify/hydrogen": "2026.1.1"
+      },
+      "devDependencies": {},
+      "removeDependencies": [
+        "@shopify/hydrogen"
+      ],
+      "fixes": [
+        {
+          "title": "Update transitive dependencies for security",
+          "info": "Updated form-data and vite to resolve known vulnerabilities.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3461",
+          "id": "3461"
+        },
+        {
+          "title": "Update undici and body-parser for security",
+          "info": "Updated undici to 7.21.0 and body-parser to 1.20.4 to resolve known vulnerabilities.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3461",
+          "id": "3461"
+        },
+        {
+          "title": "Remove React Router v7 version check",
+          "info": "Removes confusing version check from the dev command that was not needed.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3499",
+          "id": "3499"
+        },
+        {
+          "title": "Fix address form when user has no addresses",
+          "info": "Fixed an issue where users without existing addresses could not add the first one.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3456",
+          "id": "3456"
+        },
+        {
+          "title": "Update Prettier from v2 to v3",
+          "info": "Updated the Prettier dependency to the latest major version.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3461",
+          "id": "3461"
+        },
+        {
+          "title": "Auto-generate routes in hydrogen init",
+          "info": "Route scaffolding now runs automatically during hydrogen init. The --routes flag and confirmation prompt have been removed since routes are always generated.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3448",
+          "id": "3448"
+        },
+        {
+          "title": "Add store linking notice in skeleton template",
+          "info": "Added a notice with relevant information on how to link a store in case there is no store linked yet.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3448",
+          "id": "3448"
+        }
+      ],
+      "features": []
+    },
+    {
       "title": "Storefront API 2026-01 and Customer Account API 2026-01",
       "version": "2026.1.0",
       "date": "2026-02-09",

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -3,11 +3,11 @@
   "version": "1",
   "releases": [
     {
-      "title": "Accessibility improvements, CLI fixes, and dependency updates",
+      "title": "CLI fixes and dependency updates",
       "version": "2026.1.3",
       "date": "2026-03-27",
       "hash": "fcfbcaa299f46788d2fbabf24d021b8a8dcaadae",
-      "commit": "https://github.com/Shopify/hydrogen/pull/3584/commits/fcfbcaa299f46788d2fbabf24d021b8a8dcaadae",
+      "commit": "https://github.com/Shopify/hydrogen/commit/fcfbcaa299f46788d2fbabf24d021b8a8dcaadae",
       "pr": "https://github.com/Shopify/hydrogen/pull/3584",
       "dependencies": {
         "@shopify/hydrogen": "2026.1.3"
@@ -18,22 +18,10 @@
       ],
       "fixes": [
         {
-          "title": "Improve screen reader experience in paginated product grids",
-          "info": "Hide decorative arrow characters from screen readers by adding aria-hidden attributes to improve accessibility for users of assistive technology.",
-          "pr": "https://github.com/Shopify/hydrogen/pull/3557",
-          "id": "3557"
-        },
-        {
           "title": "Fix hydrogen dev --port 0 with --customer-account-push tunnel",
           "info": "Resolved issue where using port 0 (OS-assigned) with --customer-account-push caused cloudflared to target the wrong origin. The port is now resolved upfront so both cloudflared and Vite bind to the same address.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3532",
           "id": "3532"
-        },
-        {
-          "title": "Fix broken aria-label on territory code input in address form",
-          "info": "The territory code input was displaying the raw developer string 'territoryCode' instead of the human-readable label 'Country code'.",
-          "pr": "https://github.com/Shopify/hydrogen/pull/3607",
-          "id": "3607"
         },
         {
           "title": "Fix h2 upgrade failing with yarn and pnpm",
@@ -46,12 +34,6 @@
           "info": "When upgrading across multiple versions, dependencies removed in intermediate releases are now properly removed even when jumping versions.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3527",
           "id": "3527"
-        },
-        {
-          "title": "Add aria-label to ProductPrice for improved screen reader accessibility",
-          "info": "The ProductPrice component now includes an aria-label to better describe price information to users of assistive technology.",
-          "pr": "https://github.com/Shopify/hydrogen/pull/3558",
-          "id": "3558"
         },
         {
           "title": "Fix multi-version upgrades to accumulate intermediate dependency bumps",

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -67,7 +67,7 @@
       "version": "2026.1.2",
       "date": "2026-03-13",
       "hash": "f3b9b4fef8ea1bc60544132051f97346f29c6b2d",
-      "commit": "https://github.com/Shopify/hydrogen/pull/3524/commits/f3b9b4fef8ea1bc60544132051f97346f29c6b2d",
+      "commit": "https://github.com/Shopify/hydrogen/commit/f3b9b4fef8ea1bc60544132051f97346f29c6b2d",
       "pr": "https://github.com/Shopify/hydrogen/pull/3524",
       "dependencies": {
         "@shopify/hydrogen": "2026.1.2"
@@ -115,7 +115,7 @@
       "version": "2026.1.1",
       "date": "2026-02-26",
       "hash": "6c966328355bde1301cdfe6117a088213e3a442f",
-      "commit": "https://github.com/Shopify/hydrogen/pull/3468/commits/6c966328355bde1301cdfe6117a088213e3a442f",
+      "commit": "https://github.com/Shopify/hydrogen/commit/6c966328355bde1301cdfe6117a088213e3a442f",
       "pr": "https://github.com/Shopify/hydrogen/pull/3468",
       "dependencies": {
         "@shopify/hydrogen": "2026.1.1"

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -63,7 +63,7 @@
       "features": []
     },
     {
-      "title": "Accessibility, CLI, and template improvements",
+      "title": "CLI and auth improvements",
       "version": "2026.1.2",
       "date": "2026-03-13",
       "hash": "f3b9b4fef8ea1bc60544132051f97346f29c6b2d",
@@ -78,22 +78,10 @@
       ],
       "fixes": [
         {
-          "title": "Improve gift card accessibility in skeleton template",
-          "info": "Enhanced accessibility of gift card components in the default skeleton template for better screen reader support.",
-          "pr": "https://github.com/Shopify/hydrogen/pull/3518",
-          "id": "3518"
-        },
-        {
           "title": "Improved local Customer Account OAuth errors",
           "info": "In development, if you are not on a *.tryhydrogen.dev tunnel URL, Hydrogen now shows clear guidance to run shopify hydrogen dev --customer-account-push and continue from the tunnel URL.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3504",
           "id": "3504"
-        },
-        {
-          "title": "Update robots.txt defaults in skeleton template",
-          "info": "Removed disallow rules specific to Shopify themes that are not part of a new Hydrogen app by default, reducing confusion when reviewing or customizing robots rules.",
-          "pr": "https://github.com/Shopify/hydrogen/pull/3526",
-          "id": "3526"
         },
         {
           "title": "Fix --package-manager flag being ignored",
@@ -111,7 +99,7 @@
       "features": []
     },
     {
-      "title": "Security, vulnerability, and template improvements",
+      "title": "Security and dependency updates",
       "version": "2026.1.1",
       "date": "2026-02-26",
       "hash": "6c966328355bde1301cdfe6117a088213e3a442f",
@@ -158,12 +146,6 @@
         {
           "title": "Auto-generate routes in hydrogen init",
           "info": "Route scaffolding now runs automatically during hydrogen init. The --routes flag and confirmation prompt have been removed since routes are always generated.",
-          "pr": "https://github.com/Shopify/hydrogen/pull/3448",
-          "id": "3448"
-        },
-        {
-          "title": "Add store linking notice in skeleton template",
-          "info": "Added a notice with relevant information on how to link a store in case there is no store linked yet.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3448",
           "id": "3448"
         }


### PR DESCRIPTION
Updates changelog.json with the 2026.1.3 release entry, enabling the `h2 upgrade` command to detect and guide upgrades to this version.

**Release contains 10 fixes:**
- Accessibility improvements (screen reader fixes, aria-labels)
- CLI improvements (upgrade command fixes for yarn/pnpm)
- Dependency updates (undici security bump, @xstate/react removal)

This enables the upgrade CLI to discover the new version.