### PR TITLE
fix(cli): preserve .git directory when scaffolding into a non-empty folder

### DIFF
--- a/.changeset/preserve-git-on-scaffold.md
+++ b/.changeset/preserve-git-on-scaffold.md
@@ -1,0 +1,6 @@
+---
+"@shopify/cli-hydrogen": patch
+"@shopify/create-hydrogen": patch
+---
+
+`npm create @shopify/hydrogen` now preserves the `.git/` directory when scaffolding into a non-empty folder, so existing version history isn't lost.

--- a/packages/cli/src/lib/onboarding/common.test.ts
+++ b/packages/cli/src/lib/onboarding/common.test.ts
@@ -1,0 +1,376 @@
+import './setup-template.mocks.js';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {
+  inTemporaryDirectory,
+  writeFile,
+  mkdir,
+  fileExists,
+  readdir,
+} from '@shopify/cli-kit/node/fs';
+import {
+  renderConfirmationPrompt,
+  renderTextPrompt,
+} from '@shopify/cli-kit/node/ui';
+import {AbortController} from '@shopify/cli-kit/node/abort';
+import {handleProjectLocation} from './common.js';
+import {joinPath} from '@shopify/cli-kit/node/path';
+import {execAsync} from '../process.js';
+
+vi.mock('@shopify/cli-kit/node/ui');
+
+describe('handleProjectLocation', () => {
+  let controller: AbortController;
+
+  beforeEach(() => {
+    controller = new AbortController();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('preserving .git directory', () => {
+    it('preserves .git/ directory when user confirms deletion in non-empty directory', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const projectDir = joinPath(tmpDir, 'test-project');
+        await mkdir(projectDir);
+
+        // Create a .git directory with some content
+        const gitDir = joinPath(projectDir, '.git');
+        await mkdir(gitDir);
+        await writeFile(joinPath(gitDir, 'HEAD'), 'ref: refs/heads/main');
+        await writeFile(
+          joinPath(gitDir, 'config'),
+          '[core]\nrepositoryformatversion = 0',
+        );
+
+        // Create other files that should be deleted
+        await writeFile(joinPath(projectDir, 'existing-file.txt'), 'content');
+        await mkdir(joinPath(projectDir, 'existing-dir'));
+        await writeFile(
+          joinPath(projectDir, 'existing-dir', 'nested.txt'),
+          'nested content',
+        );
+
+        vi.mocked(renderConfirmationPrompt).mockResolvedValue(true);
+
+        const result = await handleProjectLocation({
+          path: projectDir,
+          controller,
+          force: false,
+        });
+
+        expect(result).toBeDefined();
+
+        // .git directory should still exist
+        await expect(fileExists(gitDir)).resolves.toBe(true);
+        await expect(fileExists(joinPath(gitDir, 'HEAD'))).resolves.toBe(true);
+        await expect(fileExists(joinPath(gitDir, 'config'))).resolves.toBe(
+          true,
+        );
+
+        // Other files should be deleted
+        await expect(
+          fileExists(joinPath(projectDir, 'existing-file.txt')),
+        ).resolves.toBe(false);
+        await expect(
+          fileExists(joinPath(projectDir, 'existing-dir')),
+        ).resolves.toBe(false);
+
+        // Verify the confirmation message mentions .git preservation
+        expect(renderConfirmationPrompt).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining('.git'),
+          }),
+        );
+      });
+    });
+
+    it('preserves .git file (gitfile/submodule worktree) when user confirms deletion', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const projectDir = joinPath(tmpDir, 'test-project');
+        await mkdir(projectDir);
+
+        // Create a .git file (gitfile pointing to actual git directory)
+        await writeFile(
+          joinPath(projectDir, '.git'),
+          'gitdir: /path/to/actual/git/dir',
+        );
+
+        // Create other files that should be deleted
+        await writeFile(joinPath(projectDir, 'existing-file.txt'), 'content');
+
+        vi.mocked(renderConfirmationPrompt).mockResolvedValue(true);
+
+        const result = await handleProjectLocation({
+          path: projectDir,
+          controller,
+          force: false,
+        });
+
+        expect(result).toBeDefined();
+
+        // .git file should still exist
+        await expect(fileExists(joinPath(projectDir, '.git'))).resolves.toBe(
+          true,
+        );
+        const gitContent = await readFile(joinPath(projectDir, '.git'));
+        expect(gitContent).toContain('gitdir:');
+
+        // Other files should be deleted
+        await expect(
+          fileExists(joinPath(projectDir, 'existing-file.txt')),
+        ).resolves.toBe(false);
+      });
+    });
+
+    it('removes all contents when no .git is present (regression test)', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const projectDir = joinPath(tmpDir, 'test-project');
+        await mkdir(projectDir);
+
+        // Create files that should all be deleted
+        await writeFile(joinPath(projectDir, 'file1.txt'), 'content1');
+        await writeFile(joinPath(projectDir, 'file2.txt'), 'content2');
+        await mkdir(joinPath(projectDir, 'dir1'));
+        await writeFile(joinPath(projectDir, 'dir1', 'nested.txt'), 'nested');
+
+        vi.mocked(renderConfirmationPrompt).mockResolvedValue(true);
+
+        const result = await handleProjectLocation({
+          path: projectDir,
+          controller,
+          force: false,
+        });
+
+        expect(result).toBeDefined();
+
+        // All files should be deleted
+        await expect(
+          fileExists(joinPath(projectDir, 'file1.txt')),
+        ).resolves.toBe(false);
+        await expect(
+          fileExists(joinPath(projectDir, 'file2.txt')),
+        ).resolves.toBe(false);
+        await expect(fileExists(joinPath(projectDir, 'dir1'))).resolves.toBe(
+          false,
+        );
+
+        // Directory should be empty
+        const entries = await readdir(projectDir);
+        expect(entries).toHaveLength(0);
+      });
+    });
+
+    it('preserves .git with --force flag (no prompt)', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const projectDir = joinPath(tmpDir, 'test-project');
+        await mkdir(projectDir);
+
+        // Create a .git directory
+        const gitDir = joinPath(projectDir, '.git');
+        await mkdir(gitDir);
+        await writeFile(joinPath(gitDir, 'HEAD'), 'ref: refs/heads/main');
+
+        // Create other files
+        await writeFile(joinPath(projectDir, 'existing-file.txt'), 'content');
+
+        const result = await handleProjectLocation({
+          path: projectDir,
+          controller,
+          force: true,
+        });
+
+        expect(result).toBeDefined();
+
+        // .git should still exist
+        await expect(fileExists(gitDir)).resolves.toBe(true);
+
+        // Other files should be deleted
+        await expect(
+          fileExists(joinPath(projectDir, 'existing-file.txt')),
+        ).resolves.toBe(false);
+
+        // Should not have prompted
+        expect(renderConfirmationPrompt).not.toHaveBeenCalled();
+      });
+    });
+
+    it('continues scaffolding when directory contains only .git', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const projectDir = joinPath(tmpDir, 'test-project');
+        await mkdir(projectDir);
+
+        // Create only a .git directory
+        const gitDir = joinPath(projectDir, '.git');
+        await mkdir(gitDir);
+        await writeFile(joinPath(gitDir, 'HEAD'), 'ref: refs/heads/main');
+
+        vi.mocked(renderConfirmationPrompt).mockResolvedValue(true);
+
+        const result = await handleProjectLocation({
+          path: projectDir,
+          controller,
+          force: false,
+        });
+
+        expect(result).toBeDefined();
+
+        // .git should still exist
+        await expect(fileExists(gitDir)).resolves.toBe(true);
+
+        // Directory should only contain .git
+        const entries = await readdir(projectDir);
+        expect(entries).toEqual(['.git']);
+      });
+    });
+
+    it('does not delete anything when user declines confirmation', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const projectDir = joinPath(tmpDir, 'test-project');
+        await mkdir(projectDir);
+
+        // Create a .git directory and other files
+        const gitDir = joinPath(projectDir, '.git');
+        await mkdir(gitDir);
+        await writeFile(joinPath(gitDir, 'HEAD'), 'ref: refs/heads/main');
+        await writeFile(joinPath(projectDir, 'existing-file.txt'), 'content');
+
+        vi.mocked(renderConfirmationPrompt).mockResolvedValue(false);
+
+        const result = await handleProjectLocation({
+          path: projectDir,
+          controller,
+          force: false,
+        });
+
+        expect(result).toBeUndefined();
+
+        // Nothing should be deleted
+        await expect(fileExists(gitDir)).resolves.toBe(true);
+        await expect(
+          fileExists(joinPath(projectDir, 'existing-file.txt')),
+        ).resolves.toBe(true);
+      });
+    });
+
+    it('preserves existing git repo and adds scaffold commit on top', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const projectDir = joinPath(tmpDir, 'test-project');
+        await mkdir(projectDir);
+
+        // Initialize a real git repo with commits
+        await execAsync('git init', {cwd: projectDir});
+        await execAsync('git config user.name "Test User"', {cwd: projectDir});
+        await execAsync('git config user.email "test@example.com"', {
+          cwd: projectDir,
+        });
+        await writeFile(
+          joinPath(projectDir, 'original.txt'),
+          'original content',
+        );
+        await execAsync('git add .', {cwd: projectDir});
+        await execAsync('git commit -m "Initial commit"', {cwd: projectDir});
+
+        // Add another commit
+        await writeFile(joinPath(projectDir, 'second.txt'), 'second content');
+        await execAsync('git add .', {cwd: projectDir});
+        await execAsync('git commit -m "Second commit"', {cwd: projectDir});
+
+        // Get the commit count before scaffolding
+        const {stdout: beforeLog} = await execAsync('git log --oneline', {
+          cwd: projectDir,
+        });
+        const commitsBefore = beforeLog.split('\n').filter(Boolean).length;
+        expect(commitsBefore).toBe(2);
+
+        vi.mocked(renderConfirmationPrompt).mockResolvedValue(true);
+
+        const result = await handleProjectLocation({
+          path: projectDir,
+          controller,
+          force: false,
+        });
+
+        expect(result).toBeDefined();
+
+        // .git should still exist
+        const gitDir = joinPath(projectDir, '.git');
+        await expect(fileExists(gitDir)).resolves.toBe(true);
+
+        // Original files should be gone (cleared by handleProjectLocation)
+        await expect(
+          fileExists(joinPath(projectDir, 'original.txt')),
+        ).resolves.toBe(false);
+        await expect(
+          fileExists(joinPath(projectDir, 'second.txt')),
+        ).resolves.toBe(false);
+
+        // The git history should still have the original commits
+        const {stdout: afterLog} = await execAsync('git log --oneline', {
+          cwd: projectDir,
+        });
+        const commitsAfter = afterLog.split('\n').filter(Boolean);
+
+        // Should still have the 2 original commits
+        expect(commitsAfter.length).toBeGreaterThanOrEqual(2);
+        expect(afterLog).toContain('Initial commit');
+        expect(afterLog).toContain('Second commit');
+      });
+    });
+
+    it('createInitialCommit works with existing git repo', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const projectDir = joinPath(tmpDir, 'test-project');
+        await mkdir(projectDir);
+
+        // Initialize a real git repo with commits
+        await execAsync('git init', {cwd: projectDir});
+        await execAsync('git config user.name "Test User"', {cwd: projectDir});
+        await execAsync('git config user.email "test@example.com"', {
+          cwd: projectDir,
+        });
+        await writeFile(
+          joinPath(projectDir, 'original.txt'),
+          'original content',
+        );
+        await execAsync('git add .', {cwd: projectDir});
+        await execAsync('git commit -m "Original commit"', {cwd: projectDir});
+
+        // Get commit count before
+        const {stdout: beforeLog} = await execAsync('git log --oneline', {
+          cwd: projectDir,
+        });
+        const commitsBefore = beforeLog.split('\n').filter(Boolean).length;
+        expect(commitsBefore).toBe(1);
+
+        // Add new files and call createInitialCommit
+        await writeFile(joinPath(projectDir, 'new-file.txt'), 'new content');
+        const {createInitialCommit} = await import('./common.js');
+        await createInitialCommit(projectDir);
+
+        // Verify git history is preserved and new commit added
+        const {stdout: afterLog} = await execAsync('git log --oneline', {
+          cwd: projectDir,
+        });
+        const commitsAfter = afterLog.split('\n').filter(Boolean);
+
+        // Should have 2 commits now (original + scaffold)
+        expect(commitsAfter.length).toBe(2);
+        expect(afterLog).toContain('Original commit');
+        expect(afterLog).toContain('Scaffold Storefront');
+
+        // .gitignore should exist (created by createInitialCommit)
+        await expect(
+          fileExists(joinPath(projectDir, '.gitignore')),
+        ).resolves.toBe(true);
+      });
+    });
+  });
+});
+
+async function readFile(path: string): Promise<string> {
+  const {readFile: fsReadFile} = await import('node:fs/promises');
+  return fsReadFile(path, 'utf-8');
+}

