### PR TITLE
test(e2e): comment out perf-kit assertions blocked by bot detection

### DIFF
--- a/e2e/specs/new-cookies/consent-tracking-accept.spec.ts
+++ b/e2e/specs/new-cookies/consent-tracking-accept.spec.ts
@@ -80,21 +80,23 @@ test.describe('Consent Tracking - Auto-Allowed (Consent Allowed by Default)', ()
       'after page load',
     );
 
+    // TODO: Uncomment once perf-kit bot detection fix ships — perf-kit produce
+    // requests are blocked by bot detection, causing verifyPerfKitRequests to fail.
     // 6. Finalize perf-kit metrics before navigation
-    await storefront.finalizePerfKitMetrics();
+    // await storefront.finalizePerfKitMetrics();
 
     // 7. Navigate to a product (triggers perf-kit to send metrics)
     await storefront.navigateToFirstProduct();
 
     // Wait for perf-kit to send metrics after visibility change
-    await storefront.page.waitForTimeout(500);
+    // await storefront.page.waitForTimeout(500);
 
     // Verify perf-kit payload contains correct tracking values
-    storefront.verifyPerfKitRequests(
-      navigationServerTiming._y!,
-      navigationServerTiming._s!,
-      'after navigation',
-    );
+    // storefront.verifyPerfKitRequests(
+    //   navigationServerTiming._y!,
+    //   navigationServerTiming._s!,
+    //   'after navigation',
+    // );
 
     // 8. Add to cart
     await storefront.addToCart();

--- a/e2e/specs/new-cookies/privacy-banner-accept.spec.ts
+++ b/e2e/specs/new-cookies/privacy-banner-accept.spec.ts
@@ -111,21 +111,23 @@ test.describe('Privacy Banner - Accept Flow', () => {
       'after consent',
     );
 
+    // TODO: Uncomment once perf-kit bot detection fix ships — perf-kit produce
+    // requests are blocked by bot detection, causing verifyPerfKitRequests to fail.
     // 9. Finalize perf-kit metrics before navigation (triggers LCP finalization)
-    await storefront.finalizePerfKitMetrics();
+    // await storefront.finalizePerfKitMetrics();
 
     // 10. Navigate to a product (this triggers perf-kit to send metrics via visibility change)
     await storefront.navigateToFirstProduct();
 
     // 11. Verify perf-kit payload contains correct tracking values
     // Wait a moment for perf-kit to send its metrics after visibility change
-    await storefront.page.waitForTimeout(500);
+    // await storefront.page.waitForTimeout(500);
 
-    storefront.verifyPerfKitRequests(
-      updatedServerTimingValues._y!,
-      updatedServerTimingValues._s!,
-      'after navigation',
-    );
+    // storefront.verifyPerfKitRequests(
+    //   updatedServerTimingValues._y!,
+    //   updatedServerTimingValues._s!,
+    //   'after navigation',
+    // );
 
     // 12. Add to cart
     await storefront.addToCart();

--- a/e2e/specs/old-cookies/consent-tracking-accept.spec.ts
+++ b/e2e/specs/old-cookies/consent-tracking-accept.spec.ts
@@ -60,21 +60,23 @@ test.describe('Consent Tracking - Auto-Allowed (Consent Allowed by Default)', ()
       'after page load',
     );
 
+    // TODO: Uncomment once perf-kit bot detection fix ships — perf-kit produce
+    // requests are blocked by bot detection, causing verifyPerfKitRequests to fail.
     // 6. Finalize perf-kit metrics before navigation
-    await storefront.finalizePerfKitMetrics();
+    // await storefront.finalizePerfKitMetrics();
 
     // 7. Navigate to a product (triggers perf-kit to send metrics)
     await storefront.navigateToFirstProduct();
 
     // Wait for perf-kit to send metrics after visibility change
-    await storefront.page.waitForTimeout(500);
+    // await storefront.page.waitForTimeout(500);
 
     // Verify perf-kit payload contains correct tracking values
-    storefront.verifyPerfKitRequests(
-      navigationServerTiming._y!,
-      navigationServerTiming._s!,
-      'after navigation',
-    );
+    // storefront.verifyPerfKitRequests(
+    //   navigationServerTiming._y!,
+    //   navigationServerTiming._s!,
+    //   'after navigation',
+    // );
 
     // 8. Add to cart
     await storefront.addToCart();

--- a/e2e/specs/old-cookies/privacy-banner-accept.spec.ts
+++ b/e2e/specs/old-cookies/privacy-banner-accept.spec.ts
@@ -92,21 +92,23 @@ test.describe('Privacy Banner - Accept Flow', () => {
       'after consent',
     );
 
+    // TODO: Uncomment once perf-kit bot detection fix ships — perf-kit produce
+    // requests are blocked by bot detection, causing verifyPerfKitRequests to fail.
     // 9. Finalize perf-kit metrics before navigation (triggers LCP finalization)
-    await storefront.finalizePerfKitMetrics();
+    // await storefront.finalizePerfKitMetrics();
 
     // 10. Navigate to a product (this triggers perf-kit to send metrics via visibility change)
     await storefront.navigateToFirstProduct();
 
     // 11. Verify perf-kit payload contains correct tracking values
     // Wait a moment for perf-kit to send its metrics after visibility change
-    await storefront.page.waitForTimeout(500);
+    // await storefront.page.waitForTimeout(500);
 
-    storefront.verifyPerfKitRequests(
-      updatedServerTimingValues._y!,
-      updatedServerTimingValues._s!,
-      'after navigation',
-    );
+    // storefront.verifyPerfKitRequests(
+    //   updatedServerTimingValues._y!,
+    //   updatedServerTimingValues._s!,
+    //   'after navigation',
+    // );
 
     // 12. Add to cart
     await storefront.addToCart();


### PR DESCRIPTION
### WHY are these changes introduced?

4 cookie e2e tests (`consent-tracking-accept` and `privacy-banner-accept` in both `new-cookies` and `old-cookies`) are failing in CI and locally. The failures are at `verifyPerfKitRequests` — perf-kit produce requests are blocked by Shopify's bot detection system. The perf-kit script itself loads fine, but its outgoing `/v1/produce` analytics requests never fire.

The bot detection fix is server-side (outside Hydrogen) and in progress separately.

### WHAT is this pull request doing?

Comments out `verifyPerfKitRequests()` and its immediate setup (`finalizePerfKitMetrics()`, `waitForTimeout(500)`) in the 4 failing specs with TODO markers for re-enablement once the server-side fix ships.

Other perf-kit calls (`waitForPerfKit`, `expectPerfKitLoaded`, `expectPerfKitNotLoaded`) are left intact — they test script loading behavior and are currently passing.

### HOW to test your changes?

```bash
npx playwright test --project=new-cookies --project=old-cookies
```

The 4 previously-failing tests should now pass. `grep -r "storefront.verifyPerfKitRequests" e2e/specs/` should return zero uncommented matches.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

Co-Authored-By: Claude <noreply@anthropic.com>