### PR TITLE
fix: widen React Router peer deps to caret ranges

### DIFF
--- a/.changeset/permissive-rr-peerdeps.md
+++ b/.changeset/permissive-rr-peerdeps.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen': patch
+'@shopify/cli-hydrogen': patch
+---
+
+Widen React Router peer dependencies from exact versions to caret ranges (`^7.12.0`). This allows Hydrogen projects to use newer React Router minor versions without peer dependency conflicts, particularly with npm's strict resolver. Hydrogen only uses stable public APIs from React Router, so minor version updates are backwards-compatible.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "@graphql-codegen/cli": "^5.0.2",
-    "@react-router/dev": "7.12.0",
+    "@react-router/dev": "^7.12.0",
     "@shopify/hydrogen-codegen": "workspace:*",
     "@shopify/mini-oxygen": "workspace:*",
     "graphql-config": "^5.0.3",

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -113,8 +113,8 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "react-router": "7.12.0",
-    "@react-router/dev": "7.12.0",
+    "react-router": "^7.12.0",
+    "@react-router/dev": "^7.12.0",
     "react": "^18.3.1 || ~19.0.3 || ~19.1.4 || ^19.2.3",
     "vite": "^5.1.0 || ^6.2.1"
   },


### PR DESCRIPTION
## Context

Discussed in [#3617](https://github.com/Shopify/hydrogen/pull/3617#issuecomment-new) - exact React Router peer dep pinning causes npm scaffolding tests to fail with `ERESOLVE` when the skeleton template uses a newer minor version than the published hydrogen package declares.

## Root Cause

Hydrogen and cli-hydrogen pin `@react-router/dev` and `react-router` to exact versions (e.g. `"7.12.0"`) in `peerDependencies`. npm's strict resolver rejects installs when the project uses `7.14.0` but the published hydrogen expects exactly `7.12.0`. pnpm and yarn are more lenient by default, which is why only npm scaffolding tests fail.

## Solution

Widen peer deps from exact (`7.12.0`) to caret ranges (`^7.12.0`). This:

- Allows any compatible minor/patch version within the 7.x range
- Aligns with how we already handle `vite` peer deps (wide ranges like `^5.1.0 || ^6.2.1`)
- Is safe because hydrogen only uses stable public APIs from react-router (`useFetcher`, `Link`, `useLocation`, `data`, `redirect`, etc.) and type-only imports from `@react-router/dev` (`Preset`, `Config`, `RouteConfigEntry`)

## Testing

- npm scaffolding tests should pass once this is published alongside the Vite 8 PR
- `pnpm install` still resolves correctly with the widened range