### PR TITLE
chore: remove doubled words in locale-check route comment

### DIFF
--- a/packages/cli/assets/routes/locale-check.ts
+++ b/packages/cli/assets/routes/locale-check.ts
@@ -7,8 +7,8 @@ export async function loader({params, context}: LoaderFunctionArgs) {
     params.locale &&
     params.locale.toLowerCase() !== `${language}-${country}`.toLowerCase()
   ) {
-    // If the locale URL param is defined, yet we still are still at the default locale
-    // then the the locale param must be invalid, send to the 404 page
+    // If the locale URL param is defined, yet we are still at the default locale
+    // then the locale param must be invalid, send to the 404 page
     throw new Response(null, {status: 404});
   }
 


### PR DESCRIPTION
## Title
Fix doubled words in locale-check route comment

## Description
### Summary
Two doubled-word typos in the comment block of `locale-check.ts`:

- Line 10: `"yet we still are still at the default locale"` → `"yet we are still at the default locale"`
- Line 11: `"then the the locale param must be invalid"` → `"then the locale param must be invalid"`

**Files changed:**
- `packages/cli/assets/routes/locale-check.ts` — comment-only fix

**Note:** This same text also appears in `packages/cli/CHANGELOG.md:792-793` and `templates/skeleton/CHANGELOG.md:2486-2487` as part of historical changelog entries. Those are left as-is since changelogs are historical records.