### PR TITLE
fix(hydrogen): storefrontRedirect now works with Single Fetch client-side navigations

### DIFF
--- a/.changeset/fix-storefront-redirect-single-fetch.md
+++ b/.changeset/fix-storefront-redirect-single-fetch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix `storefrontRedirect` not working for client-side navigations. React Router v7's Single Fetch changed how data requests work — they now use a `.data` pathname suffix instead of a `_data` query parameter. `storefrontRedirect` now correctly detects both conventions, strips the `.data` suffix before matching redirects, and returns the proper `204` status code for soft navigation redirect responses.

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -58,6 +58,7 @@ export {mockCustomerAccountOperation} from './msw/graphql';
 export {MSW_SCENARIOS} from './msw/scenarios';
 export {B2B_COMPANY_NAME} from './msw/handlers';
 export {LEGACY_CUSTOMER_MOCK} from './msw/handlers';
+export {STOREFRONT_REDIRECT_PATHS} from './msw/handlers';
 
 export const test = base.extend<
   {

--- a/e2e/fixtures/msw/handlers.ts
+++ b/e2e/fixtures/msw/handlers.ts
@@ -462,6 +462,32 @@ scenarios.set('subscriptions-logged-in', {
   mocksCustomerAccountApi: true,
 });
 
+export const STOREFRONT_REDIRECT_PATHS = {
+  from: '/old-page',
+  to: '/new-page',
+} as const;
+
+const STOREFRONT_REDIRECT_MAP: Record<string, string> = {
+  [`path:${STOREFRONT_REDIRECT_PATHS.from}`]: STOREFRONT_REDIRECT_PATHS.to,
+};
+
+scenarios.set(MSW_SCENARIOS.storefrontRedirects, {
+  handlers: [
+    graphql.query('redirects', ({variables}) => {
+      const target = STOREFRONT_REDIRECT_MAP[variables.query as string];
+      return HttpResponse.json({
+        data: {
+          urlRedirects: {
+            edges: target ? [{node: {target}}] : [],
+          },
+        },
+      });
+    }),
+  ],
+  mocksCustomerAccountApi: false,
+  mocksLegacyCustomerAuth: false,
+});
+
 function isMswScenario(scenario: string): scenario is MswScenario {
   return scenarios.has(scenario);
 }

--- a/e2e/fixtures/msw/scenarios.ts
+++ b/e2e/fixtures/msw/scenarios.ts
@@ -4,6 +4,7 @@ export const MSW_SCENARIOS = {
   b2bLoggedIn: 'b2b-logged-in',
   subscriptionsLoggedIn: 'subscriptions-logged-in',
   legacyCustomerAccountLoggedIn: 'legacy-customer-account-logged-in',
+  storefrontRedirects: 'storefront-redirects',
 } as const;
 
 export type MswScenario = (typeof MSW_SCENARIOS)[keyof typeof MSW_SCENARIOS];

--- a/e2e/specs/skeleton/storefrontRedirect.spec.ts
+++ b/e2e/specs/skeleton/storefrontRedirect.spec.ts
@@ -1,0 +1,37 @@
+import {
+  test,
+  expect,
+  setTestStore,
+  MSW_SCENARIOS,
+  STOREFRONT_REDIRECT_PATHS,
+} from '../../fixtures';
+
+setTestStore('mockShop', {
+  mock: {scenario: MSW_SCENARIOS.storefrontRedirects},
+});
+
+test.describe('storefrontRedirect', () => {
+  test('redirects on full page navigation', async ({page}) => {
+    await page.goto(STOREFRONT_REDIRECT_PATHS.from);
+    await expect(page).toHaveURL(
+      new RegExp(`${STOREFRONT_REDIRECT_PATHS.to}$`),
+    );
+  });
+
+  test('redirects on client-side navigation (Single Fetch)', async ({page}) => {
+    await page.goto('/');
+    await page.waitForFunction(() => document.readyState === 'complete');
+
+    await page.evaluate((href) => {
+      const link = document.createElement('a');
+      link.href = href;
+      link.textContent = 'test redirect link';
+      document.body.appendChild(link);
+    }, STOREFRONT_REDIRECT_PATHS.from);
+
+    await page.getByText('test redirect link').click();
+    await expect(page).toHaveURL(
+      new RegExp(`${STOREFRONT_REDIRECT_PATHS.to}$`),
+    );
+  });
+});

--- a/packages/hydrogen/src/routing/redirect.test.ts
+++ b/packages/hydrogen/src/routing/redirect.test.ts
@@ -93,121 +93,245 @@ describe('storefrontRedirect', () => {
     });
   });
 
