### PR TITLE
feat(hydrogen): add useCustomAuthDomain opt-out for tunnel domain check

### DIFF
--- a/.changeset/custom-auth-domain-opt-out.md
+++ b/.changeset/custom-auth-domain-opt-out.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add `useCustomAuthDomain` option to `createCustomerAccountClient` and `createHydrogenContext`. When set to `true`, the development tunnel domain check logs a warning instead of throwing, enabling use of custom HTTPS setups like ngrok or local HTTPS proxies for Customer Account API OAuth.

--- a/packages/hydrogen/src/createHydrogenContext.test.ts
+++ b/packages/hydrogen/src/createHydrogenContext.test.ts
@@ -226,6 +226,21 @@ describe('createHydrogenContext', () => {
         }),
       );
     });
+
+    it('passes useCustomAuthDomain to createCustomerAccountClient', async () => {
+      createHydrogenContext({
+        ...defaultOptions,
+        customerAccount: {
+          useCustomAuthDomain: true,
+        },
+      });
+
+      expect(vi.mocked(createCustomerAccountClient)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          useCustomAuthDomain: true,
+        }),
+      );
+    });
   });
 
   describe('cart client', () => {

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -76,6 +76,8 @@ export type HydrogenContextOptions<
     customAuthStatusHandler?: CustomerAccountOptions['customAuthStatusHandler'];
     /** Deprecated. `unstableB2b` is now stable. Please remove. */
     unstableB2b?: CustomerAccountOptions['unstableB2b'];
+    /** Set to true when using a custom HTTPS domain (e.g., ngrok, local proxy) instead of the default Hydrogen tunnel. */
+    useCustomAuthDomain?: CustomerAccountOptions['useCustomAuthDomain'];
   };
   /** Cart handler overwrite options. See documentation for createCartHandler for more information. */
   cart?: {
@@ -210,6 +212,7 @@ export function createHydrogenContext<
     customerApiVersion: customerAccountOptions?.apiVersion,
     authUrl: customerAccountOptions?.authUrl,
     customAuthStatusHandler: customerAccountOptions?.customAuthStatusHandler,
+    useCustomAuthDomain: customerAccountOptions?.useCustomAuthDomain,
 
     // locale - i18n.language is a union of StorefrontLanguageCode | CustomerLanguageCode
     // We cast here because createCustomerAccountClient expects CustomerLanguageCode specifically,
@@ -359,6 +362,8 @@ export type HydrogenContextOptionsForDocs<
     customAuthStatusHandler?: () => Response | NonNullable<unknown> | null;
     /** Deprecated. `unstableB2b` is now stable. Please remove. */
     unstableB2b?: boolean;
+    /** Set to true when using a custom HTTPS domain (e.g., ngrok, local proxy) instead of the default Hydrogen tunnel. */
+    useCustomAuthDomain?: boolean;
   };
   /** Cart handler overwrite options. See documentation for createCartHandler for more information. */
   cart?: {

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -952,6 +952,30 @@ describe('customer', () => {
             CUSTOMER_ACCOUNT_SESSION_KEY,
           );
         });
+
+        it('Warns with useCustomAuthDomain when calling logout in development', async () => {
+          const warnSpy = vi
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
+          process.env.NODE_ENV = 'development';
+
+          const customer = createCustomerAccountClient({
+            session,
+            customerAccountId: 'customerAccountId',
+            shopId: '1',
+            request: new Request('https://logout-test.ngrok.io'),
+            waitUntil: vi.fn(),
+            useCustomAuthDomain: true,
+          });
+
+          const response = await customer.logout();
+
+          expect(response.status).toBe(302);
+          expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('redirect_uri'),
+          );
+          warnSpy.mockRestore();
+        });
       });
 
       it('Saved redirectPath to session by default if `return_to` param was found', async () => {
@@ -1299,6 +1323,28 @@ describe('customer', () => {
             refreshToken: 'shcrt_refresh_token',
           }),
         );
+      });
+
+      it('Warns with useCustomAuthDomain when calling authorize in development', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.NODE_ENV = 'development';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://authorize-test.ngrok.io'),
+          waitUntil: vi.fn(),
+          useCustomAuthDomain: true,
+        });
+
+        // authorize() will warn via checkTunnelDomain, then throw because
+        // no code or state params are present — that's expected.
+        await expect(customer.authorize()).rejects.toThrow();
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('redirect_uri'),
+        );
+        warnSpy.mockRestore();
       });
     });
   });
