### PR TITLE
fix(upgrade): use npm pack for historical skeleton extraction in E2E test

### DIFF
--- a/packages/cli/src/commands/hydrogen/upgrade-e2e.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade-e2e.test.ts
@@ -19,7 +19,7 @@
  *   CI=1                          - Enable CI mode (set by tests)
  *
  * Key design decisions:
- *   - Scaffolds from git history (worktree + pnpm pack) instead of npm registry because
+ *   - Scaffolds from git history (worktree + npm pack) instead of npm registry because
  *     packages may not exist for older/unpublished versions, and git gives us exact state
  *   - Skips build validation when manual steps or breaking changes are present
  *     because developers must apply those steps before the project will build
@@ -29,15 +29,13 @@
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {execFile} from 'node:child_process';
-import {
-  access,
-  readFile,
-  rename,
-  writeFile,
-  mkdir,
-  readdir,
-} from 'node:fs/promises';
+import {readFile, rename, writeFile, mkdir, readdir} from 'node:fs/promises';
 import {join} from 'node:path';
+import {
+  parseCatalogFromWorkspaceYaml,
+  parseWorkspacePackagesFromYaml,
+  resolveWorkspaceProtocols,
+} from '../../lib/upgrade-e2e-utils.js';
 import {promisify} from 'node:util';
 import {exec} from '@shopify/cli-kit/node/system';
 import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs';
@@ -55,7 +53,7 @@ type ChangeLog = Awaited<ReturnType<typeof upgradeModule.getChangelog>>;
 // Subprocess timeouts prevent CI hangs when git or npm encounters corrupted
 // objects or unexpected state in historical commits.
 const GIT_TIMEOUT_IN_MS = 60_000;
-const PNPM_PACK_TIMEOUT_IN_MS = 120_000;
+const NPM_PACK_TIMEOUT_IN_MS = 120_000;
 
 // cli-kit re-exports AbortSignal from node-abort-controller (polyfill) whose
 // type is incompatible with Node's native AbortSignal. This helper bridges them.
@@ -928,6 +926,32 @@ async function resolveSkeletonCommit(
   return {commit, skeletonVersion};
 }
 
