### PR TITLE
Fix og:image string shorthand using name instead of property attribute

### DIFF
--- a/.changeset/fix-og-image-name-to-property.md
+++ b/.changeset/fix-og-image-name-to-property.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fixed `og:image` string shorthand to render as `<meta property="og:image">` instead of `<meta name="og:image">`. Open Graph meta tags require the `property` attribute, so previously these tags were not recognized by social platforms when using the string shorthand form. Other `og:*` tags and the object-form `og:image` were already correct.

--- a/packages/hydrogen/src/seo/generate-seo-tags.test.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.test.ts
@@ -278,7 +278,7 @@ describe('generateSeoTags', () => {
             key: 'meta-og:image',
             props: {
               content: 'https://example.com/image.jpg',
-              name: 'og:image',
+              property: 'og:image',
             },
             tag: 'meta',
           },
@@ -305,7 +305,7 @@ describe('generateSeoTags', () => {
             key: 'meta-og:image',
             props: {
               content: 'https://example.com/image-1.jpg',
-              name: 'og:image',
+              property: 'og:image',
             },
             tag: 'meta',
           },
@@ -313,7 +313,7 @@ describe('generateSeoTags', () => {
             key: 'meta-og:image',
             props: {
               content: 'https://example.com/image-2.jpg',
-              name: 'og:image',
+              property: 'og:image',
             },
             tag: 'meta',
           },

--- a/packages/hydrogen/src/seo/generate-seo-tags.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.ts
@@ -449,7 +449,7 @@ export function generateSeoTags(seoInput: SeoConfig): CustomHeadTagObject[] {
         for (const media of values) {
           if (typeof media === 'string') {
             tagResults.push(
-              generateTag('meta', {name: 'og:image', content: media}),
+              generateTag('meta', {property: 'og:image', content: media}),
             );
           }
 


### PR DESCRIPTION
## Title
Fix og:image string shorthand using `name` instead of `property` in SEO tags

## Description
### Summary
In `generate-seo-tags.ts` line 452, when `media` is a string, the Open Graph image tag is generated with `name: 'og:image'` instead of `property: 'og:image'`. Per the Open Graph protocol, all `og:*` tags should use the `property` attribute, not `name`.

The object-path code (line 481) correctly uses `property`, and all other `og:*` tags in the same file use `property` — this is the only inconsistency, indicating a copy-paste oversight.

**File changed:**
- `packages/hydrogen/src/seo/generate-seo-tags.ts` (line 452)

**Before:**
```typescript
generateTag('meta', {name: 'og:image', content: media}),
```

**After:**
```typescript
generateTag('meta', {property: 'og:image', content: media}),
```

### Test plan
- Verify the generated meta tag uses `property="og:image"` not `name="og:image"`
- Check existing SEO tests for string media path coverage
