### PR TITLE
fix: migrate E2E test domains to hydrogen.shop subdomains

### DIFF
--- a/e2e/envs/.env.defaultConsentAllowed_cookiesDisabled
+++ b/e2e/envs/.env.defaultConsentAllowed_cookiesDisabled
@@ -1,5 +1,5 @@
 SESSION_SECRET="mock-session"
-PUBLIC_CHECKOUT_DOMAIN="checkout.hydrogen.shop"
-PUBLIC_STORE_DOMAIN="checkout.hydrogen.shop"
+PUBLIC_CHECKOUT_DOMAIN="consent-allowed-by-default-old-cookies.hydrogen.shop"
+PUBLIC_STORE_DOMAIN="consent-allowed-by-default-old-cookies.hydrogen.shop"
 PUBLIC_STOREFRONT_API_TOKEN="b97a750a8afa8fe33f2b4012cb3a9f6f"
 PUBLIC_STOREFRONT_ID="1000014875"

--- a/e2e/envs/.env.defaultConsentAllowed_cookiesEnabled
+++ b/e2e/envs/.env.defaultConsentAllowed_cookiesEnabled
@@ -1,5 +1,5 @@
 SESSION_SECRET="mock-session"
-PUBLIC_CHECKOUT_DOMAIN="www.iwantacheapdomainfortesting12345.club"
-PUBLIC_STORE_DOMAIN="www.iwantacheapdomainfortesting12345.club"
+PUBLIC_CHECKOUT_DOMAIN="consent-allowed-by-default.hydrogen.shop"
+PUBLIC_STORE_DOMAIN="consent-allowed-by-default.hydrogen.shop"
 PUBLIC_STOREFRONT_API_TOKEN="2aac2e4420f32ba0c7dadf55c7cc387b"
 PUBLIC_STOREFRONT_ID="1000070232"

--- a/e2e/envs/.env.defaultConsentDisallowed_cookiesDisabled
+++ b/e2e/envs/.env.defaultConsentDisallowed_cookiesDisabled
@@ -1,5 +1,5 @@
 SESSION_SECRET="mock-session"
-PUBLIC_CHECKOUT_DOMAIN="www.kara2345.xyz"
-PUBLIC_STORE_DOMAIN="www.kara2345.xyz"
+PUBLIC_CHECKOUT_DOMAIN="consent-disallowed-by-default-old-cookies.hydrogen.shop"
+PUBLIC_STORE_DOMAIN="consent-disallowed-by-default-old-cookies.hydrogen.shop"
 PUBLIC_STOREFRONT_API_TOKEN="8eece95833df895900c1b285987c7f40"
 PUBLIC_STOREFRONT_ID="1000070242"

--- a/e2e/envs/.env.defaultConsentDisallowed_cookiesEnabled
+++ b/e2e/envs/.env.defaultConsentDisallowed_cookiesEnabled
@@ -1,5 +1,5 @@
 SESSION_SECRET="mock-session"
-PUBLIC_CHECKOUT_DOMAIN="checkout.daviduik.com"
-PUBLIC_STORE_DOMAIN="checkout.daviduik.com"
+PUBLIC_CHECKOUT_DOMAIN="consent-disallowed-by-default.hydrogen.shop"
+PUBLIC_STORE_DOMAIN="consent-disallowed-by-default.hydrogen.shop"
 PUBLIC_STOREFRONT_API_TOKEN="a79d329fc13657352c6e4734e5d4ca75"
 PUBLIC_STOREFRONT_ID="1000061747"


### PR DESCRIPTION
## Context

The E2E consent/cookie test stores used expired domains (`kara2345.xyz`, `iwantacheapdomainfortesting12345.club`, `checkout.daviduik.com`) that are now broken. Shopify/record-store#9763 created dedicated CNAME subdomains under `hydrogen.shop` to replace them.

## What

Replaces domains in the 4 consent test env files with their new `hydrogen.shop` subdomains. Also decouples the consent-allowed + old-cookies config from the shared demo store (`checkout.hydrogen.shop`).

| Env File | Old Domain | New Subdomain |
|----------|-----------|---------------|
| `defaultConsentAllowed_cookiesEnabled` | `iwantacheapdomainfortesting12345.club` | `consent-allowed-by-default.hydrogen.shop` |
| `defaultConsentAllowed_cookiesDisabled` | `checkout.hydrogen.shop` | `consent-allowed-by-default-old-cookies.hydrogen.shop` |
| `defaultConsentDisallowed_cookiesEnabled` | `checkout.daviduik.com` | `consent-disallowed-by-default.hydrogen.shop` |
| `defaultConsentDisallowed_cookiesDisabled` | `kara2345.xyz` | `consent-disallowed-by-default-old-cookies.hydrogen.shop` |

SFIDs and API tokens are unchanged — same stores, new custom domains.

## Post-Merge Steps

- [x] Add each subdomain as a custom domain in the corresponding Shopify store admin
- [x] Verify DNS resolution: `curl -I https://consent-allowed-by-default.hydrogen.shop`
- [x] Run `pnpm exec playwright test --project=new-cookies` and `--project=old-cookies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)