### PR TITLE
fix: ssr.optimizeDeps dependency resolution warnings with `pnpm dev`

### DIFF
--- a/.changeset/fix-skeleton-optimizedeps.md
+++ b/.changeset/fix-skeleton-optimizedeps.md
@@ -1,0 +1,7 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Fix `set-cookie-parser` and `cookie` resolution warnings during `dev` by using Vite's nested dependency syntax (`react-router > dep`). These are CJS transitive dependencies of `react-router` that weren't resolvable by bare name with strict package managers like pnpm.

--- a/cookbook/llms/express.prompt.md
+++ b/cookbook/llms/express.prompt.md
@@ -2546,7 +2546,11 @@ Configure Vite for Express deployment with Node.js module externalization
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */
--      include: ['set-cookie-parser', 'cookie', 'react-router'],
+-      include: [
+-        'react-router > set-cookie-parser',
+-        'react-router > cookie',
+-        'react-router',
+-      ],
 +      include: ['@react-router/node', '@react-router/express'],
      },
    },

--- a/cookbook/llms/multipass.prompt.md
+++ b/cookbook/llms/multipass.prompt.md
@@ -3540,8 +3540,17 @@ Configure Vite for crypto polyfills
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */
--      include: ['set-cookie-parser', 'cookie', 'react-router'],
-+      include: ['set-cookie-parser', 'cookie', 'react-router', 'crypto-js'],
+-      include: [
+-        'react-router > set-cookie-parser',
+-        'react-router > cookie',
+-        'react-router',
+-      ],
++      include: [
++        'react-router > set-cookie-parser',
++        'react-router > cookie',
++        'react-router',
++        'crypto-js',
++      ],
      },
    },
    server: {

--- a/cookbook/llms/partytown.prompt.md
+++ b/cookbook/llms/partytown.prompt.md
@@ -683,10 +683,14 @@ Configure Vite to exclude Partytown library from build optimization.
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */
--      include: ['set-cookie-parser', 'cookie', 'react-router'],
+-      include: [
+-        'react-router > set-cookie-parser',
+-        'react-router > cookie',
+-        'react-router',
+-      ],
 +      include: [
-+        'set-cookie-parser',
-+        'cookie',
++        'react-router > set-cookie-parser',
++        'react-router > cookie',
 +        'react-router',
 +        '@qwik.dev/partytown/react',
 +      ],

--- a/cookbook/recipes/express/README.md
+++ b/cookbook/recipes/express/README.md
@@ -2636,7 +2636,11 @@ index a1702446..058b559d 100644
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */
--      include: ['set-cookie-parser', 'cookie', 'react-router'],
+-      include: [
+-        'react-router > set-cookie-parser',
+-        'react-router > cookie',
+-        'react-router',
+-      ],
 +      include: ['@react-router/node', '@react-router/express'],
      },
    },

--- a/cookbook/recipes/express/patches/vite.config.ts.63904f.patch
+++ b/cookbook/recipes/express/patches/vite.config.ts.63904f.patch
@@ -7,7 +7,7 @@ index 050b6ed7..ef18f2fc 100644
 -import {oxygen} from '@shopify/mini-oxygen/vite';
  import {reactRouter} from '@react-router/dev/vite';
  import tsconfigPaths from 'vite-tsconfig-paths';
