### PR TITLE
docs: match Node.js version requirement to package.json engines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 **Requirements:**
 
-- Node.js version 16.14.0 or higher
+- Node.js 22.x or 24.x
 
 Run the following commands to get started working on Hydrogen.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Hydrogen legacy v1 has been moved [to a separate repo](https://github.com/Shopif
 
 **Requirements:**
 
-- Node.js version 18.0.0 or higher
+- Node.js 22.x or 24.x
 - `npm` (or your package manager of choice, such as `yarn` or `pnpm`)
 
 1. Install the latest version of Hydrogen:

--- a/templates/skeleton/README.md
+++ b/templates/skeleton/README.md
@@ -22,7 +22,7 @@ Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dov
 
 **Requirements:**
 
-- Node.js version 18.0.0 or higher
+- Node.js 22.x or 24.x
 
 ```bash
 npm create @shopify/hydrogen@latest


### PR DESCRIPTION
The root \`package.json\` declares \`"engines": { "node": "^22 || ^24" }\`, but three user-facing docs claim older, incorrect minimums. Users following any of these hit a hard install failure because the engines constraint excludes Node 16, 18, 20, and 23.

## Changes

\`\`\`diff
- README.md:                   Node.js version 18.0.0 or higher  ->  Node.js 22.x or 24.x
- CONTRIBUTING.md:              Node.js version 16.14.0 or higher ->  Node.js 22.x or 24.x
- templates/skeleton/README.md: Node.js version 18.0.0 or higher  ->  Node.js 22.x or 24.x
\`\`\`

The wording \`22.x or 24.x\` was chosen to match the shape of \`^22 || ^24\` precisely (LTS-only, Node 23 excluded).

Scope limited to authoritative user-facing docs. Cookbook recipe READMEs and LLM prompt files also carry the old \`18.0.0 or higher\` string, but those are generated by \`cookbook.ts\` from the skeleton template, so they should refresh on the next regeneration rather than be edited by hand.

No code or functional changes, no changeset needed.