### PR TITLE
fix: missing return statement in CartProvider example code

### DIFF
--- a/.changeset/fix-missing-return-cartprovider-example.md
+++ b/.changeset/fix-missing-return-cartprovider-example.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen-react': patch
+'@shopify/hydrogen': patch
+---
+
+Fixed the `CartProvider` example code (both TS and JS) to include the missing `return` statement in the `App` component.

--- a/packages/hydrogen-react/src/CartProvider.example.jsx
+++ b/packages/hydrogen-react/src/CartProvider.example.jsx
@@ -1,16 +1,18 @@
 import {CartProvider, useCart} from '@shopify/hydrogen-react';
 
 export function App() {
-  <CartProvider
-    onLineAdd={() => {
-      console.log('a line is being added');
-    }}
-    onLineAddComplete={() => {
-      console.log('a line has been added');
-    }}
-  >
-    <CartComponent />
-  </CartProvider>;
+  return (
+    <CartProvider
+      onLineAdd={() => {
+        console.log('a line is being added');
+      }}
+      onLineAddComplete={() => {
+        console.log('a line has been added');
+      }}
+    >
+      <CartComponent />
+    </CartProvider>
+  );
 }
 
 function CartComponent() {

--- a/packages/hydrogen-react/src/CartProvider.example.tsx
+++ b/packages/hydrogen-react/src/CartProvider.example.tsx
@@ -2,16 +2,18 @@ import {CartProvider, useCart} from '@shopify/hydrogen-react';
 import type {CartLineInput} from '@shopify/hydrogen-react/storefront-api-types';
 
 export function App() {
-  <CartProvider
-    onLineAdd={() => {
-      console.log('a line is being added');
-    }}
-    onLineAddComplete={() => {
-      console.log('a line has been added');
-    }}
-  >
-    <CartComponent />
-  </CartProvider>;
+  return (
+    <CartProvider
+      onLineAdd={() => {
+        console.log('a line is being added');
+      }}
+      onLineAddComplete={() => {
+        console.log('a line has been added');
+      }}
+    >
+      <CartComponent />
+    </CartProvider>
+  );
 }
 
 function CartComponent() {


### PR DESCRIPTION
## Title
Fix missing return statement in CartProvider example code

## Description
### Summary
The `App()` function in both the TypeScript and JavaScript CartProvider examples is missing a `return` statement before the JSX. Without it, the function returns `undefined` instead of rendering the `<CartProvider>` tree.

These example files are used to generate documentation on Shopify.dev, so the incorrect code is visible to developers learning the API.

**Files changed:**
- `packages/hydrogen-react/src/CartProvider.example.tsx` — add `return (...)` around JSX
- `packages/hydrogen-react/src/CartProvider.example.jsx` — add `return (...)` around JSX

**Before:**
```tsx
export function App() {
  <CartProvider
    onLineAdd={() => { console.log('a line is being added'); }}
    onLineAddComplete={() => { console.log('a line has been added'); }}
  >
    <CartComponent />
  </CartProvider>;
}
```

**After:**
```tsx
export function App() {
  return (
    <CartProvider
      onLineAdd={() => { console.log('a line is being added'); }}
      onLineAddComplete={() => { console.log('a line has been added'); }}
    >
      <CartComponent />
    </CartProvider>
  );
}
```

### Test plan
- No runtime changes — example files used for documentation only
- Verified the `CartComponent` function in the same file already has a correct `return` statement
