### PR TITLE
chore: replace npm/npx with pnpm counterparts

### DIFF
--- a/.changeset/enforce-calver-local.js
+++ b/.changeset/enforce-calver-local.js
@@ -143,9 +143,9 @@ CALVER_PACKAGES.forEach((pkgName) => {
 if (!opts.skipChangesets) {
   console.log('\n🦋 Running changeset version...');
   if (opts.dryRun) {
-    console.log('  [DRY RUN] Would run: npx @changesets/cli version');
+    console.log('  [DRY RUN] Would run: pnpm exec changeset version');
   } else {
-    execSync('npx @changesets/cli version', {stdio: 'inherit'});
+    execSync('pnpm exec changeset version', {stdio: 'inherit'});
   }
 } else {
   console.log('\n⏭️  Skipping changeset version');

--- a/.changeset/enforce-calver-local.js
+++ b/.changeset/enforce-calver-local.js
@@ -143,7 +143,7 @@ CALVER_PACKAGES.forEach((pkgName) => {
 if (!opts.skipChangesets) {
   console.log('\n🦋 Running changeset version...');
   if (opts.dryRun) {
-    console.log('  [DRY RUN] Would run: pnpm exec changeset version');
+    console.log('  [DRY RUN] Would run: pnpm exec @changesets/cli version');
   } else {
     execSync('pnpm exec @changesets/cli version', {stdio: 'inherit'});
   }

--- a/.changeset/enforce-calver-local.js
+++ b/.changeset/enforce-calver-local.js
@@ -145,7 +145,7 @@ if (!opts.skipChangesets) {
   if (opts.dryRun) {
     console.log('  [DRY RUN] Would run: pnpm exec changeset version');
   } else {
-    execSync('pnpm exec changeset version', {stdio: 'inherit'});
+    execSync('pnpm exec @changesets/cli version', {stdio: 'inherit'});
   }
 } else {
   console.log('\n⏭️  Skipping changeset version');

--- a/.claude/commands/apis-version-update.md
+++ b/.claude/commands/apis-version-update.md
@@ -100,7 +100,7 @@ Before starting, verify:
 
 #### Step 3a: Generate New Types in hydrogen-react
 1. Navigate to `packages/hydrogen-react/`
-2. Run: `npm run graphql-types`
+2. Run: `pnpm run graphql-types`
 3. **IMPORTANT**: Return to the root directory: `cd ../..`
 4. This will fetch the latest schemas and generate:
    - `src/storefront-api-types.d.ts` - TypeScript types for SFAPI
@@ -123,14 +123,14 @@ ls -la packages/hydrogen-react/*.schema.json
 
 ```bash
 cd packages/hydrogen-react
-npm run build
+pnpm run build
 cd ../..
 ```
 
 **Common Build Issues & Solutions:**
 - **Network timeout**: Retry the graphql-types command
 - **TypeScript errors**: Expected at this stage, continue with process
-- **Missing dependencies**: Run `npm install` from root directory
+- **Missing dependencies**: Run `pnpm install` from root directory
 - **Permission errors**: Check file permissions or try with sudo
 - **Build hangs**: Kill process and retry, might be resource issue
 
@@ -142,7 +142,7 @@ ls -la packages/hydrogen-react/dist/types/storefront-api-types.d.ts
 
 #### Step 3c: Build All Packages
 ```bash
-npm run build:pkg
+pnpm run build:pkg
 ```
 
 **Validation**: Verify build completes without errors:
@@ -156,7 +156,7 @@ npm run build:pkg
 **TODO TRACKING**: Mark Step 4 complete, add and mark Step 5 as in_progress.
 Run the documentation build to update any auto-generated docs:
 ```bash
-npm run build-docs --workspace=@shopify/hydrogen-react
+pnpm run build-docs --workspace=@shopify/hydrogen-react
 ```
 This will update generated documentation based on component changes.
 
@@ -170,10 +170,10 @@ This will update generated documentation based on component changes.
 After building packages, regenerate the skeleton template's GraphQL types:
 ```bash
 cd templates/skeleton
-npm run codegen
+pnpm run codegen
 cd ../..
 ```
-**Note**: This step MUST be done after `npm run build:pkg` as the skeleton depends on the built hydrogen-react types.
+**Note**: This step MUST be done after `pnpm run build:pkg` as the skeleton depends on the built hydrogen-react types.
 
 **Validation**: Verify these files were regenerated:
 - `templates/skeleton/storefrontapi.generated.d.ts`
@@ -181,7 +181,7 @@ cd ../..
 
 **Common Issues**: 
 - If you see errors about unknown types (e.g., `LanguageCode`), this indicates breaking changes in the API that need to be addressed
-- The skeleton codegen depends on the built packages, so ensure `npm run build:pkg` completed successfully first
+- The skeleton codegen depends on the built packages, so ensure `pnpm run build:pkg` completed successfully first
 
 **✅ CHECKPOINT**: Pause and ask the user to confirm before moving to the next task.
 **Summary**: Regenerated skeleton template's GraphQL types. Note any codegen errors that may indicate breaking API changes.
@@ -218,13 +218,13 @@ find . -name "*test*" -o -name "*spec*" | xargs grep -l "$OLD_VERSION"
 **Validation**: After updating all references, run initial validation and capture all errors:
 ```bash
 # Capture TypeScript errors
-npm run typecheck 2>&1 | tee typecheck_errors.log
+pnpm run typecheck 2>&1 | tee typecheck_errors.log
 
 # Capture test failures
-npm test 2>&1 | tee test_failures.log
+pnpm test 2>&1 | tee test_failures.log
 
 # Capture lint issues (usually less critical)
-npm run lint 2>&1 | tee lint_issues.log
+pnpm run lint 2>&1 | tee lint_issues.log
 ```
 **Important**: Save these error logs - they will be analyzed and included in the PR description for visibility.
 
@@ -533,7 +533,7 @@ query CustomerWithNewField {
 ### 1. Run Type Generation
 ```bash
 cd packages/hydrogen-react
-npm run graphql-types
+pnpm run graphql-types
 cd ../..
 ```
 - Verify no errors occur
@@ -545,7 +545,7 @@ cd ../..
 
 ### 2. Build Documentation
 ```bash
-npm run build-docs --workspace=@shopify/hydrogen-react
+pnpm run build-docs --workspace=@shopify/hydrogen-react
 ```
 
 **✅ CHECKPOINT**: Pause and ask the user to confirm before moving to the next task.
@@ -568,34 +568,34 @@ grep -r "YYYY-MM" --include="*.ts" --include="*.tsx" --include="*.js" --include=
 #### Step 4a: Test hydrogen-react types
 ```bash
 cd packages/hydrogen-react
-npm run typecheck
+pnpm run typecheck
 cd ../..
 ```
 
 #### Step 4b: Test hydrogen package types
 ```bash
 cd packages/hydrogen
-npm run typecheck
+pnpm run typecheck
 cd ../..
 ```
 
 **Common Issues and Solutions**:
 - If you see `Cannot find module '@shopify/hydrogen-react/storefront-api-types'`:
-  - Ensure you ran `npm run build` in `packages/hydrogen-react` first
+  - Ensure you ran `pnpm run build` in `packages/hydrogen-react` first
   - Verify `packages/hydrogen-react/dist/types/storefront-api-types.d.ts` exists
 - If typecheck fails with many errors, the packages may need rebuilding:
   ```bash
   cd packages/hydrogen-react
-  npm run graphql-types
-  npm run build
+  pnpm run graphql-types
+  pnpm run build
   cd ../..
-  npm run build:pkg
+  pnpm run build:pkg
   ```
 
 #### Step 4c: Run Full Test Suite
 ```bash
-npm test
-npm run lint
+pnpm test
+pnpm run lint
 ```
 
 **✅ CHECKPOINT**: Pause and ask the user to confirm before moving to the next task.
@@ -605,7 +605,7 @@ npm run lint
 
 1. **Type Resolution Failures**: The hydrogen package depends on built types from hydrogen-react
    - **Problem**: `Cannot find module '@shopify/hydrogen-react/storefront-api-types'`
-   - **Solution**: ALWAYS build hydrogen-react (`npm run build`) after generating types and before building other packages
+   - **Solution**: ALWAYS build hydrogen-react (`pnpm run build`) after generating types and before building other packages
    - **Order matters**: graphql-types → build hydrogen-react → build all packages
 
 2. **Missing API feature implementations**: Always check the API changelog for new features that need implementation
@@ -614,7 +614,7 @@ npm run lint
 
 4. **Version consistency**: SFAPI and CAAPI versions MUST match for quarterly releases
 
-5. **Generated files**: Never manually edit generated type files - always use `npm run graphql-types`
+5. **Generated files**: Never manually edit generated type files - always use `pnpm run graphql-types`
 
 6. **Test updates**: Tests must be updated to work with new API versions
 
@@ -693,7 +693,7 @@ For each issue discovered, provide:
 **Summary**: Customer Account API queries fail with "Unknown type LanguageCode" error
 
 **Details**: 
-- Discovered during: `npm run codegen` in templates/skeleton
+- Discovered during: `pnpm run codegen` in templates/skeleton
 - Error locations: 
   - app/graphql/customer-account/CustomerAddressMutations.ts:6:16
   - app/graphql/customer-account/CustomerDetailsQuery.ts:2:36
@@ -1215,9 +1215,9 @@ See [`API_CHANGES_REPORT_YYYY-MM.md`](./API_CHANGES_REPORT_YYYY-MM.md) for compl
 - [ ] Tests: Add coverage for cart warning features
 
 ### Build & Documentation Status
-- [ ] `npm run typecheck` - Currently: Failed (X errors)
-- [ ] `npm run test` - Currently: Failed (Y failures)
-- [ ] `npm run build:pkg` - Currently: Pass/Fail
+- [ ] `pnpm run typecheck` - Currently: Failed (X errors)
+- [ ] `pnpm run test` - Currently: Failed (Y failures)
+- [ ] `pnpm run build:pkg` - Currently: Pass/Fail
 - [ ] Skeleton builds - Currently: Pass/Fail
 - [ ] API version references updated
 - [ ] Examples use new API version
@@ -1225,9 +1225,9 @@ See [`API_CHANGES_REPORT_YYYY-MM.md`](./API_CHANGES_REPORT_YYYY-MM.md) for compl
 
 [IF no validation errors, include:]
 ## Build & Documentation Status
-- [x] `npm run typecheck` - Passing
-- [x] `npm run test` - All tests passing
-- [x] `npm run build:pkg` - Successful
+- [x] `pnpm run typecheck` - Passing
+- [x] `pnpm run test` - All tests passing
+- [x] `pnpm run build:pkg` - Successful
 - [x] Skeleton builds - Successful
 - [x] API version references updated
 - [x] Examples use new API version
@@ -1513,7 +1513,7 @@ echo "PR description generated: $OUTPUT_FILE"
 - [ ] Asked user about Cloudflare Workers compat date
 - [ ] Type generation completed successfully
 - [ ] hydrogen-react built successfully (critical for type resolution)
-- [ ] Documentation built with `npm run build-docs --workspace=@shopify/hydrogen-react`
+- [ ] Documentation built with `pnpm run build-docs --workspace=@shopify/hydrogen-react`
 - [ ] No references to old API versions remain
 - [ ] All tests pass with new API versions
 - [ ] Build completes successfully
@@ -1550,24 +1550,24 @@ curl --silent --request POST \
 
 # 2. Generate new types in hydrogen-react
 cd packages/hydrogen-react
-npm run graphql-types
+pnpm run graphql-types
 
 # 3. BUILD HYDROGEN-REACT (CRITICAL - DO NOT SKIP)
-npm run build
+pnpm run build
 cd ../..
 
 # 4. Verify hydrogen-react types are built
 ls -la packages/hydrogen-react/dist/types/storefront-api-types.d.ts
 
 # 5. Build all packages
-npm run build:pkg
+pnpm run build:pkg
 
 # 6. Build documentation
-npm run build-docs --workspace=@shopify/hydrogen-react
+pnpm run build-docs --workspace=@shopify/hydrogen-react
 
 # 7. Regenerate skeleton types
 cd templates/skeleton
-npm run codegen
+pnpm run codegen
 cd ../..
 
 # 8. Search for old versions and update (replace YYYY-MM with actual old version)
@@ -1575,20 +1575,20 @@ grep -r "YYYY-MM" --include="*.ts" --include="*.tsx" --include="*.js" --include=
 # Update all found references
 
 # 9. Verify type checking works (CRITICAL VALIDATION)
-cd packages/hydrogen-react && npm run typecheck && cd ../..
-cd packages/hydrogen && npm run typecheck && cd ../..
+cd packages/hydrogen-react && pnpm run typecheck && cd ../..
+cd packages/hydrogen && pnpm run typecheck && cd ../..
 
 # 10. Run full validation suite
-npm run typecheck
-npm run lint
-npm test
+pnpm run typecheck
+pnpm run lint
+pnpm test
 # Keep track of any errors for final review
 
 # 11. Format the code
-npm run format
+pnpm run format
 
 # 12. Create changeset
-npm run changeset add
+pnpm run changeset add
 
 # 13. Commit changes
 git add -A

--- a/.claude/commands/changelog-update.md
+++ b/.claude/commands/changelog-update.md
@@ -200,7 +200,7 @@ git show COMMIT_HASH --name-only | grep templates/skeleton | grep -v "CHANGELOG.
   ````bash
   echo <<EOF | base64 -w 0
   ```diff
-  npx codemod remix/2/react-router/upgrade
+  pnpm dlx codemod remix/2/react-router/upgrade
   ````
 
 - **Use git diff format** with `+` and `-` prefixes for changes

--- a/.claude/commands/fix-cookbook-recipe.md
+++ b/.claude/commands/fix-cookbook-recipe.md
@@ -23,12 +23,12 @@ The cookbook system applies patches to the skeleton template (`templates/skeleto
 
 ```bash
 cd cookbook
-SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npx ts-node src/index.ts validate --recipe {name}
+SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false pnpm exec ts-node src/index.ts validate --recipe {name}
 ```
 
 If `$ARGUMENTS` is `all`, run without `--recipe` to validate everything:
 ```bash
-SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npx ts-node src/index.ts validate
+SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false pnpm exec ts-node src/index.ts validate
 ```
 
 ### 2. Classify the validation output
@@ -62,7 +62,7 @@ These occur after patches apply. They may indicate the recipe's code changes are
 ❌ README.md  validateReadmeExists: README.md not found
 ❌ LLM prompt  validateLlmPromptExists: LLM prompt not found
 ```
-Fix by running `npm run cookbook -- render --recipe {name}` for README, or creating the LLM prompt file.
+Fix by running `pnpm run cookbook -- render --recipe {name}` for README, or creating the LLM prompt file.
 
 ### 3. If validation passes with no errors, skip to Phase 4
 
@@ -83,7 +83,7 @@ rm -f {any ingredient files listed in recipe.yaml}
 
 ```bash
 cd cookbook
-npx ts-node src/index.ts apply --recipe {name} 2>&1
+pnpm exec ts-node src/index.ts apply --recipe {name} 2>&1
 ```
 
 The command will fail with "PATCH CONFLICTS DETECTED" if there are `.orig` files, but the patches DO apply (just with offsets). That's exactly what we want.
@@ -146,7 +146,7 @@ Edit `recipe.yaml` directly:
 ```bash
 # Regenerate README
 cd cookbook
-npx ts-node src/index.ts render --recipe {name}
+pnpm exec ts-node src/index.ts render --recipe {name}
 
 # For missing LLM prompts, check if other recipes have them as reference
 ls llms/
@@ -158,7 +158,7 @@ Run validation again to confirm the fix:
 
 ```bash
 cd cookbook
-SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false npx ts-node src/index.ts validate --recipe {name}
+SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false pnpm exec ts-node src/index.ts validate --recipe {name}
 ```
 
 **Expected success output:**

--- a/.claude/commands/shopify-cli-update.md
+++ b/.claude/commands/shopify-cli-update.md
@@ -227,7 +227,7 @@ EOF
 
    a. **Decrypt webhook URL**
       ```bash
-      npm run decrypt
+      pnpm run decrypt
       ```
       - If this fails, abort and notify user
       - The webhook URL is stored in `secrets.ejson` as `slack_cli_release_request_webhook_url`

--- a/.claude/skills/e2e-test-writing/SKILL.md
+++ b/.claude/skills/e2e-test-writing/SKILL.md
@@ -45,7 +45,7 @@ Examples:
 ## Verification Commands
 
 ```bash
-npx playwright test --project=skeleton
+pnpm exec playwright test --project=skeleton
 ```
 
 Use narrower test paths during iteration, then run the appropriate full project suite before finishing.

--- a/.claude/skills/hydrogen-dev-workflow/SKILL.md
+++ b/.claude/skills/hydrogen-dev-workflow/SKILL.md
@@ -20,12 +20,12 @@ To test anything in Hydrogen that requires a customer login (order history, acco
 1. **Start the dev server with the customer account push flag:**
    ```bash
    # Using npm
-   npm run dev -- --customer-account-push
+   pnpm run dev -- --customer-account-push
 
    # Using Hydrogen CLI directly (h2 is the Hydrogen CLI binary)
    h2 dev --customer-account-push
    ```
-   Note the `--` separator when using `npm run dev`.
+   Note the `--` separator when using `pnpm run dev`.
 
 2. **Place a test order** using the [bogus gateway test payment details](https://help.shopify.com/en/manual/checkout-settings/test-orders/payments-test-mode#bogus-gateway-test-payment-details).
 
@@ -46,8 +46,8 @@ Each recipe has two layers that need to stay in sync:
 **Generated documentation** (`cookbook/recipes/{name}/README.md` and `cookbook/llms/{name}.prompt.md`): These files are **auto-generated** from the ingredient source files. They inline the full route source code, so if you fix the ingredient `.tsx` files, you MUST also regenerate the docs:
 
 ```bash
-npm run cookbook -- render --recipe {name}
-npm run cookbook -- validate --recipe {name}
+pnpm run cookbook -- render --recipe {name}
+pnpm run cookbook -- validate --recipe {name}
 ```
 
 Both the `README.md` and `llms/{name}.prompt.md` must be committed as part of the same fix. Failing to regenerate means the docs teach the wrong pattern even after the ingredient files are correct.
@@ -74,7 +74,7 @@ Recipe patch files can break when the skeleton template changes. Two approaches:
 The best way to upgrade a Hydrogen storefront is the [`upgrade` CLI command](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-upgrade):
 
 ```bash
-npx shopify hydrogen upgrade
+pnpm exec shopify hydrogen upgrade
 ```
 
 This command:

--- a/.claude/skills/hydrogen-release-process/SKILL.md
+++ b/.claude/skills/hydrogen-release-process/SKILL.md
@@ -17,7 +17,7 @@ Hydrogen uses an automated release system built on Changesets, GitHub Actions (`
 
 1. **Developer creates PR with changes**
    - If changes affect `packages/*/src/**` or `packages/*/package.json`, a changeset is required
-   - Run `npm run changeset add` to create a changeset file **(MANUAL)**
+   - Run `pnpm run changeset add` to create a changeset file **(MANUAL)**
    - Changeset specifies which packages are affected and version bump type (patch/minor/major)
 
 2. **On merge to main, TWO parallel processes occur:**
@@ -108,7 +108,7 @@ Hydrogen uses an automated release system built on Changesets, GitHub Actions (`
 ### Manual Steps (Human Intervention Required)
 
 1. **Developer Actions**
-   - **Create changesets**: Run `npm run changeset add` for any PR with code changes
+   - **Create changesets**: Run `pnpm run changeset add` for any PR with code changes
    - **Skeleton changes**: MUST include all three packages in changeset: `skeleton`, `@shopify/cli-hydrogen`, AND `@shopify/create-hydrogen` — see changeset rules in CLAUDE.md
    - **Write PR descriptions**: Include clear explanations of changes
    - **Request snapshot builds**: Comment `/snapit` on PR to test changes

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged && npm run pre-commit:encrypt && bash cookbook/scripts/pre-commit.sh
+pnpm exec lint-staged && pnpm run pre-commit:encrypt && bash cookbook/scripts/pre-commit.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Changeset Rules
 
-Changesets track what packages need new releases and at what version bump level. They can be added via `npx changeset add` or by manually creating a markdown file with proper YAML frontmatter (either method is fine).
+Changesets track what packages need new releases and at what version bump level. They can be added via `pnpm changeset add` or by manually creating a markdown file with proper YAML frontmatter (either method is fine).
 
 If changes affect `packages/*/src/**` or `packages/*/package.json`, a changeset is required.
 
@@ -104,7 +104,7 @@ The `dist` branch also receives compiled templates for alternative distribution 
 - `@shopify/cli-hydrogen` — bundles skeleton into its dist
 - `@shopify/create-hydrogen` — bundles cli-hydrogen into its dist
 
-⚠️ **Important**: When you run `npm run changeset add`, it only shows packages with
+⚠️ **Important**: When you run `pnpm run changeset add`, it only shows packages with
 actual code changes. You must **manually select** cli-hydrogen and create-hydrogen
 even though you didn't change their code. Alternatively, manually add those lines
 to the changeset file after creation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,9 @@ Run the following commands to get started working on Hydrogen.
 | Command                                         | Description                                   |
 | ----------------------------------------------- | --------------------------------------------- |
 | `git clone git@github.com:Shopify/hydrogen.git` | Clones the repo to your local computer        |
-| `npm install`                                   | Installs the dependencies with `npm`          |
-| `npm run dev`                                   | Runs the `dev` command in all packages        |
-| `npm run build`                                 | `build`s packages for production distribution |
+| `pnpm install`                                  | Installs the dependencies with `pnpm`         |
+| `ppnpm run dev`                                  | Runs the `dev` command in all packages        |
+| `pnpm run build`                                | `build`s packages for production distribution |
 
 ### Shopify Contributors
 
@@ -46,7 +46,7 @@ Hydrogen is a monorepo built with [Turborepo](https://turbo.build/) and consists
 - `packages/cli`: A plugin for the [Shopify CLI](https://github.com/Shopify/cli) to provide specific commands for working on Hydrogen storefronts.
 - `templates`: Full working implementations of Hydrogen storefronts. Used for scaffolding new starter Hydrogen apps, testing, and feature development.
 
-Running `npm run dev` at the root of the monorepo is the most common way to develop in Hydrogen. With this task running, each package will be rebuilt when files change. In a different terminal, change directory to any project inside `templates` and serve with `npm run dev`. The preview URL will be printed in the terminal.
+Running `pnpm run dev` at the root of the monorepo is the most common way to develop in Hydrogen. With this task running, each package will be rebuilt when files change. In a different terminal, change directory to any project inside `templates` and serve with `pnpm run dev`. The preview URL will be printed in the terminal.
 
 The `Readme.md` files in the directories of individual packages and templates contain more specific information for developing in that workspace.
 
@@ -56,9 +56,9 @@ The Hydrogen monorepo provides commands for linting and formatting, and uses [Hu
 
 | Command             | Description                               |
 | ------------------- | ----------------------------------------- |
-| `npm run typecheck` | Checks source-code for invalid TypeScript |
-| `npm run lint`      | Lints the code with ESLint                |
-| `npm run format`    | Formats the code with prettier            |
+| `pnpm run typecheck` | Checks source-code for invalid TypeScript |
+| `pnpm run lint`      | Lints the code with ESLint                |
+| `pnpm run format`    | Formats the code with prettier            |
 
 ## Naming conventions
 
@@ -85,7 +85,7 @@ If you are contributing a user-facing or noteworthy change to Hydrogen that shou
 
 | Command                 | Description             |
 | ----------------------- | ----------------------- |
-| `npm run changeset add` | Add a changeset locally |
+| `pnpm run changeset add` | Add a changeset locally |
 
 Follow the prompts to select which package(s) are affected by your change, and whether the change is a major, minor or patch change. This will create a file in the `.changesets` directory of the repo. This change should be committed and included with your PR.
 
@@ -103,8 +103,8 @@ Hydrogen tests are run using [vitest](https://vitest.dev). You can run the tests
 
 | Command              | Description                                             |
 | -------------------- | ------------------------------------------------------- |
-| `npm run test`       | Run the tests once                                      |
-| `npm run test:watch` | Run the tests once and re-run them when files are saved |
+| `pnpm run test`       | Run the tests once                                      |
+| `pnpm run test:watch` | Run the tests once and re-run them when files are saved |
 
 ### Debugging tests in Github Actions
 
@@ -136,7 +136,7 @@ In both cases, the reference documentation is stored in the Hydrogen repo in `*.
 ### Generate the docs
 
 1. From the command line, `cd` to either `packages/hydrogen` or `packages/hydrogen-react`.
-1. Run `npm run build-docs` (view [build script](https://github.com/Shopify/hydrogen/blob/-/packages/hydrogen-react/docs/build-docs.sh))
+1. Run `pnpm run build-docs` (view [build script](https://github.com/Shopify/hydrogen/blob/-/packages/hydrogen-react/docs/build-docs.sh))
 1. The script compiles and formats either one or both JSON files:
    - `packages/{PACKAGE}/docs/generated/generated_docs_data.json`
    - `packages/{PACKAGE}/docs/generated/generated_static_pages.json`
@@ -175,7 +175,7 @@ Consider how to provide the best developer experience when using this component 
 
 ## Secrets
 
-We use the ejson file `secrets.ejson` to store all our secrets. You can add new secrets to this file and they will be automatically encrypted when you commit the changes. Secrets can also be manually encrypted by running `npm run encrypt`. The public key (which is inside the `secrets.ejson` file) is used to encrypt secrets.
+We use the ejson file `secrets.ejson` to store all our secrets. You can add new secrets to this file and they will be automatically encrypted when you commit the changes. Secrets can also be manually encrypted by running `pnpm run encrypt`. The public key (which is inside the `secrets.ejson` file) is used to encrypt secrets.
 
 Secrets can only be decrypted if you have the private key. If you are new to the Shopify Hydrogen team, ask one of the other team members to send you a hush link with the private key.
 

--- a/cookbook/CLAUDE.md
+++ b/cookbook/CLAUDE.md
@@ -7,18 +7,18 @@ The Hydrogen Cookbook transforms the skeleton template into specific scenarios t
 ## Quick Reference
 
 ```bash
-npm run cookbook -- validate                    # Validate all recipes
-npm run cookbook -- validate --recipe {name}    # Validate one recipe
-npm run cookbook -- apply --recipe {name}       # Apply recipe to skeleton
-npm run cookbook -- generate --recipe {name}    # Generate recipe from changes
-npm run cookbook -- render                      # Render all documentation
+pnpm run cookbook -- validate                    # Validate all recipes
+pnpm run cookbook -- validate --recipe {name}    # Validate one recipe
+pnpm run cookbook -- apply --recipe {name}       # Apply recipe to skeleton
+pnpm run cookbook -- generate --recipe {name}    # Generate recipe from changes
+pnpm run cookbook -- render                      # Render all documentation
 ```
 
 ## IMPORTANT: Critical Rules
 
 **YOU MUST validate before committing:**
 ```bash
-npm run cookbook -- validate --recipe {name}
+pnpm run cookbook -- validate --recipe {name}
 ```
 
 **Recipe requirements:**
@@ -31,7 +31,7 @@ npm run cookbook -- validate --recipe {name}
 
 **After modifying recipe.yaml, regenerate docs:**
 ```bash
-npm run cookbook -- render --recipe {name}
+pnpm run cookbook -- render --recipe {name}
 ```
 
 ## Common Errors
@@ -52,7 +52,7 @@ npm run cookbook -- render --recipe {name}
 ```
 **Fix**: Regenerate documentation:
 ```bash
-npm run cookbook -- render --recipe {name}
+pnpm run cookbook -- render --recipe {name}
 ```
 
 ### Orphaned Files
@@ -79,13 +79,13 @@ npm run cookbook -- render --recipe {name}
 
 ```bash
 # Run all cookbook tests
-npm test
+pnpm test
 
 # Run validation tests only
-npm test -- validate.test.ts
+pnpm test -- validate.test.ts
 
 # Full validation pipeline (what CI runs)
-npm run cookbook -- validate --recipe {name}
+pnpm run cookbook -- validate --recipe {name}
 ```
 
 ## Architecture
@@ -119,7 +119,7 @@ cookbook/
 Apply recipe to skeleton template.
 
 ```bash
-npm run cookbook -- apply --recipe infinite-scroll
+pnpm run cookbook -- apply --recipe infinite-scroll
 ```
 
 **Options:**
@@ -135,13 +135,13 @@ Generate recipe from skeleton template changes.
 
 ```bash
 # Generate from all changes
-npm run cookbook -- generate --recipe my-feature
+pnpm run cookbook -- generate --recipe my-feature
 
 # Generate from specific file only
-npm run cookbook -- generate --recipe my-feature --filePath app/routes/products.tsx
+pnpm run cookbook -- generate --recipe my-feature --filePath app/routes/products.tsx
 
 # Generate against different branch
-npm run cookbook -- generate --recipe hotfix --referenceBranch origin/2025-01
+pnpm run cookbook -- generate --recipe hotfix --referenceBranch origin/2025-01
 ```
 
 **Options:**
@@ -169,13 +169,13 @@ Validate recipe integrity and functionality.
 
 ```bash
 # Validate all recipes
-npm run cookbook -- validate
+pnpm run cookbook -- validate
 
 # Validate single recipe
-npm run cookbook -- validate --recipe infinite-scroll
+pnpm run cookbook -- validate --recipe infinite-scroll
 
 # Validate against specific Hydrogen version
-npm run cookbook -- validate --recipe my-recipe --hydrogenPackagesVersion 2025.1.0
+pnpm run cookbook -- validate --recipe my-recipe --hydrogenPackagesVersion 2025.1.0
 ```
 
 **Options:**
@@ -185,7 +185,7 @@ npm run cookbook -- validate --recipe my-recipe --hydrogenPackagesVersion 2025.1
 **Pipeline:**
 1. Schema validation → Verifies recipe.yaml
 2. Recipe application → Applies to skeleton
-3. Dependency installation → npm install
+3. Dependency installation → pnpm install
 4. TypeScript check → Verifies types
 5. Build → Ensures project builds
 6. Cleanup → Resets skeleton
@@ -195,7 +195,7 @@ npm run cookbook -- validate --recipe my-recipe --hydrogenPackagesVersion 2025.1
 ❌ Recipe 'gtm' - 5 error(s):
 
 recipe.yaml:52      steps.0.step                  RecipeSchema: Invalid input: expected string, received number (actual value: 1)
-                    README.md                     validateReadmeExists: README.md not found. Run: npm run cookbook render gtm
+                    README.md                     validateReadmeExists: README.md not found. Run: pnpm run cookbook render gtm
 ```
 
 ---
@@ -206,10 +206,10 @@ Generate README documentation from recipe.yaml.
 
 ```bash
 # Render all recipes (GitHub format)
-npm run cookbook -- render
+pnpm run cookbook -- render
 
 # Render single recipe for shopify.dev
-npm run cookbook -- render --recipe infinite-scroll --format shopify.dev
+pnpm run cookbook -- render --recipe infinite-scroll --format shopify.dev
 ```
 
 **Options:**
@@ -230,13 +230,13 @@ Complete refresh: apply → generate → render.
 
 ```bash
 # Regenerate single recipe
-npm run cookbook -- regenerate --recipe infinite-scroll --format github
+pnpm run cookbook -- regenerate --recipe infinite-scroll --format github
 
 # Regenerate all recipes
-npm run cookbook -- regenerate --format github
+pnpm run cookbook -- regenerate --format github
 
 # Regenerate files only (preserve manual recipe.yaml edits)
-npm run cookbook -- regenerate --recipe my-recipe --onlyFiles --format github
+pnpm run cookbook -- regenerate --recipe my-recipe --onlyFiles --format github
 ```
 
 **Options:**
@@ -255,10 +255,10 @@ Update recipe to remain compatible with latest main branch.
 
 ```bash
 # Update recipe to latest main
-npm run cookbook -- update --recipe infinite-scroll
+pnpm run cookbook -- update --recipe infinite-scroll
 
 # Update against specific branch
-npm run cookbook -- update --recipe legacy-feature --referenceBranch origin/2024-12
+pnpm run cookbook -- update --recipe legacy-feature --referenceBranch origin/2024-12
 ```
 
 **Options:**
@@ -283,7 +283,7 @@ npm run cookbook -- update --recipe legacy-feature --referenceBranch origin/2024
 Generate JSON schema from Zod definitions for recipe.yaml validation and IDE support.
 
 ```bash
-npm run cookbook -- schema
+pnpm run cookbook -- schema
 ```
 
 **Result**: Updated recipe.schema.json
@@ -294,18 +294,18 @@ npm run cookbook -- schema
 
 ```bash
 # New recipe development
-npm run cookbook -- generate --recipe my-feature
-npm run cookbook -- validate --recipe my-feature
-npm run cookbook -- render --recipe my-feature
+pnpm run cookbook -- generate --recipe my-feature
+pnpm run cookbook -- validate --recipe my-feature
+pnpm run cookbook -- render --recipe my-feature
 
 # Recipe maintenance
-npm run cookbook -- update --recipe existing-feature
-npm run cookbook -- validate --recipe existing-feature
+pnpm run cookbook -- update --recipe existing-feature
+pnpm run cookbook -- validate --recipe existing-feature
 
 # Bulk operations
-npm run cookbook -- validate
-npm run cookbook -- render
-npm run cookbook -- regenerate --format github
+pnpm run cookbook -- validate
+pnpm run cookbook -- render
+pnpm run cookbook -- regenerate --format github
 ```
 
 ## Recipe YAML Structure
@@ -332,7 +332,7 @@ steps:
 ## Repository Etiquette
 
 **Before committing recipes:**
-1. Run validation: `npm run cookbook -- validate --recipe {name}`
+1. Run validation: `pnpm run cookbook -- validate --recipe {name}`
 2. Fix all errors before pushing
 3. Include recipe changes in PR descriptions
 4. Update LLM prompts when recipe logic changes

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -52,7 +52,7 @@ Recipes come paired with LLM prompts that can be included in a Hydrogen project 
 
 ## Usage
 
-The cookbook comes with a set of commands for creating and managing recipes. All commands are managed by the main `cookbook.ts` script, which can be invoked from this folder with `npm run cookbook`.
+The cookbook comes with a set of commands for creating and managing recipes. All commands are managed by the main `cookbook.ts` script, which can be invoked from this folder with `pnpm run cookbook`.
 
 ```plain
 cookbook.ts <command>
@@ -92,7 +92,7 @@ Options:
 #### Example
 
 ```sh
-npm run cookbook -- apply --recipe my-recipe
+pnpm run cookbook -- apply --recipe my-recipe
 ```
 
 ### Generate
@@ -132,7 +132,7 @@ Options:
 #### Example
 
 ```sh
-npm run cookbook -- generate --recipe my-recipe
+pnpm run cookbook -- generate --recipe my-recipe
 ```
 
 
@@ -179,7 +179,7 @@ Options:
 #### Example
 
 ```sh
-npm run cookbook -- validate --recipe my-recipe
+pnpm run cookbook -- validate --recipe my-recipe
 ```
 
 ### Render
@@ -204,7 +204,7 @@ Options:
 #### Example
 
 ```sh
-npm run cookbook -- render --recipe my-recipe --format github
+pnpm run cookbook -- render --recipe my-recipe --format github
 ```
 
 ### Regenerate
@@ -240,7 +240,7 @@ Options:
 #### Example
 
 ```sh
-npm run cookbook -- regenerate --recipe my-recipe --format github
+pnpm run cookbook -- regenerate --recipe my-recipe --format github
 ```
 
 ### Update
@@ -267,7 +267,7 @@ Options:
 #### Example
 
 ```sh
-npm run cookbook -- update --recipe my-recipe
+pnpm run cookbook -- update --recipe my-recipe
 ```
 
 ### Schema
@@ -289,7 +289,7 @@ Options:
 #### Example
 
 ```sh
-npm run cookbook -- schema
+pnpm run cookbook -- schema
 ```
 
 ### Skeleton Files
@@ -319,16 +319,16 @@ Options:
 
 ```sh
 # List all skeleton files referenced by any recipe
-npm run cookbook -- skeleton-files
+pnpm run cookbook -- skeleton-files
 
 # List files for a specific recipe
-npm run cookbook -- skeleton-files --recipe my-recipe
+pnpm run cookbook -- skeleton-files --recipe my-recipe
 
 # List files for multiple recipes, as JSON
-npm run cookbook -- skeleton-files --recipe recipe-a --recipe recipe-b --json
+pnpm run cookbook -- skeleton-files --recipe recipe-a --recipe recipe-b --json
 
 # Only show files that currently exist on disk
-npm run cookbook -- skeleton-files --existing-only
+pnpm run cookbook -- skeleton-files --existing-only
 ```
 
 Default (text) output format:
@@ -373,15 +373,15 @@ Options:
 
 ```sh
 # Check which recipes are affected by a changed file
-npm run cookbook -- affected-recipes templates/skeleton/app/root.tsx
+pnpm run cookbook -- affected-recipes templates/skeleton/app/root.tsx
 
 # Pass multiple files
-npm run cookbook -- affected-recipes \
+pnpm run cookbook -- affected-recipes \
   templates/skeleton/app/root.tsx \
   templates/skeleton/app/server.ts
 
 # Output as a JSON array (useful for scripting / CI matrix jobs)
-npm run cookbook -- affected-recipes --json templates/skeleton/app/root.tsx
+pnpm run cookbook -- affected-recipes --json templates/skeleton/app/root.tsx
 ```
 
 Default (text) output — one recipe name per line:

--- a/cookbook/scripts/pre-commit.sh
+++ b/cookbook/scripts/pre-commit.sh
@@ -18,7 +18,7 @@ fi
 # 2. Find affected recipes (one name per line)
 #    Capture stderr separately so errors surface as warnings without mixing into output.
 STDERR_FILE=$(mktemp)
-AFFECTED=$(cd "$REPO_ROOT/cookbook" && npm run --silent cookbook -- affected-recipes "${STAGED_ARGS[@]}" 2>"$STDERR_FILE")
+AFFECTED=$(cd "$REPO_ROOT/cookbook" && pnpm run --silent cookbook -- affected-recipes "${STAGED_ARGS[@]}" 2>"$STDERR_FILE")
 STATUS=$?
 STDERR_CONTENT=$(cat "$STDERR_FILE")
 rm -f "$STDERR_FILE"
@@ -43,7 +43,7 @@ done <<< "$AFFECTED"
 echo ""
 echo "  After committing your skeleton changes, run the following to update affected recipes:"
 while IFS= read -r recipe; do
-  echo "    cd cookbook && npm run cookbook -- regenerate --recipe $recipe --format github"
+  echo "    cd cookbook && pnpm run cookbook -- regenerate --recipe $recipe --format github"
 done <<< "$AFFECTED"
 echo ""
 echo "  Note: the regenerate command requires a clean working tree — run it after committing."

--- a/cookbook/src/lib/validate.test.ts
+++ b/cookbook/src/lib/validate.test.ts
@@ -701,7 +701,7 @@ describe('validateReadmeExists', () => {
     expect(result.errors[0]).toMatchObject({
       validator: 'validateReadmeExists',
       message: expect.stringContaining(
-        'Run: npm run cookbook render nonexistent-recipe',
+        'Run: pnpm run cookbook render nonexistent-recipe',
       ),
     });
   });
@@ -735,7 +735,7 @@ describe('validateLlmPromptExists', () => {
     expect(result.errors[0]).toMatchObject({
       validator: 'validateLlmPromptExists',
       message: expect.stringContaining(
-        'Run: npm run cookbook render nonexistent-recipe',
+        'Run: pnpm run cookbook render nonexistent-recipe',
       ),
     });
   });

--- a/cookbook/src/lib/validate.ts
+++ b/cookbook/src/lib/validate.ts
@@ -327,7 +327,7 @@ export function validateReadmeExists(recipeName: string): ValidationResult {
   if (!fs.existsSync(readmePath)) {
     errors.push({
       validator: 'validateReadmeExists',
-      message: `README.md not found. Run: npm run cookbook render ${recipeName}`,
+      message: `README.md not found. Run: pnpm run cookbook render ${recipeName}`,
       location: RENDER_FILENAME_GITHUB,
     });
   }
@@ -344,7 +344,7 @@ export function validateLlmPromptExists(recipeName: string): ValidationResult {
   if (!fs.existsSync(promptPath)) {
     errors.push({
       validator: 'validateLlmPromptExists',
-      message: `LLM prompt file not found at llms/${recipeName}.prompt.md. Run: npm run cookbook render ${recipeName}`,
+      message: `LLM prompt file not found at llms/${recipeName}.prompt.md. Run: pnpm run cookbook render ${recipeName}`,
       location: `llms/${recipeName}.prompt.md`,
     });
   }

--- a/docs/CALVER.md
+++ b/docs/CALVER.md
@@ -245,7 +245,7 @@ The CalVer system integrates with changesets through a two-step process:
 
 The transformation happens in the npm version script:
 ```json
-"version": "npm run version:changeset && node .changeset/enforce-calver-ci.js && npm run version:post && npm run format"
+"version": "pnpm run version:changeset && node .changeset/enforce-calver-ci.js && pnpm run version:post && pnpm run format"
 ```
 
 Execution order:
@@ -270,13 +270,13 @@ Major releases align with Shopify's API calendar:
 ### Unit Testing
 ```bash
 # Test CalVer comparison
-npm run test:calver
+pnpm run test:calver
 
 # Test with dry-run (reads actual changesets)
-npm run test:calver:dry
+pnpm run test:calver:dry
 
 # Test branch detection
-npm run test:calver:branch
+pnpm run test:calver:branch
 ```
 
 ### CI Testing
@@ -516,7 +516,7 @@ ls .changeset/*.md | xargs grep -l "major"
 **Solution**: Ensure the script runs after changesets
 ```bash
 # Correct order
-npm run version:changeset && node .changeset/enforce-calver-ci.js
+pnpm run version:changeset && node .changeset/enforce-calver-ci.js
 ```
 
 ### Issue: Changesets with single quotes not detected
@@ -583,7 +583,7 @@ rm .changeset/test-cli.md
 ### For Maintainers
 - **No more manual updates**: The `latestBranch` in release.yml is detected automatically
 - **Branch naming unchanged**: Still uses `YYYY-MM` format (e.g., `2025-05`)
-- **Changeset process unchanged**: Continue using `npm run changeset add`
+- **Changeset process unchanged**: Continue using `pnpm run changeset add`
 
 ### For Contributors
 - **No changes required**: Continue creating changesets as normal

--- a/docs/preview/README.md
+++ b/docs/preview/README.md
@@ -9,7 +9,7 @@ Run the dev command from a path that contains a `docs/generated/generated_docs_d
 Example from the `packages/hydrogen` or `packages/hydrogen-react` directories:
 
 ```bash
-npm run dev --prefix ../../docs/preview
+pnpm run dev --prefix ../../docs/preview
 ```
 
 Alternatively, pass `GEN_DOCS_PATH` as an environment variable to overwrite the default path.

--- a/docs/tasks/prd-automated-playwright-tests.md
+++ b/docs/tasks/prd-automated-playwright-tests.md
@@ -1,23 +1,23 @@
 # Automated Playwright End-to-End Test Suite
 
 ## 1. Introduction / Overview
-Hydrogen’s skeleton template currently relies on manual smoke-testing to catch regressions. Missed issues have reached production, forcing lengthy post-hoc debugging and `git bisect` sessions. This project introduces an automated Playwright test suite that PR authors, reviewers, and CI pipelines can execute locally (`npm run e2e`) and on GitHub Actions. The first iteration delivers a fast smoke test against the skeleton template and a single scaffolded project; later iterations will cover every permutation of the `npm create @shopify/hydrogen` options and all available recipes.
+Hydrogen’s skeleton template currently relies on manual smoke-testing to catch regressions. Missed issues have reached production, forcing lengthy post-hoc debugging and `git bisect` sessions. This project introduces an automated Playwright test suite that PR authors, reviewers, and CI pipelines can execute locally (`pnpm run e2e`) and on GitHub Actions. The first iteration delivers a fast smoke test against the skeleton template and a single scaffolded project; later iterations will cover every permutation of the `npm create @shopify/hydrogen` options and all available recipes.
 
 ## 2. Goals
 1. Eliminate regressions that previously escaped manual review.
-2. Provide a single command (`npm run e2e`) that passes locally on macOS/Linux and in CI.
+2. Provide a single command (`pnpm run e2e`) that passes locally on macOS/Linux and in CI.
 3. Integrate the suite with GitHub Actions so failures block merges.
 4. Keep the “basic smoke” subset under **60 s** and the full matrix under **20 min**.
 5. Maintain **<1 %** flake rate across 100 sequential runs.
 
 ## 3. User Stories
-* **PR Author**: I can run `npm run e2e` locally to verify my changes did not break critical storefront flows.
+* **PR Author**: I can run `pnpm run e2e` locally to verify my changes did not break critical storefront flows.
 * **Reviewer**: CI executes the same suite and surfaces failures directly in the pull request, so I don’t need to test manually.
 * **Maintainer**: Failures provide readable output plus screenshots/videos/logs, enabling quick diagnosis.
 * **Future Contributor**: Clear setup docs let me onboard and run the suite without friction.
 
 ## 4. Functional Requirements
-1. `npm run e2e` spins up the dev server for the target project and executes Playwright tests.
+1. `pnpm run e2e` spins up the dev server for the target project and executes Playwright tests.
 2. A **Smoke Test Pack** (≤60 s) must:
    1. Run against the repository’s existing skeleton template without scaffolding a new project.
    2. Navigate to `/` and assert the main hero image, product grid, and “Add to Cart” buttons are present with no client/server errors.
@@ -39,11 +39,11 @@ Hydrogen’s skeleton template currently relies on manual smoke-testing to catch
 
 ## 5. Non-Goals / Out of Scope
 * Validating checkout, payment, discount codes, gift cards, or third-party integrations.
-* Testing production bundles (`npm run build && npm run preview`).
+* Testing production bundles (`pnpm run build && pnpm run preview`).
 * Mobile-viewport coverage (can be added later).
 * Performance benchmarking.
 * Recipes are **deferred** to a future phase—they are **out of scope** for this iteration.
-* Testing production bundles (`npm run build && npm run preview`
+* Testing production bundles (`pnpm run build && pnpm run preview`
 
 ## 6. Design Considerations (Optional)
 * **Playwright Test Structure**: Place tests under `e2e/`, separate “smoke” vs “matrix” folders.

--- a/docs/tasks/tasks-prd-automated-playwright-tests.md
+++ b/docs/tasks/tasks-prd-automated-playwright-tests.md
@@ -17,7 +17,7 @@
 
 - Follow Outside-In TDD: write failing tests first, implement minimal code to pass, then refactor.
 - Keep each pull request self-contained, reviewable, and **≤500 lines changed** (ideal ≈300 LOC).
-- After completing every parent task below, open a new PR targeting `main` in the Hydrogen repository and include instructions for reviewers to run `npm run e2e`.
+- After completing every parent task below, open a new PR targeting `main` in the Hydrogen repository and include instructions for reviewers to run `pnpm run e2e`.
 - All new code must be lint-clean and pass the full test suite in CI.
 
 ### Implementation Learnings
@@ -44,7 +44,7 @@
 - **Note**: The `--smoke` flag mentioned in the PRD wasn't implemented yet as it requires additional Playwright configuration. The `e2e:smoke` script achieves the same goal by specifying the test directory.
 
 #### Common Pitfalls to Avoid
-- **Don't assume npm scripts exist**: Always check `package.json` before trying to run commands like `npm run e2e`.
+- **Don't assume npm scripts exist**: Always check `package.json` before trying to run commands like `pnpm run e2e`.
 - **Test timing is critical**: The smoke tests complete in ~9-10 seconds, well under the 60-second requirement.
 - **Network idle states**: The skeleton template makes multiple API calls on page load and after cart actions. Always wait for these to complete.
 
@@ -52,7 +52,7 @@
 
 - [x] 1. Establish Playwright infrastructure and baseline configuration (PR #1)
 
-  - [x] 1.1. Write a failing system test in `e2e/setup/launch.spec.ts` that launches the dev server for the existing skeleton template and asserts the root page title contains "Hydrogen". Run with `npx playwright test e2e/setup/launch.spec.ts` and confirm it fails.
+  - [x] 1.1. Write a failing system test in `e2e/setup/launch.spec.ts` that launches the dev server for the existing skeleton template and asserts the root page title contains "Hydrogen". Run with `pnpm exec playwright test e2e/setup/launch.spec.ts` and confirm it fails.
 
   - [x] 1.2. Create `e2e/playwright.config.ts` with a minimal configuration (base URL `http://localhost:3000`, retries 0, reporters = `list`).
 
@@ -60,7 +60,7 @@
 
   - [x] 1.4. Implement the minimal code necessary for the launch test to pass (update config, helper, etc.).
 
-  - [x] 1.5. Verify by running `npx playwright test e2e/setup/launch.spec.ts` locally—tests must pass and exit 0.
+  - [x] 1.5. Verify by running `pnpm exec playwright test e2e/setup/launch.spec.ts` locally—tests must pass and exit 0.
 
   - [x] 1.6. Push branch `e2e_infra-baseline` to GitHub, and open PR #1 titled "E2E Infra: Baseline Playwright Setup".
   - [x] 1.7. Wait for the full CI pipeline on PR #1 to complete successfully; fix issues if it fails.
@@ -77,18 +77,18 @@
 
   - [x] 2.4. Implement assertions and helper utilities to make tests pass without changing application code.
 
-  - [x] 2.5. Verify by running `npm run e2e -- --smoke` and ensuring the pack completes in <60 s.
+  - [x] 2.5. Verify by running `pnpm run e2e -- --smoke` and ensuring the pack completes in <60 s.
 
   - [x] 2.6. Push branch and open PR #2 titled "E2E: Smoke Test Pack for Skeleton Template". Ensure PR #2 is **stacked on top of PR #1**.
   - [x] 2.7. Wait for CI to finish and pass on PR #2.
 
-- [ ] 3. Add `npm run e2e` script and integrate Smoke Pack with CI workflow (PR #3)
+- [ ] 3. Add `pnpm run e2e` script and integrate Smoke Pack with CI workflow (PR #3)
 
   - [x] 3.1. Create branch `e2e_ci-smoke` **based on `e2e_smoke-pack`**.
 
   - [x] 3.2. Add `"e2e": "playwright test"` to `package.json` plus `--smoke` flag support.
 
-  - [ ] 3.3. Add `.github/workflows/e2e.yml` workflow that runs `npm run e2e -- --smoke` on `pull_request` events only.
+  - [ ] 3.3. Add `.github/workflows/e2e.yml` workflow that runs `pnpm run e2e -- --smoke` on `pull_request` events only.
 
   - [ ] 3.4. Verify workflow by pushing a draft PR—CI must pass and upload artifacts on failure.
 
@@ -116,20 +116,20 @@
         - [ ] A. Determine timestamped project name pattern `tmp/hydrogen-<permutation>-<YYYYMMDDHHMMSS>`.
         - [ ] B. Create failing test `e2e/matrix/<permutation>.spec.ts` exercising root load + cart flow against the new project.
         - [ ] C. Implement permutation flags and timestamped directory logic in `scaffold.ts`. When the helper detects multiple projects matching the same permutation pattern, it must pick **only the most recent** timestamped directory for running tests. Do **not** delete any projects after tests.
-        - [ ] D. Verify locally with `npm run e2e -- --matrix=<permutation>`; confirm that:
+        - [ ] D. Verify locally with `pnpm run e2e -- --matrix=<permutation>`; confirm that:
             1. The helper selects the latest project if duplicates exist.
             2. The chosen project remains in `tmp/` after tests complete.
         - [ ] E. Create branch `e2e_matrix-<permutation>` **based on the branch from the previous permutation**.
         - [ ] F. Push branch and open PR titled “E2E Matrix: <Permutation Description>”, stacked on the previous permutation PR.
         - [ ] G. Wait for CI to complete on this PR and ensure it passes before beginning the next permutation.
 
-  - [ ] 4.4. After all 32 permutation PRs are merged, run full matrix locally (`npm run e2e -- --matrix all`) to ensure runtime ≤20 min.
+  - [ ] 4.4. After all 32 permutation PRs are merged, run full matrix locally (`pnpm run e2e -- --matrix all`) to ensure runtime ≤20 min.
 
 - [ ] 5. Extend CI workflow to include the Full Matrix Pack in regular CI runs (PR after permutations complete)
 
   - [ ] 5.1. Create branch `e2e_ci-full-matrix` **based on the last merged permutation branch**.
 
-  - [ ] 5.2. Update `.github/workflows/e2e.yml` to run the full matrix (`npm run e2e -- --matrix all`) on `pull_request` events with a job strategy (3 parallel workers, 20-min timeout).
+  - [ ] 5.2. Update `.github/workflows/e2e.yml` to run the full matrix (`pnpm run e2e -- --matrix all`) on `pull_request` events with a job strategy (3 parallel workers, 20-min timeout).
 
   - [ ] 5.3. Ensure failure artifacts (screenshots, videos, logs) are uploaded for any failing matrix job.
 
@@ -144,7 +144,7 @@
 
   - [ ] 6.3. Add a short section to the project `README.md` linking to the guide.
 
-  - [ ] 6.4. Verify by running `npm run lint` and checking links work in rendered Markdown.
+  - [ ] 6.4. Verify by running `pnpm run lint` and checking links work in rendered Markdown.
 
   - [ ] 6.5. Push branch and open PR #11 titled “Docs: E2E Testing Guide”, stacked on top of PR #10.
   - [ ] 6.6. Wait for CI to pass on PR #11.

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -256,10 +256,10 @@ The Playwright config does not specify a headed mode by default, so tests run he
 
 ```bash
 # CORRECT: Run tests (headless by default)
-npx playwright test --project=skeleton
+pnpm exec playwright test --project=skeleton
 
 # AVOID: Running with headed browser
-npx playwright test --project=skeleton --headed  # Don't do this
+pnpm exec playwright test --project=skeleton --headed  # Don't do this
 ```
 
 If you need to debug visually, use Playwright's trace viewer or UI mode temporarily, but never commit headed configuration.
@@ -315,22 +315,22 @@ getCartLineItems() {
 ### Running Locally
 
 **Prerequisites:**
-- Shopify CLI authenticated: `cd templates/skeleton && npx shopify auth login`
-- Skeleton linked to benchmark store: `cd templates/skeleton && npx shopify hydrogen link`
+- Shopify CLI authenticated: `cd templates/skeleton && pnpm exec shopify auth login`
+- Skeleton linked to benchmark store: `cd templates/skeleton && pnpm exec shopify hydrogen link`
 - ejson configured (`./scripts/setup-ejson-private-key.sh`) — required for both the test email and the loadtest header (OTP bypass)
 
 ```bash
 # With ejson configured:
-npx playwright test --project=skeleton e2e/specs/skeleton/customerAccount.spec.ts
+pnpm exec playwright test --project=skeleton e2e/specs/skeleton/customerAccount.spec.ts
 
 # Override test email (ejson is still required for the loadtest header):
 CUSTOMER_ACCOUNT_TEST_EMAIL="hydrogen-e2e-test@example.com" \
-  npx playwright test --project=skeleton e2e/specs/skeleton/customerAccount.spec.ts
+  pnpm exec playwright test --project=skeleton e2e/specs/skeleton/customerAccount.spec.ts
 
 # Against an existing Oxygen deployment (skips tunnel):
 CUSTOMER_ACCOUNT_URL=https://your-oxygen-deployment.oxygen.myshopify.com \
 OXYGEN_AUTH_BYPASS_TOKEN=your-token \
-  npx playwright test --project=skeleton e2e/specs/skeleton/customerAccount.spec.ts
+  pnpm exec playwright test --project=skeleton e2e/specs/skeleton/customerAccount.spec.ts
 ```
 
 Without `CUSTOMER_ACCOUNT_URL`, the test starts a local dev server with `--customer-account-push` which creates a Cloudflare quick-tunnel.

--- a/e2e/fixtures/recipe.ts
+++ b/e2e/fixtures/recipe.ts
@@ -218,9 +218,9 @@ const generateFixture = async ({
     console.log(`[recipe-fixture] Applying ${recipeName} recipe...`);
     // Note: recipeName comes from test file literals (not user input), and
     // recipeFixturePath is constructed from controlled paths. Safe for test environment.
-    // Using exec (not execFile) because npm run requires shell for script resolution.
+    // Using exec (not execFile) because pnpm run requires shell for script resolution.
     await execAsync(
-      `npm run cookbook --workspace=cookbook -- apply --recipe ${recipeName} --template ${stagingPath}`,
+      `pnpm --filter cookbook run cookbook -- apply --recipe ${recipeName} --template ${stagingPath}`,
       {
         cwd: repoRoot,
         env: {...process.env, ...envOverrides, CI: 'true'},

--- a/e2e/fixtures/server.ts
+++ b/e2e/fixtures/server.ts
@@ -167,7 +167,7 @@ export class DevServer {
           this.stop();
           reject(
             new Error(
-              'Not logged in to Shopify CLI. Run: cd templates/skeleton && npx shopify auth login',
+              'Not logged in to Shopify CLI. Run: cd templates/skeleton && pnpm exec shopify auth login',
             ),
           );
         } else if (
@@ -178,7 +178,7 @@ export class DevServer {
           this.stop();
           reject(
             new Error(
-              'Storefront not linked. Run: cd templates/skeleton && npx shopify hydrogen link',
+              'Storefront not linked. Run: cd templates/skeleton && pnpm exec shopify hydrogen link',
             ),
           );
         }

--- a/e2e/specs/skeleton/customerAccount.spec.ts
+++ b/e2e/specs/skeleton/customerAccount.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../../fixtures';
 
 // Pass CUSTOMER_ACCOUNT_URL to skip the tunnel and use an existing dev server, e.g.:
-//   CUSTOMER_ACCOUNT_URL=https://xyz.tryhydrogen.dev npx playwright test --project=skeleton
+//   CUSTOMER_ACCOUNT_URL=https://xyz.tryhydrogen.dev pnpm exec playwright test --project=skeleton
 const externalUrl = process.env.CUSTOMER_ACCOUNT_URL;
 
 if (externalUrl) {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ The Hydrogen extension for the [Shopify CLI](https://shopify.dev/apps/tools/cli)
 
 The most common way to test the cli changes locally is to do the following:
 
-- Run `npm run build` in this directory (`packages/cli` from the root of the repo).
+- Run `pnpm run build` in this directory (`packages/cli` from the root of the repo).
 - Run `npx shopify hydrogen` anywhere else in the monorepo, for example `npx shopify hydrogen init`.
 - If you want to test a command inside of a template, run the command from within that template or use the `--path` flag to point to another template or any Hydrogen app.
 - If you want to make changes to a file that is generated when running `npx shopify hydrogen generate`, make changes to that file from inside of the `templates/skeleton` directory.

--- a/packages/hydrogen-react/CONTRIBUTING.md
+++ b/packages/hydrogen-react/CONTRIBUTING.md
@@ -3,10 +3,10 @@
 There are two ways you can develop Hydrogen React components:
 
 - Develop components in isolation (faster & easier):
-  1. Run `npm run dev:story` in the `packages/hydrogen-react` directory to spin up an instance of [Ladle](https://ladle.dev/)
+  1. Run `pnpm run dev:story` in the `packages/hydrogen-react` directory to spin up an instance of [Ladle](https://ladle.dev/)
   2. Edit the component or the component's story `[ComponentName].stories.tsx`
 - Develop components in a demo app (good for testing out the ecosystem support)
-  1. Run `npm run dev`
+  1. Run `pnpm run dev`
 
 ## Authoring Components
 
@@ -47,7 +47,7 @@ Documentation lives in the `*.doc.ts` files, and uses a Shopify library called `
 After adding or updating docs, you'll need to:
 
 1. `cd` into `packages/hydrogen-react` folder
-1. Run `npm run build-docs`
+1. Run `pnpm run build-docs`
 
 Which will update the generated output, and then will be picked up by the Shopify website on a regular cadence.
 
@@ -57,7 +57,7 @@ For most contributions, this should be enough information to work off of. Howeve
 
 ## Running CI Checks Locally
 
-Every PR must pass certain CI checks in order to be merged; you can run these checks locally yourself by running `npm run ci:checks` from the root of the repo.
+Every PR must pass certain CI checks in order to be merged; you can run these checks locally yourself by running `pnpm run ci:checks` from the root of the repo.
 
 ## Updating the Storefront API & Customer Account API version
 

--- a/packages/hydrogen-react/codegen.ts
+++ b/packages/hydrogen-react/codegen.ts
@@ -36,7 +36,7 @@ const config: CodegenConfig = {
               /**
                * THIS FILE IS AUTO-GENERATED, DO NOT EDIT
                * Based on Storefront API ${SF_API_VERSION}
-               * If changes need to happen to the types defined in this file, then generally the Storefront API needs to update. After it's updated, you can run \`npm run graphql-types\`.
+               * If changes need to happen to the types defined in this file, then generally the Storefront API needs to update. After it's updated, you can run \`pnpm run graphql-types\`.
                * Except custom Scalars, which are defined in the \`codegen.ts\` file
                */
               /* eslint-disable */`,
@@ -75,7 +75,7 @@ const config: CodegenConfig = {
               /**
                * THIS FILE IS AUTO-GENERATED, DO NOT EDIT
                * Based on Customer Account API ${CA_API_VERSION}
-               * If changes need to happen to the types defined in this file, then generally the Storefront API needs to update. After it's updated, you can run \`npm run graphql-types\`.
+               * If changes need to happen to the types defined in this file, then generally the Storefront API needs to update. After it's updated, you can run \`pnpm run graphql-types\`.
                * Except custom Scalars, which are defined in the \`codegen.ts\` file
                */
               /* eslint-disable */`,

--- a/packages/hydrogen-react/scripts/prepare-next.mjs
+++ b/packages/hydrogen-react/scripts/prepare-next.mjs
@@ -8,7 +8,7 @@ packageJson.version = version;
 fs.writeFileSync('../package.json', JSON.stringify(packageJson, null, 2));
 
 try {
-  execSync('npm publish --tag next');
+  execSync('pnpm publish --tag next');
 } catch (e) {
   console.log(e);
   console.log('Publish failed');


### PR DESCRIPTION
### WHY are these changes introduced?

Our monorepo uses pnpm but several scripts and contributor docs still referenced npm/npx directly, breaking the pre-commit hook and other tooling on every commit attempt.

### WHAT is this pull request doing?

**Fixes 6 broken command invocations:**
- `.husky/pre-commit` — `npx lint-staged` and `npm run pre-commit:encrypt`
- `cookbook/scripts/pre-commit.sh` — `npm run cookbook` invocations
- `e2e/fixtures/recipe.ts` — `npm run cookbook --workspace=cookbook`
- `.changeset/enforce-calver-local.js` — `npx @changesets/cli version`
- `packages/hydrogen-react/scripts/prepare-next.mjs` — `npm publish`

**Updates 22 contributor doc files** (CONTRIBUTING.md, CLAUDE.md files, cookbook docs, e2e docs, skills/commands, CALVER docs, task PRDs) to reference pnpm instead of npm.

**Preserves all end-user-facing references** — CLI source code, templates, and user-facing READMEs correctly reference npm for customers who may use any package manager.

28 files changed, 178 insertions, 178 deletions (pure replacements).

### HOW to test your changes?

- Verify pre-commit hook works: stage any file and commit — `pnpm exec lint-staged`, `pnpm run pre-commit:encrypt`, and the cookbook pre-commit script should all run
- Verify `pnpm run cookbook -- validate` still works
- CI should pass (lint, typecheck, tests)

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or noteworthy changes
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)