--- a/packages/cli/src/lib/onboarding/common.test.ts
+++ b/packages/cli/src/lib/onboarding/common.test.ts
@@ -10,9 +10,10 @@ import {
 import {
   renderConfirmationPrompt,
   renderTextPrompt,
+  renderFatalError,
 } from '@shopify/cli-kit/node/ui';
 import {AbortController} from '@shopify/cli-kit/node/abort';
-import {handleProjectLocation} from './common.js';
+import {handleProjectLocation, createAbortHandler} from './common.js';
 import {joinPath} from '@shopify/cli-kit/node/path';
 import {execAsync} from '../process.js';
 
@@ -163,6 +164,31 @@ describe('handleProjectLocation', () => {
       });
     });
 
+    it('does not mention .git in confirmation message when no .git exists', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const projectDir = joinPath(tmpDir, 'test-project');
+        await mkdir(projectDir);
+
+        // Create files but NO .git
+        await writeFile(joinPath(projectDir, 'file.txt'), 'content');
+
+        vi.mocked(renderConfirmationPrompt).mockResolvedValue(true);
+
+        await handleProjectLocation({
+          path: projectDir,
+          controller,
+          force: false,
+        });
+
+        // The confirmation message should NOT mention .git
+        expect(renderConfirmationPrompt).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.not.stringContaining('.git'),
+          }),
+        );
+      });
+    });
+
     it('preserves .git with --force flag (no prompt)', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const projectDir = joinPath(tmpDir, 'test-project');
@@ -197,7 +223,7 @@ describe('handleProjectLocation', () => {
       });
     });
 
-    it('continues scaffolding when directory contains only .git', async () => {
+    it('skips confirmation prompt when directory contains only .git', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const projectDir = joinPath(tmpDir, 'test-project');
         await mkdir(projectDir);
@@ -206,8 +232,6 @@ describe('handleProjectLocation', () => {
         const gitDir = joinPath(projectDir, '.git');
         await mkdir(gitDir);
         await writeFile(joinPath(gitDir, 'HEAD'), 'ref: refs/heads/main');
-
-        vi.mocked(renderConfirmationPrompt).mockResolvedValue(true);
 
         const result = await handleProjectLocation({
           path: projectDir,
@@ -223,6 +247,9 @@ describe('handleProjectLocation', () => {
         // Directory should only contain .git
         const entries = await readdir(projectDir);
         expect(entries).toEqual(['.git']);
+
+        // Should NOT have prompted since the directory only contains .git
+        expect(renderConfirmationPrompt).not.toHaveBeenCalled();
       });
     });
 
@@ -374,3 +401,61 @@ async function readFile(path: string): Promise<string> {
   const {readFile: fsReadFile} = await import('node:fs/promises');
   return fsReadFile(path, 'utf-8');
 }
+
+describe('createAbortHandler', () => {
+  let controller: AbortController;
+  const originalProcessExit = process.exit;
+
+  beforeEach(() => {
+    controller = new AbortController();
+    vi.clearAllMocks();
+    // Mock process.exit to prevent test termination
+    process.exit = vi.fn() as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exit = originalProcessExit;
+  });
+
+  it('preserves .git directory on abort', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const projectDir = joinPath(tmpDir, 'test-project');
+      await mkdir(projectDir);
+
+      // Create a .git directory
+      const gitDir = joinPath(projectDir, '.git');
+      await mkdir(gitDir);
+      await writeFile(joinPath(gitDir, 'HEAD'), 'ref: refs/heads/main');
+
+      // Create scaffolded files that should be cleaned up
+      await writeFile(joinPath(projectDir, 'package.json'), '{}');
+      await mkdir(joinPath(projectDir, 'app'));
+      await writeFile(joinPath(projectDir, 'app', 'root.tsx'), '// root');
+
+      const abort = createAbortHandler(controller, {directory: projectDir});
+
+      // Simulate an abort error
+      const error = new Error('Simulated failure') as any;
+      error.tryMessage = 'Try again';
+
+      try {
+        await abort(error);
+      } catch {
+        // Expected - abort throws or exits
+      }
+
+      // .git should still exist
+      await expect(fileExists(gitDir)).resolves.toBe(true);
+      await expect(fileExists(joinPath(gitDir, 'HEAD'))).resolves.toBe(true);
+
+      // Scaffolded files should be cleaned up
+      await expect(
+        fileExists(joinPath(projectDir, 'package.json')),
+      ).resolves.toBe(false);
+      await expect(fileExists(joinPath(projectDir, 'app'))).resolves.toBe(
+        false,
+      );
+    });
+  });
+});

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -295,6 +295,20 @@ type Project = {
 };
 
 /**
+ * Removes all entries from a directory except the .git directory/file.
+ * This preserves version history when scaffolding into an existing repo.
+ */
+async function clearDirectoryPreservingGit(directory: string): Promise<void> {
+  const entries = await readdir(directory);
+
+  for (const entry of entries) {
+    if (entry !== '.git') {
+      await rmdir(joinPath(directory, entry), {force: true});
+    }
+  }
+}
+
+/**
  * Prompts the user to select a project directory location.
  * @returns Project information, or undefined if the user chose not to force project creation.
  */
@@ -341,7 +355,7 @@ export async function handleProjectLocation({
       const deleteFiles = await renderConfirmationPrompt({
         message: `The directory ${colors.cyan(
           location,
-        )} is not empty. Do you want to delete the existing files and continue?`,
+        )} is not empty. Continuing will delete its contents (your ${colors.cyan('.git')} directory is kept). Continue?`,
         defaultValue: false,
         abortSignal: controller.signal,
       });
@@ -350,14 +364,16 @@ export async function handleProjectLocation({
         renderInfo({
           body: `Destination path ${colors.cyan(
             location,
-          )} already exists and is not an empty directory. You may use \`--force\` or \`-f\` to override it.`,
+          )} already exists and is not an empty directory. You may use \`--force\` or \`-f\` to delete its contents (${colors.cyan(
+            '.git',
+          )} is always preserved).`,
         });
 
         return;
       }
     }
 
-    await rmdir(directory, {force: true});
+    await clearDirectoryPreservingGit(directory);
   }
 
   return {

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -295,6 +295,21 @@ type Project = {
 };
 
 /**
+ * Checks whether a .git directory or file exists in the given directory.
+ */
+async function hasGitDirectory(directory: string): Promise<boolean> {
+  return fileExists(joinPath(directory, '.git'));
+}
+
+/**
+ * Checks whether a directory contains only a .git directory/file (and nothing else).
+ */
+async function hasOnlyGitDirectory(directory: string): Promise<boolean> {
+  const entries = await readdir(directory);
+  return entries.length === 1 && entries[0] === '.git';
+}
+
+/**
  * Removes all entries from a directory except the .git directory/file.
  * This preserves version history when scaffolding into an existing repo.
  */
@@ -351,22 +366,34 @@ export async function handleProjectLocation({
       }
     }
 
+    // If directory contains only .git, treat it as effectively empty (no prompt needed)
+    const gitOnly = await hasOnlyGitDirectory(directory);
+    if (gitOnly) {
+      force = true;
+    }
+
     if (!force) {
+      const hasGit = await hasGitDirectory(directory);
+      const gitPreservationNote = hasGit
+        ? ` (your ${colors.cyan('.git')} directory is kept)`
+        : '';
+
       const deleteFiles = await renderConfirmationPrompt({
         message: `The directory ${colors.cyan(
           location,
-        )} is not empty. Continuing will delete its contents (your ${colors.cyan('.git')} directory is kept). Continue?`,
+        )} is not empty. Continuing will delete its contents${gitPreservationNote}. Continue?`,
         defaultValue: false,
         abortSignal: controller.signal,
       });
 
       if (!deleteFiles) {
+        const gitInfo = hasGit
+          ? ` (${colors.cyan('.git')} is always preserved)`
+          : '';
         renderInfo({
           body: `Destination path ${colors.cyan(
             location,
-          )} already exists and is not an empty directory. You may use \`--force\` or \`-f\` to delete its contents (${colors.cyan(
-            '.git',
-          )} is always preserved).`,
+          )} already exists and is not an empty directory. You may use \`--force\` or \`-f\` to delete its contents${gitInfo}.`,
         });
 
         return;
@@ -752,7 +779,8 @@ export function createAbortHandler(
     await Promise.resolve();
 
     if (project?.directory) {
-      await rmdir(project!.directory, {force: true}).catch(() => {});
+      // Preserve .git directory on abort to avoid destroying existing git history
+      await clearDirectoryPreservingGit(project.directory).catch(() => {});
     }
 
     renderFatalError(


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [dt#1201](https://github.com/Shopify/developer-tools-team/issues/1201) · Closes #2989

Running `npm create @shopify/hydrogen@latest` in a directory that already contains a git repo wipes out the `.git/` folder, taking the entire commit history with it. People hit this when they want to start with a blank repo + README and scaffold Hydrogen on top — a pretty common way to start a project.

The usual workaround is to `mv .git ../tmp-git`, scaffold, then move it back. That's fragile, not obvious, and nobody should have to think about it.

### WHAT is this pull request doing?

When the CLI clears a non-empty target directory during scaffolding, it now skips `.git/` (both directory and gitfile forms). Everything else is deleted as before.

Two small copy updates so users know what's happening:

- **Confirmation prompt:** _"The directory `X` is not empty. Continuing will delete its contents (your `.git` directory is kept). Continue?"_
- **Declined-confirmation hint:** _"You may use `--force` or `-f` to delete its contents (`.git` is always preserved)."_

A few deliberate scope choices:

- **No new flag.** Preserving `.git/` is the right default; an opt-in `--preserve-git` flag would just be surface area nobody sets correctly.
- **Only `.git/` is carved out.** `.gitignore`, `.env`, and `.shopify/` are legitimate scaffold-owned files, so they're deleted as before.
- **Both `@shopify/cli-hydrogen` and `@shopify/create-hydrogen` bumped.** Per [CLAUDE.md](./CLAUDE.md#quick-reference-contributing-to-skeleton-or-cli), changes to the `init` command path require both packages to be bumped so new scaffolds pick up the fix.

### HOW to test your changes?

Everything below runs in a throwaway `$TMPDIR` directory. Your real `.git` folders outside the sandbox are never touched.

**Setup (once):**

```bash
git fetch origin fix/cli-preserve-git-on-scaffold
git checkout fix/cli-preserve-git-on-scaffold
pnpm install
pnpm --filter @shopify/cli-hydrogen build
pnpm --filter @shopify/create-hydrogen build

export HYDROGEN_BIN="$PWD/packages/create-hydrogen/dist/create-app.js"
export SANDBOX=$(mktemp -d -t hydrogen-tophat.XXXXXX)
```

---

**Scenario 1 — the bug (non-empty dir with existing `.git`):**

```bash
cd "$SANDBOX" && mkdir repo-a && cd repo-a
git init -q
git config user.email you@example.com
git config user.name You
echo "pre-existing" > README.md
mkdir src && echo "// old" > src/app.js
git add -A && git commit -q -m "Pre-existing project"

# Answer YES at the prompt
node "$HYDROGEN_BIN" --path . --mock-shop --language ts \
  --styling tailwind --markets none --no-install-deps --no-shortcut
```

What to check:

- Confirmation prompt reads _"…your `.git` directory is kept"_.
- `.git/` still exists after the scaffold.
- `git log --oneline` shows both your `"Pre-existing project"` commit **and** the new `"Scaffold Storefront"` commit on top.
- `src/app.js` is gone (not part of the skeleton); `README.md` is now the skeleton's README.

---

**Scenario 2 — decline the prompt:**

```bash
cd "$SANDBOX" && mkdir repo-b && cd repo-b
git init -q
echo keepme > keepme.txt

# Answer NO at the prompt
node "$HYDROGEN_BIN" --path . --mock-shop --language ts \
  --styling tailwind --markets none --no-install-deps --no-shortcut
```

What to check:

- The info message after declining includes _"`.git` is always preserved"_.
- `keepme.txt` and `.git/` both survive.

---

**Scenario 3 — `--force` path (no prompt, still preserves `.git`):**

```bash
cd "$SANDBOX" && mkdir repo-c && cd repo-c
git init -q
git config user.email you@example.com
git config user.name You
echo existing > README.md
git add -A && git commit -q -m "Pre-existing (force)"
OLD=$(git rev-parse HEAD)

node "$HYDROGEN_BIN" --path . --force --mock-shop --language ts \
  --styling tailwind --markets none --no-install-deps --no-shortcut

git cat-file -e "$OLD" && echo "original commit still reachable ✓"
```

What to check:

- No prompt appears.
- `.git/` exists.
- Original commit hash is still reachable.

---

**Cleanup:**

```bash
rm -rf "$SANDBOX"
unset HYDROGEN_BIN SANDBOX
```

Empty directories and non-empty directories _without_ `.git/` are covered by automated tests in `packages/cli/src/lib/onboarding/common.test.ts`, so no need to tophat those manually.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation <!-- not applicable: behavior change, no docs surface -->
