### PR TITLE
fix: prevent cookbook package from being published to npm

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
+  "ignore": ["cookbook"],
   "privatePackages": {"version": true, "tag": true}
 }

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cookbook",
+  "private": true,
   "version": "1.0.1",
   "description": "A CLI tool to generate and apply recipes to the Hydrogen skeleton template.",
   "scripts": {


### PR DESCRIPTION
### WHY are these changes introduced?

The cookbook package was missing `"private": true`, causing the changesets Release workflow to attempt publishing `cookbook@1.0.1` to npm on every push to `main`. The publish failed with a 404 since the Shopify npm token can't create the unscoped `cookbook` name on the public registry.

Fixes the [Release workflow failure](https://github.com/Shopify/hydrogen/actions/runs/23797774467/job/69349505343).

Recreates [shopify-playground/modularizing-hydrogen#15](https://github.com/shopify-playground/modularizing-hydrogen/pull/15) in the Hydrogen repo.

### WHAT is this pull request doing?

Two changes for defense-in-depth:
- Add `"private": true` to `cookbook/package.json` — npm-level guard against publishing
- Add `"cookbook"` to changeset `"ignore"` list in `.changeset/config.json` — build-system-level guard against versioning/publishing

### HOW to test your changes?

- [ ] Verify `cookbook/package.json` has `"private": true`
- [ ] Verify `.changeset/config.json` has `"cookbook"` in the ignore array
- [ ] Confirm next Release workflow run on `main` no longer attempts to publish cookbook

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes — N/A, config-only change
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes — N/A, config-only change
- [x] I've added or updated the documentation — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)