### PR TITLE
Fix search route error catch handler result being discarded

### DIFF
--- a/.changeset/fix-search-catch-discards-result.md
+++ b/.changeset/fix-search-catch-discards-result.md
@@ -1,0 +1,7 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Fixed search route error handling so search errors are gracefully handled with a fallback instead of causing unhandled rejections.

--- a/templates/skeleton/app/routes/search.tsx
+++ b/templates/skeleton/app/routes/search.tsx
@@ -25,12 +25,10 @@ export async function loader({request, context}: Route.LoaderArgs) {
       ? predictiveSearch({request, context})
       : regularSearch({request, context});
 
-  searchPromise.catch((error: Error) => {
+  return await searchPromise.catch((error: Error) => {
     console.error(error);
     return {term: '', result: null, error: error.message};
   });
-
-  return await searchPromise;
 }
 
 /**


### PR DESCRIPTION
### Summary
In the skeleton template's `search.tsx` loader, the `.catch()` handler on `searchPromise` returns a fallback value, but this return value is discarded because `return await searchPromise` on line 33 awaits the **original** promise, not the one with the catch handler attached. `.catch()` creates a new promise chain — the original promise still rejects.

If `searchPromise` rejects, two things happen:
1. The `.catch()` handler logs the error and returns a fallback (but this value goes nowhere)
2. `await searchPromise` throws, resulting in a 500 error

**File changed:**
- `templates/skeleton/app/routes/search.tsx` (lines 28-33)

**Before:**
```typescript
searchPromise.catch((error: Error) => {
  console.error(error);
  return {term: '', result: null, error: error.message};
});

return await searchPromise;
```

**After:**
```typescript
return await searchPromise.catch((error: Error) => {
  console.error(error);
  return {term: '', result: null, error: error.message};
});
```