@@ -1681,6 +1727,37 @@ describe('customer', () => {
       } catch {
         expect(customAuthStatusHandler).toHaveBeenCalledOnce();
       }
+    });
+  });
+
+  describe('mutate', () => {
+    it('Warns with useCustomAuthDomain when calling mutate in development', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.NODE_ENV = 'development';
+
+      const customer = createCustomerAccountClient({
+        session,
+        customerAccountId: 'customerAccountId',
+        shopId: '1',
+        request: new Request('https://mutate-test.ngrok.io'),
+        waitUntil: vi.fn(),
+        useCustomAuthDomain: true,
+      });
+
+      (session.get as any).mockImplementation(() => ({
+        ...mockCustomerAccountSession,
+        expiresAt: new Date().getTime() + 10000 + '',
+      }));
+
+      const someJson = {data: 'json'};
+      fetch.mockResolvedValue(createFetchResponse(someJson, {ok: true}));
+
+      const response = await customer.mutate(`mutation {...}`);
+      expect(response).toStrictEqual({data: 'json'});
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('redirect_uri'),
+      );
+      warnSpy.mockRestore();
     });
   });
 

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -170,6 +170,130 @@ describe('customer', () => {
         );
       });
 
+      it('Warns instead of throwing when useCustomAuthDomain is true in development', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.NODE_ENV = 'development';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://my-ngrok-tunnel.ngrok.io'),
+          waitUntil: vi.fn(),
+          useCustomAuthDomain: true,
+        });
+
+        const response = await customer.login();
+        const url = new URL(response.headers.get('location')!);
+
+        expect(response.status).toBe(302);
+        expect(url.origin).toBe('https://shopify.com');
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('redirect_uri'),
+        );
+
+        warnSpy.mockRestore();
+      });
+
+      it('Still throws 400 when useCustomAuthDomain is false in development', async () => {
+        expect.assertions(2);
+        process.env.NODE_ENV = 'development';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://my-custom-domain.example'),
+          waitUntil: vi.fn(),
+          useCustomAuthDomain: false,
+        });
+
+        try {
+          await customer.login();
+        } catch (error) {
+          const response = error as Response & {message?: string};
+          expect(response.status).toBe(400);
+          expect(response.message).toContain('.tryhydrogen.dev');
+        }
+      });
+
+      it('Still throws 400 when useCustomAuthDomain is omitted in development', async () => {
+        expect.assertions(2);
+        process.env.NODE_ENV = 'development';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://my-other-domain.example'),
+          waitUntil: vi.fn(),
+        });
+
+        try {
+          await customer.login();
+        } catch (error) {
+          const response = error as Response & {message?: string};
+          expect(response.status).toBe(400);
+          expect(response.message).toContain('.tryhydrogen.dev');
+        }
+      });
+
+      it('Allows query with useCustomAuthDomain in development', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.NODE_ENV = 'development';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://query-test.ngrok.io'),
+          waitUntil: vi.fn(),
+          useCustomAuthDomain: true,
+        });
+
+        (session.get as any).mockImplementation(() => ({
+          ...mockCustomerAccountSession,
+          expiresAt: new Date().getTime() + 10000 + '',
+        }));
+
+        const someJson = {data: 'json'};
+        fetch.mockResolvedValue(createFetchResponse(someJson, {ok: true}));
+
+        const response = await customer.query(`query {...}`);
+        expect(response).toStrictEqual({data: 'json'});
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('redirect_uri'),
+        );
+
+        warnSpy.mockRestore();
+      });
+
+      it('warnOnce fires exactly once across multiple method calls with useCustomAuthDomain', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.NODE_ENV = 'development';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://unique-warn-once-test.ngrok.io'),
+          waitUntil: vi.fn(),
+          useCustomAuthDomain: true,
+        });
+
+        await customer.login();
+        await customer.login();
+
+        const tunnelWarnings = warnSpy.mock.calls.filter(
+          (call) =>
+            typeof call[0] === 'string' &&
+            call[0].includes('unique-warn-once-test.ngrok.io'),
+        );
+        expect(tunnelWarnings).toHaveLength(1);
+
+        warnSpy.mockRestore();
+      });
+
       it('Redirects to the customer account api login url with authUrl as param', async () => {
         const origin = 'https://localhost';
         const authUrl = '/customer-account/auth';
@@ -1325,6 +1449,42 @@ describe('customer', () => {
         expect(response.message).toContain('--customer-account-push');
         expect(response.message).toContain('.tryhydrogen.dev');
       }
+    });
+
+    it('Warns instead of throwing when useCustomAuthDomain is true in development', async () => {
+      expect.assertions(3);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.NODE_ENV = 'development';
+
+      const customer = createCustomerAccountClient({
+        session,
+        customerAccountId: 'customerAccountId',
+        shopId: '1',
+        request: new Request(
+          'https://handle-auth-status-test.ngrok.io/account/orders',
+        ),
+        waitUntil: vi.fn(),
+        useCustomAuthDomain: true,
+      });
+
+      (session.get as any).mockReturnValueOnce(undefined);
+
+      try {
+        await customer.handleAuthStatus();
+      } catch (error) {
+        const response = error as Response;
+        // Should get a 302 redirect, NOT a 400 tunnel error
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe(
+          '/account/login?return_to=%2Faccount%2Forders',
+        );
+      }
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('redirect_uri'),
+      );
+
+      warnSpy.mockRestore();
     });
 
     it('throw redirect to login path and current path as param if logged out', async () => {

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -294,6 +294,26 @@ describe('customer', () => {
         warnSpy.mockRestore();
       });
 
+      it('Does not warn or throw in production even with useCustomAuthDomain', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.NODE_ENV = 'production';
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://my-ngrok-tunnel.ngrok.io'),
+          waitUntil: vi.fn(),
+          useCustomAuthDomain: true,
+        });
+
+        const response = await customer.login();
+
+        expect(response.status).toBe(302);
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+      });
+
       it('Redirects to the customer account api login url with authUrl as param', async () => {
         const origin = 'https://localhost';
         const authUrl = '/customer-account/auth';

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -54,40 +54,39 @@ import {LanguageCode} from '@shopify/hydrogen-react/customer-account-api-types';
 
 const HYDROGEN_TUNNEL_DOMAIN_SUFFIX = '.tryhydrogen.dev';
 
-function throwIfNotTunnelled(
+function checkTunnelDomain(
   hostname: string,
   useCustomAuthDomain?: boolean,
   redirectUri?: string,
 ) {
-  if (process.env.NODE_ENV === 'development') {
-    // Keep this suffix in sync with the domain used by --customer-account-push.
-    if (!hostname.endsWith(HYDROGEN_TUNNEL_DOMAIN_SUFFIX)) {
-      if (useCustomAuthDomain) {
-        const redirectHint = redirectUri ? ` (${redirectUri})` : '';
-        warnOnce(
-          `[h2:warn:customerAccount] You are using a custom domain (${hostname}) instead of a Hydrogen dev tunnel. ` +
-            `Make sure you have manually registered your redirect_uri${redirectHint} ` +
-            `in your Customer Account API settings in the Shopify admin. ` +
-            `See https://shopify.dev/docs/api/customer for details.`,
-        );
-        return;
-      }
+  if (process.env.NODE_ENV !== 'development') return;
+  // Keep this suffix in sync with the domain used by --customer-account-push.
+  if (hostname.endsWith(HYDROGEN_TUNNEL_DOMAIN_SUFFIX)) return;
 
-      throw new Response(
-        [
-          'Customer Account API OAuth requires a Hydrogen tunnel in local development.',
-          'Run the development server with the `--customer-account-push` flag,',
-          `then open the tunnel URL shown in your terminal (\`https://*${HYDROGEN_TUNNEL_DOMAIN_SUFFIX}\`) instead of localhost.`,
-        ].join('\n\n'),
-        {
-          status: 400,
-          headers: {
-            'Content-Type': 'text/plain; charset=utf-8',
-          },
-        },
-      );
-    }
+  if (useCustomAuthDomain) {
+    const redirectHint = redirectUri ? ` (${redirectUri})` : '';
+    warnOnce(
+      `[h2:warn:customerAccount] You are using a custom domain (${hostname}) instead of a Hydrogen dev tunnel. ` +
+        `Make sure you have manually registered your redirect_uri${redirectHint} ` +
+        `in your Customer Account API settings in the Shopify admin. ` +
+        `See https://shopify.dev/docs/api/customer for details.`,
+    );
+    return;
   }
+
+  throw new Response(
+    [
+      'Customer Account API OAuth requires a Hydrogen tunnel in local development.',
+      'Run the development server with the `--customer-account-push` flag,',
+      `then open the tunnel URL shown in your terminal (\`https://*${HYDROGEN_TUNNEL_DOMAIN_SUFFIX}\`) instead of localhost.`,
+    ].join('\n\n'),
+    {
+      status: 400,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+    },
+  );
 }
 
 function defaultAuthStatusHandler(
@@ -166,7 +165,7 @@ export function createCustomerAccountClient({
   });
 
   const ensureTunnel = (hostname: string) =>
-    throwIfNotTunnelled(hostname, useCustomAuthDomain, redirectUri);
+    checkTunnelDomain(hostname, useCustomAuthDomain, redirectUri);
 
   const authStatusHandler = customAuthStatusHandler
     ? customAuthStatusHandler

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -54,10 +54,25 @@ import {LanguageCode} from '@shopify/hydrogen-react/customer-account-api-types';
 
 const HYDROGEN_TUNNEL_DOMAIN_SUFFIX = '.tryhydrogen.dev';
 
-function throwIfNotTunnelled(hostname: string) {
+function throwIfNotTunnelled(
+  hostname: string,
+  useCustomAuthDomain?: boolean,
+  redirectUri?: string,
+) {
   if (process.env.NODE_ENV === 'development') {
     // Keep this suffix in sync with the domain used by --customer-account-push.
     if (!hostname.endsWith(HYDROGEN_TUNNEL_DOMAIN_SUFFIX)) {
+      if (useCustomAuthDomain) {
+        const redirectHint = redirectUri ? ` (${redirectUri})` : '';
+        warnOnce(
+          `[h2:warn:customerAccount] You are using a custom domain (${hostname}) instead of a Hydrogen dev tunnel. ` +
+            `Make sure you have manually registered your redirect_uri${redirectHint} ` +
+            `in your Customer Account API settings in the Shopify admin. ` +
+            `See https://shopify.dev/docs/api/customer for details.`,
+        );
+        return;
+      }
+
       throw new Response(
         [
           'Customer Account API OAuth requires a Hydrogen tunnel in local development.',
@@ -81,8 +96,7 @@ function defaultAuthStatusHandler(
 ) {
   if (!request.url) return defaultLoginUrl;
 
-  const {hostname, pathname} = new URL(request.url);
-  throwIfNotTunnelled(hostname);
+  const {pathname} = new URL(request.url);
 
   /**
    * Remix (single-fetch) request objects have different url
@@ -120,6 +134,7 @@ export function createCustomerAccountClient({
   authorizePath = '/account/authorize',
   defaultRedirectPath = '/account',
   language,
+  useCustomAuthDomain,
 }: CustomerAccountOptions): CustomerAccount {
   if (customerApiVersion !== DEFAULT_CUSTOMER_API_VERSION) {
     console.warn(
@@ -139,10 +154,6 @@ export function createCustomerAccountClient({
     );
   }
 
-  const authStatusHandler = customAuthStatusHandler
-    ? customAuthStatusHandler
-    : () => defaultAuthStatusHandler(request, loginPath);
-
   const requestUrl = new URL(request.url);
   const httpsOrigin =
     requestUrl.protocol === 'http:'
@@ -153,6 +164,16 @@ export function createCustomerAccountClient({
     defaultUrl: authorizePath,
     redirectUrl: authUrl,
   });
+
+  const ensureTunnel = (hostname: string) =>
+    throwIfNotTunnelled(hostname, useCustomAuthDomain, redirectUri);
+
+  const authStatusHandler = customAuthStatusHandler
+    ? customAuthStatusHandler
+    : () => {
+        ensureTunnel(requestUrl.hostname);
+        return defaultAuthStatusHandler(request, loginPath);
+      };
 
   const getCustomerAccountUrl = createCustomerAccountHelper(
     customerApiVersion,
@@ -318,7 +339,7 @@ export function createCustomerAccountClient({
     mutation: Parameters<CustomerAccount['mutate']>[0],
     options?: Parameters<CustomerAccount['mutate']>[1],
   ) {
-    throwIfNotTunnelled(requestUrl.hostname);
+    ensureTunnel(requestUrl.hostname);
     ifInvalidCredentialThrowError();
 
     mutation = minifyQuery(mutation);
@@ -334,7 +355,7 @@ export function createCustomerAccountClient({
     query: Parameters<CustomerAccount['query']>[0],
     options?: Parameters<CustomerAccount['query']>[1],
   ) {
-    throwIfNotTunnelled(requestUrl.hostname);
+    ensureTunnel(requestUrl.hostname);
     ifInvalidCredentialThrowError();
 
     query = minifyQuery(query);
@@ -366,7 +387,7 @@ export function createCustomerAccountClient({
   return {
     i18n: {language: language ?? ('EN' as LanguageCode)},
     login: async (options?: LoginOptions) => {
-      throwIfNotTunnelled(requestUrl.hostname);
+      ensureTunnel(requestUrl.hostname);
       ifInvalidCredentialThrowError();
 
       const loginUrl = new URL(getCustomerAccountUrl(URL_TYPE.AUTH));
@@ -435,7 +456,7 @@ export function createCustomerAccountClient({
     },
 
     logout: async (options?: LogoutOptions) => {
-      throwIfNotTunnelled(requestUrl.hostname);
+      ensureTunnel(requestUrl.hostname);
       ifInvalidCredentialThrowError();
 
       const idToken = session.get(CUSTOMER_ACCOUNT_SESSION_KEY)?.idToken;
@@ -482,7 +503,7 @@ export function createCustomerAccountClient({
     mutate: mutate as CustomerAccount['mutate'],
     query: query as CustomerAccount['query'],
     authorize: async () => {
-      throwIfNotTunnelled(requestUrl.hostname);
+      ensureTunnel(requestUrl.hostname);
       ifInvalidCredentialThrowError();
 
       const code = requestUrl.searchParams.get('code');

--- a/packages/hydrogen/src/customer/types.ts
+++ b/packages/hydrogen/src/customer/types.ts
@@ -173,6 +173,10 @@ export type CustomerAccountOptions = {
   unstableB2b?: boolean;
   /** Localization data. */
   language?: LanguageCode;
+  /** Set to true when using a custom HTTPS domain (e.g., ngrok, local proxy)
+   * instead of the default Hydrogen tunnel for local development.
+   * You must manually register your redirect_uri in Customer Account API settings. */
+  useCustomAuthDomain?: boolean;
 };
 
 /** Below are types meant for documentation only. Ensure it stay in sync with the type above. */


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3619
Alternative to #3592

Since #3504, the Customer Account API client throws a 400 error in development when the request origin isn't a `*.tryhydrogen.dev` tunnel domain. This is good DX for the common case — it catches misconfigured redirect URIs early. But it blocks legitimate HTTPS setups like ngrok static domains and local HTTPS proxies (see [Discussion #2976](https://github.com/Shopify/hydrogen/discussions/2976)).

#3592 attempted to fix this by loosening the check to just "HTTPS + not localhost", but that silently removes the DX protection that #3504 was specifically designed to provide — developers with custom HTTPS domains who forget to manually register their redirect_uri would hit a cryptic OAuth error.

### WHAT is this pull request doing?

Adds a `useCustomAuthDomain` boolean option to `createCustomerAccountClient` and `createHydrogenContext`. When set to `true`, the tunnel domain check logs a `warnOnce` with actionable guidance (including the exact redirect_uri to register) instead of throwing. Default behavior is unchanged.

Implementation uses a closure pattern (`ensureTunnel`) inside `createCustomerAccountClient` to bind the option and `redirectUri` once, avoiding pass-through parameters at all 6 call sites. The tunnel check was also extracted from `defaultAuthStatusHandler` into the `authStatusHandler` closure for consistent call-site ownership.

Usage:
```ts
createHydrogenContext({
  // ...
  customerAccount: {
    useCustomAuthDomain: true,
  },
});
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes