### PR TITLE
fix(skeleton): include line item children recursively

### DIFF
--- a/.changeset/odd-numbers-hug.md
+++ b/.changeset/odd-numbers-hug.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+'skeleton': patch
+---
+
+Include line item children recursively in cart.

--- a/templates/skeleton/app/components/CartMain.tsx
+++ b/templates/skeleton/app/components/CartMain.tsx
@@ -23,8 +23,8 @@ function getLineItemChildrenMap(lines: CartLine[]): LineItemChildrenMap {
       children[parentId].push(line);
     }
     if ('lineComponents' in line) {
-      const children = getLineItemChildrenMap(line.lineComponents);
-      for (const [parentId, childIds] of Object.entries(children)) {
+      const lineChildren = getLineItemChildrenMap(line.lineComponents);
+      for (const [parentId, childIds] of Object.entries(lineChildren)) {
         if (!children[parentId]) children[parentId] = [];
         children[parentId].push(...childIds);
       }


### PR DESCRIPTION
It seems to me that the `children` variable in the if statement shadows the returned children and thus prevents children to be included recursively.
This is not tested in any way it just seemed to me that the intention is to include line item children recursively.