### PR TITLE
Fix merchandise {is: string} typo to {id: string} in useOptimisticCart

### DIFF
--- a/.changeset/fix-useoptimisticcart-type-typo.md
+++ b/.changeset/fix-useoptimisticcart-type-typo.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fixed a typo in `useOptimisticCart`'s default generic type where `merchandise` was typed as `{is: string}` instead of `{id: string}`.

--- a/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
+++ b/packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx
@@ -47,7 +47,7 @@ export type OptimisticCart<T = CartReturn> = T extends undefined | null
 export function useOptimisticCart<
   DefaultCart = {
     lines?: {
-      nodes: Array<{id: string; quantity: number; merchandise: {is: string}}>;
+      nodes: Array<{id: string; quantity: number; merchandise: {id: string}}>;
     };
   },
 >(cart?: DefaultCart): OptimisticCart<DefaultCart> {


### PR DESCRIPTION
## Title
Fix `merchandise: {is: string}` typo to `{id: string}` in useOptimisticCart

## Description
### Summary
The default generic type parameter for `useOptimisticCart` has `merchandise: {is: string}` on line 50, which should be `merchandise: {id: string}`. This is a single-character typo (`is` vs `id`) in the TypeScript generic default.

This affects consumers who rely on the default type parameter (i.e., don't pass an explicit type argument to `useOptimisticCart`). TypeScript won't correctly type-check `merchandise.id` accesses when using the default generic.

**File changed:**
- `packages/hydrogen/src/cart/optimistic/useOptimisticCart.tsx` (line 50)

**Before:**
```typescript
export function useOptimisticCart<
  DefaultCart = {
    lines?: {
      nodes: Array<{id: string; quantity: number; merchandise: {is: string}}>;
    };
  },
>
```

**After:**
```typescript
export function useOptimisticCart<
  DefaultCart = {
    lines?: {
      nodes: Array<{id: string; quantity: number; merchandise: {id: string}}>;
    };
  },
>
```