+/**
+ * Builds a map of workspace package name → version by reading package.json
+ * files at the paths listed in pnpm-workspace.yaml.
+ */
+async function buildWorkspaceVersionMap(
+  worktreeDir: string,
+  workspaceYamlContent: string,
+): Promise<Map<string, string>> {
+  const versionMap = new Map<string, string>();
+  const workspacePaths = parseWorkspacePackagesFromYaml(workspaceYamlContent);
+
+  for (const wsPath of workspacePaths) {
+    const pkgJsonPath = join(worktreeDir, wsPath, 'package.json');
+    try {
+      const pkg = JSON.parse(await readFile(pkgJsonPath, 'utf8'));
+      if (pkg.name && pkg.version) {
+        versionMap.set(pkg.name, pkg.version);
+      }
+    } catch {
+      // package.json may not exist at this path in historical commits
+    }
+  }
+
+  return versionMap;
+}
+
 async function extractSkeletonTemplate(
   tempDir: string,
   commit: string,
@@ -945,25 +969,34 @@ async function extractSkeletonTemplate(
 
   try {
     // Worktree gives filesystem access to the full monorepo at the historical
-    // commit so pnpm can read pnpm-workspace.yaml and resolve protocols.
+    // commit for reading workspace package versions and catalog config.
     await exec('git', ['worktree', 'add', worktreeDir, commit], {
       cwd: repoRoot,
       signal: timeoutSignal(GIT_TIMEOUT_IN_MS),
     });
     await mkdir(packOutputDir, {recursive: true});
 
-    // pnpm pack natively resolves workspace:* and catalog: protocols,
-    // matching the strategy in template-pack.ts (getPackedTemplatePackageJson).
-    await exec('pnpm', ['pack', '--pack-destination', packOutputDir], {
-      cwd: join(worktreeDir, 'templates', 'skeleton'),
-      signal: timeoutSignal(PNPM_PACK_TIMEOUT_IN_MS),
-    });
+    // npm pack is protocol-agnostic — it tars whatever is on disk without
+    // trying to resolve pnpm-specific protocols (workspace:*, catalog:).
+    // We resolve those manually after extraction via resolveWorkspaceProtocols.
+    // --ignore-scripts prevents the prepare hook from failing in historical commits.
+    await exec(
+      'npm',
+      [
+        'pack',
+        './templates/skeleton',
+        '--pack-destination',
+        packOutputDir,
+        '--ignore-scripts',
+      ],
+      {cwd: worktreeDir, signal: timeoutSignal(NPM_PACK_TIMEOUT_IN_MS)},
+    );
 
     const files = await readdir(packOutputDir);
     const tarball = files.find((f) => f.endsWith('.tgz'));
     if (!tarball) {
       throw new Error(
-        `pnpm pack did not generate a tarball in ${packOutputDir}`,
+        `npm pack did not generate a tarball in ${packOutputDir}`,
       );
     }
 
@@ -985,16 +1018,53 @@ async function extractSkeletonTemplate(
       {signal: timeoutSignal(GIT_TIMEOUT_IN_MS)},
     );
 
-    // pnpm pack tarballs extract to a "package/" subdirectory
+    // npm pack tarballs extract to a "package/" subdirectory
     const skeletonPath = join(extractDir, 'package');
+    const packageJsonPath = join(skeletonPath, 'package.json');
 
+    let packageJson: Record<string, unknown>;
     try {
-      await access(join(skeletonPath, 'package.json'));
+      packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
     } catch {
       throw new Error(
         `Skeleton template was not extracted successfully from commit ${commit} (version ${skeletonVersion}).\n` +
           `Expected path ${skeletonPath} does not exist or is missing package.json.\n` +
           `This might indicate templates/skeleton doesn't exist at that commit.`,
+      );
+    }
+
+    // Resolve pnpm-specific protocols (workspace:*, catalog:) that npm pack
+    // left as-is. Post-pnpm-migration commits (2026.1.1+) have these;
+    // pre-pnpm commits have plain version strings and skip this step.
+    const workspaceYamlPath = join(worktreeDir, 'pnpm-workspace.yaml');
+    let workspaceYaml: string | null = null;
+    try {
+      workspaceYaml = await readFile(workspaceYamlPath, 'utf8');
+    } catch {
+      // Pre-pnpm commits have no pnpm-workspace.yaml — no protocols to resolve
+    }
+
+    if (workspaceYaml) {
+      const catalogVersions = parseCatalogFromWorkspaceYaml(workspaceYaml);
+      const workspaceVersions = await buildWorkspaceVersionMap(
+        worktreeDir,
+        workspaceYaml,
+      );
+
+      const resolved = await resolveWorkspaceProtocols({
+        packageJson: packageJson as Parameters<
+          typeof resolveWorkspaceProtocols
+        >[0]['packageJson'],
+        catalogVersions,
+        resolveWorkspaceVersion: async (name) => {
+          return workspaceVersions.get(name) ?? null;
+        },
+        fallbackVersion: skeletonVersion,
+      });
+
+      await writeFile(
+        packageJsonPath,
+        JSON.stringify(resolved, null, 2) + '\n',
       );
     }
 

--- a/packages/cli/src/lib/upgrade-e2e-utils.test.ts
+++ b/packages/cli/src/lib/upgrade-e2e-utils.test.ts
@@ -1,0 +1,338 @@
+import {describe, expect, it, vi} from 'vitest';
+import {
+  parseCatalogFromWorkspaceYaml,
+  parseWorkspacePackagesFromYaml,
+  resolveWorkspaceProtocols,
+} from './upgrade-e2e-utils.js';
+
+describe('parseCatalogFromWorkspaceYaml', () => {
+  it('parses catalog entries with unquoted package names', () => {
+    const yaml = `packages:
+  - packages/*
+  - templates/skeleton
+
+catalog:
+  react: '^18.3.1'
+  react-dom: '^18.3.1'
+`;
+    expect(parseCatalogFromWorkspaceYaml(yaml)).toEqual({
+      react: '^18.3.1',
+      'react-dom': '^18.3.1',
+    });
+  });
+
+  it('parses catalog entries with quoted package names', () => {
+    const yaml = `packages:
+  - packages/*
+
+catalog:
+  '@types/react': '^18.3.28'
+  '@types/react-dom': '^18.3.7'
+  '@shopify/prettier-config': '^1.1.2'
+`;
+    expect(parseCatalogFromWorkspaceYaml(yaml)).toEqual({
+      '@types/react': '^18.3.28',
+      '@types/react-dom': '^18.3.7',
+      '@shopify/prettier-config': '^1.1.2',
+    });
+  });
+
+  it('handles catalog at end of file without trailing content', () => {
+    const yaml = `packages:
+  - packages/*
+
+overrides:
+  vite: '^6.2.1'
+
+catalog:
+  react: '^18.3.1'
+  react-dom: '^18.3.1'
+`;
+    expect(parseCatalogFromWorkspaceYaml(yaml)).toEqual({
+      react: '^18.3.1',
+      'react-dom': '^18.3.1',
+    });
+  });
+
+  it('handles catalog followed by another top-level key', () => {
+    const yaml = `catalog:
+  react: '^18.3.1'
+
+somethingElse:
+  key: value
+`;
+    expect(parseCatalogFromWorkspaceYaml(yaml)).toEqual({
+      react: '^18.3.1',
+    });
+  });
+
+  it('returns empty object when no catalog section exists', () => {
+    const yaml = `packages:
+  - packages/*
+
+overrides:
+  vite: '^6.2.1'
+`;
+    expect(parseCatalogFromWorkspaceYaml(yaml)).toEqual({});
+  });
+
+  it('ignores malformed lines in catalog section', () => {
+    const yaml = `catalog:
+  react: '^18.3.1'
+  this is not valid yaml
+  react-dom: '^18.3.1'
+`;
+    const result = parseCatalogFromWorkspaceYaml(yaml);
+    expect(result.react).toBe('^18.3.1');
+    expect(result['react-dom']).toBe('^18.3.1');
+  });
+
+  it('handles unquoted version values', () => {
+    const yaml = `catalog:
+  '@types/node': ^22
+`;
+    expect(parseCatalogFromWorkspaceYaml(yaml)).toEqual({
+      '@types/node': '^22',
+    });
+  });
+});
+
+describe('parseWorkspacePackagesFromYaml', () => {
+  it('parses explicit package paths', () => {
+    const yaml = `packages:
+  - cookbook
+  - packages/cli
+  - packages/hydrogen
+  - templates/skeleton
+
+catalog:
+  react: '^18.3.1'
+`;
+    expect(parseWorkspacePackagesFromYaml(yaml)).toEqual([
+      'cookbook',
+      'packages/cli',
+      'packages/hydrogen',
+      'templates/skeleton',
+    ]);
+  });
+
+  it('returns empty array when no packages section exists', () => {
+    const yaml = `catalog:
+  react: '^18.3.1'
+`;
+    expect(parseWorkspacePackagesFromYaml(yaml)).toEqual([]);
+  });
+
+  it('handles packages at end of file', () => {
+    const yaml = `catalog:
+  react: '^18.3.1'
+
+packages:
+  - packages/hydrogen
+  - packages/cli
+`;
+    expect(parseWorkspacePackagesFromYaml(yaml)).toEqual([
+      'packages/hydrogen',
+      'packages/cli',
+    ]);
+  });
+});
+
+describe('resolveWorkspaceProtocols', () => {
+  it('resolves workspace:* in dependencies', async () => {
+    const pkg = {
+      dependencies: {
+        '@shopify/hydrogen': 'workspace:*',
+        graphql: '^16.10.0',
+      },
+    };
+
+    const resolveWorkspaceVersion = vi.fn().mockResolvedValue('2026.1.3');
+
+    const result = await resolveWorkspaceProtocols({
+      packageJson: pkg,
+      catalogVersions: {},
+      resolveWorkspaceVersion,
+      fallbackVersion: '0.0.0',
+    });
+
+    expect(result.dependencies!['@shopify/hydrogen']).toBe('2026.1.3');
+    expect(result.dependencies!.graphql).toBe('^16.10.0');
+    expect(resolveWorkspaceVersion).toHaveBeenCalledWith('@shopify/hydrogen');
+  });
+
+  it('resolves workspace:*<version> variant from changesets publishing', async () => {
+    const pkg = {
+      dependencies: {
+        '@shopify/hydrogen': 'workspace:*2026.1.1',
+      },
+    };
+
+    const resolveWorkspaceVersion = vi.fn().mockResolvedValue('2026.1.1');
+
+    const result = await resolveWorkspaceProtocols({
+      packageJson: pkg,
+      catalogVersions: {},
+      resolveWorkspaceVersion,
+      fallbackVersion: '0.0.0',
+    });
+
+    expect(result.dependencies!['@shopify/hydrogen']).toBe('2026.1.1');
+  });
+
+  it('resolves workspace:* in devDependencies', async () => {
+    const pkg = {
+      dependencies: {
+        graphql: '^16.10.0',
+      },
+      devDependencies: {
+        '@shopify/hydrogen-codegen': 'workspace:*',
+        '@shopify/mini-oxygen': 'workspace:*',
+        typescript: '^5.9.2',
+      },
+    };
+
+    const resolveWorkspaceVersion = vi
+      .fn()
+      .mockResolvedValueOnce('0.6.2')
+      .mockResolvedValueOnce('3.1.0');
+
+    const result = await resolveWorkspaceProtocols({
+      packageJson: pkg,
+      catalogVersions: {},
+      resolveWorkspaceVersion,
+      fallbackVersion: '0.0.0',
+    });
+
+    expect(result.devDependencies!['@shopify/hydrogen-codegen']).toBe('0.6.2');
+    expect(result.devDependencies!['@shopify/mini-oxygen']).toBe('3.1.0');
+    expect(result.devDependencies!.typescript).toBe('^5.9.2');
+  });
+
+  it('resolves catalog: in dependencies and devDependencies', async () => {
+    const pkg = {
+      dependencies: {
+        react: 'catalog:',
+        'react-dom': 'catalog:',
+      },
+      devDependencies: {
+        '@types/react': 'catalog:',
+        '@shopify/prettier-config': 'catalog:',
+      },
+    };
+
+    const catalogVersions = {
+      react: '^18.3.1',
+      'react-dom': '^18.3.1',
+      '@types/react': '^18.3.28',
+      '@shopify/prettier-config': '^1.1.2',
+    };
+
+    const result = await resolveWorkspaceProtocols({
+      packageJson: pkg,
+      catalogVersions,
+      resolveWorkspaceVersion: vi.fn(),
+      fallbackVersion: '0.0.0',
+    });
+
+    expect(result.dependencies!.react).toBe('^18.3.1');
+    expect(result.dependencies!['react-dom']).toBe('^18.3.1');
+    expect(result.devDependencies!['@types/react']).toBe('^18.3.28');
+    expect(result.devDependencies!['@shopify/prettier-config']).toBe('^1.1.2');
+  });
+
+  it('uses fallback version when workspace package is not found', async () => {
+    const pkg = {
+      dependencies: {
+        '@shopify/hydrogen': 'workspace:*',
+      },
+    };
+
+    const resolveWorkspaceVersion = vi.fn().mockResolvedValue(null);
+
+    const result = await resolveWorkspaceProtocols({
+      packageJson: pkg,
+      catalogVersions: {},
+      resolveWorkspaceVersion,
+      fallbackVersion: '2026.1.3',
+    });
+
+    expect(result.dependencies!['@shopify/hydrogen']).toBe('2026.1.3');
+  });
+
+  it('leaves non-protocol versions unchanged', async () => {
+    const pkg = {
+      dependencies: {
+        graphql: '^16.10.0',
+        isbot: '^5.1.22',
+      },
+      devDependencies: {
+        typescript: '^5.9.2',
+        vite: '^6.2.4',
+      },
+    };
+
+    const result = await resolveWorkspaceProtocols({
+      packageJson: pkg,
+      catalogVersions: {},
+      resolveWorkspaceVersion: vi.fn(),
+      fallbackVersion: '0.0.0',
+    });
+
+    expect(result.dependencies).toEqual(pkg.dependencies);
+    expect(result.devDependencies).toEqual(pkg.devDependencies);
+  });
+
+  it('handles package.json with missing dependency sections', async () => {
+    const pkg = {
+      name: 'skeleton',
+      version: '2026.1.3',
+    };
+
+    const result = await resolveWorkspaceProtocols({
+      packageJson: pkg,
+      catalogVersions: {},
+      resolveWorkspaceVersion: vi.fn(),
+      fallbackVersion: '0.0.0',
+    });
+
+    expect(result.dependencies).toBeUndefined();
+    expect(result.devDependencies).toBeUndefined();
+  });
+
+  it('leaves catalog: unchanged when catalog version is not found', async () => {
+    const pkg = {
+      dependencies: {
+        'unknown-package': 'catalog:',
+      },
+    };
+
+    const result = await resolveWorkspaceProtocols({
+      packageJson: pkg,
+      catalogVersions: {},
+      resolveWorkspaceVersion: vi.fn(),
+      fallbackVersion: '0.0.0',
+    });
+
+    expect(result.dependencies!['unknown-package']).toBe('catalog:');
+  });
+
+  it('does not mutate the original package.json object', async () => {
+    const pkg = {
+      dependencies: {
+        '@shopify/hydrogen': 'workspace:*',
+        react: 'catalog:',
+      },
+    };
+    const original = JSON.parse(JSON.stringify(pkg));
+
+    await resolveWorkspaceProtocols({
+      packageJson: pkg,
+      catalogVersions: {react: '^18.3.1'},
+      resolveWorkspaceVersion: vi.fn().mockResolvedValue('2026.1.3'),
+      fallbackVersion: '0.0.0',
+    });
+
+    expect(pkg).toEqual(original);
+  });
+});

--- a/packages/cli/src/lib/upgrade-e2e-utils.ts
+++ b/packages/cli/src/lib/upgrade-e2e-utils.ts
@@ -1,0 +1,100 @@
+type DependencySection = 'dependencies' | 'devDependencies';
+
+const DEPENDENCY_SECTIONS: DependencySection[] = [
+  'dependencies',
+  'devDependencies',
+];
+
+type PackageJsonWithDeps = Record<string, unknown> & {
+  [K in DependencySection]?: Record<string, string>;
+};
+
+/**
+ * Parses the `catalog:` section from pnpm-workspace.yaml content.
+ *
+ * Uses a regex rather than a full YAML parser to avoid adding a
+ * dependency for this test utility. The regex captures all consecutive
+ * indented lines after `catalog:`, matching YAML block mapping semantics
+ * where indentation defines the block boundary.
+ */
+export function parseCatalogFromWorkspaceYaml(
+  yamlContent: string,
+): Record<string, string> {
+  const catalogVersions: Record<string, string> = {};
+
+  const catalogMatch = yamlContent.match(/^catalog:\s*\n((?:[ \t]+.+\n?)*)/m);
+
+  const catalogSection = catalogMatch?.[1];
+  if (!catalogSection) return catalogVersions;
+
+  for (const line of catalogSection.split('\n')) {
+    const match = line.match(
+      /^\s+['"]?([^'":]+?)['"]?\s*:\s*['"]?([^'"]+?)['"]?\s*$/,
+    );
+    if (match?.[1] && match[2]) {
+      catalogVersions[match[1].trim()] = match[2].trim();
+    }
+  }
+
+  return catalogVersions;
+}
+
+/**
+ * Parses the `packages:` section from pnpm-workspace.yaml content.
+ * Returns raw path entries (e.g., ['packages/cli', 'templates/skeleton']).
+ * Glob patterns are returned as-is — the Hydrogen monorepo uses explicit paths.
+ */
+export function parseWorkspacePackagesFromYaml(yamlContent: string): string[] {
+  const packagesMatch = yamlContent.match(
+    /^packages:\s*\n((?:[ \t]+-.+\n?)*)/m,
+  );
+
+  const packagesSection = packagesMatch?.[1];
+  if (!packagesSection) return [];
+
+  return packagesSection
+    .split('\n')
+    .map((line) => line.match(/^\s+-\s+(.+)/)?.[1]?.trim())
+    .filter((path): path is string => Boolean(path));
+}
+
+interface ResolveWorkspaceProtocolsOptions {
+  packageJson: PackageJsonWithDeps;
+  catalogVersions: Record<string, string>;
+  resolveWorkspaceVersion: (packageName: string) => Promise<string | null>;
+  fallbackVersion: string;
+}
+
+/**
+ * Resolves pnpm-specific protocols (`workspace:*` and `catalog:`) in a
+ * package.json's dependency sections.
+ *
+ * Handles `workspace:*` (plain) and `workspace:*<version>` (with suffix,
+ * seen in some changesets-published releases like 2026.1.1).
+ *
+ * Returns a new object — the input is not mutated.
+ */
+export async function resolveWorkspaceProtocols({
+  packageJson,
+  catalogVersions,
+  resolveWorkspaceVersion,
+  fallbackVersion,
+}: ResolveWorkspaceProtocolsOptions): Promise<PackageJsonWithDeps> {
+  const resolved: PackageJsonWithDeps = JSON.parse(JSON.stringify(packageJson));
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    const deps = resolved[section];
+    if (!deps) continue;
+
+    for (const [name, version] of Object.entries(deps)) {
+      if (version.startsWith('workspace:')) {
+        const resolvedVersion = await resolveWorkspaceVersion(name);
+        deps[name] = resolvedVersion ?? fallbackVersion;
+      } else if (version === 'catalog:' && catalogVersions[name]) {
+        deps[name] = catalogVersions[name];
+      }
+    }
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

The upgrade E2E test (`upgrade-e2e.test.ts`) extracts historical skeleton templates by checking out a git worktree at past release commits and running `pnpm pack`. This fails on post-pnpm-migration commits (2026.1.1+) because `pnpm pack` can't resolve `workspace:*` and `catalog:` protocols without an installed workspace (no lockfile, no `node_modules`).

```
ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL  Cannot resolve workspace protocol
of dependency "@shopify/hydrogen" because this dependency is not installed.
```

PR #3640 attempted to fix this by using `pnpm pack` in a worktree, but `pnpm pack` requires a fully installed workspace to resolve protocols — which a bare worktree doesn't have.

### WHAT is this pull request doing?

Replaces `pnpm pack` with `npm pack` + manual protocol resolution in `extractSkeletonTemplate`:

- **`npm pack`** is protocol-agnostic — it tars whatever is on disk without trying to resolve `workspace:*` or `catalog:`. This defines the error out of existence.
- **Resolution helpers** in `upgrade-e2e-utils.ts` resolve protocols after extraction by reading workspace package versions and the `pnpm-workspace.yaml` catalog section from the worktree.
- Handles the `workspace:*<version>` variant (e.g. `workspace:*2026.1.1`) seen in some changesets-published releases.
- Pre-pnpm commits (2026.1.0 and older) have no protocols and skip resolution entirely.

### HOW to test your changes?

```bash
# Unit tests for resolution helpers (19 tests)
cd packages/cli
pnpm vitest run src/lib/upgrade-e2e-utils.test.ts

# Full E2E test (runs against ~8 historical versions)
pnpm vitest run src/commands/hydrogen/upgrade-e2e.test.ts
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)