### PR TITLE
fix: make Release.devDependencies optional in upgrade command

### DIFF
--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -375,7 +375,6 @@ describe('upgrade', async () => {
         expect(latestRelease).toHaveProperty('hash');
         expect(latestRelease).toHaveProperty('commit');
         expect(latestRelease).toHaveProperty('dependencies');
-        expect(latestRelease).toHaveProperty('devDependencies');
         expect(latestRelease).toHaveProperty('features');
         expect(latestRelease).toHaveProperty('fixes');
 
@@ -389,7 +388,9 @@ describe('upgrade', async () => {
 
         // Verify dependencies are objects
         expect(typeof latestRelease.dependencies).toBe('object');
-        expect(typeof latestRelease.devDependencies).toBe('object');
+        if (latestRelease.devDependencies !== undefined) {
+          expect(typeof latestRelease.devDependencies).toBe('object');
+        }
 
         // Verify features and fixes are arrays
         expect(Array.isArray(latestRelease.features)).toBe(true);
@@ -423,11 +424,12 @@ describe('upgrade', async () => {
 
       expect(sampleRelease.version).toBeDefined();
       expect(sampleRelease.dependencies).toBeDefined();
-      expect(sampleRelease.devDependencies).toBeDefined();
 
       // Test that the structure matches what upgrade functions expect
       expect(typeof sampleRelease.dependencies).toBe('object');
-      expect(typeof sampleRelease.devDependencies).toBe('object');
+      if (sampleRelease.devDependencies !== undefined) {
+        expect(typeof sampleRelease.devDependencies).toBe('object');
+      }
       expect(Array.isArray(sampleRelease.features)).toBe(true);
       expect(Array.isArray(sampleRelease.fixes)).toBe(true);
     });
@@ -2200,7 +2202,7 @@ describe('--version=next functionality', () => {
       });
 
       expect(result.dependencies['@shopify/hydrogen']).toBe('next');
-      expect(result.devDependencies['@shopify/mini-oxygen']).toBe('next');
+      expect(result.devDependencies?.['@shopify/mini-oxygen']).toBe('next');
       expect(result.dependencies['react-router']).toBe('7.9.2');
       expect(result.title).toContain('(next versions)');
     });
@@ -2242,7 +2244,7 @@ describe('--version=next functionality', () => {
       });
 
       expect(result.dependencies['@shopify/hydrogen']).toBe('next');
-      expect(result.devDependencies['@shopify/mini-oxygen']).toBe('next');
+      expect(result.devDependencies?.['@shopify/mini-oxygen']).toBe('next');
       expect(result.dependencies['react-router']).toBe('7.9.2'); // Non-Shopify packages unchanged
     });
 

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -56,7 +56,7 @@ export type Release = {
   commit: `https://${string}`;
   date: string;
   dependencies: Record<string, string>;
-  devDependencies: Record<string, string>;
+  devDependencies?: Record<string, string>;
   dependenciesMeta?: Record<string, {required: boolean}>;
   removeDependencies?: string[];
   removeDevDependencies?: string[];
@@ -299,7 +299,7 @@ export async function isRunningFromHydrogenMonorepo(): Promise<boolean> {
 function createNextRelease(latestRelease: Release): Release {
   // Use latest release as base and override specific @shopify packages to "next"
   const dependencies = {...latestRelease.dependencies};
-  const devDependencies = {...latestRelease.devDependencies};
+  const devDependencies = {...(latestRelease.devDependencies ?? {})};
 
   // Override @shopify/hydrogen and @shopify/mini-oxygen to "next" if they exist
   if (dependencies['@shopify/hydrogen']) {
@@ -446,7 +446,7 @@ function hasOutdatedDependencies({
 }) {
   return Object.entries({
     ...release.dependencies,
-    ...release.devDependencies,
+    ...(release.devDependencies ?? {}),
   }).some(([name, version]) => {
     // Skip checking the bundled CLI for now because it's always outdated.
     // (we release a new version of the CLI after every Hydrogen release)
@@ -883,7 +883,7 @@ export function buildUpgradeCommandArgs({
   };
   const effectiveDevDependencies = {
     ...(cumulativeDevDependencies ?? {}),
-    ...selectedRelease.devDependencies,
+    ...(selectedRelease.devDependencies ?? {}),
   };
 
   // upgrade dependencies


### PR DESCRIPTION
## Context

CI on main is failing — 2 unit tests in `upgrade.test.ts` break because when the 2026.4.0 changelog entry was initally added it didn’t have a `devDependencies` field.

[CI run 24208645030](https://github.com/Shopify/hydrogen/actions/runs/24208645030) shows the failures.

## Root Cause

The `Release` type declares `devDependencies: Record<string, string>` (required), but the 2026.4.0 entry in `docs/changelog.json` legitimately omits it — no dev deps changed in this release. The runtime code already handled this with `?? {}` patterns; only the type and tests were wrong.

## Solution

- Make `devDependencies` optional (`?`) in the `Release` type
- Add `?? {}` guards to 3 bare spread sites for consistency
- Use optional chaining (`?.`) in test assertions
- Add empty `devDependencies: {}` to the 2026.4.0 changelog entry for data consistency

## Testing

- [x] `fetchChangelog` tests pass locally (2/2)
- [x] Zero new TypeScript errors (`pnpm tsc --noEmit | grep devDependencies` is empty)
- [ ] CI unit tests pass

## Risk Assessment

Low — the runtime code already treated `devDependencies` as optional via `?? {}`. This just makes the type and tests honest about it.