### PR TITLE
fix: "uncommited" typo to "uncommitted" in deploy command

### DIFF
--- a/.changeset/fix-typo-uncommited-deploy.md
+++ b/.changeset/fix-typo-uncommited-deploy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fixed "uncommited" typo to "uncommitted" in `shopify hydrogen deploy` flag descriptions and the uncommitted-changes warning message.

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -92,7 +92,7 @@ export default class Deploy extends Command {
     force: Flags.boolean({
       char: 'f',
       description:
-        'Forces a deployment to proceed if there are uncommited changes in its Git repository.',
+        'Forces a deployment to proceed if there are uncommitted changes in its Git repository.',
       default: false,
       env: 'SHOPIFY_HYDROGEN_FLAG_FORCE',
       required: false,
@@ -140,7 +140,7 @@ export default class Deploy extends Command {
     }),
     'metadata-description': Flags.string({
       description:
-        'Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.',
+        'Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommitted changes.',
       required: false,
       env: 'SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION',
     }),
@@ -250,7 +250,7 @@ export async function runDeploy(
     env: envHandle,
     envBranch,
     environmentFile,
-    force: forceOnUncommitedChanges,
+    force: forceOnUncommittedChanges,
     forceClientSourcemap = false,
     noVerify,
     lockfileCheck,
@@ -272,7 +272,7 @@ export async function runDeploy(
       isCleanGit = false;
     }
 
-    if (!forceOnUncommitedChanges && !isCleanGit) {
+    if (!forceOnUncommittedChanges && !isCleanGit) {
       let errorMessage = 'Uncommitted changes detected';
       let changedFiles = undefined;
 
@@ -333,7 +333,7 @@ export async function runDeploy(
     renderWarning({
       headline: 'No deployment description provided',
       body: [
-        'Deploying uncommited changes, but no description has been provided. Use the ',
+        'Deploying uncommitted changes, but no description has been provided. Use the ',
         {command: '--metadata-description'},
         'flag to provide a description. If no description is provided, the description defaults to ',
         {userInput: '<sha> with additional changes'},


### PR DESCRIPTION
## Title
Fix "uncommited" typo to "uncommitted" in deploy command

## Description
### Summary
The word "uncommited" (missing a "t") appears in 3 user-facing strings and 1 local variable name in the `hydrogen deploy` command. The test file (`deploy.test.ts:382`) already uses the correct spelling "uncommitted", confirming this is a typo rather than an intentional choice.

**Files changed:**
- `packages/cli/src/commands/hydrogen/deploy.ts` — 3 string fixes + 1 variable rename

**Changes:**
- Line 95: `'Forces a deployment to proceed if there are uncommited changes'` → `'uncommitted changes'`
- Line 143: `'if there are no uncommited changes.'` → `'no uncommitted changes.'`
- Line 253, 275: `forceOnUncommitedChanges` → `forceOnUncommittedChanges` (local destructured variable)
- Line 336: `'Deploying uncommited changes'` → `'Deploying uncommitted changes'`

**Note:** `oclif.manifest.json` also contains this typo but is auto-generated from command definitions and will self-correct on next build.

### Test plan
- No behavioral changes — string and local variable rename only
- The variable `forceOnUncommitedChanges` is a local destructuring alias (line 253) used only on line 275 — no external API surface affected
- Existing test at `deploy.test.ts:382` already uses "uncommitted" spelling