-  it('strips remix _data query parameter on soft navigations', async () => {
-    queryMock.mockResolvedValueOnce({
-      urlRedirects: {edges: [{node: {target: shopifyDomain + '/some-page'}}]},
+  describe('Single Fetch soft navigations (.data suffix)', () => {
+    it('detects .data suffix as soft navigation and returns redirect headers', async () => {
+      queryMock.mockResolvedValueOnce({
+        urlRedirects: {edges: [{node: {target: shopifyDomain + '/some-page'}}]},
+      });
+
+      await expect(
+        storefrontRedirect({
+          storefront: storefrontMock,
+          request: new Request(
+            'https://domain.com/some-page.data?_routes=root,routes/some-page',
+          ),
+        }),
+      ).resolves.toEqual(
+        new Response(null, {
+          status: 204,
+          headers: {
+            'X-Remix-Redirect': shopifyDomain + '/some-page',
+            'X-Remix-Status': '301',
+          },
+        }),
+      );
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:/some-page'},
+      });
     });
 
-    await expect(
-      storefrontRedirect({
-        storefront: storefrontMock,
-        request: new Request(
-          'https://domain.com/some-page?_data=%2Fcollections%2Fbackcountry',
-        ),
-      }),
-    ).resolves.toEqual(
-      new Response(null, {
-        status: 200,
-        headers: {
-          'X-Remix-Redirect': shopifyDomain + '/some-page',
-          'X-Remix-Status': '301',
+    it('strips .data suffix before matching redirects', async () => {
+      queryMock.mockResolvedValueOnce({
+        urlRedirects: {edges: [{node: {target: '/collections/new'}}]},
+      });
+
+      await expect(
+        storefrontRedirect({
+          storefront: storefrontMock,
+          request: new Request(
+            'https://domain.com/old-collection.data?_routes=root,routes/$',
+          ),
+        }),
+      ).resolves.toEqual(
+        new Response(null, {
+          status: 204,
+          headers: {
+            'X-Remix-Redirect': '/collections/new',
+            'X-Remix-Status': '301',
+          },
+        }),
+      );
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:/old-collection'},
+      });
+    });
+
+    it('handles admin redirect during soft navigation', async () => {
+      await expect(
+        storefrontRedirect({
+          storefront: storefrontMock,
+          request: new Request(
+            'https://domain.com/admin.data?_routes=root,routes/$',
+          ),
+        }),
+      ).resolves.toEqual(
+        new Response(null, {
+          status: 204,
+          headers: {
+            'X-Remix-Redirect': shopifyDomain + '/admin',
+            'X-Remix-Status': '301',
+          },
+        }),
+      );
+    });
+
+    it('matches query parameters with matchQueryParams enabled', async () => {
+      queryMock.mockResolvedValueOnce({
+        urlRedirects: {edges: [{node: {target: shopifyDomain + '/some-page'}}]},
+      });
+
+      await expect(
+        storefrontRedirect({
+          storefront: storefrontMock,
+          request: new Request(
+            'https://domain.com/some-page.data?test=true&_routes=root,routes/$',
+          ),
+          matchQueryParams: true,
+        }),
+      ).resolves.toEqual(
+        new Response(null, {
+          status: 204,
+          headers: {
+            'X-Remix-Redirect': shopifyDomain + '/some-page',
+            'X-Remix-Status': '301',
+          },
+        }),
+      );
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:/some-page?test=true'},
+      });
+    });
+
+    it('propagates query parameters to the redirect destination', async () => {
+      queryMock.mockResolvedValueOnce({
+        urlRedirects: {
+          edges: [
+            {
+              node: {
+                target: shopifyDomain + '/some-redirect?redirectParam=true',
+              },
+            },
+          ],
         },
-      }),
-    );
+      });
 
-    expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      await expect(
+        storefrontRedirect({
+          storefront: storefrontMock,
+          request: new Request(
+            'https://domain.com/some-page.data?requestParam=true&_routes=root,routes/$',
+          ),
+        }),
+      ).resolves.toEqual(
+        new Response(null, {
+          status: 204,
+          headers: {
+            'X-Remix-Redirect':
+              shopifyDomain +
+              '/some-redirect?redirectParam=true&requestParam=true',
+            'X-Remix-Status': '301',
+          },
+        }),
+      );
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:/some-page'},
+      });
     });
