### PR TITLE
fix: prevent misleading server startup errors + fix turbo build step in dev up

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -7,9 +7,12 @@ up:
       package_manager: pnpm@10.16.1
   - packages:
       - ejson
+  # The build runs as met? (not meet) so dev-up re-verifies by re-running it.
+  # TURBO_FORCE bypasses turbo's shared worktree cache, which can serve
+  # corrupted entries that replay logs without restoring output files.
   - custom:
       name: Build packages
-      met?: pnpm run build
+      met?: TURBO_FORCE=true pnpm run build
       meet: 'true'
 
 # So the Shopify CLI loads the local @shopify/cli-hydrogen plugin when running

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -209,7 +209,7 @@ export const configureDevServer = (options: DevServerLifecycleOptions) => {
       mockEnvDir = mockEnvFiles.mockEnvDir;
     }
 
-    server = new DevServer({
+    const devServer = new DevServer({
       storeKey,
       customerAccountPush: options.customerAccountPush ?? false,
       envFile: runtimeEnvFile,
@@ -219,7 +219,8 @@ export const configureDevServer = (options: DevServerLifecycleOptions) => {
       projectPath,
     });
 
-    await server.start();
+    await devServer.start();
+    server = devServer;
   });
 };
 


### PR DESCRIPTION
## Summary

- Fix "publish before initialization" bug in `e2e/fixtures/index.ts` where the `server` closure variable was assigned before `start()` completed, causing a misleading secondary error:

| Before | After |
|:---:|:---:|
| <img width="2672" height="1078" alt="image" src="https://github.com/user-attachments/assets/25f662e4-2a48-4156-92cf-b65e99a1be37" /> | <img width="1149" height="656" alt="image" src="https://github.com/user-attachments/assets/15a35d82-41a5-4a2c-bf22-bb1d47918441" /> |

- Add `TURBO_FORCE=true` to `dev.yml` build step to bypass turbo's shared worktree cache, to protect against corrupted entries (archives with only log files, no dist output) which I was experiencing, or any other Turbo issues. Power users can just run the finer-grained build commands directly, but it's important for anyone new to this repo that `dev up` basically guarantees a working state

Co-Authored-By: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)