### PR TITLE
fix(calver): correct stale CHANGELOG body version references after CalVer override

### DIFF
--- a/.changeset/calver-bump-type.test.js
+++ b/.changeset/calver-bump-type.test.js
@@ -18,6 +18,7 @@ const {
   getNextVersion,
   parseVersion,
   hasMajorChangesets,
+  replaceChangelogBodyVersions,
 } = require('./calver-shared.js');
 const {
   detectBumpType,
@@ -544,6 +545,54 @@ function testWriteAndCleanup() {
   cleanupTestChangesets();
 }
 
+function testReplaceChangelogBodyVersions() {
+  console.log('\n📝 Testing replaceChangelogBodyVersions()...\n');
+
+  // Reproduces the PR #3645 scenario: "minor" changeset on @shopify/hydrogen causes
+  // changesets to compute 2026.2.0, but CalVer corrects it to 2026.1.4. The skeleton
+  // CHANGELOG body then contains "Updated dependencies: @shopify/hydrogen@2026.2.0"
+  // which must be replaced.
+  console.log('Test 1: Replaces stale dependency reference in CHANGELOG body');
+  const skeletonChangelog = `## 2026.1.4\n\n### Patch Changes\n\n- Updated dependencies [abc123]:\n  - @shopify/hydrogen@2026.2.0\n`;
+  const staleToCorrect = new Map([
+    ['@shopify/hydrogen@2026.2.0', '@shopify/hydrogen@2026.1.4'],
+  ]);
+  const result = replaceChangelogBodyVersions(
+    skeletonChangelog,
+    staleToCorrect,
+  );
+  assert(
+    result.includes('@shopify/hydrogen@2026.1.4'),
+    'Stale version replaced with CalVer version',
+  );
+  assert(
+    !result.includes('@shopify/hydrogen@2026.2.0'),
+    'Stale version no longer present',
+  );
+
+  console.log(
+    '\nTest 2: No-op when changesetVersion equals newVersion (patch bump)',
+  );
+  const changelog = `## 2026.1.4\n\n- Updated dependencies:\n  - @shopify/hydrogen@2026.1.4\n`;
+  const emptyMap = new Map();
+  const unchanged = replaceChangelogBodyVersions(changelog, emptyMap);
+  assertEqual(unchanged, changelog, 'Content unchanged when map is empty');
+
+  console.log('\nTest 3: Replaces multiple packages in one pass');
+  const multiChangelog = `## 2026.1.4\n\n- @shopify/hydrogen@2026.2.0\n- @shopify/hydrogen-react@2026.2.0\n`;
+  const multiMap = new Map([
+    ['@shopify/hydrogen@2026.2.0', '@shopify/hydrogen@2026.1.4'],
+    ['@shopify/hydrogen-react@2026.2.0', '@shopify/hydrogen-react@2026.1.4'],
+  ]);
+  const multiResult = replaceChangelogBodyVersions(multiChangelog, multiMap);
+  assert(
+    multiResult.includes('@shopify/hydrogen@2026.1.4') &&
+      multiResult.includes('@shopify/hydrogen-react@2026.1.4'),
+    'Both packages replaced',
+  );
+  assert(!multiResult.includes('2026.2.0'), 'No stale versions remain');
+}
+
 function main() {
   console.log(
     '═══════════════════════════════════════════════════════════════',
@@ -562,6 +611,7 @@ function main() {
     testHasMajorChangesets();
     testSkeletonMajorBugScenario();
     testWriteAndCleanup();
+    testReplaceChangelogBodyVersions();
   } finally {
     cleanupTestChangesets();
     restoreBackedUpChangesets();

--- a/.changeset/calver-shared.js
+++ b/.changeset/calver-shared.js
@@ -314,6 +314,27 @@ Commands:
   }
 }
 
+/**
+ * Replaces stale package@version references in a CHANGELOG body string.
+ *
+ * When the CalVer override corrects a semver-computed version (e.g., changesets
+ * says 2026.2.0 for a "minor" bump but CalVer requires 2026.1.4), the
+ * "Updated dependencies" lines that changesets wrote into dependent packages'
+ * CHANGELOGs will reference the stale semver version. This function corrects
+ * those body references given a map of stale → correct version strings.
+ *
+ * @param {string} content - CHANGELOG file content
+ * @param {Map<string, string>} staleToCorrect - e.g., Map { "@shopify/hydrogen@2026.2.0" => "@shopify/hydrogen@2026.1.4" }
+ * @returns {string} Updated content with stale references replaced
+ */
+function replaceChangelogBodyVersions(content, staleToCorrect) {
+  let result = content;
+  for (const [stale, correct] of staleToCorrect) {
+    result = result.replaceAll(stale, correct);
+  }
+  return result;
+}
+
 module.exports = {
   QUARTERS,
   CALVER_PACKAGES,
@@ -332,4 +353,5 @@ module.exports = {
   getAllPackagePaths,
   updateInternalDependencies,
   updateChangelogs,
+  replaceChangelogBodyVersions,
 };

--- a/.changeset/enforce-calver-ci.js
+++ b/.changeset/enforce-calver-ci.js
@@ -245,17 +245,10 @@ function updateChangelogs(updates) {
     .filter((p) => fs.existsSync(p));
 
   for (const changelogPath of allChangelogPaths) {
-    let content = fs.readFileSync(changelogPath, 'utf-8');
-    let modified = false;
-
+    const content = fs.readFileSync(changelogPath, 'utf-8');
     const updated = replaceChangelogBodyVersions(content, staleToCorrect);
     if (updated !== content) {
-      content = updated;
-      modified = true;
-    }
-
-    if (modified) {
-      fs.writeFileSync(changelogPath, content);
+      fs.writeFileSync(changelogPath, updated);
     }
   }
 }

--- a/.changeset/enforce-calver-ci.js
+++ b/.changeset/enforce-calver-ci.js
@@ -22,6 +22,7 @@ const {
   getPackagePath,
   readPackage,
   writePackage,
+  replaceChangelogBodyVersions,
 } = require('./calver-shared.js');
 const {CALVER_BUMP_FILE} = require('./detect-calver-bump-type.js');
 
@@ -179,6 +180,8 @@ function calculateNewVersions(versions, preComputedBumpType) {
       path: data.path,
       pkg: data.pkg,
       oldVersion: data.oldVersion,
+      // Capture what changesets computed before applyUpdates mutates pkg.version.
+      changesetVersion: data.pkg.version,
       bumpType: effectiveBumpType,
       newVersion,
     });
@@ -196,26 +199,67 @@ function applyUpdates(updates) {
   }
 }
 
-// Update CHANGELOG headers
+// Update CHANGELOG headers and body references to use CalVer versions.
+//
+// Changesets writes two things we need to correct:
+//   1. The section header (e.g., "## 2026.2.0") in each package's own CHANGELOG
+//   2. "Updated dependencies" lines (e.g., "@shopify/hydrogen@2026.2.0") in the
+//      CHANGELOGs of packages that depend on a bumped CalVer package
+//
+// The package.json files are already corrected by applyUpdates and
+// updateInternalDependencies, but the CHANGELOG bodies are not touched by those.
 function updateChangelogs(updates) {
+  // Fix each CalVer package's own CHANGELOG header.
   for (const update of updates) {
-    const dir = path.dirname(update.path);
-    const changelogPath = path.join(dir, 'CHANGELOG.md');
-
+    const changelogPath = path.join(path.dirname(update.path), 'CHANGELOG.md');
     if (!fs.existsSync(changelogPath)) continue;
 
     let content = fs.readFileSync(changelogPath, 'utf-8');
 
-    // Replace the version that changesets generated with our CalVer version
+    // Replace the first ## X.X.X header (the one changesets just added).
     const regex = new RegExp(`^## \\d+\\.\\d+\\.\\d+`, 'gm');
     content = content.replace(regex, (match) => {
-      // Only replace if it's a recent addition (first occurrence)
       return content.indexOf(match) === content.search(regex)
         ? `## ${update.newVersion}`
         : match;
     });
 
     fs.writeFileSync(changelogPath, content);
+  }
+
+  // Build a map of stale package@version strings → correct package@version strings.
+  // A stale reference exists when changesets computed a different version than CalVer
+  // (e.g., "minor" on 2026.1.3 → changesets says 2026.2.0, CalVer says 2026.1.4).
+  const staleToCorrect = new Map();
+  for (const update of updates) {
+    if (update.changesetVersion !== update.newVersion) {
+      staleToCorrect.set(
+        `${update.name}@${update.changesetVersion}`,
+        `${update.name}@${update.newVersion}`,
+      );
+    }
+  }
+
+  if (staleToCorrect.size === 0) return;
+
+  // Apply body replacements across every package's CHANGELOG.
+  const allChangelogPaths = getAllPackageJsonPaths()
+    .map((p) => path.join(path.dirname(p), 'CHANGELOG.md'))
+    .filter((p) => fs.existsSync(p));
+
+  for (const changelogPath of allChangelogPaths) {
+    let content = fs.readFileSync(changelogPath, 'utf-8');
+    let modified = false;
+
+    const updated = replaceChangelogBodyVersions(content, staleToCorrect);
+    if (updated !== content) {
+      content = updated;
+      modified = true;
+    }
+
+    if (modified) {
+      fs.writeFileSync(changelogPath, content);
+    }
   }
 }
 

--- a/.changeset/enforce-calver-ci.js
+++ b/.changeset/enforce-calver-ci.js
@@ -209,14 +209,12 @@ function applyUpdates(updates) {
 // The package.json files are already corrected by applyUpdates and
 // updateInternalDependencies, but the CHANGELOG bodies are not touched by those.
 function updateChangelogs(updates) {
-  // Fix each CalVer package's own CHANGELOG header.
   for (const update of updates) {
     const changelogPath = path.join(path.dirname(update.path), 'CHANGELOG.md');
     if (!fs.existsSync(changelogPath)) continue;
 
     let content = fs.readFileSync(changelogPath, 'utf-8');
 
-    // Replace the first ## X.X.X header (the one changesets just added).
     const regex = new RegExp(`^## \\d+\\.\\d+\\.\\d+`, 'gm');
     content = content.replace(regex, (match) => {
       return content.indexOf(match) === content.search(regex)
@@ -242,7 +240,6 @@ function updateChangelogs(updates) {
 
   if (staleToCorrect.size === 0) return;
 
-  // Apply body replacements across every package's CHANGELOG.
   const allChangelogPaths = getAllPackageJsonPaths()
     .map((p) => path.join(path.dirname(p), 'CHANGELOG.md'))
     .filter((p) => fs.existsSync(p));


### PR DESCRIPTION
## Summary

When a changeset uses `minor` for `@shopify/hydrogen`, Changesets computes the next semver version (e.g., `2026.1.3 + minor = 2026.2.0`). The CalVer enforcement in `enforce-calver-ci.js` then corrects this to `2026.1.4` in `package.json` and CHANGELOG headers — but the **CHANGELOG body text** that Changesets wrote (specifically the `Updated dependencies: @shopify/hydrogen@2026.2.0` lines in dependent packages like `skeleton`) was left with the stale semver version.

This caused PR #3645 to show `@shopify/hydrogen@2026.2.0` in skeleton's "Updated dependencies" section even though hydrogen was actually being released as `2026.1.4`.

## Changes

- **`enforce-calver-ci.js`**: Capture `changesetVersion` on each update object before `applyUpdates()` mutates `pkg.version`. In `updateChangelogs`, build a stale→correct map for packages where they differ, then replace all occurrences across every CHANGELOG file.
- **`calver-shared.js`**: Extract the pure replacement logic into `replaceChangelogBodyVersions(content, staleToCorrect)` so it can be tested in isolation.
- **`calver-bump-type.test.js`**: Add 3 tests covering the PR #3645 scenario, the no-op case, and multi-package replacement.

## Test plan

- [x] All 37 existing + new tests pass: `node .changeset/calver-bump-type.test.js`
- [x] No-op path verified: when `changesetVersion === newVersion` (normal patch bump), the stale map is empty and no file I/O happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)