### PR TITLE
fix(ci): remove invalid --ignore-engines flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,7 +310,7 @@ jobs:
           node-version: 24
 
       - name: Install the packages
-        run: pnpm install --frozen-lockfile --ignore-engines
+        run: pnpm install --frozen-lockfile
 
       - name: Build the dist code
         run: pnpm run build


### PR DESCRIPTION
## Summary
Removes `--ignore-engines` from the `compile-templates` post-release job in `release.yml`.

## Root cause
`--ignore-engines` is an npm/yarn flag — it has never been supported by pnpm ([pnpm/pnpm#7719](https://github.com/pnpm/pnpm/issues/7719)).

The flag was introduced on 2026-01-08 in #3347 as part of a valid `npm install` command. When the repo switched from npm to pnpm on 2026-02-24 in #3475, `npm` was replaced with `pnpm` but `--ignore-engines` was carried over unchanged.

Every CI release since the pnpm switch has failed at this step:

| Release | Run | Failure |
|---|---|---|
| 2026.1.4 | [#24206724643](https://github.com/Shopify/hydrogen/actions/runs/24206724643) | Compile templates → Install packages |
| semver | [#24395345393](https://github.com/Shopify/hydrogen/actions/runs/24395345393) | Compile templates → Install packages |
| 2026.4.1 | [#24567261322](https://github.com/Shopify/hydrogen/actions/runs/24567261322) | Compile templates → Install packages |

The npm publish job succeeded in all cases — only the dist branch compilation was broken.

## Why is removing the flag safe?
Without `--ignore-engines`, pnpm's default behavior (`engine-strict: false`) is to warn on engine mismatches but not fail. CI runs `node-version: 24` and the repo requires `node: "^22 || ^24"` — satisfied. No additional configuration needed.

## Test plan
- [ ] Verify the compile-templates job passes on the next release