### PR TITLE
chore: fix "overriden" typo to "overridden" in codegen test description

### DIFF
--- a/packages/hydrogen-codegen/tests/client.test-d.ts
+++ b/packages/hydrogen-codegen/tests/client.test-d.ts
@@ -63,7 +63,7 @@ describe('Client types', async () => {
       expectTypeOf(clientQuery(Queries.Unknown)).resolves.toEqualTypeOf<any>();
     });
 
-    it('can be overriden', async () => {
+    it('can be overridden', async () => {
       // Non-recognized query, override return type
       expectTypeOf(
         clientQuery<{test: string}>(Queries.Unknown),


### PR DESCRIPTION
## Title
Fix "overriden" typo to "overridden" in codegen test

## Description
### Summary
A single `it()` block name in the hydrogen-codegen type tests misspells "overridden" as "overriden":

- Line 66: `it('can be overriden', async () => {` → `it('can be overridden', async () => {`

**Files changed:**
- `packages/hydrogen-codegen/tests/client.test-d.ts` — 1 test description fix

### Test plan
- No functional changes — test description string only
- Existing type tests unaffected
