### PR TITLE
Fix auto-reload script never injected due to strict Content-Type check

### DIFF
--- a/.changeset/fix-autoreload-content-type-check.md
+++ b/.changeset/fix-autoreload-content-type-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/mini-oxygen': patch
+---
+
+Fixed dev server auto-reload to work with Content-Type headers that include charset parameters (e.g. `text/html; charset=utf-8`).

--- a/packages/mini-oxygen/src/node/server.ts
+++ b/packages/mini-oxygen/src/node/server.ts
@@ -202,7 +202,8 @@ function createRequestMiddleware(
       let autoReloadScript = autoReloadScriptTemplate;
 
       const shouldAutoreload =
-        autoReload && response.headers.get('content-type') === 'text/html';
+        autoReload &&
+        response.headers.get('content-type')?.startsWith('text/html');
 
       if (shouldAutoreload) {
         const csp = response.headers.get('content-security-policy');


### PR DESCRIPTION
### Summary
In `mini-oxygen`'s `server.ts` line 204-205, the auto-reload check uses strict equality:

```typescript
response.headers.get('content-type') === 'text/html'
```

Most HTML responses include a charset suffix like `text/html; charset=utf-8`, so this check almost never passes. The auto-reload script is effectively never injected during development.

**File changed:**
- `packages/mini-oxygen/src/node/server.ts` (line 205)

**Before:**
```typescript
const shouldAutoreload =
  autoReload && response.headers.get('content-type') === 'text/html';
```

**After:**
```typescript
const shouldAutoreload =
  autoReload && response.headers.get('content-type')?.startsWith('text/html');
```
