### PR TITLE
fix(e2e): make product navigation resilient to sold-out inventory

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -56,7 +56,7 @@ Per [Playwright best practices](https://playwright.dev/docs/best-practices#make-
 test.describe('Quantity Management', () => {
   test.beforeEach(async ({storefront}) => {
     await storefront.goto('/');
-    await storefront.navigateToFirstProduct();
+    await storefront.navigateToInStockProduct();
     await storefront.addToCart();
   });
 
@@ -70,7 +70,7 @@ test.describe('Quantity Management', () => {
 // ACCEPTABLE: Duplicate simple 1-2 line setups when it improves clarity
 test('adds item to empty cart', async ({storefront}) => {
   await storefront.goto('/');
-  await storefront.navigateToFirstProduct();
+  await storefront.navigateToInStockProduct();
   await storefront.addToCart();
 
   await expect(storefront.getCartLineItems()).toHaveCount(1);
@@ -79,7 +79,7 @@ test('adds item to empty cart', async ({storefront}) => {
 // AVOID: Repeating 3+ lines in every test
 test('increases quantity', async ({storefront}) => {
   await storefront.goto('/'); // Repeated
-  await storefront.navigateToFirstProduct(); // Repeated
+  await storefront.navigateToInStockProduct(); // Repeated
   await storefront.addToCart(); // Repeated
   // Use beforeEach instead
 });

--- a/e2e/fixtures/storefront.ts
+++ b/e2e/fixtures/storefront.ts
@@ -475,9 +475,11 @@ export class StorefrontPage {
     // Cap attempts to avoid slow failure on pages with many products
     const MAX_PRODUCT_ATTEMPTS = 10;
     const attemptsToMake = Math.min(linkCount, MAX_PRODUCT_ATTEMPTS);
-    // Shorter timeout than addToCart — just checking presence, not waiting
-    // for a slow action. Long enough for SSR pages to render the button.
-    const IN_STOCK_CHECK_TIMEOUT_MS = 5000;
+    // Shorter timeout than addToCart — just checking button presence, not
+    // waiting for a slow action. SSR pages include the button in initial
+    // HTML, so 2s is generous. Keeps worst-case (10 sold-out products)
+    // under 20s — well within typical Playwright test timeouts.
+    const IN_STOCK_CHECK_TIMEOUT_MS = 2000;
 
     for (let i = 0; i < attemptsToMake; i++) {
       const link = productLinks.nth(i);
@@ -486,7 +488,8 @@ export class StorefrontPage {
       await link.click();
 
       const isInStock = await this.getAddToCartButton()
-        .isVisible({timeout: IN_STOCK_CHECK_TIMEOUT_MS})
+        .waitFor({state: 'visible', timeout: IN_STOCK_CHECK_TIMEOUT_MS})
+        .then(() => true)
         .catch(() => false);
 
       if (isInStock) return;

--- a/e2e/fixtures/storefront.ts
+++ b/e2e/fixtures/storefront.ts
@@ -481,11 +481,16 @@ export class StorefrontPage {
     // under 20s — well within typical Playwright test timeouts.
     const IN_STOCK_CHECK_TIMEOUT_MS = 2000;
 
+    const triedUrls: string[] = [];
+
     for (let i = 0; i < attemptsToMake; i++) {
       const link = productLinks.nth(i);
+      // Fast-path skip: avoids a full navigation + timeout wait for links
+      // that aren't actionable (e.g., hidden by CSS or not yet in the DOM).
       if (!(await link.isVisible())) continue;
 
       await link.click();
+      triedUrls.push(this.page.url());
 
       const isInStock = await this.getAddToCartButton()
         .waitFor({state: 'visible', timeout: IN_STOCK_CHECK_TIMEOUT_MS})
@@ -502,13 +507,8 @@ export class StorefrontPage {
     throw new Error(
       `No in-stock products found at ${listingUrl} ` +
         `(checked ${attemptsToMake} of ${linkCount} product links). ` +
-        'All products appear to be sold out.',
+        `All products appear to be sold out. Tried: ${triedUrls.join(', ')}`,
     );
-  }
-
-  /** @deprecated Use {@link navigateToInStockProduct} instead */
-  async navigateToFirstProduct() {
-    return this.navigateToInStockProduct();
   }
 
   private getAddToCartButton() {

--- a/e2e/fixtures/storefront.ts
+++ b/e2e/fixtures/storefront.ts
@@ -460,22 +460,63 @@ export class StorefrontPage {
   }
 
   /**
-   * Navigate to the first product on the page
+   * Navigate to an in-stock product by trying product links sequentially.
+   * Skips sold-out products (no "Add to cart" button) so that tests only
+   * fail when every product on the page is unavailable.
    */
+  async navigateToInStockProduct() {
+    const listingUrl = this.page.url();
+    const productLinks = this.page.locator('a[href*="/products/"]');
+    const linkCount = await productLinks.count();
+    expect(linkCount, 'At least one product link should exist').toBeGreaterThan(
+      0,
+    );
+
+    // Cap attempts to avoid slow failure on pages with many products
+    const MAX_PRODUCT_ATTEMPTS = 10;
+    const attemptsToMake = Math.min(linkCount, MAX_PRODUCT_ATTEMPTS);
+    // Shorter timeout than addToCart — just checking presence, not waiting
+    // for a slow action. Long enough for SSR pages to render the button.
+    const IN_STOCK_CHECK_TIMEOUT_MS = 5000;
+
+    for (let i = 0; i < attemptsToMake; i++) {
+      const link = productLinks.nth(i);
+      if (!(await link.isVisible())) continue;
+
+      await link.click();
+
+      const isInStock = await this.getAddToCartButton()
+        .isVisible({timeout: IN_STOCK_CHECK_TIMEOUT_MS})
+        .catch(() => false);
+
+      if (isInStock) return;
+
+      // Product is sold out — return to listing and try the next one
+      await this.page.goto(listingUrl);
+      await expect(productLinks.first()).toBeVisible();
+    }
+
+    throw new Error(
+      `No in-stock products found at ${listingUrl} ` +
+        `(checked ${attemptsToMake} of ${linkCount} product links). ` +
+        'All products appear to be sold out.',
+    );
+  }
+
+  /** @deprecated Use {@link navigateToInStockProduct} instead */
   async navigateToFirstProduct() {
-    const productLink = this.page.locator('a[href*="/products/"]').first();
-    await expect(productLink).toBeVisible();
-    await productLink.click();
-    await this.page.waitForLoadState('networkidle');
+    return this.navigateToInStockProduct();
+  }
+
+  private getAddToCartButton() {
+    return this.page.getByRole('button', {name: /add to cart/i});
   }
 
   /**
    * Click the "Add to cart" button and wait for cart drawer with checkout URL
    */
   async addToCart() {
-    const addToCartButton = this.page.locator(
-      'button:has-text("Add to cart"), button:has-text("Add to Cart")',
-    );
+    const addToCartButton = this.getAddToCartButton();
     await expect(addToCartButton).toBeVisible({timeout: 10000});
     await addToCartButton.click();
 

--- a/e2e/specs/new-cookies/consent-tracking-accept.spec.ts
+++ b/e2e/specs/new-cookies/consent-tracking-accept.spec.ts
@@ -84,7 +84,7 @@ test.describe('Consent Tracking - Auto-Allowed (Consent Allowed by Default)', ()
     await storefront.finalizePerfKitMetrics();
 
     // 7. Navigate to a product (triggers perf-kit to send metrics)
-    await storefront.navigateToFirstProduct();
+    await storefront.navigateToInStockProduct();
 
     // Wait for perf-kit to send metrics after visibility change
     await storefront.page.waitForTimeout(500);

--- a/e2e/specs/new-cookies/consent-tracking-decline.spec.ts
+++ b/e2e/specs/new-cookies/consent-tracking-decline.spec.ts
@@ -53,7 +53,7 @@ test.describe('Consent Tracking - No Banner (Declined by Default)', () => {
     storefront.expectNoMonorailRequests();
 
     // 10. Navigate to first product and add to cart
-    await storefront.navigateToFirstProduct();
+    await storefront.navigateToInStockProduct();
     await storefront.addToCart();
 
     // 11. Check server-timing from cart mutation - should be mock values

--- a/e2e/specs/new-cookies/privacy-banner-accept.spec.ts
+++ b/e2e/specs/new-cookies/privacy-banner-accept.spec.ts
@@ -115,7 +115,7 @@ test.describe('Privacy Banner - Accept Flow', () => {
     await storefront.finalizePerfKitMetrics();
 
     // 10. Navigate to a product (this triggers perf-kit to send metrics via visibility change)
-    await storefront.navigateToFirstProduct();
+    await storefront.navigateToInStockProduct();
 
     // 11. Verify perf-kit payload contains correct tracking values
     // Wait a moment for perf-kit to send its metrics after visibility change

--- a/e2e/specs/new-cookies/privacy-banner-consent-change.spec.ts
+++ b/e2e/specs/new-cookies/privacy-banner-consent-change.spec.ts
@@ -83,7 +83,7 @@ test.describe('Privacy Banner - Consent Change', () => {
       storefront.expectNoMonorailRequests();
 
       // 11. Navigate to a product page to verify no tracking on navigation
-      await storefront.navigateToFirstProduct();
+      await storefront.navigateToInStockProduct();
 
       // Still no analytics requests after navigation
       storefront.expectNoMonorailRequests();
@@ -198,7 +198,7 @@ test.describe('Privacy Banner - Consent Change', () => {
 
       // 11. Navigate to a product page
       await storefront.finalizePerfKitMetrics();
-      await storefront.navigateToFirstProduct();
+      await storefront.navigateToInStockProduct();
 
       // Note: We skip perf-kit request verification here because it captures Y/S values
       // only when its script is first downloaded so it won't update the values after changing

--- a/e2e/specs/new-cookies/privacy-banner-decline.spec.ts
+++ b/e2e/specs/new-cookies/privacy-banner-decline.spec.ts
@@ -56,7 +56,7 @@ test.describe('Privacy Banner - Decline Flow', () => {
     storefront.expectNoMonorailRequests();
 
     // 11. Navigate to first product and add to cart to verify server-timing mock values
-    await storefront.navigateToFirstProduct();
+    await storefront.navigateToInStockProduct();
 
     // Add item to cart
     await storefront.addToCart();

--- a/e2e/specs/old-cookies/consent-tracking-accept.spec.ts
+++ b/e2e/specs/old-cookies/consent-tracking-accept.spec.ts
@@ -64,7 +64,7 @@ test.describe('Consent Tracking - Auto-Allowed (Consent Allowed by Default)', ()
     await storefront.finalizePerfKitMetrics();
 
     // 7. Navigate to a product (triggers perf-kit to send metrics)
-    await storefront.navigateToFirstProduct();
+    await storefront.navigateToInStockProduct();
 
     // Wait for perf-kit to send metrics after visibility change
     await storefront.page.waitForTimeout(500);

--- a/e2e/specs/old-cookies/consent-tracking-decline.spec.ts
+++ b/e2e/specs/old-cookies/consent-tracking-decline.spec.ts
@@ -53,7 +53,7 @@ test.describe('Consent Tracking - No Banner (Declined by Default)', () => {
     storefront.expectNoMonorailRequests();
 
     // 10. Navigate to first product and add to cart
-    await storefront.navigateToFirstProduct();
+    await storefront.navigateToInStockProduct();
     await storefront.addToCart();
 
     // 11. Check server-timing from cart mutation - should be mock values

--- a/e2e/specs/old-cookies/privacy-banner-accept.spec.ts
+++ b/e2e/specs/old-cookies/privacy-banner-accept.spec.ts
@@ -96,7 +96,7 @@ test.describe('Privacy Banner - Accept Flow', () => {
     await storefront.finalizePerfKitMetrics();
 
     // 10. Navigate to a product (this triggers perf-kit to send metrics via visibility change)
-    await storefront.navigateToFirstProduct();
+    await storefront.navigateToInStockProduct();
 
     // 11. Verify perf-kit payload contains correct tracking values
     // Wait a moment for perf-kit to send its metrics after visibility change

--- a/e2e/specs/old-cookies/privacy-banner-decline.spec.ts
+++ b/e2e/specs/old-cookies/privacy-banner-decline.spec.ts
@@ -56,7 +56,7 @@ test.describe('Privacy Banner - Decline Flow', () => {
     storefront.expectNoMonorailRequests();
 
     // 11. Navigate to first product and add to cart to verify server-timing mock values
-    await storefront.navigateToFirstProduct();
+    await storefront.navigateToInStockProduct();
 
     // Add item to cart
     await storefront.addToCart();

--- a/e2e/specs/recipes/b2b.spec.ts
+++ b/e2e/specs/recipes/b2b.spec.ts
@@ -123,7 +123,7 @@ test.describe('B2B Recipe', () => {
       storefront,
     }) => {
       await storefront.goto('/');
-      await storefront.navigateToFirstProduct();
+      await storefront.navigateToInStockProduct();
 
       await expect(page.getByRole('heading', {level: 1})).toBeVisible();
       await expect(
@@ -137,7 +137,7 @@ test.describe('B2B Recipe', () => {
       b2b,
     }) => {
       await storefront.goto('/');
-      await storefront.navigateToFirstProduct();
+      await storefront.navigateToInStockProduct();
 
       await expect(page.getByRole('heading', {level: 1})).toBeVisible();
       await b2b.assertQuantityRulesHidden();


### PR DESCRIPTION
### WHY are these changes introduced?

`navigateToFirstProduct()` clicked the first product link on the page regardless of stock status. When a test store's inventory changed (e.g., the first product on `Johns Tackle` became sold out), `addToCart()` would fail with a misleading timeout — the "Add to cart" button doesn't exist on sold-out products.

This affected `consent-tracking-accept` (new-cookies) deterministically and could flake on any test that calls `addToCart()` if store inventory shifts.

### WHAT is this pull request doing?

Introduces `navigateToInStockProduct()` which tries product links sequentially, checking for an "Add to cart" button before settling. Sold-out products are skipped. Tests only fail when every product on the page is unavailable.

### HOW to test your changes?

On a store where the first product is sold out but other products are in stock:

```bash
npx playwright test --project=new-cookies e2e/specs/new-cookies/consent-tracking-accept.spec.ts
```

The test should skip the sold-out product and succeed on the next in-stock one.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

Co-Authored-By: Claude <noreply@anthropic.com>