### PR TITLE
Fix double-slash redirect dropping query parameters

### DIFF
--- a/packages/remix-oxygen/src/server.ts
+++ b/packages/remix-oxygen/src/server.ts
@@ -39,7 +39,7 @@ export function createRequestHandler<Context = unknown>({
       return new Response(null, {
         status: 301,
         headers: {
-          location: url.pathname.replace(/\/+/g, '/'),
+          location: url.pathname.replace(/\/+/g, '/') + url.search,
         },
       });
     }


### PR DESCRIPTION
### Summary
In `remix-oxygen`'s `createRequestHandler`, when a URL pathname contains `//`, a 301 redirect is issued to the cleaned pathname. However, the redirect `location` header only includes the cleaned pathname — the query string (`url.search`) is silently dropped.

A request to `/products//foo?color=red&size=M` redirects to `/products/foo` instead of `/products/foo?color=red&size=M`. This is a real data-loss bug that affects any URL that happens to have a double slash and also has query parameters (e.g., from malformed links, crawlers, or UTM tracking parameters).

**File changed:**
- `packages/remix-oxygen/src/server.ts` (line 42)

**Before:**
```typescript
location: url.pathname.replace(/\/+/g, '/'),
```

**After:**
```typescript
location: url.pathname.replace(/\/+/g, '/') + url.search,
```
