### PR TITLE
Fix locale-param flag sharing same env var as adapter flag

### DIFF
--- a/.changeset/fix-duplicate-env-var-generate-route.md
+++ b/.changeset/fix-duplicate-env-var-generate-route.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fixed `shopify hydrogen generate route` where `--locale-param` shared the `SHOPIFY_HYDROGEN_FLAG_ADAPTER` environment variable with `--adapter`, causing both flags to receive the same value when that env var was set. `--locale-param` now reads from `SHOPIFY_HYDROGEN_FLAG_LOCALE_PARAM`.

--- a/packages/cli/src/commands/hydrogen/generate/route.ts
+++ b/packages/cli/src/commands/hydrogen/generate/route.ts
@@ -30,7 +30,7 @@ export default class GenerateRoute extends Command {
     'locale-param': Flags.string({
       description:
         'The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).',
-      env: 'SHOPIFY_HYDROGEN_FLAG_ADAPTER',
+      env: 'SHOPIFY_HYDROGEN_FLAG_LOCALE_PARAM',
     }),
     ...commonFlags.force,
     ...commonFlags.path,


### PR DESCRIPTION
### Summary
In `generate/route.ts`, both the `adapter` flag (line 24) and the `locale-param` flag (line 33) use the same environment variable `SHOPIFY_HYDROGEN_FLAG_ADAPTER`. If a user sets this env var, oclif will use the value for both flags — an adapter name like `@shopify/remix-oxygen` will also be used as the locale param name, which is clearly wrong.

**File changed:**
- `packages/cli/src/commands/hydrogen/generate/route.ts` (line 33)

**Before:**
```typescript
'locale-param': Flags.string({
  description: 'The param name in Remix routes for the i18n locale...',
  env: 'SHOPIFY_HYDROGEN_FLAG_ADAPTER',
}),
```

**After:**
```typescript
'locale-param': Flags.string({
  description: 'The param name in Remix routes for the i18n locale...',
  env: 'SHOPIFY_HYDROGEN_FLAG_LOCALE_PARAM',
}),
```