-  });
 
-  it('matches query parameters', async () => {
-    queryMock.mockResolvedValueOnce({
-      urlRedirects: {edges: [{node: {target: shopifyDomain + '/some-page'}}]},
-    });
-
-    await expect(
-      storefrontRedirect({
-        storefront: storefrontMock,
-        request: new Request(
-          'https://domain.com/some-page?test=true&_data=%2Fcollections%2Fbackcountry',
-        ),
-        matchQueryParams: true,
-      }),
-    ).resolves.toEqual(
-      new Response(null, {
-        status: 200,
-        headers: {
-          'X-Remix-Redirect': shopifyDomain + '/some-page',
-          'X-Remix-Status': '301',
+    it('propagates query parameters to relative redirect URLs', async () => {
+      queryMock.mockResolvedValueOnce({
+        urlRedirects: {
+          edges: [{node: {target: '/some-redirect?redirectParam=true'}}],
         },
-      }),
-    );
+      });
 
-    expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page?test=true'},
-    });
-  });
+      await expect(
+        storefrontRedirect({
+          storefront: storefrontMock,
+          request: new Request(
+            'https://domain.com/some-page.data?requestParam=true&_routes=root,routes/$',
+          ),
+        }),
+      ).resolves.toEqual(
+        new Response(null, {
+          status: 204,
+          headers: {
+            'X-Remix-Redirect':
+              '/some-redirect?redirectParam=true&requestParam=true',
+            'X-Remix-Status': '301',
+          },
+        }),
+      );
 
-  it('propogates query parameters to the final redirect', async () => {
-    queryMock.mockResolvedValueOnce({
-      urlRedirects: {
-        edges: [
-          {node: {target: shopifyDomain + '/some-redirect?redirectParam=true'}},
-        ],
-      },
-    });
-
-    await expect(
-      storefrontRedirect({
-        storefront: storefrontMock,
-        request: new Request(
-          'https://domain.com/some-page?requestParam=true&_data=%2Fcollections%2Fbackcountry',
-        ),
-      }),
-    ).resolves.toEqual(
-      new Response(null, {
-        status: 200,
-        headers: {
-          'X-Remix-Redirect':
-            shopifyDomain +
-            '/some-redirect?redirectParam=true&requestParam=true',
-          'X-Remix-Status': '301',
-        },
-      }),
-    );
-
-    expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
-    });
-  });
-
-  it('propogates query parameters to the final redirect for relative URLs', async () => {
-    queryMock.mockResolvedValueOnce({
-      urlRedirects: {
-        edges: [{node: {target: '/some-redirect?redirectParam=true'}}],
-      },
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:/some-page'},
+      });
     });
 
