### PR TITLE
Fix BuyNowButton disabled prop being silently ignored

### DIFF
--- a/.changeset/fix-buynowbutton-disabled-prop-ignored.md
+++ b/.changeset/fix-buynowbutton-disabled-prop-ignored.md
@@ -1,0 +1,6 @@
+---
+'@shopify/hydrogen-react': patch
+'@shopify/hydrogen': patch
+---
+
+Fixed BuyNowButton to respect the consumer's `disabled` prop when not in a loading state. Previously, the nullish coalescing operator (`??`) prevented the fallback from ever being evaluated since `loading` is always a boolean.

--- a/packages/hydrogen-react/src/BuyNowButton.tsx
+++ b/packages/hydrogen-react/src/BuyNowButton.tsx
@@ -66,7 +66,7 @@ export function BuyNowButton<AsType extends React.ElementType = 'button'>(
   return (
     <BaseButton
       // Only certain 'as' types such as 'button' contain `disabled`
-      disabled={loading ?? (passthroughProps as {disabled?: boolean}).disabled}
+      disabled={loading || (passthroughProps as {disabled?: boolean}).disabled}
       {...passthroughProps}
       onClick={onClick}
       defaultOnClick={handleBuyNow}


### PR DESCRIPTION
### Summary
In `BuyNowButton.tsx` line 69, the `disabled` attribute uses `??` (nullish coalescing) with `loading` on the left side:

```tsx
disabled={loading ?? (passthroughProps as {disabled?: boolean}).disabled}
```

Since `loading` is a boolean (always `true` or `false`, never `null` or `undefined`), the right side is **never evaluated**. The consumer's `disabled` prop is silently ignored. Compare this to `AddToCartButton` which correctly combines conditions with `||`.

**File changed:**
- `packages/hydrogen-react/src/BuyNowButton.tsx` (line 69)

**Before:**
```tsx
disabled={loading ?? (passthroughProps as {disabled?: boolean}).disabled}
```

**After:**
```tsx
disabled={loading || (passthroughProps as {disabled?: boolean}).disabled}
```