### PR TITLE
add missing js doc comment descriptions for hydrogen 2025-07 gen docs v1

### DIFF
--- a/packages/hydrogen-react/src/ExternalVideo.tsx
+++ b/packages/hydrogen-react/src/ExternalVideo.tsx
@@ -3,7 +3,7 @@ import type {Entries, PartialDeep} from 'type-fest';
 import {forwardRef, IframeHTMLAttributes} from 'react';
 
 /**
- * The `ExternalVideo` component renders an embedded video for the Storefront API's [ExternalVideo object](https://shopify.dev/api/storefront/reference/products/externalvideo).
+ * Takes in the same props as a native `<iframe>` element, except for `src`.
  * @publicDocs
  */
 export interface ExternalVideoBaseProps {

--- a/packages/hydrogen-react/src/analytics.ts
+++ b/packages/hydrogen-react/src/analytics.ts
@@ -137,7 +137,7 @@ function sendToShopify(
 }
 
 /**
- * Gathers client browser values commonly used for analytics.
+ * If executed on server, this method will return empty string for each field.
  * @publicDocs
  */
 export function getClientBrowserParameters(): ClientBrowserParameters {

--- a/packages/hydrogen-react/src/parse-metafield.ts
+++ b/packages/hydrogen-react/src/parse-metafield.ts
@@ -13,7 +13,13 @@ import {flattenConnection} from './flatten-connection.js';
 import {RootASTNode as RichTextRootASTNode} from './RichText.types.js';
 
 /**
- * Use the `ParsedMetafields` type as the returned type of `parseMetafield(metafield)`
+ * A function that uses `metafield.type` to parse the Metafield's `value` or `reference` or `references` (depending on the `metafield.type`) and places the result in `metafield.parsedValue`
+ *
+ * TypeScript developers can use the type `ParsedMetafields` from this package to get the returned object's type correct. For example:
+ *
+ * ```
+ * parseMetafield<ParsedMetafields['boolean']>({type: 'boolean', value: 'false'}
+ * ```
  * @publicDocs
  */
 export function parseMetafield<ReturnGeneric>(

--- a/packages/hydrogen-react/src/parse-metafield.ts
+++ b/packages/hydrogen-react/src/parse-metafield.ts
@@ -13,13 +13,7 @@ import {flattenConnection} from './flatten-connection.js';
 import {RootASTNode as RichTextRootASTNode} from './RichText.types.js';
 
 /**
- * A function that uses `metafield.type` to parse the Metafield's `value` or `reference` or `references` (depending on the `metafield.type`) and places the result in `metafield.parsedValue`
- *
- * TypeScript developers can use the type `ParsedMetafields` from this package to get the returned object's type correct. For example:
- *
- * ```
- * parseMetafield<ParsedMetafields['boolean']>({type: 'boolean', value: 'false'}
- * ```
+ * Use the `ParsedMetafields` type as the returned type of `parseMetafield(metafield)`
  * @publicDocs
  */
 export function parseMetafield<ReturnGeneric>(

--- a/packages/hydrogen/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen/docs/generated/generated_docs_data.json
@@ -6474,7 +6474,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -7415,7 +7415,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -8356,7 +8356,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -9309,7 +9309,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -10255,7 +10255,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -11201,7 +11201,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -12135,7 +12135,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -13076,7 +13076,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -13969,7 +13969,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -14903,7 +14903,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -15837,7 +15837,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -16778,7 +16778,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -17712,7 +17712,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -18653,7 +18653,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -19587,7 +19587,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -20550,7 +20550,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -21484,7 +21484,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },
@@ -22795,7 +22795,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17597",
+                "name": "__@toStringTag@17840",
                 "value": "string",
                 "description": ""
               },

--- a/packages/hydrogen/docs/generated/generated_docs_data.json
+++ b/packages/hydrogen/docs/generated/generated_docs_data.json
@@ -6474,7 +6474,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -7415,7 +7415,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -8356,7 +8356,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -9309,7 +9309,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -10255,7 +10255,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -11201,7 +11201,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -12135,7 +12135,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -13076,7 +13076,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -13969,7 +13969,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -14903,7 +14903,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -15837,7 +15837,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -16778,7 +16778,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -17712,7 +17712,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -18653,7 +18653,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -19587,7 +19587,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -20550,7 +20550,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -21484,7 +21484,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -22795,7 +22795,7 @@
               {
                 "filePath": "src/utils/graphql.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@toStringTag@17841",
+                "name": "__@toStringTag@17597",
                 "value": "string",
                 "description": ""
               },
@@ -30332,7 +30332,7 @@
               "name": "string",
               "value": "string"
             },
-            "value": "export type Loader = (params: LoaderParams) => string;"
+            "value": "(params: LoaderParams) => string"
           },
           "LoaderParams": {
             "filePath": "src/Image.tsx",
@@ -30457,7 +30457,8 @@
           "ExternalVideoBaseProps": {
             "filePath": "src/ExternalVideo.tsx",
             "name": "ExternalVideoBaseProps",
-            "description": "",
+            "description": "The `ExternalVideo` component renders an embedded video for the Storefront API's [ExternalVideo object](https://shopify.dev/api/storefront/reference/products/externalvideo).",
+            "isPublicDocs": true,
             "members": [
               {
                 "filePath": "src/ExternalVideo.tsx",
@@ -30872,7 +30873,8 @@
           "MediaFileProps": {
             "filePath": "src/MediaFile.tsx",
             "name": "MediaFileProps",
-            "description": "",
+            "description": "MediaFile renders an `Image`, `Video`, `ExternalVideo`, or `ModelViewer` component. Use the `mediaOptions` prop to customize the props sent to each of these components.",
+            "isPublicDocs": true,
             "members": [
               {
                 "filePath": "src/MediaFile.tsx",
@@ -33159,7 +33161,7 @@
               "name": "string",
               "value": "string"
             },
-            "value": "export type Loader = (params: LoaderParams) => string;"
+            "value": "(params: LoaderParams) => string"
           },
           "LoaderParams": {
             "filePath": "src/Image.tsx",
@@ -33254,7 +33256,7 @@
         "url": "/api/hydrogen/hooks/useMoney"
       }
     ],
-    "description": "The `Money` component renders a string of the Storefront API's[MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) according to the `locale` in the [`ShopifyProvider` component](/api/hydrogen/components/global/shopifyprovider).\nThe component outputs a `<div>`. You can [customize this component](https://api/hydrogen/components#customizing-hydrogen-components) using passthrough props.",
+    "description": "The `Money` component renders a string of the Storefront API's [MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) according to the `locale` in the [`ShopifyProvider` component](/api/hydrogen/components/global/shopifyprovider).\nThe component outputs a `<div>`. You can [customize this component](https://api/hydrogen/components#customizing-hydrogen-components) using passthrough props.",
     "type": "component",
     "defaultExample": {
       "description": "I am the default example",
@@ -33283,7 +33285,8 @@
           "MoneyPropsBase": {
             "filePath": "src/Money.tsx",
             "name": "MoneyPropsBase",
-            "description": "",
+            "description": "The `Money` component renders a string of the Storefront API's [MoneyV2 object](https://shopify.dev/api/storefront/reference/common-objects/moneyv2) according to the `locale` in the `ShopifyProvider` component.",
+            "isPublicDocs": true,
             "members": [
               {
                 "filePath": "src/Money.tsx",
@@ -33389,7 +33392,8 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ModelViewerBaseProps",
             "value": "{\n  /** An object with fields that correspond to the Storefront API's [Model3D object](https://shopify.dev/api/storefront/2025-07/objects/model3d). */\n  data: PartialDeep<Model3d, {recurseIntoArrays: true}>;\n  /** The callback to invoke when the 'error' event is triggered. Refer to [error in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-loading-events-error). */\n  onError?: (event: Event) => void;\n  /** The callback to invoke when the `load` event is triggered. Refer to [load in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-loading-events-load). */\n  onLoad?: (event: Event) => void;\n  /** The callback to invoke when the 'preload' event is triggered. Refer to [preload in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-loading-events-preload). */\n  onPreload?: (event: Event) => void;\n  /** The callback to invoke when the 'model-visibility' event is triggered. Refer to [model-visibility in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-loading-events-modelVisibility). */\n  onModelVisibility?: (event: Event) => void;\n  /** The callback to invoke when the 'progress' event is triggered. Refer to [progress in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-loading-events-progress). */\n  onProgress?: (event: Event) => void;\n  /** The callback to invoke when the 'ar-status' event is triggered. Refer to [ar-status in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-augmentedreality-events-arStatus). */\n  onArStatus?: (event: Event) => void;\n  /** The callback to invoke when the 'ar-tracking' event is triggered. Refer to [ar-tracking in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-augmentedreality-events-arTracking). */\n  onArTracking?: (event: Event) => void;\n  /** The callback to invoke when the 'quick-look-button-tapped' event is triggered. Refer to [quick-look-button-tapped in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-augmentedreality-events-quickLookButtonTapped). */\n  onQuickLookButtonTapped?: (event: Event) => void;\n  /** The callback to invoke when the 'camera-change' event is triggered. Refer to [camera-change in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-stagingandcameras-events-cameraChange). */\n  onCameraChange?: (event: Event) => void;\n  /** The callback to invoke when the 'environment-change' event is triggered. Refer to [environment-change in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-lightingandenv-events-environmentChange).  */\n  onEnvironmentChange?: (event: Event) => void;\n  /**  The callback to invoke when the 'play' event is triggered. Refer to [play in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-animation-events-play). */\n  onPlay?: (event: Event) => void;\n  /**  The callback to invoke when the 'pause' event is triggered. Refer to [pause in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-animation-events-pause). */\n  onPause?: (event: Event) => void;\n  /** The callback to invoke when the 'scene-graph-ready' event is triggered. Refer to [scene-graph-ready in the <model-viewer> documentation](https://modelviewer.dev/docs/index.html#entrydocs-scenegraph-events-sceneGraphReady). */\n  onSceneGraphReady?: (event: Event) => void;\n}",
-            "description": "",
+            "description": "The `ModelViewer` component renders a 3D model (with the `model-viewer` custom element) for the Storefront API's [Model3d object](https://shopify.dev/api/storefront/reference/products/model3d). The `model-viewer` custom element is lazily downloaded through a dynamically-injected `<script type='module'>` tag when the `<ModelViewer />` component is rendered. ModelViewer is using version `1.21.1` of the `@google/model-viewer` library.",
+            "isPublicDocs": true,
             "members": [
               {
                 "filePath": "src/ModelViewer.tsx",
@@ -33567,7 +33571,8 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ShopPayButtonProps",
             "value": "ShopPayButtonStyleProps & ShopPayDomainProps & ShopPayChannelAttribution & (ShopPayVariantIds | ShopPayVariantAndQuantities)",
-            "description": ""
+            "description": "The `ShopPayButton` component renders a button that redirects to the Shop Pay checkout. It renders a [`<shop-pay-button>`](https://shopify.dev/custom-storefronts/tools/web-components) custom element, for which it will lazy-load the source code automatically.",
+            "isPublicDocs": true
           },
           "ShopPayButtonStyleProps": {
             "filePath": "src/ShopPayButton.tsx",
@@ -33716,7 +33721,8 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "RichTextPropsForDocs",
             "value": "RichTextPropsBase<AsType>",
-            "description": "",
+            "description": "The `RichText` component renders a metafield of type `rich_text_field`. By default the rendered output uses semantic HTML tags. Customize how nodes are rendered with the `components` prop.",
+            "isPublicDocs": true,
             "members": [
               {
                 "filePath": "src/RichText.tsx",
@@ -33866,7 +33872,8 @@
           "VideoProps": {
             "filePath": "src/Video.tsx",
             "name": "VideoProps",
-            "description": "",
+            "description": "The `Video` component renders a video for the Storefront API's [Video object](https://shopify.dev/api/storefront/reference/products/video). The component outputs a `video` element.",
+            "isPublicDocs": true,
             "members": [
               {
                 "filePath": "src/Video.tsx",
@@ -33987,6 +33994,7 @@
             "filePath": "src/useMoney.tsx",
             "name": "UseMoneyGeneratedType",
             "description": "The `useMoney` hook takes a [MoneyV2 object from the Storefront API](https://shopify.dev/docs/api/storefront/2025-07/objects/MoneyV2) or a [MoneyV2 object from the Customer Account API](https://shopify.dev/docs/api/customer/2025-07/objects/moneyv2) and returns a default-formatted string of the amount with the correct currency indicator, along with some of the parts provided by [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat). Uses `locale` from `ShopifyProvider` &nbsp;",
+            "isPublicDocs": true,
             "params": [
               {
                 "name": "money",
@@ -34263,7 +34271,8 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "LoadScriptParams",
             "value": "[src: string, options?: LoadScriptOptions]",
-            "description": ""
+            "description": "The `useLoadScript` hook loads an external script tag in the browser. It allows React components to lazy-load third-party dependencies.",
+            "isPublicDocs": true
           },
           "LoadScriptOptions": {
             "filePath": "src/load-script.tsx",
@@ -34356,6 +34365,7 @@
             "filePath": "src/useShopifyCookies.tsx",
             "name": "UseShopifyCookiesGeneratedType",
             "description": "Sets the `shopify_y` and `shopify_s` cookies in the browser based on user consent for backward compatibility support.\n\nIf `fetchTrackingValues` is true, it makes a request to Storefront API to fetch or refresh Shopiy analytics and marketing cookies and tracking values. Generally speaking, this should only be needed if you're not using Hydrogen's built-in analytics components and hooks that already handle this automatically. For example, set it to `true` if you are using `hydrogen-react` only with a different framework and still need to make a same-domain request to Storefront API to set cookies.\n\nIf `ignoreDeprecatedCookies` is true, it skips setting the deprecated cookies entirely. Useful when you only want to use the newer tracking values and not rely on the deprecated ones.",
+            "isPublicDocs": true,
             "params": [
               {
                 "name": "options",
@@ -34453,6 +34463,7 @@
             "filePath": "src/optionValueDecoder.ts",
             "name": "DecodeEncodedVariantGeneratedType",
             "description": "For an encoded option value string, decode into option value combinations. Entries represent a valid combination formatted as an array of option value positions.",
+            "isPublicDocs": true,
             "params": [
               {
                 "name": "encodedVariantField",
@@ -34514,7 +34525,8 @@
           "ConnectionGenericForDoc": {
             "filePath": "src/flatten-connection.ts",
             "name": "ConnectionGenericForDoc",
-            "description": "",
+            "description": "The `flattenConnection` utility transforms a connection object from the Storefront API (for example, [Product-related connections](https://shopify.dev/api/storefront/reference/products/product)) into a flat array of nodes. The utility works with either `nodes` or `edges.node`. If `connection` is null or undefined, will return an empty array instead in production. In development, an error will be thrown.",
+            "isPublicDocs": true,
             "members": [
               {
                 "filePath": "src/flatten-connection.ts",
@@ -34571,7 +34583,8 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "FlattenConnectionReturnForDoc",
             "value": "unknown[]",
-            "description": ""
+            "description": "",
+            "isPublicDocs": true
           }
         }
       }
@@ -34662,7 +34675,8 @@
           "GetClientBrowserParametersGeneratedType": {
             "filePath": "src/analytics.ts",
             "name": "GetClientBrowserParametersGeneratedType",
-            "description": "",
+            "description": "Gathers client browser values commonly used for analytics.",
+            "isPublicDocs": true,
             "params": [],
             "returns": {
               "filePath": "src/analytics.ts",
@@ -34846,6 +34860,7 @@
             "filePath": "src/cookies-utils.tsx",
             "name": "GetShopifyCookiesGeneratedType",
             "description": "Gets the values of _shopify_y and _shopify_s cookies from the provided cookie string.",
+            "isPublicDocs": true,
             "params": [
               {
                 "name": "cookies",
@@ -34868,6 +34883,7 @@
             "name": "ShopifyCookies",
             "value": "{\n  /** Shopify unique user token: Value of `_shopify_y` cookie. */\n  [SHOPIFY_Y]: string;\n  /** Shopify session token: Value of `_shopify_s` cookie. */\n  [SHOPIFY_S]: string;\n}",
             "description": "",
+            "isPublicDocs": true,
             "members": [
               {
                 "filePath": "src/analytics-types.ts",
@@ -34898,6 +34914,7 @@
             "name": "ShopifyCookies",
             "value": "{\n  /** Shopify unique user token: Value of `_shopify_y` cookie. */\n  [SHOPIFY_Y]: string;\n  /** Shopify session token: Value of `_shopify_s` cookie. */\n  [SHOPIFY_S]: string;\n}",
             "description": "",
+            "isPublicDocs": true,
             "members": [
               {
                 "filePath": "src/analytics-types.ts",
@@ -34967,6 +34984,7 @@
             "filePath": "src/tracking-utils.ts",
             "name": "GetTrackingValuesGeneratedType",
             "description": "Retrieves user session tracking values for analytics and marketing from the browser environment.",
+            "isPublicDocs": true,
             "params": [],
             "returns": {
               "filePath": "src/tracking-utils.ts",
@@ -35046,6 +35064,7 @@
             "filePath": "src/optionValueDecoder.ts",
             "name": "IsOptionValueCombinationInEncodedVariant",
             "description": "",
+            "isPublicDocs": true,
             "params": [
               {
                 "name": "targetOptionValueCombination",
@@ -35066,7 +35085,7 @@
               "name": "boolean",
               "value": "boolean"
             },
-            "value": "export type IsOptionValueCombinationInEncodedVariant = (\n  targetOptionValueCombination: number[],\n  encodedVariantField: string,\n) => boolean;"
+            "value": "(\n  targetOptionValueCombination: number[],\n  encodedVariantField: string,\n) => boolean"
           }
         }
       }
@@ -35140,6 +35159,7 @@
             "filePath": "src/analytics-utils.ts",
             "name": "ParseGidGeneratedType",
             "description": "Parses global id (gid) and returns the resource type and id.",
+            "isPublicDocs": true,
             "params": [
               {
                 "name": "gid",
@@ -35214,6 +35234,7 @@
             "filePath": "src/parse-metafield.ts",
             "name": "ParseMetafieldGeneratedType",
             "description": "A function that uses `metafield.type` to parse the Metafield's `value` or `reference` or `references` (depending on the `metafield.type`) and places the result in `metafield.parsedValue`\n\nTypeScript developers can use the type `ParsedMetafields` from this package to get the returned object's type correct. For example:\n\n``` parseMetafield<ParsedMetafields['boolean']>({type: 'boolean', value: 'false'} ```",
+            "isPublicDocs": true,
             "params": [
               {
                 "name": "metafield",
@@ -35282,6 +35303,7 @@
             "filePath": "src/analytics.ts",
             "name": "SendShopifyAnalyticsGeneratedType",
             "description": "Set user and session cookies and refresh the expiry time",
+            "isPublicDocs": true,
             "params": [
               {
                 "name": "event",
@@ -35670,14 +35692,14 @@
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "headless",
-                "value": "\"headless\"",
+                "value": "'headless'",
                 "description": "Shopify Headless sales channel"
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "hydrogen",
-                "value": "\"hydrogen\"",
+                "value": "'hydrogen'",
                 "description": "Shopify Hydrogen sales channel"
               }
             ],
@@ -35916,14 +35938,14 @@
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "ADD_TO_CART",
-                "value": "\"ADD_TO_CART\"",
+                "value": "'ADD_TO_CART'",
                 "description": "Add to cart"
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "PAGE_VIEW",
-                "value": "\"PAGE_VIEW\"",
+                "value": "'PAGE_VIEW'",
                 "description": "Page view"
               }
             ],
@@ -35945,154 +35967,154 @@
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "article",
-                "value": "\"article\"",
+                "value": "'article'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "blog",
-                "value": "\"blog\"",
+                "value": "'blog'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "captcha",
-                "value": "\"captcha\"",
+                "value": "'captcha'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "cart",
-                "value": "\"cart\"",
+                "value": "'cart'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "collection",
-                "value": "\"collection\"",
+                "value": "'collection'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "customersAccount",
-                "value": "\"customers/account\"",
+                "value": "'customers/account'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "customersActivateAccount",
-                "value": "\"customers/activate_account\"",
+                "value": "'customers/activate_account'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "customersAddresses",
-                "value": "\"customers/addresses\"",
+                "value": "'customers/addresses'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "customersLogin",
-                "value": "\"customers/login\"",
+                "value": "'customers/login'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "customersOrder",
-                "value": "\"customers/order\"",
+                "value": "'customers/order'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "customersRegister",
-                "value": "\"customers/register\"",
+                "value": "'customers/register'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "customersResetPassword",
-                "value": "\"customers/reset_password\"",
+                "value": "'customers/reset_password'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "forbidden",
-                "value": "\"403\"",
+                "value": "'403'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "giftCard",
-                "value": "\"gift_card\"",
+                "value": "'gift_card'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "home",
-                "value": "\"index\"",
+                "value": "'index'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "listCollections",
-                "value": "\"list-collections\"",
+                "value": "'list-collections'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "notFound",
-                "value": "\"404\"",
+                "value": "'404'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "page",
-                "value": "\"page\"",
+                "value": "'page'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "password",
-                "value": "\"password\"",
+                "value": "'password'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "policy",
-                "value": "\"policy\"",
+                "value": "'policy'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "product",
-                "value": "\"product\"",
+                "value": "'product'",
                 "description": ""
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "search",
-                "value": "\"search\"",
+                "value": "'search'",
                 "description": ""
               }
             ],
@@ -36114,14 +36136,14 @@
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "headless",
-                "value": "\"headless\"",
+                "value": "'headless'",
                 "description": "Shopify Headless sales channel"
               },
               {
                 "filePath": "src/analytics-constants.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "hydrogen",
-                "value": "\"hydrogen\"",
+                "value": "'hydrogen'",
                 "description": "Shopify Hydrogen sales channel"
               }
             ],

--- a/packages/hydrogen/docs/generated/generated_docs_data_v2.json
+++ b/packages/hydrogen/docs/generated/generated_docs_data_v2.json
@@ -554,7 +554,7 @@
         {
           "filePath": "src/utils/graphql.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@toStringTag@218393",
+          "name": "__@toStringTag@109539",
           "value": "string",
           "description": ""
         },
@@ -13814,7 +13814,7 @@
     "../hydrogen-react/src/parse-metafield.ts": {
       "filePath": "../hydrogen-react/src/parse-metafield.ts",
       "name": "ParseMetafieldGeneratedType",
-      "description": "Use the `ParsedMetafields` type as the returned type of `parseMetafield(metafield)`",
+      "description": "A function that uses `metafield.type` to parse the Metafield's `value` or `reference` or `references` (depending on the `metafield.type`) and places the result in `metafield.parsedValue`\n\nTypeScript developers can use the type `ParsedMetafields` from this package to get the returned object's type correct. For example:\n\n``` parseMetafield<ParsedMetafields['boolean']>({type: 'boolean', value: 'false'} ```",
       "isPublicDocs": true,
       "params": [
         {

--- a/packages/hydrogen/docs/generated/generated_docs_data_v2.json
+++ b/packages/hydrogen/docs/generated/generated_docs_data_v2.json
@@ -554,7 +554,7 @@
         {
           "filePath": "src/utils/graphql.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@toStringTag@218394",
+          "name": "__@toStringTag@218393",
           "value": "string",
           "description": ""
         },
@@ -9547,7 +9547,7 @@
     "../hydrogen-react/src/ExternalVideo.tsx": {
       "filePath": "../hydrogen-react/src/ExternalVideo.tsx",
       "name": "ExternalVideoBaseProps",
-      "description": "The `ExternalVideo` component renders an embedded video for the Storefront API's [ExternalVideo object](https://shopify.dev/api/storefront/reference/products/externalvideo).",
+      "description": "Takes in the same props as a native `<iframe>` element, except for `src`.",
       "isPublicDocs": true,
       "members": [
         {
@@ -13633,7 +13633,7 @@
     "../hydrogen-react/src/analytics.ts": {
       "filePath": "../hydrogen-react/src/analytics.ts",
       "name": "GetClientBrowserParametersGeneratedType",
-      "description": "Gathers client browser values commonly used for analytics.",
+      "description": "If executed on server, this method will return empty string for each field.",
       "isPublicDocs": true,
       "params": [],
       "returns": {
@@ -13814,7 +13814,7 @@
     "../hydrogen-react/src/parse-metafield.ts": {
       "filePath": "../hydrogen-react/src/parse-metafield.ts",
       "name": "ParseMetafieldGeneratedType",
-      "description": "A function that uses `metafield.type` to parse the Metafield's `value` or `reference` or `references` (depending on the `metafield.type`) and places the result in `metafield.parsedValue`\n\nTypeScript developers can use the type `ParsedMetafields` from this package to get the returned object's type correct. For example:\n\n``` parseMetafield<ParsedMetafields['boolean']>({type: 'boolean', value: 'false'} ```",
+      "description": "Use the `ParsedMetafields` type as the returned type of `parseMetafield(metafield)`",
       "isPublicDocs": true,
       "params": [
         {


### PR DESCRIPTION
<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Part of https://github.com/shop/issues-learn/issues/1460

Shopify-dev PR: https://github.com/shop/world/pull/547474

After merging the gen docs v1 migration, some JSDoc comments on types/interfaces/functions were missing or didn't match their corresponding `.doc.ts` definition descriptions. This caused descriptions to not show up correctly in the generated docs UI.

### WHAT is this pull request doing?

Fixes JSDoc comments to match `.doc.ts` definition descriptions in `hydrogen-react` and `hydrogen` packages (2025-07 branch):

**Description mismatches (JSDoc had wrong text):**
- `ExternalVideoBaseProps` in `ExternalVideo.tsx` — was using the component description instead of the props description
- `getClientBrowserParameters` in `analytics.ts` — updated to match `.doc.ts` definition description
- `parseMetafield` in `parse-metafield.ts` — updated to match `.doc.ts` definition description

### HOW to test your changes?

1. Run `npm run build` to confirm no build errors
2. Run docs generation and verify the descriptions now appear correctly in the generated docs output for the affected pages

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