- 
+
  export default defineConfig({
 -  plugins: [hydrogen(), oxygen(), reactRouter(), tsconfigPaths()],
 +  plugins: [hydrogen(), reactRouter(), tsconfigPaths()],
@@ -22,11 +22,15 @@ index 050b6ed7..ef18f2fc 100644
      optimizeDeps: {
        /**
         * Include dependencies here if they throw CJS<>ESM errors.
-@@ -23,10 +24,7 @@ export default defineConfig({
+@@ -23,14 +24,7 @@ export default defineConfig({
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */
--      include: ['set-cookie-parser', 'cookie', 'react-router'],
+-      include: [
+-        'react-router > set-cookie-parser',
+-        'react-router > cookie',
+-        'react-router',
+-      ],
 +      include: ['@react-router/node', '@react-router/express'],
      },
    },

--- a/cookbook/recipes/multipass/README.md
+++ b/cookbook/recipes/multipass/README.md
@@ -3760,8 +3760,17 @@ index 050b6ed7..14ae8119 100644
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */
--      include: ['set-cookie-parser', 'cookie', 'react-router'],
-+      include: ['set-cookie-parser', 'cookie', 'react-router', 'crypto-js'],
+-      include: [
+-        'react-router > set-cookie-parser',
+-        'react-router > cookie',
+-        'react-router',
+-      ],
++      include: [
++        'react-router > set-cookie-parser',
++        'react-router > cookie',
++        'react-router',
++        'crypto-js',
++      ],
      },
    },
    server: {

--- a/cookbook/recipes/multipass/patches/vite.config.ts.63904f.patch
+++ b/cookbook/recipes/multipass/patches/vite.config.ts.63904f.patch
@@ -1,12 +1,21 @@
 index 050b6ed7..14ae8119 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
-@@ -23,7 +23,7 @@ export default defineConfig({
+@@ -23,11 +23,12 @@ export default defineConfig({
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */
--      include: ['set-cookie-parser', 'cookie', 'react-router'],
-+      include: ['set-cookie-parser', 'cookie', 'react-router', 'crypto-js'],
+-      include: [
+-        'react-router > set-cookie-parser',
+-        'react-router > cookie',
+-        'react-router',
+-      ],
++      include: [
++        'react-router > set-cookie-parser',
++        'react-router > cookie',
++        'react-router',
++        'crypto-js',
++      ],
      },
    },
    server: {

--- a/cookbook/recipes/partytown/README.md
+++ b/cookbook/recipes/partytown/README.md
@@ -693,10 +693,14 @@ index a1702446..a2e3dda9 100644
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */
--      include: ['set-cookie-parser', 'cookie', 'react-router'],
+-      include: [
+-        'react-router > set-cookie-parser',
+-        'react-router > cookie',
+-        'react-router',
+-      ],
 +      include: [
-+        'set-cookie-parser',
-+        'cookie',
++        'react-router > set-cookie-parser',
++        'react-router > cookie',
 +        'react-router',
 +        '@qwik.dev/partytown/react',
 +      ],

--- a/cookbook/recipes/partytown/patches/vite.config.ts.63904f.patch
+++ b/cookbook/recipes/partytown/patches/vite.config.ts.63904f.patch
@@ -1,14 +1,18 @@
 index 050b6ed7..77b27fae 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
-@@ -23,7 +23,12 @@ export default defineConfig({
+@@ -23,11 +23,12 @@ export default defineConfig({
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */
--      include: ['set-cookie-parser', 'cookie', 'react-router'],
+-      include: [
+-        'react-router > set-cookie-parser',
+-        'react-router > cookie',
+-        'react-router',
+-      ],
 +      include: [
-+        'set-cookie-parser',
-+        'cookie',
++        'react-router > set-cookie-parser',
++        'react-router > cookie',
 +        'react-router',
 +        '@qwik.dev/partytown/react',
 +      ],

--- a/templates/skeleton/vite.config.ts
+++ b/templates/skeleton/vite.config.ts
@@ -23,7 +23,11 @@ export default defineConfig({
        * Include 'example-dep' in the array below.
        * @see https://vitejs.dev/config/dep-optimization-options
        */
-      include: ['set-cookie-parser', 'cookie', 'react-router'],
+      include: [
+        'react-router > set-cookie-parser',
+        'react-router > cookie',
+        'react-router',
+      ],
     },
   },
   server: {


### PR DESCRIPTION
### WHY are these changes introduced?

A freshly scaffolded Hydrogen app (not in the monorepo) shows two warnings on `dev`:

```
Failed to resolve dependency: set-cookie-parser, present in ssr 'optimizeDeps.include'
Failed to resolve dependency: cookie, present in ssr 'optimizeDeps.include'
```

`cookie` and `set-cookie-parser` are CJS transitive dependencies of `react-router`. Listed by bare name in `ssr.optimizeDeps.include`, Vite can't resolve them with pnpm's strict hoisting — transitive deps aren't accessible from the project root.

### WHAT is this pull request doing?

Uses Vite's nested dependency syntax (`react-router > dep`) to resolve through `react-router`'s own `node_modules`. This is the [documented approach](https://vite.dev/config/dep-optimization-options) for strict package managers like pnpm.

```diff
-      include: ['set-cookie-parser', 'cookie', 'react-router'],
+      include: [
+        'react-router > set-cookie-parser',
+        'react-router > cookie',
+        'react-router',
+      ],
```

### HOW to test your changes?

1. `pnpm create @shopify/hydrogen@latest`
2. `pnpm run dev`
3. see warnings
4. change vite.config according to previous step
5. run dev again
6. Confirm no `Failed to resolve dependency` warnings in the console

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- ~I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes~
- ~I've added or updated the documentation~