### PR TITLE
fix: use provided cartId in cartGetDefault before falling back to getCartId

### DIFF
--- a/.changeset/fix-cart-get-cartid.md
+++ b/.changeset/fix-cart-get-cartid.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Fix `cart.get()` to use provided `cartId` before falling back to `getCartId()`

--- a/.changeset/fix-cart-get-cartid.md
+++ b/.changeset/fix-cart-get-cartid.md
@@ -1,5 +1,0 @@
----
-"@shopify/hydrogen": patch
----
-
-Fix `cart.get()` to use provided `cartId` before falling back to `getCartId()`

--- a/.changeset/fix-cart-get-default-cartid.md
+++ b/.changeset/fix-cart-get-default-cartid.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Fix `cart.get()` to use provided `cartId` before falling back to `getCartId()`

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.test.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.test.ts
@@ -53,6 +53,18 @@ describe('cartGetDefault', () => {
     expect(result).toHaveProperty('id', 'gid://shopify/Cart/c1-456');
   });
 
+  it('should use provided cartId even when getCartId returns undefined', async () => {
+    const cartGet = cartGetDefault({
+      storefront: mockCreateStorefrontClient(),
+      getCartId: () => undefined,
+    });
+
+    const result = await cartGet({cartId: 'gid://shopify/Cart/c1-456'});
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('id', 'gid://shopify/Cart/c1-456');
+  });
+
   describe('run with customerAccount option', () => {
     it('should add logged_in search param to checkout link if customer is logged in', async () => {
       const cartGet = cartGetDefault({

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.ts
@@ -63,7 +63,7 @@ export function cartGetDefault({
   cartFragment,
 }: CartGetOptions): CartGetFunction {
   return async (cartInput?: CartGetProps) => {
-    const cartId = getCartId();
+    const cartId = cartInput?.cartId ?? getCartId();
 
     if (!cartId) return null;
 


### PR DESCRIPTION
## Problem
The `cartGetDefault` function ignores the `cartId` passed via `cartInput` and always calls `getCartId()`. This makes it impossible to query a specific cart by its ID when using `cart.get()`.

https://github.com/Shopify/hydrogen/blob/fcfbcaa299f46788d2fbabf24d021b8a8dcaadae/packages/hydrogen/src/cart/queries/cartGetDefault.ts#L66

## Solution
Use nullish coalescing (`??`) to prefer `cartInput.cartId` when provided, falling back to `getCartId()` otherwise.

```diff
- const cartId = getCartId();
+ const cartId = cartInput?.cartId ?? getCartId();
```

This aligns with the JSDoc on `CartGetProps.cartId` which states:
> @default cart.getCartId();

...implying `getCartId()` should be the fallback, not the only source.

Fixes #3639