-    await expect(
-      storefrontRedirect({
-        storefront: storefrontMock,
-        request: new Request(
-          'https://domain.com/some-page?requestParam=true&_data=%2Fcollections%2Fbackcountry',
-        ),
-      }),
-    ).resolves.toEqual(
-      new Response(null, {
-        status: 200,
-        headers: {
-          'X-Remix-Redirect':
-            '/some-redirect?redirectParam=true&requestParam=true',
-          'X-Remix-Status': '301',
-        },
-      }),
-    );
+    it('handles _root.data for root route soft navigation', async () => {
+      queryMock.mockResolvedValueOnce({
+        urlRedirects: {edges: [{node: {target: '/home'}}]},
+      });
 
-    expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
+      await expect(
+        storefrontRedirect({
+          storefront: storefrontMock,
+          request: new Request('https://domain.com/_root.data?_routes=root'),
+        }),
+      ).resolves.toEqual(
+        new Response(null, {
+          status: 204,
+          headers: {
+            'X-Remix-Redirect': '/home',
+            'X-Remix-Status': '301',
+          },
+        }),
+      );
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        // Root "/" becomes "" after trailing-slash stripping
+        variables: {query: 'path:'},
+      });
+    });
+
+    it('handles /_.data for trailing-slash-aware soft navigation', async () => {
+      queryMock.mockResolvedValueOnce({
+        urlRedirects: {edges: [{node: {target: '/products'}}]},
+      });
+
+      await expect(
+        storefrontRedirect({
+          storefront: storefrontMock,
+          request: new Request(
+            'https://domain.com/products/_.data?_routes=root,routes/products',
+          ),
+        }),
+      ).resolves.toEqual(
+        new Response(null, {
+          status: 204,
+          headers: {
+            'X-Remix-Redirect': '/products',
+            'X-Remix-Status': '301',
+          },
+        }),
+      );
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:/products'},
+      });
+    });
+
+    it('returns 404 when no redirect matches', async () => {
+      queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
+      const response = new Response('Not Found', {status: 404});
+
+      await expect(
+        storefrontRedirect({
+          response,
+          storefront: storefrontMock,
+          request: new Request(
+            'https://domain.com/nonexistent.data?_routes=root,routes/$',
+          ),
+        }),
+      ).resolves.toEqual(response);
+
+      expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
+        variables: {query: 'path:/nonexistent'},
+      });
     });
   });
 
@@ -231,25 +355,8 @@ describe('storefrontRedirect', () => {
     });
   });
 
-  it('queries the SFAPI and returns 404 on mismatch', async () => {
-    queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
-    const response = new Response('Not Found', {status: 404});
-
-    await expect(
-      storefrontRedirect({
-        response,
-        storefront: storefrontMock,
-        request: new Request('https://domain.com/some-page'),
-      }),
-    ).resolves.toEqual(response);
-
-    expect(queryMock).toHaveBeenCalledWith(expect.anything(), {
-      variables: {query: 'path:/some-page'},
-    });
-  });
-
   describe('redirect fallback with search params', () => {
-    it('uses the "redirect" serach param as a fallback', async () => {
+    it('uses the "redirect" search param as a fallback', async () => {
       queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
       const response = new Response('Not Found', {status: 404});
 
@@ -266,7 +373,7 @@ describe('storefrontRedirect', () => {
       );
     });
 
-    it('uses the "return_to" serach param as a fallback', async () => {
+    it('uses the "return_to" search param as a fallback', async () => {
       queryMock.mockResolvedValueOnce({urlRedirects: {edges: []}});
       const response = new Response('Not Found', {status: 404});
 

--- a/packages/hydrogen/src/routing/redirect.ts
+++ b/packages/hydrogen/src/routing/redirect.ts
@@ -2,6 +2,10 @@ import type {UrlRedirectConnection} from '@shopify/hydrogen-react/storefront-api
 import type {I18nBase, Storefront} from '../storefront';
 import {getRedirectUrl} from '../utils/get-redirect-url';
 
+const SINGLE_FETCH_DATA_SUFFIX = '.data';
+const SINGLE_FETCH_ROOT_SEGMENT = '_root.data';
+const SINGLE_FETCH_TRAILING_SLASH_SEGMENT = '_.data';
+
 type StorefrontRedirect = {
   /** The [Storefront client](/docs/api/hydrogen/utilities/createstorefrontclient) instance */
   storefront: Storefront<I18nBase>;
@@ -36,18 +40,18 @@ export async function storefrontRedirect(
   } = options;
 
   const url = new URL(request.url);
-  const {pathname, searchParams} = url;
-  const isSoftNavigation = searchParams.has('_data');
+  const {searchParams} = url;
+  const {pathname, isSoftNavigation} = parseSingleFetchPathname(url.pathname);
 
   searchParams.delete('redirect');
   searchParams.delete('return_to');
-  searchParams.delete('_data');
+  searchParams.delete('_routes');
 
   const redirectFrom = (
-    matchQueryParams ? url.toString().replace(url.origin, '') : pathname
+    matchQueryParams ? `${pathname}${url.search}` : pathname
   ).toLowerCase();
 
-  if (url.pathname === '/admin' && !noAdminRedirect) {
+  if (pathname === '/admin' && !noAdminRedirect) {
     return createRedirectResponse(
       `${storefront.getShopifyDomain()}/admin`,
       isSoftNavigation,
@@ -108,15 +112,14 @@ function createRedirectResponse(
 
   if (!matchQueryParams) {
     for (const [key, value] of searchParams) {
-      // The redirect destination might include query params, so merge the
-      // original query params with the redirect destination query params
+      // Merge with any query params already present in the redirect target
       url.searchParams.append(key, value);
     }
   }
 
   if (isSoftNavigation) {
     return new Response(null, {
-      status: 200,
+      status: 204,
       headers: {
         'X-Remix-Redirect': url.toString().replace(TEMP_DOMAIN, ''),
         'X-Remix-Status': '301',
@@ -128,6 +131,45 @@ function createRedirectResponse(
       headers: {location: url.toString().replace(TEMP_DOMAIN, '')},
     });
   }
+}
+
+/**
+ * Strips the Single Fetch `.data` suffix from a pathname, handling all
+ * three URL patterns that React Router's `singleFetchUrl` produces:
+ * - `/some-page.data` → `/some-page` (standard)
+ * - `/_.data` or `/prefix/_.data` → `/` or `/prefix/` (trailingSlashAware)
+ * - `/_root.data` or `/prefix/_root.data` → `/` or `/prefix/` (root route)
+ */
+function parseSingleFetchPathname(rawPathname: string): {
+  pathname: string;
+  isSoftNavigation: boolean;
+} {
+  if (!rawPathname.endsWith(SINGLE_FETCH_DATA_SUFFIX)) {
+    return {pathname: rawPathname, isSoftNavigation: false};
+  }
+
+  if (rawPathname.endsWith('/' + SINGLE_FETCH_TRAILING_SLASH_SEGMENT)) {
+    return {
+      pathname: rawPathname.slice(
+        0,
+        -SINGLE_FETCH_TRAILING_SLASH_SEGMENT.length,
+      ),
+      isSoftNavigation: true,
+    };
+  }
+
+  if (
+    rawPathname === '/' + SINGLE_FETCH_ROOT_SEGMENT ||
+    rawPathname.endsWith('/' + SINGLE_FETCH_ROOT_SEGMENT)
+  ) {
+    const prefix = rawPathname.slice(0, -SINGLE_FETCH_ROOT_SEGMENT.length);
+    return {pathname: prefix || '/', isSoftNavigation: true};
+  }
+
+  return {
+    pathname: rawPathname.slice(0, -SINGLE_FETCH_DATA_SUFFIX.length),
+    isSoftNavigation: true,
+  };
 }
 
 const REDIRECT_QUERY = `#graphql


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/hydrogen/issues/3738

React Router v7's Single Fetch protocol changed how client-side data requests are made: from `?_data=route/id` query params to a `.data` pathname suffix (e.g. `/old-page.data`). `storefrontRedirect` was checking `searchParams.has('_data')` which no longer matches, causing **all client-side navigations to redirected URLs to silently return 404s** instead of following the redirect. Full-page navigations were unaffected.

### WHAT is this pull request doing?

Detects Single Fetch soft navigations via the `.data` pathname suffix, strips it to recover the real pathname, and returns the correct `204` + `X-Remix-Redirect` headers that React Router's turbo-stream protocol expects.

Handles all three URL patterns that React Router's `singleFetchUrl` produces:
- `/page.data` — standard
- `/_root.data` — root route (non-trailing-slash-aware)
- `/page/_.data` — trailing-slash-aware

Also strips the `_routes` query param (replaces `_data` from the old protocol) before the SFAPI redirect lookup.

### HOW to test your changes?

1. Set up a Storefront API redirect (e.g., `/old-page` → `/new-page`) in Shopify admin
2. Navigate directly to `/old-page` — should 301 redirect (this already worked)
3. From any page, click a link to `/old-page` — should now redirect via client-side navigation (this was broken)

Or run the new tests:
```bash
# Unit tests (17 tests)
cd packages/hydrogen && npx vitest run src/routing/redirect.test.ts

# E2E tests (2 tests — full-page + client-side navigation)
npx playwright test --project=skeleton e2e/specs/skeleton/storefrontRedirect.spec.ts
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation