### PR TITLE
fix: restore Vite external function for @xstate/fsm bundling

### DIFF
--- a/packages/hydrogen-react/vite.config.ts
+++ b/packages/hydrogen-react/vite.config.ts
@@ -67,13 +67,25 @@ export default defineConfig(({mode, isSsrBuild}) => {
       minify: false,
       emptyOutDir: false,
       rollupOptions: {
-        external: externals,
+        // @xstate/fsm must be bundled (not externalized) because it's an
+        // internal implementation detail of the cart state machine. With
+        // preserveModules, externalizing it produces a bare `import "@xstate/fsm"`
+        // in the dist — which fails in contexts where the package isn't directly
+        // resolvable (e.g. the CLI setup test, which symlinks skeleton's
+        // node_modules where pnpm strict isolation doesn't hoist transitive deps).
+        external: (id) => {
+          if (id.includes('@xstate/fsm')) return false;
+          return externals.includes(id);
+        },
         output: {
           // keep the folder structure of the components in the dist folder
           preserveModules: true,
           preserveModulesRoot: 'src',
         },
       },
+    },
+    ssr: {
+      noExternal: ['@xstate/fsm'],
     },
     define: {
       __HYDROGEN_DEV__: mode === 'devbuild' || mode === 'test',


### PR DESCRIPTION
## Context

The CLI setup test (`setup.test.ts > sets up an i18n strategy and generates routes`) has been failing on `main` since the Vite 6.4.2 bump exposed a latent issue from #3594.

## Root Cause

PR #3594 (inline useMachine hook) simplified the Rollup `external` option from a function to a plain array. This inadvertently externalized `@xstate/fsm` in the dist output as a bare `import from "@xstate/fsm"` specifier.

The CLI setup test creates a temp dir with skeleton template files and symlinks skeleton's `node_modules` into it. When Vite resolves the config, ViteNodeRunner loads `hydrogen-react/dist/node-dev/useMachine.mjs` — but `@xstate/fsm` isn't resolvable from skeleton's `node_modules` because pnpm's strict isolation doesn't hoist transitive dependencies.

Before #3594, the `external` function explicitly returned `false` for xstate packages, telling Rollup to bundle them into the dist output. #3594 removed that function as part of the Vite config cleanup, breaking the bundling.

## Solution

Restore the `external` function form that returns `false` for `@xstate/fsm`, plus the `ssr.noExternal` config for SSR builds. This matches the pre-#3594 behavior.

The change is 6 lines in `vite.config.ts`.

## Testing

- [x] `setup.test.ts` passes (was failing)
- [x] hydrogen-react: 34/34 test files pass
- [x] Typecheck passes

## Risk Assessment

Low — this restores the pre-#3594 behavior for `@xstate/fsm` only. The xstate code ends up bundled in `dist/` via Rollup's `preserveModules` output, which is exactly how it shipped before #3594.