### PR TITLE
Fix "Makerts" typo and use toLowerCase in markets setup message

### DIFF
--- a/packages/cli/src/commands/hydrogen/setup/markets.ts
+++ b/packages/cli/src/commands/hydrogen/setup/markets.ts
@@ -65,9 +65,9 @@ export async function runSetupMarkets({
   ]);
 
   renderSuccess({
-    headline: `Makerts support setup complete with strategy ${I18N_STRATEGY_NAME_MAP[
+    headline: `Markets support setup complete with strategy ${I18N_STRATEGY_NAME_MAP[
       strategy
-    ].toLocaleLowerCase()}.`,
+    ].toLowerCase()}.`,
     body: `You can now modify the supported locales in ${
       remixConfig.serverEntryPoint ?? 'your server entry file.'
     }\n`,


### PR DESCRIPTION
### Summary
Two issues in `setup/markets.ts` line 68-70:

1. **"Makerts" typo** — should be "Markets" in the success message
2. **`.toLocaleLowerCase()`** — uses system locale for case conversion, which can produce wrong results on non-English systems (e.g., Turkish locale converts `I` to `ı` instead of `i`). Since these are technical strategy names, `.toLowerCase()` is correct.

**File changed:**
- `packages/cli/src/commands/hydrogen/setup/markets.ts` (lines 68-70)

**Before:**
```typescript
headline: `Makerts support setup complete with strategy ${I18N_STRATEGY_NAME_MAP[
  strategy
].toLocaleLowerCase()}.`,
```

**After:**
```typescript
headline: `Markets support setup complete with strategy ${I18N_STRATEGY_NAME_MAP[
  strategy
].toLowerCase()}.`,
```
