### PR TITLE
Fix validateProducts always returning true due to return inside forEach

### DIFF
--- a/.changeset/fix-validate-products-foreach-return.md
+++ b/.changeset/fix-validate-products-foreach-return.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Fixed `validateProducts` in the Shopify analytics manager to actually block invalid product payloads. Previously, `return false` inside a `forEach` callback only exited the iteration and the function always returned `true`, so analytics events were sent despite validation failures (with warnings logged). Products missing required fields (`id`, `title`, `price`, `vendor`, `variantId`, `variantTitle`) will now be blocked.

--- a/packages/hydrogen/src/analytics-manager/ShopifyAnalytics.tsx
+++ b/packages/hydrogen/src/analytics-manager/ShopifyAnalytics.tsx
@@ -398,7 +398,7 @@ function validateProducts({
     return false;
   }
 
-  products.forEach((product) => {
+  for (const product of products) {
     if (!product.id) {
       missingErrorMessage(type, 'id', false);
       return false;
@@ -423,7 +423,7 @@ function validateProducts({
       missingErrorMessage(type, 'title', true, 'variantTitle');
       return false;
     }
-  });
+  }
   return true;
 }
 


### PR DESCRIPTION
## Title
Fix validateProducts always returning true due to return inside forEach

## Description
### Summary
The `validateProducts` function in `ShopifyAnalytics.tsx` uses `return false` inside a `forEach` callback to indicate validation failure. However, `return` inside a `forEach` callback only exits the current iteration — it does not exit the outer function. The function always falls through to `return true` on line 427 regardless of whether any product is missing required fields.

This means analytics events with incomplete product data (missing `id`, `title`, `price`, `vendor`, `variantId`, or `variantTitle`) are still sent to Shopify's analytics pipeline, potentially producing invalid data. The warning messages ARE logged via `missingErrorMessage`, but the function does not actually prevent the event from being dispatched.

**File changed:**
- `packages/hydrogen/src/analytics-manager/ShopifyAnalytics.tsx` (lines 389-428)

**Before:**
```typescript
products.forEach((product) => {
  if (!product.id) {
    missingErrorMessage(type, 'id', false);
    return false;  // only exits forEach callback
  }
  // ...
});
return true;  // always reached
```

**After:**
```typescript
for (const product of products) {
  if (!product.id) {
    missingErrorMessage(type, 'id', false);
    return false;  // exits the function
  }
  // ...
}
return true;
```