### PR TITLE
fix(hydrogen): respect cartId arg in cartGetDefault

### DIFF
--- a/.changeset/cart-get-respects-cartid.md
+++ b/.changeset/cart-get-respects-cartid.md
@@ -2,4 +2,4 @@
 "@shopify/hydrogen": patch
 ---
 
-Fix `cartGetDefault` ignoring the `cartId` argument. Previously, when callers invoked the returned function with `{cartId: '...'}`, that value was ignored and the function called `getCartId()` instead — which could return `undefined` and cause an early `return null`, even though the caller had provided a valid cart id. The resolved cart id now prefers `cartInput.cartId` before falling back to `getCartId()`.
+Fix `cartGetDefault` not respecting the `cartId` argument. The returned function accepts an optional `cartInput.cartId`, but the implementation called `getCartId()` unconditionally and then early-returned `null` when that was falsy — so a caller passing `{cartId: '…'}` with no cart cookie got `null` back. The resolved cart id now prefers `cartInput.cartId` before falling back to `getCartId()`, and the GraphQL `variables` spread order was swapped so the resolved cart id always wins over an explicit `{cartId: undefined}` in the input.

--- a/.changeset/cart-get-respects-cartid.md
+++ b/.changeset/cart-get-respects-cartid.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Fix `cartGetDefault` ignoring the `cartId` argument. Previously, when callers invoked the returned function with `{cartId: '...'}`, that value was ignored and the function called `getCartId()` instead — which could return `undefined` and cause an early `return null`, even though the caller had provided a valid cart id. The resolved cart id now prefers `cartInput.cartId` before falling back to `getCartId()`.

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.test.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.test.ts
@@ -53,6 +53,17 @@ describe('cartGetDefault', () => {
     expect(result).toHaveProperty('id', 'gid://shopify/Cart/c1-456');
   });
 
+  it('should use the cartId passed in when getCartId returns undefined', async () => {
+    const cartGet = cartGetDefault({
+      storefront: mockCreateStorefrontClient(),
+      getCartId: () => undefined,
+    });
+
+    const result = await cartGet({cartId: 'gid://shopify/Cart/c1-456'});
+
+    expect(result).toHaveProperty('id', 'gid://shopify/Cart/c1-456');
+  });
+
   describe('run with customerAccount option', () => {
     it('should add logged_in search param to checkout link if customer is logged in', async () => {
       const cartGet = cartGetDefault({

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.test.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.test.ts
@@ -64,6 +64,17 @@ describe('cartGetDefault', () => {
     expect(result).toHaveProperty('id', 'gid://shopify/Cart/c1-456');
   });
 
+  it('should fall back to getCartId when cartInput.cartId is explicitly undefined', async () => {
+    const cartGet = cartGetDefault({
+      storefront: mockCreateStorefrontClient(),
+      getCartId: () => CART_ID,
+    });
+
+    const result = await cartGet({cartId: undefined});
+
+    expect(result).toHaveProperty('id', CART_ID);
+  });
+
   describe('run with customerAccount option', () => {
     it('should add logged_in search param to checkout link if customer is logged in', async () => {
       const cartGet = cartGetDefault({

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.ts
@@ -70,7 +70,7 @@ export function cartGetDefault({
     const [isCustomerLoggedIn, {cart, errors}] = await Promise.all([
       customerAccount ? customerAccount.isLoggedIn() : false,
       storefront.query<{cart: Cart | null}>(CART_QUERY(cartFragment), {
-        variables: {cartId, ...cartInput},
+        variables: {...cartInput, cartId},
         cache: storefront.CacheNone(),
       }),
     ]);

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.ts
@@ -63,7 +63,7 @@ export function cartGetDefault({
   cartFragment,
 }: CartGetOptions): CartGetFunction {
   return async (cartInput?: CartGetProps) => {
-    const cartId = getCartId();
+    const cartId = cartInput?.cartId ?? getCartId();
 
     if (!cartId) return null;
 


### PR DESCRIPTION
Closes #3639.

## Problem

\`cartGetDefault\` returns a function whose public type declares a \`cartInput?: CartGetProps\` parameter, with \`cartInput.cartId\` documented as \"The cart ID\" and \`@default cart.getCartId()\`. But the implementation ignored \`cartInput.cartId\` entirely:

\`\`\`ts
return async (cartInput?: CartGetProps) => {
  const cartId = getCartId();        // cartInput.cartId ignored
  if (!cartId) return null;           // <-- bails even when caller provided one
  // ...
  variables: {cartId, ...cartInput},  // spread masks it *in the variables*, but only if we get here
};
\`\`\`

If \`getCartId()\` returns \`undefined\` (e.g. no cart cookie) and the caller passes \`cartGet({cartId: 'gid://shopify/Cart/...'})\`, the early return fires and the function yields \`null\` instead of fetching the cart the caller asked for.

## Fix

One-line change: prefer the caller's \`cartId\` before falling back to \`getCartId()\`.

\`\`\`diff
-    const cartId = getCartId();
+    const cartId = cartInput?.cartId ?? getCartId();
\`\`\`

## Why the existing test didn't catch it

There's already a test (\"should return a cartId passed in\") that passes \`cartGet({cartId: '...'})\`. It passes on the broken code because:

1. \`getCartId: () => CART_ID\` in the test returns a value, so \`if (!cartId) return null\` doesn't fire.
2. The spread \`...cartInput\` in the GraphQL \`variables\` object then overrides \`cartId\` with the caller's value, so the mock storefront happens to echo back the \"correct\" id.

The bug only manifests when \`getCartId()\` returns falsy — exactly the scenario in #3639.

## New regression test

\`\`\`ts
it('should use the cartId passed in when getCartId returns undefined', async () => {
  const cartGet = cartGetDefault({
    storefront: mockCreateStorefrontClient(),
    getCartId: () => undefined,
  });

  const result = await cartGet({cartId: 'gid://shopify/Cart/c1-456'});

  expect(result).toHaveProperty('id', 'gid://shopify/Cart/c1-456');
});
\`\`\`

This fails on the old code (\`result\` is \`null\`) and passes after the fix.

## Scope note

Other cart operations (\`cartLinesAddDefault\`, etc.) accept \`optionalParams.cartId\` via \`CartOptionalInput\` and use the same \`{cartId: options.getCartId(), ..., ...optionalParams}\` pattern, where the spread happens to override cleanly. They don't share cartGet's early-return problem, so they're left untouched in this PR.

## Changeset

Patch bump for \`@shopify/hydrogen\` included.