### PR TITLE
Fix check command class named GenerateRoute instead of Check

### DIFF
--- a/packages/cli/src/commands/hydrogen/check.ts
+++ b/packages/cli/src/commands/hydrogen/check.ts
@@ -11,7 +11,7 @@ import {
 
 import {Args} from '@oclif/core';
 
-export default class GenerateRoute extends Command {
+export default class Check extends Command {
   static descriptionWithMarkdown = `Checks whether your Hydrogen app includes a set of standard Shopify routes.`;
 
   static description =

--- a/packages/cli/src/commands/hydrogen/check.ts
+++ b/packages/cli/src/commands/hydrogen/check.ts
@@ -31,7 +31,7 @@ export default class Check extends Command {
   };
 
   async run(): Promise<void> {
-    const {flags, args} = await this.parse(GenerateRoute);
+    const {flags, args} = await this.parse(Check);
     const directory = flags.path ? resolvePath(flags.path) : process.cwd();
 
     if (args.resource === 'routes') {


### PR DESCRIPTION
### Summary
In `commands/hydrogen/check.ts`, the class is named `GenerateRoute` but implements the `check` command. This is a copy-paste error from when the file was created based on `generate/route.ts`. While oclif uses file-based routing so the class name doesn't affect command resolution, it appears incorrectly in stack traces and causes confusion for developers maintaining the code.

**File changed:**
- `packages/cli/src/commands/hydrogen/check.ts` (line 14)

**Before:**
```typescript
export default class GenerateRoute extends Command {
```

**After:**
```typescript
export default class Check extends Command {
```
