### PR TITLE
Fix "defautlUrl" variable name typo in ensureLocalRedirectUrl

### DIFF
--- a/packages/hydrogen/src/utils/get-redirect-url.ts
+++ b/packages/hydrogen/src/utils/get-redirect-url.ts
@@ -49,18 +49,18 @@ export function ensureLocalRedirectUrl({
   redirectUrl?: string;
 }): string {
   const fromUrl = requestUrl;
-  const defautlUrl = buildURLObject(requestUrl, defaultUrl);
+  const parsedDefaultUrl = buildURLObject(requestUrl, defaultUrl);
   const toUrl = redirectUrl
     ? buildURLObject(requestUrl, redirectUrl)
-    : defautlUrl;
+    : parsedDefaultUrl;
 
   if (isLocalPath(requestUrl, toUrl.toString())) {
     return toUrl.toString();
   } else {
     console.warn(
-      `Cross-domain redirects are not supported. Tried to redirect from ${fromUrl} to ${toUrl}. Default url ${defautlUrl} is used instead.`,
+      `Cross-domain redirects are not supported. Tried to redirect from ${fromUrl} to ${toUrl}. Default url ${parsedDefaultUrl} is used instead.`,
     );
-    return defautlUrl.toString();
+    return parsedDefaultUrl.toString();
   }
 }
 


### PR DESCRIPTION
### Summary
In `get-redirect-url.ts` line 52, the local variable `defautlUrl` is a transposition typo of `defaultUrl`. The typo is used consistently within the function (lines 52, 55, 61, 63) so it doesn't cause a runtime bug, but it could cause confusion when reading or maintaining the code.

**File changed:**
- `packages/hydrogen/src/utils/get-redirect-url.ts` (lines 52, 55, 61, 63)

**Before:**
```typescript
const defautlUrl = buildURLObject(requestUrl, defaultUrl);
const toUrl = redirectUrl
  ? buildURLObject(requestUrl, redirectUrl)
  : defautlUrl;
// ...
return defautlUrl.toString();
```

**After:**
```typescript
const parsedDefaultUrl = buildURLObject(requestUrl, defaultUrl);
const toUrl = redirectUrl
  ? buildURLObject(requestUrl, redirectUrl)
  : parsedDefaultUrl;
// ...
return parsedDefaultUrl.toString();
```
