### PR TITLE
report friendly error when cli fails to find shops to display

### DIFF
--- a/.changeset/hot-laws-wave.md
+++ b/.changeset/hot-laws-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Render a helpful message (instead of stacktrace) when user logs in with no active shops

--- a/packages/cli/src/lib/auth.test.ts
+++ b/packages/cli/src/lib/auth.test.ts
@@ -128,6 +128,16 @@ describe('auth', () => {
       expect(result).toStrictEqual(EXPECTED_LOGIN_RESULT);
     });
 
+    it('throws an error when account has no active shops', async () => {
+      vi.mocked(getUserAccount).mockResolvedValue({
+        email: EMAIL,
+        activeShops: [],
+      });
+
+      await expect(login(ROOT)).rejects.toThrow(AbortError);
+      expect(renderSelectPrompt).not.toHaveBeenCalled();
+    });
+
     it('prompts for shop is not found in arguments and local config', async () => {
       const result = await login(ROOT);
 

--- a/packages/cli/src/lib/auth.test.ts
+++ b/packages/cli/src/lib/auth.test.ts
@@ -134,7 +134,11 @@ describe('auth', () => {
         activeShops: [],
       });
 
-      await expect(login(ROOT)).rejects.toThrow(AbortError);
+      await expect(login(ROOT)).rejects.toThrow(/No active shops found/);
+      await expect(login(ROOT, SHOP_DOMAIN)).rejects.toThrow(
+        /No active shops found/,
+      );
+      await expect(login(ROOT, true)).rejects.toThrow(/No active shops found/);
       expect(renderSelectPrompt).not.toHaveBeenCalled();
     });
 

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -67,6 +67,13 @@ export async function login(root?: string, shop?: string | true) {
       shop &&
       userAccount.activeShops.find(({fqdn}) => shop === fqdn);
 
+    if (!preselected && userAccount.activeShops.length === 0) {
+      throw new AbortError(
+        'No shops found for your Shopify account.',
+        "If you're just getting started, create a free dev store in your Shopify Dev Dashboard, then run the command again.",
+      );
+    }
+
     const selected =
       preselected ||
       (await renderSelectPrompt({

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -67,7 +67,7 @@ export async function login(root?: string, shop?: string | true) {
       shop &&
       userAccount.activeShops.find(({fqdn}) => shop === fqdn);
 
-    if (!preselected && userAccount.activeShops.length === 0) {
+    if (userAccount.activeShops.length === 0) {
       throw new AbortError(
         'No shops found for your Shopify account.',
         "If you're just getting started, create a free dev store in your Shopify Dev Dashboard, then run the command again.",

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -69,8 +69,8 @@ export async function login(root?: string, shop?: string | true) {
 
     if (userAccount.activeShops.length === 0) {
       throw new AbortError(
-        'No shops found for your Shopify account.',
-        "If you're just getting started, create a free dev store in your Shopify Dev Dashboard, then run the command again.",
+        'No active shops found for your Shopify account.',
+        'To create a new development store, visit https://dev.shopify.com/dashboard. If you already have a store, try running `shopify hydrogen logout` and logging in with a different account.',
       );
     }
 

--- a/packages/cli/src/lib/auth.ts
+++ b/packages/cli/src/lib/auth.ts
@@ -62,17 +62,17 @@ export async function login(root?: string, shop?: string | true) {
 
     const userAccount = await getUserAccount(token);
 
-    const preselected =
-      !forcePrompt &&
-      shop &&
-      userAccount.activeShops.find(({fqdn}) => shop === fqdn);
-
     if (userAccount.activeShops.length === 0) {
       throw new AbortError(
         'No active shops found for your Shopify account.',
         'To create a new development store, visit https://dev.shopify.com/dashboard. If you already have a store, try running `shopify hydrogen logout` and logging in with a different account.',
       );
     }
+
+    const preselected =
+      !forcePrompt &&
+      shop &&
+      userAccount.activeShops.find(({fqdn}) => shop === fqdn);
 
     const selected =
       preselected ||


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2772 and #1463

The SelectPrompt component is being called and erroring out with 0 choices passed to it.

This approach avoids modifying the re-used SelectPrompt, isolating the change to one invocation of SelectPrompt.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

By checking for the condition before calling SelectPrompt, a friendly error message can be raised.

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

With a new user account that has no stores associated with it, attempt to link a store to a hydrogen project.

```
node [/path/to/shopify-cli]/packages/cli/bin/run.js hydrogen link
```

##### Before this change

```log
$ node ./shopify-cli/packages/cli/bin/run.js hydrogen link

╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Release notes for 3.93.0                                                    │
│                                                                              │
│  Release highlights:                                                         │
│                                                                              │
│    - [App] Add app config validate command with --json support               │
│    - [App] Allow non-interactive app init                                    │
│    - [App] Deprecate --force on app deploy and app release                   │
│    - [App] Improve import scanning performance on app dev                    │
│    - [Theme] Allow --development flag to create a new theme                  │
│    - [Theme] Add JSON flag to theme preview                                  │
│                                                                              │
│  Read the complete release notes                                             │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯


  ERROR  SelectPrompt requires at least one choice

 file:///path/to/shopify-cli/packages/cli-kit/dist/private/node/ui/components/SelectPro
 mpt.js:8:15

 -SelectPromp (file:///path/to/shopify-cli/packages/cli-kit/dist/private/node/ui/compon
             ents/SelectPrompt.js:8:15)
 -Object.react_stack_bott (/path/to/shopify-cli/node_modules/.pnpm/react-reconciler@0.3
  m_frame                3.0_react@19.2.4/node_modules/react-reconciler/cjs/react-reconciler.developme
                         nt.js:17596:20)
 -renderWithHoo (/path/to/shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@
  s            19.2.4/node_modules/react-reconciler/cjs/react-reconciler.development.js:5335:22)
 -updateFunctionCompo (/path/to/shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_
  ent                react@19.2.4/node_modules/react-reconciler/cjs/react-reconciler.development.js:77
                     20:19)
 -beginWor (/path/to/shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.
          4/node_modules/react-reconciler/cjs/react-reconciler.development.js:9277:18)
 -runWithFiberIn (/path/to/shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react
  EV            @19.2.4/node_modules/react-reconciler/cjs/react-reconciler.development.js:2505:30)
 -performUnitOfW (/path/to/shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react
  rk            @19.2.4/node_modules/react-reconciler/cjs/react-reconciler.development.js:15273:22)
 -workLoopSyn (/path/to/shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19
             .2.4/node_modules/react-reconciler/cjs/react-reconciler.development.js:15099:41)
 -renderRootSy (/path/to/shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@1
  c           9.2.4/node_modules/react-reconciler/cjs/react-reconciler.development.js:15080:11)
 -performWorkOnR (/path/to/shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react
  ot            @19.2.4/node_modules/react-reconciler/cjs/react-reconciler.development.js:14245:35)

╭─ error ──────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  SelectPrompt requires at least one choice                                   │
│                                                                              │
│  To investigate the issue, examine this stack trace:                         │
│    at SelectPrompt                                                           │
│    (cli-kit/src/private/node/ui/components/SelectPrompt.tsx:33)              │
│      throw new Error('SelectPrompt requires at least one choice')            │
│    at react_stack_bottom_frame                                               │
│    (../shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.4/  │
│    node_modules/react-reconciler/cjs/react-reconciler.development.js:17596)  │
│      return Component(props, secondArg);                                     │
│    at renderWithHooks                                                        │
│    (../shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.4/  │
│    node_modules/react-reconciler/cjs/react-reconciler.development.js:5335)   │
│      var children = callComponentInDEV(Component, props, secondArg);         │
│    at updateFunctionComponent                                                │
│    (../shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.4/  │
│    node_modules/react-reconciler/cjs/react-reconciler.development.js:7720)   │
│      Component = renderWithHooks(                                            │
│    at beginWork                                                              │
│    (../shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.4/  │
│    node_modules/react-reconciler/cjs/react-reconciler.development.js:9277)   │
│      return updateFunctionComponent(                                         │
│    at runWithFiberInDEV                                                      │
│    (../shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.4/  │
│    node_modules/react-reconciler/cjs/react-reconciler.development.js:2505)   │
│      ? fiber._debugTask.run(                                                 │
│    at performUnitOfWork                                                      │
│    (../shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.4/  │
│    node_modules/react-reconciler/cjs/react-reconciler.development.js:15273)  │
│      (current = runWithFiberInDEV(                                           │
│    at workLoopSync                                                           │
│    (../shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.4/  │
│    node_modules/react-reconciler/cjs/react-reconciler.development.js:15099)  │
│      for (; null !== workInProgress; ) performUnitOfWork(workInProgress);    │
│    at renderRootSync                                                         │
│    (../shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.4/  │
│    node_modules/react-reconciler/cjs/react-reconciler.development.js:15080)  │
│      workLoopSync();                                                         │
│    at performWorkOnRoot                                                      │
│    (../shopify-cli/node_modules/.pnpm/react-reconciler@0.33.0_react@19.2.4/  │
│    node_modules/react-reconciler/cjs/react-reconciler.development.js:14245)  │
│      errorRetryLanes = renderRootSync(                                       │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```


##### After this change

```log
$ node /path/to/shopify-cli/packages/cli/bin/run.js hydrogen link

To run this command, log in to Shopify.
User verification code: NCZB-TFMN
👉 Press any key to open the login page on your browser
Opened link to start the auth process: https://accounts.shopify.com/activate-with-code?device_code%5Buser_code%5D=NCZB-TFMN
✔ Logged in.
╭─ error ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                            │
│  No shops found for your Shopify account.                                                                  │
│                                                                                                            │
│  If you're just getting started, create a free dev store in your Shopify Dev Dashboard, then run the       │
│  command again.                                                                                            │
│                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

$ node /path/to/shopify-cli/packages/cli/bin/run.js hydrogen link
╭─ error ────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                            │
│  No shops found for your Shopify account.                                                                  │
│                                                                                                            │
│  If you're just getting started, create a free dev store in your Shopify Dev Dashboard, then run the       │
│  command again.                                                                                            │
│                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```


#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset. 
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

