### PR TITLE
Missing return in map callback and stray semicolon in ProductProvider

### DIFF
--- a/.changeset/fix-productprovider-example-bugs.md
+++ b/.changeset/fix-productprovider-example-bugs.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen-react': patch
+'@shopify/hydrogen': patch
+---
+
+Fixed the `ProductProvider` example code (both TS and JS): restored the missing `return` in the `.map()` callback so option buttons render, and removed a stray semicolon that rendered as visible text.

--- a/packages/hydrogen-react/src/ProductProvider.example.jsx
+++ b/packages/hydrogen-react/src/ProductProvider.example.jsx
@@ -13,12 +13,11 @@ function UsingProduct() {
   return (
     <>
       <h1>{product?.title}</h1>
-      {variants?.map((variant) => {
+      {variants?.map((variant) => (
         <button onClick={() => setSelectedVariant(variant)} key={variant?.id}>
           {variant?.title}
-        </button>;
-      })}
-      ;
+        </button>
+      ))}
     </>
   );
 }

--- a/packages/hydrogen-react/src/ProductProvider.example.tsx
+++ b/packages/hydrogen-react/src/ProductProvider.example.tsx
@@ -14,12 +14,11 @@ function UsingProduct() {
   return (
     <>
       <h1>{product?.title}</h1>
-      {variants?.map((variant) => {
+      {variants?.map((variant) => (
         <button onClick={() => setSelectedVariant(variant)} key={variant?.id}>
           {variant?.title}
-        </button>;
-      })}
-      ;
+        </button>
+      ))}
     </>
   );
 }


### PR DESCRIPTION
## Title
Fix missing return in map callback and stray semicolon in ProductProvider example

## Description
### Summary
Two bugs in the `UsingProduct()` function of both TypeScript and JavaScript ProductProvider examples:

1. **Missing `return` in `.map()` callback** — The callback uses a block body `{ }` but has no `return` before the `<button>` JSX, so the `.map()` always produces an array of `undefined` and no buttons render. Fixed by switching to a concise arrow function body with `( )`.

2. **Stray semicolon** — A lone `;` on line 22 (tsx) / line 21 (jsx) sits between the closing `})}` of the map and the `</>` fragment close. This renders as visible text (a literal semicolon character) in the output.

These example files are used to generate documentation on Shopify.dev.