### PR TITLE
Fix SEO description validation threshold to match error message

### DIFF
--- a/.changeset/fix-seo-description-threshold-mismatch.md
+++ b/.changeset/fix-seo-description-threshold-mismatch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Aligned the SEO `description` length validation with its error message. Descriptions are now only rejected when longer than 160 characters (previously 155), matching the "should not be longer than 160 characters" error and standard SEO guidance. Descriptions between 156–160 characters that were previously rejected will now be accepted.

--- a/packages/hydrogen/src/seo/generate-seo-tags.ts
+++ b/packages/hydrogen/src/seo/generate-seo-tags.ts
@@ -33,7 +33,7 @@ export const schema = {
         );
       }
 
-      if (typeof value === 'string' && value.length > 155) {
+      if (typeof value === 'string' && value.length > 160) {
         throw new Error(
           ERROR_PREFIX.concat(
             '`description` should not be longer than 160 characters',


### PR DESCRIPTION
### Summary
In `generate-seo-tags.ts`, the description validation rejects values longer than 155 characters (`value.length > 155`), but the error message tells the user the limit is 160 characters. A 156-character description would be rejected with the message "should not be longer than 160 characters" — which is contradictory.

Standard SEO guidance typically recommends ~155-160 characters. The fix should align the threshold with the message.

**File changed:**
- `packages/hydrogen/src/seo/generate-seo-tags.ts` (lines 36-41)

**Change threshold to match message:**
```typescript
if (typeof value === 'string' && value.length > 160) {
```