### PR TITLE
Fix "explicity" typo to "explicitly" in AddToCartButton test descript…

### DIFF
--- a/packages/hydrogen-react/src/AddToCartButton.test.tsx
+++ b/packages/hydrogen-react/src/AddToCartButton.test.tsx
@@ -63,7 +63,7 @@ describe('<AddToCartButton/>', () => {
     expect(screen.getByRole('button')).toHaveClass('bg-blue-600');
   });
 
-  describe('when variantId is set explicity', () => {
+  describe('when variantId is set explicitly', () => {
     it('renders a disabled button if the variantId is null', () => {
       render(
         <MockWrapper>
@@ -176,7 +176,7 @@ describe('<AddToCartButton/>', () => {
       });
     });
 
-    describe('and the initialVariantId is explicity set to null', () => {
+    describe('and the initialVariantId is explicitly set to null', () => {
       it('disables the button', () => {
         const product = getProduct();
 


### PR DESCRIPTION
## Title
Fix "explicity" typo to "explicitly" in AddToCartButton test

## Description
### Summary
Two `describe()` block names in `AddToCartButton.test.tsx` misspell "explicitly" as "explicity":

- Line 66: `'when variantId is set explicity'` → `'when variantId is set explicitly'`
- Line 179: `'and the initialVariantId is explicity set to null'` → `'and the initialVariantId is explicitly set to null'`

**Files changed:**
- `packages/hydrogen-react/src/AddToCartButton.test.tsx` — 2 test description fixes

### Test plan
- No functional changes — test description strings only
- All tests continue to pass with the corrected descriptions