### PR TITLE
chore: update changelog.json for 2026.4.0

### DIFF
--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -17,8 +17,8 @@
       ],
       "fixes": [
         {
-          "title": "Widen React Router peer dependency ranges to caret",
-          "info": "React Router peer dependencies are now specified as caret ranges (^7.12.0) instead of exact versions. This allows Hydrogen projects to use newer React Router minor versions without peer dependency conflicts, particularly with npm's strict resolver.",
+          "title": "Fix React Router peer dependency conflicts with strict resolvers",
+          "info": "React Router peer dependencies are now caret ranges (^7.12.0) instead of exact versions, allowing projects to use newer React Router minor versions without peer dependency conflicts in npm's strict resolver.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3677",
           "id": "3677"
         }
@@ -26,14 +26,14 @@
       "features": [
         {
           "title": "Update Storefront API and Customer Account API to 2026-04",
-          "info": "Quarterly API version update from 2026-01 to 2026-04. Notable changes: JSON metafield writes are now limited to 128KB for new apps using 2026-04 (apps using metafields before April 1, 2026 are grandfathered at 2MB). Cart operations now return a specific MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR error code when a Cart Transform Function fails, instead of the previous generic INVALID code.",
+          "info": "Quarterly API version update from 2026-01 to 2026-04. JSON metafield writes are now limited to 128KB for new apps (apps using metafields before April 1, 2026 are grandfathered at 2MB). Cart operations now return MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR instead of the generic INVALID code when a Cart Transform Function fails.",
           "breaking": true,
           "pr": "https://github.com/Shopify/hydrogen/pull/3651",
           "id": "3651"
         },
         {
-          "title": "Remove proxyStandardRoutes option — Storefront API proxy is now always enabled",
-          "info": "The proxyStandardRoutes option has been removed from createRequestHandler. The Storefront API proxy is now always on. If you were passing this option, remove it. If your load context does not include a storefront instance, the request handler will now throw an error instead of logging a warning.",
+          "title": "Remove proxyStandardRoutes option from createRequestHandler",
+          "info": "The proxyStandardRoutes option has been removed — the Storefront API proxy is now always enabled. Remove this option if you were passing it. If your load context does not include a storefront instance, the request handler will now throw instead of warn.",
           "breaking": true,
           "code": "YGBgZGlmZgotIHByb3h5U3RhbmRhcmRSb3V0ZXM6IGZhbHNlLCAvLyBvciB0cnVlCmBgYAo=",
           "pr": "https://github.com/Shopify/hydrogen/pull/3649",
@@ -41,7 +41,7 @@
         },
         {
           "title": "Enable backend consent mode for Customer Privacy API",
-          "info": "window.Shopify.customerPrivacy.backendConsentEnabled is now set to true before the Customer Privacy API script loads. This tells the consent library to use server-set cookies via the Storefront API proxy instead of the legacy _tracking_consent JS cookie. No code changes are required — this behavior is automatic.",
+          "info": "window.Shopify.customerPrivacy.backendConsentEnabled is now set to true automatically before the Customer Privacy API script loads, switching the consent library to server-set cookies via the Storefront API proxy instead of the legacy _tracking_consent JS cookie.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3649",
           "id": "3649"
         }

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -26,22 +26,22 @@
       "features": [
         {
           "title": "Update Storefront API and Customer Account API to 2026-04",
-          "info": "Quarterly API version update from 2026-01 to 2026-04. JSON metafield writes are now limited to 128KB for new apps (apps using metafields before April 1, 2026 are grandfathered at 2MB). Cart operations now return MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR instead of the generic INVALID code when a Cart Transform Function fails.",
+          "info": "Quarterly API version update from 2026-01 to 2026-04. JSON metafield writes are now limited to 128KB for storefronts created after April 1, 2026 (existing storefronts are grandfathered at 2MB). Cart operations now return MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR instead of the generic INVALID code when a Cart Transform Function fails. No Customer Account API changes require code updates.",
           "breaking": true,
           "pr": "https://github.com/Shopify/hydrogen/pull/3651",
           "id": "3651"
         },
         {
           "title": "Remove proxyStandardRoutes option from createRequestHandler",
-          "info": "The proxyStandardRoutes option has been removed — the Storefront API proxy is now always enabled. Remove this option if you were passing it. If your load context does not include a storefront instance, the request handler will now throw instead of warn.",
+          "info": "The proxyStandardRoutes option has been removed — the Storefront API proxy is now always enabled and cannot be disabled. Remove this option if you were passing it. If you were intentionally disabling the proxy (proxyStandardRoutes: false), there is no workaround; the proxy is required for Hydrogen analytics and backend consent to function. If your load context does not include a storefront instance, the request handler will now throw instead of warn.",
           "breaking": true,
-          "code": "YGBgZGlmZgotIHByb3h5U3RhbmRhcmRSb3V0ZXM6IGZhbHNlLCAvLyBvciB0cnVlCmBgYAo=",
+          "code": "YGBgZGlmZgogY3JlYXRlUmVxdWVzdEhhbmRsZXIoewogICBidWlsZCwKICAgZ2V0TG9hZENvbnRleHQsCi0gIHByb3h5U3RhbmRhcmRSb3V0ZXM6IGZhbHNlLAogfSk7CmBgYAo=",
           "pr": "https://github.com/Shopify/hydrogen/pull/3649",
           "id": "3649"
         },
         {
           "title": "Enable backend consent mode for Customer Privacy API",
-          "info": "window.Shopify.customerPrivacy.backendConsentEnabled is now set to true automatically before the Customer Privacy API script loads, switching the consent library to server-set cookies via the Storefront API proxy instead of the legacy _tracking_consent JS cookie.",
+          "info": "window.Shopify.customerPrivacy.backendConsentEnabled is now set to true automatically before the Customer Privacy API script loads, switching the consent library to server-set cookies via the Storefront API proxy instead of the legacy _tracking_consent JS cookie. No action is required — consent banners and tracking will continue to work as before.",
           "pr": "https://github.com/Shopify/hydrogen/pull/3649",
           "id": "3649"
         }

--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -3,6 +3,51 @@
   "version": "1",
   "releases": [
     {
+      "title": "Update Storefront API to 2026-04 and enable backend consent mode",
+      "version": "2026.4.0",
+      "date": "2026-04-09",
+      "hash": "e115ebaa0f38ceccf76cf7e47b0e4e8088c6edd2",
+      "commit": "https://github.com/Shopify/hydrogen/pull/3676/commits/e115ebaa0f38ceccf76cf7e47b0e4e8088c6edd2",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3676",
+      "dependencies": {
+        "@shopify/hydrogen": "2026.4.0"
+      },
+      "removeDependencies": [
+        "@shopify/hydrogen"
+      ],
+      "fixes": [
+        {
+          "title": "Widen React Router peer dependency ranges to caret",
+          "info": "React Router peer dependencies are now specified as caret ranges (^7.12.0) instead of exact versions. This allows Hydrogen projects to use newer React Router minor versions without peer dependency conflicts, particularly with npm's strict resolver.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3677",
+          "id": "3677"
+        }
+      ],
+      "features": [
+        {
+          "title": "Update Storefront API and Customer Account API to 2026-04",
+          "info": "Quarterly API version update from 2026-01 to 2026-04. Notable changes: JSON metafield writes are now limited to 128KB for new apps using 2026-04 (apps using metafields before April 1, 2026 are grandfathered at 2MB). Cart operations now return a specific MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR error code when a Cart Transform Function fails, instead of the previous generic INVALID code.",
+          "breaking": true,
+          "pr": "https://github.com/Shopify/hydrogen/pull/3651",
+          "id": "3651"
+        },
+        {
+          "title": "Remove proxyStandardRoutes option — Storefront API proxy is now always enabled",
+          "info": "The proxyStandardRoutes option has been removed from createRequestHandler. The Storefront API proxy is now always on. If you were passing this option, remove it. If your load context does not include a storefront instance, the request handler will now throw an error instead of logging a warning.",
+          "breaking": true,
+          "code": "YGBgZGlmZgotIHByb3h5U3RhbmRhcmRSb3V0ZXM6IGZhbHNlLCAvLyBvciB0cnVlCmBgYAo=",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3649",
+          "id": "3649"
+        },
+        {
+          "title": "Enable backend consent mode for Customer Privacy API",
+          "info": "window.Shopify.customerPrivacy.backendConsentEnabled is now set to true before the Customer Privacy API script loads. This tells the consent library to use server-set cookies via the Storefront API proxy instead of the legacy _tracking_consent JS cookie. No code changes are required — this behavior is automatic.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3649",
+          "id": "3649"
+        }
+      ]
+    },
+    {
       "title": "Add Storefront MCP proxy for AI agent integration",
       "version": "2026.1.4",
       "date": "2026-04-09",


### PR DESCRIPTION
Adds the changelog entry for 2026.4.0 to enable `h2 upgrade` to detect and guide merchants through the new version.

## Changes documented

- **Breaking**: Storefront API + Customer Account API updated to 2026-04
- **Breaking**: `proxyStandardRoutes` removed from `createRequestHandler` (proxy is now always on)
- **Feature**: Backend consent mode automatically enabled via `window.Shopify.customerPrivacy.backendConsentEnabled`
- **Fix**: React Router peer deps widened to caret ranges (`^7.12.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)