### PR TITLE
fix(cookbook): remove withResolvedCatalog from regenerate command

### DIFF
--- a/cookbook/src/commands/regenerate.ts
+++ b/cookbook/src/commands/regenerate.ts
@@ -2,7 +2,6 @@ import {execSync} from 'child_process';
 import {CommandModule} from 'yargs';
 import {applyRecipe} from '../lib/apply';
 import {FILES_TO_IGNORE_FOR_GENERATE, TEMPLATE_PATH} from '../lib/constants';
-import {withResolvedCatalog} from '../lib/workspace';
 import {generateRecipe} from '../lib/generate';
 import {isRenderFormat, RENDER_FORMATS, renderRecipe} from '../lib/render';
 import {listRecipes, separator, RecipeManifestFormat} from '../lib/util';
@@ -71,24 +70,19 @@ async function handler(args: RegenerateArgs) {
 
   for await (const recipe of recipes) {
     console.log(`🔄 Regenerating recipe '${recipe}'`);
-    // resolve catalog/workspace protocols, apply recipe, then restore
-    await withResolvedCatalog(async () => {
-      applyRecipe({
-        recipeTitle: recipe,
-      });
-      // generate the recipe
-      await generateRecipe({
-        recipeName: recipe,
-        onlyFiles: args.onlyFiles,
-        filenamesToIgnore: FILES_TO_IGNORE_FOR_GENERATE,
-        referenceBranch: args.referenceBranch,
-        recipeManifestFormat: args.recipeManifestFormat,
-      });
-      // render the recipe
-      renderRecipe({
-        recipeName: recipe,
-        format,
-      });
+    applyRecipe({
+      recipeTitle: recipe,
+    });
+    await generateRecipe({
+      recipeName: recipe,
+      onlyFiles: args.onlyFiles,
+      filenamesToIgnore: FILES_TO_IGNORE_FOR_GENERATE,
+      referenceBranch: args.referenceBranch,
+      recipeManifestFormat: args.recipeManifestFormat,
+    });
+    renderRecipe({
+      recipeName: recipe,
+      format,
     });
     // clean up the skeleton template directory
     execSync(`git checkout -- ${TEMPLATE_PATH}`);


### PR DESCRIPTION
### WHY are these changes introduced?

`withResolvedCatalog()` resolves `workspace:*` and `catalog:` protocols to concrete versions in all workspace `package.json` files. The `regenerate` command wraps all three steps inside this helper, which means `applyRecipe()` sees resolved values (e.g. `"@shopify/hydrogen": "2026.4.0"`) instead of the original protocol strings. Patches whose context lines include `"workspace:*"` or `"catalog:"` fail to apply because the file no longer matches.

Recipes whose patch context windows happen to avoid those lines (e.g. infinite-scroll, metaobjects) regenerate fine. Recipes like **multipass** and **partytown** fail.

#### How this went undetected

The bug was latent because the E2E validation tests use `--template <copy>`, which applies patches to a *copy* of the skeleton that isn't modified by catalog resolution. So validation always passed. The issue only surfaces when running `regenerate` against the in-tree skeleton (without `--template`), which is the normal developer workflow for refreshing recipes after skeleton changes.

This was discovered while working on the Vite 8 migration (`fd-vite-8`), where skeleton `package.json` changes caused `regenerate` to fail on recipes like multipass and partytown. The workaround was calling `applyRecipe()` directly and running generate/render separately — this PR eliminates the need for that workaround.

### WHAT is this pull request doing?

Removes the `withResolvedCatalog()` wrapper from the `regenerate` command. The three inner steps don't need it:

- `applyRecipe()` needs `workspace:*` intact so patch context matches
- `generateRecipe()` diffs against HEAD, which also has `workspace:*`
- `renderRecipe()` reads YAML and generates markdown

The existing `git checkout`/`git clean` at the end of each loop iteration already handles skeleton restoration. The `apply` and `validate` commands still use `withResolvedCatalog()` — no dead code.

### HOW to test your changes?

```bash
cd cookbook
npx ts-node src/index.ts regenerate --recipe multipass
npx ts-node src/index.ts regenerate --recipe partytown
```

Both should succeed where they previously failed with patch application errors.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation