### PR TITLE
fix: correct Image component descriptor handling for fluid images

### DIFF
--- a/.changeset/fix-image-fluid-x-descriptors.md
+++ b/.changeset/fix-image-fluid-x-descriptors.md
@@ -1,0 +1,10 @@
+---
+"@shopify/hydrogen-react": patch
+"@shopify/hydrogen": patch
+---
+
+Fix `Image` component generating `1x/2x/3x` density descriptors instead of `w` descriptors for fluid (responsive) images whose source dimensions cap the srcset to exactly 3 entries.
+
+**What was happening:** When a product image stored in Shopify was small enough that the default srcset ladder (200px, 400px, 600px, 800px, …) was filtered down to exactly 3 entries by the source-dimension cap, the `Image` component incorrectly switched to density descriptors (`1x`/`2x`/`3x`) and silently ignored the `sizes` attribute. On a DPR-1 screen this caused the smallest srcset entry (200px) to be used regardless of the rendered image size, resulting in blurry images.
+
+**The fix:** Descriptor type (density vs width) is now determined by whether the image is in fixed or fluid mode — not by how many srcset entries happen to survive source-dimension filtering.

--- a/packages/hydrogen-react/src/Image.test.tsx
+++ b/packages/hydrogen-react/src/Image.test.tsx
@@ -197,14 +197,18 @@ describe('<Image />', () => {
       ).not.toContain('600w');
     });
 
-    it('does not create srcset with greater dimensions than source image when using width', () => {
+    it('uses x descriptors for fixed-width images and respects source dimensions', () => {
+      // width=200 (number) → fixed mode → imageWidths=[200, 400, 600]
+      // source width=400 filters out 600w → sizesArray=[200, 400]
+      // should produce 1x/2x but NOT 3x (600px would exceed source)
       const data = {height: 300, width: 400};
 
       render(<Image {...defaultProps} data={data} width={200} />);
 
-      expect(
-        screen.getByTestId<HTMLImageElement>('test-element').srcset,
-      ).not.toContain('3x');
+      const img = screen.getByTestId<HTMLImageElement>('test-element');
+      expect(img.srcset).toContain('1x');
+      expect(img.srcset).toContain('2x');
+      expect(img.srcset).not.toContain('3x');
     });
 
     it('does not create srcset with greater dimensions than source image when using aspect-ratio', () => {
@@ -239,6 +243,27 @@ describe('<Image />', () => {
       expect(
         screen.getByTestId<HTMLImageElement>('test-element').srcset,
       ).not.toContain('2x');
+    });
+
+    it('uses w descriptors for fluid images when source dimensions cap srcset to exactly 3 entries', () => {
+      // A 600px source caps the srcset ladder (200, 400, 600, 800, ...) to exactly 3 entries.
+      // Verify that fluid images always use w-descriptors regardless of how many entries
+      // survive source-dimension filtering — even when that count happens to equal 3.
+      const data = {height: 600, width: 600};
+
+      render(
+        <Image
+          {...defaultProps}
+          data={data}
+          sizes="(min-width: 45em) 40vw, 100vw"
+        />,
+      );
+
+      const img = screen.getByTestId<HTMLImageElement>('test-element');
+      expect(img.srcset).toContain('200w');
+      expect(img.srcset).toContain('400w');
+      expect(img.srcset).toContain('600w');
+      expect(img.srcset).not.toContain('1x');
     });
   });
 

--- a/packages/hydrogen-react/src/Image.test.tsx
+++ b/packages/hydrogen-react/src/Image.test.tsx
@@ -264,6 +264,8 @@ describe('<Image />', () => {
       expect(img.srcset).toContain('400w');
       expect(img.srcset).toContain('600w');
       expect(img.srcset).not.toContain('1x');
+      expect(img.srcset).not.toContain('2x');
+      expect(img.srcset).not.toContain('3x');
     });
   });
 

--- a/packages/hydrogen-react/src/Image.tsx
+++ b/packages/hydrogen-react/src/Image.tsx
@@ -400,7 +400,7 @@ const FixedWidthImage = React.forwardRef<
         normalizedProps.src,
         sizesArray,
         loader,
-        true,
+        'density',
       );
       const src = loader({
         src: normalizedProps.src,
@@ -649,14 +649,14 @@ function isFixedWidth(width: string | number): boolean {
  * @param src - The source URL of the image, e.g. https://cdn.shopify.com/static/sample-images/garnished.jpeg
  * @param sizesArray - An array of objects containing the `width`, `height`, and `crop` of the image, e.g. [\{width: 200, height: 200, crop: 'center'\}, \{width: 400, height: 400, crop: 'center'\}]
  * @param loader - A function that takes a Shopify image URL and returns a Shopify image URL with the correct query parameters
- * @param fixed - Whether the image is fixed width or not
+ * @param descriptorType - Whether to use `w` (width) or `x` (density) descriptors in the srcset. Use `'density'` for fixed-width images and `'width'` (default) for fluid images.
  * @returns A srcSet for Shopify images, e.g. 'https://cdn.shopify.com/static/sample-images/garnished.jpeg?width=200&height=200&crop=center 200w, https://cdn.shopify.com/static/sample-images/garnished.jpeg?width=400&height=400&crop=center 400w'
  */
 export function generateSrcSet(
   src?: string,
   sizesArray?: Array<{width?: number; height?: number; crop?: Crop}>,
   loader: Loader = shopifyLoader,
-  fixed = false,
+  descriptorType: 'width' | 'density' = 'width',
 ): string {
   if (!src) {
     return '';
@@ -674,7 +674,7 @@ export function generateSrcSet(
           width: size.width,
           height: size.height,
           crop: size.crop,
-        })} ${fixed ? `${i + 1}x` : `${size.width ?? 0}w`}`,
+        })} ${descriptorType === 'density' ? `${i + 1}x` : `${size.width ?? 0}w`}`,
     )
     .join(`, `);
 }

--- a/packages/hydrogen-react/src/Image.tsx
+++ b/packages/hydrogen-react/src/Image.tsx
@@ -396,7 +396,12 @@ const FixedWidthImage = React.forwardRef<
           ? intWidth * (parseAspectRatio(fixedAspectRatio) ?? 1)
           : undefined;
 
-      const srcSet = generateSrcSet(normalizedProps.src, sizesArray, loader);
+      const srcSet = generateSrcSet(
+        normalizedProps.src,
+        sizesArray,
+        loader,
+        true,
+      );
       const src = loader({
         src: normalizedProps.src,
         width: intWidth,
@@ -644,12 +649,14 @@ function isFixedWidth(width: string | number): boolean {
  * @param src - The source URL of the image, e.g. https://cdn.shopify.com/static/sample-images/garnished.jpeg
  * @param sizesArray - An array of objects containing the `width`, `height`, and `crop` of the image, e.g. [\{width: 200, height: 200, crop: 'center'\}, \{width: 400, height: 400, crop: 'center'\}]
  * @param loader - A function that takes a Shopify image URL and returns a Shopify image URL with the correct query parameters
+ * @param fixed - Whether the image is fixed width or not
  * @returns A srcSet for Shopify images, e.g. 'https://cdn.shopify.com/static/sample-images/garnished.jpeg?width=200&height=200&crop=center 200w, https://cdn.shopify.com/static/sample-images/garnished.jpeg?width=400&height=400&crop=center 400w'
  */
 export function generateSrcSet(
   src?: string,
   sizesArray?: Array<{width?: number; height?: number; crop?: Crop}>,
   loader: Loader = shopifyLoader,
+  fixed = false,
 ): string {
   if (!src) {
     return '';
@@ -667,7 +674,7 @@ export function generateSrcSet(
           width: size.width,
           height: size.height,
           crop: size.crop,
-        })} ${sizesArray.length === 3 ? `${i + 1}x` : `${size.width ?? 0}w`}`,
+        })} ${fixed ? `${i + 1}x` : `${size.width ?? 0}w`}`,
     )
     .join(`, `);
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The `Image` component can produce `1x`/`2x`/`3x` density descriptors for fluid (responsive) images when the source image dimensions are small enough that the srcset ladder is filtered down to exactly 3 entries. In that case the `sizes` attribute is silently ignored and the browser always picks images by DPR instead of container size, causing blurry images on low-DPR screens.

### WHAT is this pull request doing?

`generateSrcSet` determined descriptor type (`x` vs `w`) by checking `sizesArray.length === 3`, under the assumption that only fixed-width images produce exactly 3 entries. That assumption breaks when source-dimension filtering reduces a fluid image's srcset to exactly 3 entries (e.g. a 600px-wide image with default `srcSetOptions` produces `[200, 400, 600]`).

The fix adds an explicit `fixed` boolean parameter to `generateSrcSet` (defaulting to `false`) and uses it instead of the length heuristic. `FixedWidthImage` passes `true`; `FluidImage` uses the default.

### HOW to test your changes?

Render a fluid `Image` with a small source image (e.g. `data={{ url: '...', width: 600, height: 600 }}`) and a `sizes` prop. Before this fix, the `srcset` attribute contains `1x`/`2x`/`3x` descriptors and `sizes` is ignored. After this fix, `srcset` contains `200w`/`400w`/`600w` descriptors and `sizes` is respected.

The new regression test in `Image.test.tsx` covers this case directly.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

Made with [Cursor](https://cursor.com)