### PR TITLE
fix: use pnpx to spawn test server locally

### DIFF
--- a/e2e/fixtures/server.ts
+++ b/e2e/fixtures/server.ts
@@ -94,13 +94,14 @@ export class DevServer {
         args.push('--entry', this.entry);
       }
 
-      this.process = spawn('npx', args, {
+      this.process = spawn('pnpx', args, {
         cwd: this.projectPath,
         detached: true,
         env: {
           ...process.env,
           NODE_ENV: 'development',
           SHOPIFY_HYDROGEN_FLAG_PORT: allocatedPort.toString(),
+          INIT_CWD: this.projectPath,
         },
         stdio: ['pipe', 'pipe', 'pipe'],
       });


### PR DESCRIPTION
### WHY are these changes introduced?

The E2E dev server fixture was spawning Hydrogen through `npx`, which can block or behave inconsistently in the repo’s pnpm-based setup. This could prevent local Playwright E2E tests from starting the test server reliably.

### WHAT is this pull request doing?

Updates the E2E `DevServer` fixture to:

  - Spawn Hydrogen dev through `pnpx` instead of `npx`
  - Set `INIT_CWD` to the fixture project path so the spawned command resolves from the intended project directory

### HOW to test your changes?

  1. Run the E2E suite:
     ```pnpm run e2e```

  2. Optionally run a focused project that starts the dev server fixture:
     ```pnpm exec playwright test --project=skeleton```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset. 
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
