### PR TITLE
fix(e2e): remove spurious -- separator from pnpm cookbook command

### DIFF
--- a/e2e/fixtures/recipe.ts
+++ b/e2e/fixtures/recipe.ts
@@ -220,7 +220,7 @@ const generateFixture = async ({
     // recipeFixturePath is constructed from controlled paths. Safe for test environment.
     // Using exec (not execFile) because pnpm run requires shell for script resolution.
     await execAsync(
-      `pnpm --filter cookbook run cookbook -- apply --recipe ${recipeName} --template ${stagingPath}`,
+      `pnpm --filter cookbook run cookbook apply --recipe ${recipeName} --template ${stagingPath}`,
       {
         cwd: repoRoot,
         env: {...process.env, ...envOverrides, CI: 'true'},


### PR DESCRIPTION
### WHY are these changes introduced?

Extracted from #3649.

PR #3670 migrated the repo from npm to pnpm. In pnpm, `--` after `run` signals end-of-pnpm-flags and passes remaining arguments as raw argv directly to ts-node. This caused `apply` to be swallowed before reaching the yargs CLI, so the cookbook ran without applying any recipe patch. The resulting fixture was indistinguishable from a vanilla skeleton — all recipe-specific tests failed silently.

### WHAT is this pull request doing?

Removes the `--` separator from `pnpm --filter cookbook run cookbook -- apply` in `e2e/fixtures/recipe.ts`, so `apply` is correctly passed to the yargs subcommand parser.

### HOW to test your changes?

Run the recipe E2E tests and confirm patches are applied:

```bash
pnpm playwright test e2e/recipes
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset. 
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation