### PR TITLE
chore: update changelog.json for 2026.1.4

### DIFF
--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -27,7 +27,7 @@
         },
         {
           "title": "Fix useMachine bundling regression with @xstate/fsm",
-          "info": "Restores @xstate/fsm bundling in hydrogen-react's dist output, fixing a regression introduced in 2026.1.3. In strict pnpm setups, useMachine from @shopify/hydrogen-react could fail with an unresolvable @xstate/fsm import. The Vite external configuration is now restored to ensure @xstate/fsm is bundled into the dist rather than referenced as a bare import specifier.",
+          "info": "Fixed a bundling regression from 2026.1.3 where useMachine from @shopify/hydrogen-react could fail with an unresolvable @xstate/fsm import in strict pnpm setups.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3672",
           "id": "3672"
         }
@@ -35,7 +35,7 @@
       "features": [
         {
           "title": "Add Storefront MCP proxy for AI agent integration",
-          "info": "Hydrogen now automatically proxies requests to /api/mcp to Shopify's Storefront MCP server, enabling AI assistants like Claude and ChatGPT to connect to your storefront to browse products, manage carts, and access store policies. No configuration changes are needed — the proxy activates automatically with the default createRequestHandler setup. To connect an MCP client, point it at your storefront's /api/mcp path (for example, http://localhost:3000/api/mcp in development). For full setup instructions, see the Storefront MCP server documentation at https://shopify.dev/docs/apps/build/storefront-mcp/servers/storefront. Separately, if your app has a manual /api/:version/graphql.json route file from an earlier Hydrogen version, you can safely delete it — Hydrogen has automatically handled these GraphQL requests since December 2025 and the route file is no longer needed.",
+          "info": "Hydrogen now automatically proxies requests to /api/mcp to Shopify's Storefront MCP server, enabling AI assistants like Claude and ChatGPT to connect to your storefront to browse products, manage carts, and access store policies. No configuration changes are needed — the proxy activates automatically with the default createRequestHandler setup, and MCP clients can connect to your storefront at the /api/mcp path.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3572",
           "id": "3572"
         },

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -3,6 +3,45 @@
   "version": "1",
   "releases": [
     {
+      "title": "Add Storefront MCP proxy for AI agent integration",
+      "version": "2026.1.4",
+      "date": "2026-04-09",
+      "hash": "1e74e2c412c0237083f7e3a8b24d5a524efe8562",
+      "commit": "https://github.com/Shopify/hydrogen/pull/3645/commits/1e74e2c412c0237083f7e3a8b24d5a524efe8562",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3645",
+      "dependencies": {
+        "@shopify/hydrogen": "2026.1.4"
+      },
+      "devDependencies": {
+        "vite": "^6.4.2"
+      },
+      "removeDependencies": [
+        "@shopify/hydrogen"
+      ],
+      "fixes": [
+        {
+          "title": "Fix GraphQL access denied error surfaced as unexpected error",
+          "info": "GraphQL access denied errors from the Storefront API are now handled as expected user errors instead of being reported as unexpected failures.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3654",
+          "id": "3654"
+        }
+      ],
+      "features": [
+        {
+          "title": "Add Storefront MCP proxy for AI agent integration",
+          "info": "Hydrogen now automatically proxies requests to /api/mcp to Shopify's Storefront MCP server, enabling AI assistants like Claude and ChatGPT to connect to your storefront to browse products, manage carts, and access store policies. No code changes required — the proxy is available automatically when using the default createRequestHandler configuration. If your app has a manual /api/:version/graphql.json route file, you can optionally delete it as the server-level proxy now handles those requests automatically.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3572",
+          "id": "3572"
+        },
+        {
+          "title": "Add useCustomAuthDomain option for custom HTTPS setups",
+          "info": "createCustomerAccountClient and createHydrogenContext now accept a useCustomAuthDomain option. When set to true, the development tunnel domain check logs a warning instead of throwing an error, enabling Customer Account API OAuth with custom HTTPS setups like ngrok or local HTTPS proxies.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3642",
+          "id": "3642"
+        }
+      ]
+    },
+    {
       "title": "CLI fixes and dependency updates",
       "version": "2026.1.3",
       "date": "2026-03-27",

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -21,21 +21,27 @@
       "fixes": [
         {
           "title": "Fix GraphQL access denied error surfaced as unexpected error",
-          "info": "GraphQL access denied errors from the Storefront API are now handled as expected user errors instead of being reported as unexpected failures.",
+          "info": "GraphQL access denied errors from the Storefront API are now surfaced as actionable errors rather than unexpected application failures, reducing noise in error monitoring.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3654",
           "id": "3654"
+        },
+        {
+          "title": "Fix useMachine bundling regression with @xstate/fsm",
+          "info": "Restores @xstate/fsm bundling in hydrogen-react's dist output, fixing a regression introduced in 2026.1.3. In strict pnpm setups, useMachine from @shopify/hydrogen-react could fail with an unresolvable @xstate/fsm import. The Vite external configuration is now restored to ensure @xstate/fsm is bundled into the dist rather than referenced as a bare import specifier.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3672",
+          "id": "3672"
         }
       ],
       "features": [
         {
           "title": "Add Storefront MCP proxy for AI agent integration",
-          "info": "Hydrogen now automatically proxies requests to /api/mcp to Shopify's Storefront MCP server, enabling AI assistants like Claude and ChatGPT to connect to your storefront to browse products, manage carts, and access store policies. No code changes required — the proxy is available automatically when using the default createRequestHandler configuration. If your app has a manual /api/:version/graphql.json route file, you can optionally delete it as the server-level proxy now handles those requests automatically.",
+          "info": "Hydrogen now automatically proxies requests to /api/mcp to Shopify's Storefront MCP server, enabling AI assistants like Claude and ChatGPT to connect to your storefront to browse products, manage carts, and access store policies. No configuration changes are needed — the proxy activates automatically with the default createRequestHandler setup. To connect an MCP client, point it at your storefront's /api/mcp path (for example, http://localhost:3000/api/mcp in development). For full setup instructions, see the Storefront MCP server documentation at https://shopify.dev/docs/apps/build/storefront-mcp/servers/storefront. Separately, if your app has a manual /api/:version/graphql.json route file from an earlier Hydrogen version, you can safely delete it — Hydrogen has automatically handled these GraphQL requests since December 2025 and the route file is no longer needed.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3572",
           "id": "3572"
         },
         {
           "title": "Add useCustomAuthDomain option for custom HTTPS setups",
-          "info": "createCustomerAccountClient and createHydrogenContext now accept a useCustomAuthDomain option. When set to true, the development tunnel domain check logs a warning instead of throwing an error, enabling Customer Account API OAuth with custom HTTPS setups like ngrok or local HTTPS proxies.",
+          "info": "If you use a custom HTTPS domain in development rather than the default *.tryhydrogen.dev tunnel, createCustomerAccountClient and createHydrogenContext now accept a useCustomAuthDomain option. When set to true, the domain check logs a warning instead of throwing an error, enabling Customer Account API OAuth with setups like ngrok or local HTTPS proxies.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3642",
           "id": "3642"
         }


### PR DESCRIPTION
Adds the `docs/changelog.json` entry for the 2026.1.4 release to enable the `h2 upgrade` CLI command to detect this version.

## Changes in this release

- **Feature**: Storefront MCP proxy for AI agent integration ([#3572](https://github.com/Shopify/hydrogen/pull/3572)) — no code changes required for users
- **Feature**: `useCustomAuthDomain` option for custom HTTPS/ngrok setups ([#3642](https://github.com/Shopify/hydrogen/pull/3642))
- **Fix**: GraphQL access denied errors now handled as user errors ([#3654](https://github.com/Shopify/hydrogen/pull/3654))
- `vite` bumped to `^6.4.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)