### PR TITLE
fix: strip prettier plugins from resolved config in codegen formatting

### DIFF
--- a/.changeset/fix-codegen-prettier-plugins.md
+++ b/.changeset/fix-codegen-prettier-plugins.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix codegen failing when Prettier plugins (e.g. `prettier-plugin-tailwindcss`, `prettier-plugin-organize-imports`) are configured in the project's `.prettierrc`. Prettier plugins are now excluded from the resolved config used for formatting generated files.

--- a/packages/cli/src/lib/format-code.test.ts
+++ b/packages/cli/src/lib/format-code.test.ts
@@ -90,14 +90,12 @@ describe('formatCode', () => {
     expect(result.trim()).toBe('const x = 1;');
   });
 
-  it('formats without plugins in config', async () => {
-    // Verify that formatCode works when config has no plugins
-    // (the normal path after getCodeFormatOptions strips them)
+  it('formats TSX code with the typescript parser', async () => {
     const result = await formatCode(
-      'const x=1',
+      'const x = <div/>',
       {singleQuote: true},
-      'file.ts',
+      'file.tsx',
     );
-    expect(result.trim()).toBe('const x = 1;');
+    expect(result.trim()).toBe('const x = <div />;');
   });
 });

--- a/packages/cli/src/lib/format-code.test.ts
+++ b/packages/cli/src/lib/format-code.test.ts
@@ -1,0 +1,103 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {getCodeFormatOptions, formatCode} from './format-code.js';
+
+vi.mock('prettier', async () => {
+  const actual = await vi.importActual<typeof import('prettier')>('prettier');
+  return {
+    ...actual,
+    resolveConfig: vi.fn(),
+  };
+});
+
+describe('getCodeFormatOptions', () => {
+  let resolveConfig: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const prettier = await import('prettier');
+    resolveConfig = prettier.resolveConfig as ReturnType<typeof vi.fn>;
+    resolveConfig.mockReset();
+  });
+
+  it('strips plugins from resolved config', async () => {
+    resolveConfig.mockResolvedValue({
+      singleQuote: true,
+      plugins: ['prettier-plugin-tailwindcss'],
+    });
+
+    const result = await getCodeFormatOptions(__filename);
+
+    expect(result).toEqual({singleQuote: true});
+    expect(result).not.toHaveProperty('plugins');
+  });
+
+  it('strips plugins even when there are multiple', async () => {
+    resolveConfig.mockResolvedValue({
+      singleQuote: true,
+      trailingComma: 'all',
+      plugins: [
+        'prettier-plugin-tailwindcss',
+        'prettier-plugin-organize-imports',
+      ],
+    });
+
+    const result = await getCodeFormatOptions(__filename);
+
+    expect(result).toEqual({singleQuote: true, trailingComma: 'all'});
+    expect(result).not.toHaveProperty('plugins');
+  });
+
+  it('returns config as-is when no plugins are present', async () => {
+    resolveConfig.mockResolvedValue({
+      singleQuote: true,
+      bracketSpacing: false,
+    });
+
+    const result = await getCodeFormatOptions(__filename);
+
+    expect(result).toEqual({singleQuote: true, bracketSpacing: false});
+  });
+
+  it('returns default config when resolveConfig returns null', async () => {
+    resolveConfig.mockResolvedValue(null);
+
+    const result = await getCodeFormatOptions(__filename);
+
+    expect(result).toEqual({
+      arrowParens: 'always',
+      singleQuote: true,
+      bracketSpacing: false,
+      trailingComma: 'all',
+    });
+  });
+
+  it('returns default config when resolveConfig throws', async () => {
+    resolveConfig.mockRejectedValue(new Error('config error'));
+
+    const result = await getCodeFormatOptions(__filename);
+
+    expect(result).toEqual({
+      arrowParens: 'always',
+      singleQuote: true,
+      bracketSpacing: false,
+      trailingComma: 'all',
+    });
+  });
+});
+
+describe('formatCode', () => {
+  it('formats TypeScript code', async () => {
+    const result = await formatCode('const x=1', {singleQuote: true}, 'file.ts');
+    expect(result.trim()).toBe('const x = 1;');
+  });
+
+  it('formats without plugins in config', async () => {
+    // Verify that formatCode works when config has no plugins
+    // (the normal path after getCodeFormatOptions strips them)
+    const result = await formatCode(
+      'const x=1',
+      {singleQuote: true},
+      'file.ts',
+    );
+    expect(result.trim()).toBe('const x = 1;');
+  });
+});

--- a/packages/cli/src/lib/format-code.ts
+++ b/packages/cli/src/lib/format-code.ts
@@ -21,7 +21,16 @@ export async function getCodeFormatOptions(filePath = process.cwd()) {
     : Path.resolve(filePath, 'prettier.file');
   try {
     // Try to read a prettier config file from the project.
-    return (await resolveConfig(pathToUse)) || DEFAULT_PRETTIER_CONFIG;
+    const config = (await resolveConfig(pathToUse)) || DEFAULT_PRETTIER_CONFIG;
+
+    // Strip `plugins` from the resolved config. Prettier v3.1+ returns
+    // plugin strings (e.g. "prettier-plugin-tailwindcss") from resolveConfig,
+    // which format() then tries to dynamically import. This fails when the
+    // plugin can't be resolved from the CLI's module context.
+    // Codegen formatting only needs style options, not plugins.
+    // See: https://github.com/Shopify/hydrogen/issues/2994
+    const {plugins, ...safeConfig} = config;
+    return safeConfig;
   } catch {
     return DEFAULT_PRETTIER_CONFIG;
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2994

When users install any Prettier plugin (e.g., `prettier-plugin-tailwindcss`, `prettier-plugin-organize-imports`), Hydrogen's codegen breaks during `npm run dev`. This has been reported across multiple Hydrogen versions (v2025.4.0 through v2025.10.0).

The root cause is that Prettier v3.1+ changed `resolveConfig()` to return the `plugins` array from the user's `.prettierrc`. The CLI's `getCodeFormatOptions()` passes this config (including plugin strings) directly to `format()`, which then tries to dynamically import those plugins. The import fails because the plugins can't be resolved from the CLI's module context.

### WHAT is this pull request doing?

Strips the `plugins` field from the resolved Prettier config in `getCodeFormatOptions()` before it's passed to `format()`. Codegen formatting only needs style options (quotes, semicolons, trailing commas, etc.) — Prettier plugins like Tailwind class sorting or import organizing are not needed for formatting generated type definition files.

Also adds unit tests for `format-code.ts` which previously had no test coverage.

### HOW to test your changes?

1. Create a fresh Hydrogen project: `npm create @shopify/hydrogen@latest`
2. Install a Prettier plugin: `npm install -D prettier prettier-plugin-tailwindcss`
3. Add the plugin to `.prettierrc`:
   ```json
   {
     "plugins": ["prettier-plugin-tailwindcss"]
   }
   ```
4. Run `npm run dev`
5. **Before this fix**: Codegen shows an error and types are not generated
6. **After this fix**: Codegen works normally, types are generated

Unit tests can be run with:
```bash
cd packages/cli
npx vitest run --config vitest.config.ts src/lib/format-code.test.ts
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset. 
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation