### PR TITLE
Update `--customer-account-push` to support  multiple dev instances

### DIFF
--- a/.changeset/bold-drinks-fly.md
+++ b/.changeset/bold-drinks-fly.md
@@ -2,4 +2,4 @@
 '@shopify/cli-hydrogen': patch
 ---
 
-Updates `customer-account push` to support multiple concurrent dev servers. Previously, starting a second dev server with `--customer-account-push` would overwrite the callback URIs set by the first, breaking Customer Account sign-in for the first server. Now each server additively registers its own callbIck URIs and removes only its own on shutdown.
+Updates `customer-account push` to support multiple concurrent dev servers. Previously, starting a second dev server with `--customer-account-push` would overwrite the callback URIs set by the first, breaking Customer Account sign-in for the first server. Now each server additively registers its own callback URIs and removes only its own on shutdown.

--- a/.changeset/bold-drinks-fly.md
+++ b/.changeset/bold-drinks-fly.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Updates `customer-account push` to support multiple concurrent dev servers. Previously, starting a second dev server with `--customer-account-push` would overwrite the callback URIs set by the first, breaking Customer Account sign-in for the first server. Now each server additively registers its own callbIck URIs and removes only its own on shutdown.

--- a/packages/cli/src/commands/hydrogen/customer-account/push.test.ts
+++ b/packages/cli/src/commands/hydrogen/customer-account/push.test.ts
@@ -248,6 +248,7 @@ describe('getStorefrontId', () => {
     vi.mocked(linkStorefront).mockResolvedValue({
       id: STOREFRONT_ID,
       title: 'Linked Store',
+      productionUrl: 'https://example.com',
     });
 
     vi.mocked(getConfig).mockResolvedValue({

--- a/packages/cli/src/commands/hydrogen/customer-account/push.test.ts
+++ b/packages/cli/src/commands/hydrogen/customer-account/push.test.ts
@@ -1,0 +1,280 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {type AdminSession, login} from '../../../lib/auth.js';
+import {replaceCustomerApplicationUrls} from '../../../lib/graphql/admin/customer-application-update.js';
+import {
+  getConfig,
+  setCustomerAccountConfig,
+} from '../../../lib/shopify-config.js';
+import {linkStorefront} from '../link.js';
+import {runCustomerAccountPush, getStorefrontId} from './push.js';
+import {AbortError} from '@shopify/cli-kit/node/error';
+
+vi.mock('../../../lib/auth.js');
+vi.mock('../../../lib/graphql/admin/customer-application-update.js');
+vi.mock('../../../lib/shopify-config.js');
+vi.mock('../link.js');
+vi.mock('../../../lib/shell.js', () => ({getCliCommand: () => 'h2'}));
+
+const ADMIN_SESSION: AdminSession = {
+  token: 'abc123',
+  storeFqdn: 'my-shop.myshopify.com',
+};
+
+const STOREFRONT_ID = 'gid://shopify/HydrogenStorefront/1';
+
+const SHOPIFY_CONFIG = {
+  shop: 'my-shop.myshopify.com',
+  shopName: 'My Shop',
+  email: 'dev@example.com',
+  storefront: {
+    id: STOREFRONT_ID,
+    title: 'Hydrogen',
+  },
+};
+
+const DEV_ORIGIN = 'https://abc123.tryhydrogen.dev';
+
+beforeEach(() => {
+  vi.mocked(login).mockResolvedValue({
+    session: ADMIN_SESSION,
+    config: SHOPIFY_CONFIG,
+  });
+
+  vi.mocked(replaceCustomerApplicationUrls).mockResolvedValue({
+    success: true,
+    userErrors: [],
+  });
+
+  vi.mocked(setCustomerAccountConfig).mockResolvedValue(undefined as any);
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('runCustomerAccountPush', () => {
+  it('adds URLs without removing existing ones', async () => {
+    await runCustomerAccountPush({
+      devOrigin: DEV_ORIGIN,
+      storefrontId: STOREFRONT_ID,
+    });
+
+    expect(replaceCustomerApplicationUrls).toHaveBeenCalledWith(
+      ADMIN_SESSION,
+      STOREFRONT_ID,
+      {
+        redirectUri: {add: [`${DEV_ORIGIN}/account/authorize`]},
+        javascriptOrigin: {add: [DEV_ORIGIN]},
+        logoutUris: {add: [DEV_ORIGIN]},
+      },
+    );
+  });
+
+  it('does not send removeRegex during push', async () => {
+    await runCustomerAccountPush({
+      devOrigin: DEV_ORIGIN,
+      storefrontId: STOREFRONT_ID,
+    });
+
+    const callArgs = vi.mocked(replaceCustomerApplicationUrls).mock.calls[0]!;
+    const urlsInput = callArgs[2];
+
+    expect(urlsInput.redirectUri).not.toHaveProperty('removeRegex');
+    expect(urlsInput.javascriptOrigin).not.toHaveProperty('removeRegex');
+    expect(urlsInput.logoutUris).not.toHaveProperty('removeRegex');
+  });
+
+  it('uses custom relative redirect and logout URIs', async () => {
+    await runCustomerAccountPush({
+      devOrigin: DEV_ORIGIN,
+      storefrontId: STOREFRONT_ID,
+      redirectUriRelativeUrl: '/custom/callback',
+      logoutUriRelativeUrl: '/custom/logout',
+    });
+
+    const callArgs = vi.mocked(replaceCustomerApplicationUrls).mock.calls[0]!;
+    const urlsInput = callArgs[2];
+
+    expect(urlsInput.redirectUri).toEqual({
+      add: [`${DEV_ORIGIN}/custom/callback`],
+    });
+    expect(urlsInput.logoutUris).toEqual({
+      add: [`${DEV_ORIGIN}/custom/logout`],
+    });
+  });
+
+  it('persists pushed URLs to local config', async () => {
+    await runCustomerAccountPush({
+      devOrigin: DEV_ORIGIN,
+      storefrontId: STOREFRONT_ID,
+    });
+
+    expect(setCustomerAccountConfig).toHaveBeenCalledWith(expect.any(String), {
+      redirectUri: `${DEV_ORIGIN}/account/authorize`,
+      javascriptOrigin: DEV_ORIGIN,
+      logoutUri: DEV_ORIGIN,
+    });
+  });
+
+  it('returns a cleanup function that removes only this session URLs', async () => {
+    const cleanup = await runCustomerAccountPush({
+      devOrigin: DEV_ORIGIN,
+      storefrontId: STOREFRONT_ID,
+    });
+
+    expect(cleanup).toBeTypeOf('function');
+
+    vi.mocked(replaceCustomerApplicationUrls).mockClear();
+
+    await cleanup!();
+
+    expect(replaceCustomerApplicationUrls).toHaveBeenCalledWith(
+      ADMIN_SESSION,
+      STOREFRONT_ID,
+      {
+        redirectUri: {removeRegex: `${DEV_ORIGIN}/account/authorize`},
+        javascriptOrigin: {removeRegex: DEV_ORIGIN},
+        logoutUris: {removeRegex: DEV_ORIGIN},
+      },
+    );
+  });
+
+  it('cleanup does not send add fields', async () => {
+    const cleanup = await runCustomerAccountPush({
+      devOrigin: DEV_ORIGIN,
+      storefrontId: STOREFRONT_ID,
+    });
+
+    vi.mocked(replaceCustomerApplicationUrls).mockClear();
+
+    await cleanup!();
+
+    const callArgs = vi.mocked(replaceCustomerApplicationUrls).mock.calls[0]!;
+    const urlsInput = callArgs[2];
+
+    expect(urlsInput.redirectUri).not.toHaveProperty('add');
+    expect(urlsInput.javascriptOrigin).not.toHaveProperty('add');
+    expect(urlsInput.logoutUris).not.toHaveProperty('add');
+  });
+
+  it('throws AbortError when mutation returns userErrors', async () => {
+    vi.mocked(replaceCustomerApplicationUrls).mockResolvedValue({
+      success: false,
+      userErrors: [
+        {message: 'Invalid URL', field: ['redirectUri'], code: 'INVALID'},
+      ],
+    });
+
+    await expect(
+      runCustomerAccountPush({
+        devOrigin: DEV_ORIGIN,
+        storefrontId: STOREFRONT_ID,
+      }),
+    ).rejects.toThrow(AbortError);
+  });
+
+  it('throws AbortError with confidential access hint when applicable', async () => {
+    vi.mocked(replaceCustomerApplicationUrls).mockResolvedValue({
+      success: false,
+      userErrors: [
+        {
+          message: 'Javascript origin is not allowed for this application type',
+          field: ['javascriptOrigin'],
+          code: 'INVALID',
+        },
+      ],
+    });
+
+    await expect(
+      runCustomerAccountPush({
+        devOrigin: DEV_ORIGIN,
+        storefrontId: STOREFRONT_ID,
+      }),
+    ).rejects.toThrow(AbortError);
+  });
+
+  it('throws AbortError when no storefrontId is available', async () => {
+    vi.mocked(login).mockResolvedValue({
+      session: ADMIN_SESSION,
+      config: {
+        ...SHOPIFY_CONFIG,
+        storefront: undefined,
+      },
+    });
+
+    await expect(
+      runCustomerAccountPush({
+        devOrigin: DEV_ORIGIN,
+      }),
+    ).rejects.toThrow(AbortError);
+  });
+
+  it('skips mutation when all URLs are empty', async () => {
+    const result = await runCustomerAccountPush({
+      devOrigin: '',
+      storefrontId: STOREFRONT_ID,
+      redirectUriRelativeUrl: '',
+    });
+
+    expect(result).toBeUndefined();
+    expect(replaceCustomerApplicationUrls).not.toHaveBeenCalled();
+  });
+});
+
+describe('getStorefrontId', () => {
+  it('returns storefrontId from flag when provided', async () => {
+    const result = await getStorefrontId('/tmp', STOREFRONT_ID);
+
+    expect(result).toBe(STOREFRONT_ID);
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it('returns storefrontId from config when no flag', async () => {
+    const result = await getStorefrontId('/tmp');
+
+    expect(result).toBe(STOREFRONT_ID);
+  });
+
+  it('falls back to interactive linking when config has no storefront', async () => {
+    vi.mocked(login).mockResolvedValue({
+      session: ADMIN_SESSION,
+      config: {
+        shop: 'my-shop.myshopify.com',
+        shopName: 'My Shop',
+        email: 'dev@example.com',
+      },
+    });
+
+    vi.mocked(linkStorefront).mockResolvedValue({
+      id: STOREFRONT_ID,
+      title: 'Linked Store',
+    });
+
+    vi.mocked(getConfig).mockResolvedValue({
+      storefront: {id: STOREFRONT_ID, title: 'Linked Store'},
+    });
+
+    const result = await getStorefrontId('/tmp');
+
+    expect(linkStorefront).toHaveBeenCalled();
+    expect(result).toBe(STOREFRONT_ID);
+  });
+
+  it('returns undefined when linking is cancelled', async () => {
+    vi.mocked(login).mockResolvedValue({
+      session: ADMIN_SESSION,
+      config: {
+        shop: 'my-shop.myshopify.com',
+        shopName: 'My Shop',
+        email: 'dev@example.com',
+      },
+    });
+
+    vi.mocked(linkStorefront).mockResolvedValue(undefined as any);
+    vi.mocked(getConfig).mockResolvedValue({});
+
+    const result = await getStorefrontId('/tmp');
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/hydrogen/customer-account/push.test.ts
+++ b/packages/cli/src/commands/hydrogen/customer-account/push.test.ts
@@ -33,6 +33,7 @@ const SHOPIFY_CONFIG = {
 };
 
 const DEV_ORIGIN = 'https://abc123.tryhydrogen.dev';
+const ESCAPED_DEV_ORIGIN = 'https://abc123\\.tryhydrogen\\.dev';
 
 beforeEach(() => {
   vi.mocked(login).mockResolvedValue({
@@ -132,9 +133,9 @@ describe('runCustomerAccountPush', () => {
       ADMIN_SESSION,
       STOREFRONT_ID,
       {
-        redirectUri: {removeRegex: `${DEV_ORIGIN}/account/authorize`},
-        javascriptOrigin: {removeRegex: DEV_ORIGIN},
-        logoutUris: {removeRegex: DEV_ORIGIN},
+        redirectUri: {removeRegex: `${ESCAPED_DEV_ORIGIN}/account/authorize`},
+        javascriptOrigin: {removeRegex: ESCAPED_DEV_ORIGIN},
+        logoutUris: {removeRegex: ESCAPED_DEV_ORIGIN},
       },
     );
   });
@@ -185,12 +186,22 @@ describe('runCustomerAccountPush', () => {
       ],
     });
 
-    await expect(
-      runCustomerAccountPush({
+    try {
+      await runCustomerAccountPush({
         devOrigin: DEV_ORIGIN,
         storefrontId: STOREFRONT_ID,
-      }),
-    ).rejects.toThrow(AbortError);
+      });
+      expect.fail('Expected AbortError');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AbortError);
+      expect((error as AbortError).nextSteps).toContainEqual(
+        expect.objectContaining({
+          link: expect.objectContaining({
+            label: 'Enable Public access for Hydrogen',
+          }),
+        }),
+      );
+    }
   });
 
   it('throws AbortError when no storefrontId is available', async () => {

--- a/packages/cli/src/commands/hydrogen/customer-account/push.ts
+++ b/packages/cli/src/commands/hydrogen/customer-account/push.ts
@@ -187,14 +187,22 @@ async function cleanupCustomerApplicationUrls(
   );
 
   await replaceCustomerApplicationUrls(session, storefrontId, {
-    redirectUri: {removeRegex: customerAccountConfig?.redirectUri},
-    javascriptOrigin: {removeRegex: customerAccountConfig?.javascriptOrigin},
-    logoutUris: {removeRegex: customerAccountConfig?.logoutUri},
+    redirectUri: {
+      removeRegex: escapeRegex(customerAccountConfig?.redirectUri),
+    },
+    javascriptOrigin: {
+      removeRegex: escapeRegex(customerAccountConfig?.javascriptOrigin),
+    },
+    logoutUris: {removeRegex: escapeRegex(customerAccountConfig?.logoutUri)},
   }).catch((error) => {
     outputDebug(
       `Failed to clean up Customer Application url "${customerAccountConfig.redirectUri}":\n${error?.message}`,
     );
   });
+}
+
+function escapeRegex(value?: string) {
+  return value?.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 export async function getStorefrontId(

--- a/packages/cli/src/commands/hydrogen/customer-account/push.ts
+++ b/packages/cli/src/commands/hydrogen/customer-account/push.ts
@@ -54,7 +54,6 @@ export async function runCustomerAccountPush({
   devOrigin: string;
   redirectUriRelativeUrl?: string;
   logoutUriRelativeUrl?: string;
-  removeRegex?: string;
 }) {
   const storefrontId = await getStorefrontId(root, storefrontIdFromFlag);
 
@@ -77,23 +76,19 @@ export async function runCustomerAccountPush({
       return;
     }
 
-    const {session, config} = await login(root);
-    const customerAccountConfig = config?.storefront?.customerAccountConfig;
+    const {session} = await login(root);
     const {success, userErrors} = await replaceCustomerApplicationUrls(
       session,
       storefrontId,
       {
         redirectUri: {
           add: redirectUri ? [redirectUri] : undefined,
-          removeRegex: customerAccountConfig?.redirectUri,
         },
         javascriptOrigin: {
           add: javascriptOrigin ? [javascriptOrigin] : undefined,
-          removeRegex: customerAccountConfig?.javascriptOrigin,
         },
         logoutUris: {
           add: logoutUri ? [logoutUri] : undefined,
-          removeRegex: customerAccountConfig?.logoutUri,
         },
       },
     );

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -11,7 +11,10 @@ import {
   renderInfo,
 } from '@shopify/cli-kit/node/ui';
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output';
-import {type PackageJson} from '@shopify/cli-kit/node/node-package-manager';
+import {
+  type PackageJson,
+  getPackageManager,
+} from '@shopify/cli-kit/node/node-package-manager';
 import {exec} from '@shopify/cli-kit/node/system';
 import {
   buildUpgradeCommandArgs,
@@ -38,6 +41,15 @@ const TEST_VERSION_DEPENDENCY_UPGRADE = '9999.99.99';
 const TEST_VERSION_DEV_DEPENDENCY_UPGRADE = '9999.99.98';
 
 vi.mock('@shopify/cli-kit/node/session');
+vi.mock('@shopify/cli-kit/node/node-package-manager', async () => {
+  const original = await vi.importActual<
+    typeof import('@shopify/cli-kit/node/node-package-manager')
+  >('@shopify/cli-kit/node/node-package-manager');
+  return {
+    ...original,
+    getPackageManager: vi.fn(() => Promise.resolve('pnpm')),
+  };
+});
 
 vi.mock('../../lib/shell.js', () => ({getCliCommand: vi.fn(() => 'h2')}));
 


### PR DESCRIPTION
### WHY are these changes introduced?

When multiple developers (or the same developer) run `dev --customer-account-push` concurrently on the same store, the second instance overwrites the Customer Account callback URIs set by the first. This breaks Customer Account sign-in for the first dev server because its tunnel URL is no longer registered as a valid callback URI.

### WHAT is this pull request doing?

Removes `removeRegex` from the push path so that each dev server **additively** registers its own callback URIs without touching any other session's URLs. The cleanup function (invoked on dev server shutdown) still uses `removeRegex` to remove only that session's specific URLs.

### HOW to test your changes?

1. Run `npx shopify hydrogen dev --customer-account-push` in a Hydrogen project — confirm Customer Account sign-in works
2. In a separate terminal, start a second dev server with `--customer-account-push` on the same storefront
3. Verify **both** servers can sign in via Customer Account (the first should no longer break)
4. Stop the second server — verify the first still works
5. Stop the first server — verify URLs are cleaned up

Unit tests: `pnpm vitest packages/cli/src/commands/hydrogen/customer-account/push.test.ts`

<img width="737" height="700" alt="image" src="https://github.com/user-attachments/assets/c48cbc86-ac76-4e3f-9911-ec18742fa405" />


#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation