### PR TITLE
docs: fix broken links and malformed markdown

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -41,7 +41,7 @@ A _recipe_ is a reproducible sequence of steps meant to be applied to the [skele
 
 Each recipe is located in the [cookbook's recipes folder](/cookbook/recipes/) and is structured with a specific set of conventions. This is how a recipe folder is organized:
 
-- `recipe.yaml`: the JSON file containig the whole recipe definition, in a machine-readable format.
+- `recipe.yaml`: the YAML file containing the whole recipe definition, in a machine-readable format.
 - `ingredients/`: a folder containing _new_ files that the recipe introduces. They will be copied as-is to the skeleton template.
 - `patches/`: a folder containing patches to be applied to existing files in the skeleton template. The file ↔ patch mappings are defined in the `recipe.yaml` file under the `ingredients` key.
 - `README.md`: the human-readable Markdown render of the recipe, based off of the `recipe.yaml` file.

--- a/docs/CALVER.md
+++ b/docs/CALVER.md
@@ -599,7 +599,7 @@ Potential enhancements being considered:
 
 ## Related Documentation
 
-- [Hydrogen Release Process](../CLAUDE.md#hydrogen-release-process) - Complete release workflow
+- [Hydrogen Release Process](../.claude/skills/hydrogen-release-process/SKILL.md) - Complete release workflow
 - [Major Protection Workflow](../.github/workflows/major-protection.yml) - Protection implementation
-- [Protection Utilities](../.github/scripts/changeset-protection-utils.js) - Shared utilities
+- [Protection Utilities](../.changeset/changeset-protection-utils.js) - Shared utilities
 - [.changeset/README.md](../.changeset/README.md) - Changesets documentation

--- a/packages/hydrogen-react/README.md
+++ b/packages/hydrogen-react/README.md
@@ -68,7 +68,7 @@ The following will help you troubleshoot common problems in this version of Hydr
 
 ### GraphQL autocompletion
 
-If you can't get [GraphQL autocompletion](<(#storefront-api-graphql-autocompletion)>) to work, then try restarting the GraphQL server in your IDE.
+If you can't get GraphQL autocompletion to work, then try restarting the GraphQL server in your IDE.
 
 For example, in VSCode do the following:
 

--- a/packages/hydrogen/README.md
+++ b/packages/hydrogen/README.md
@@ -18,5 +18,5 @@ npm create @shopify/hydrogen@latest
 - Interested in contributing to Hydrogen? [Read our contributing guide](../../CONTRIBUTING.md)
 - Want to learn more? [Check out the Hydrogen docs on Shopify.dev](https://shopify.dev/custom-storefronts/hydrogen)
 - Questions? Feedback? Feature requests? [Discussions](https://github.com/Shopify/hydrogen/discussions)
-- Upgrading from a previous version? [View the Changelog](./packages/hydrogen/CHANGELOG.md)
+- Upgrading from a previous version? [View the Changelog](./CHANGELOG.md)
 - Looking for Hydrogen v1? [The source code has been moved](https://github.com/Shopify/hydrogen-v1)


### PR DESCRIPTION
Follow-up to #3712, this one targets genuinely broken links rather than typos. Each fix was verified by checking the target file/anchor exists at the claimed location.

## Fixes

### `packages/hydrogen/README.md` — broken relative CHANGELOG link
\`\`\`diff
-- Upgrading from a previous version? [View the Changelog](./packages/hydrogen/CHANGELOG.md)
+- Upgrading from a previous version? [View the Changelog](./CHANGELOG.md)
\`\`\`
The link was copied from the root \`README.md\` without adjusting the relative path. From \`packages/hydrogen/README.md\`, \`./packages/hydrogen/CHANGELOG.md\` resolves to \`packages/hydrogen/packages/hydrogen/CHANGELOG.md\`, which doesn't exist.

### `packages/hydrogen-react/README.md` — malformed self-referential link
\`\`\`diff
-If you can't get [GraphQL autocompletion](<(#storefront-api-graphql-autocompletion)>) to work, then try restarting the GraphQL server in your IDE.
+If you can't get GraphQL autocompletion to work, then try restarting the GraphQL server in your IDE.
\`\`\`
The markdown link \`[text](<(#anchor)>)\` is malformed (stray angle brackets and parentheses in the URL slot), the anchor \`#storefront-api-graphql-autocompletion\` does not exist in the file, and the link sits inside the \`### GraphQL autocompletion\` section it pointed to. Dropped the link and kept plain text.

### `docs/CALVER.md` — two broken links in *Related Documentation*
\`\`\`diff
-- [Hydrogen Release Process](../CLAUDE.md#hydrogen-release-process) - Complete release workflow
+- [Hydrogen Release Process](../.claude/skills/hydrogen-release-process/SKILL.md) - Complete release workflow
\`\`\`
There is no \`#hydrogen-release-process\` anchor in \`CLAUDE.md\`. That file actually points readers to the release-process skill (\`CLAUDE.md\` line 25: *"see the \`hydrogen-release-process\` skill"*). Updated to link straight to \`.claude/skills/hydrogen-release-process/SKILL.md\`, which exists.

\`\`\`diff
-- [Protection Utilities](../.github/scripts/changeset-protection-utils.js) - Shared utilities
+- [Protection Utilities](../.changeset/changeset-protection-utils.js) - Shared utilities
\`\`\`
\`.github/scripts/changeset-protection-utils.js\` does not exist. The file lives at \`.changeset/changeset-protection-utils.js\`.

(Note: the following bullet, \`[.changeset/README.md](../.changeset/README.md)\`, also points to a file that doesn't exist. Left alone since it's unclear whether the right fix is to remove the bullet or to create the README — happy to do either in a follow-up if a maintainer has a preference.)

### `cookbook/README.md` — wrong file format + typo
\`\`\`diff
-- \`recipe.yaml\`: the JSON file containig the whole recipe definition, in a machine-readable format.
+- \`recipe.yaml\`: the YAML file containing the whole recipe definition, in a machine-readable format.
\`\`\`
\`recipe.yaml\` is a YAML file (has a \`# yaml-language-server: \$schema\` header and uses YAML syntax), not a JSON file. Also fixed \`containig\` → \`containing\`.

---

No functional changes, docs-only, no changeset needed.