### PR TITLE
Docs: `destructure` register in JS `ThirdPartyAnalyticsIntegration` example

### DIFF
--- a/docs/shopify-dev/analytics-setup/js/app/components/ThirdPartyAnalyticsIntegration.jsx
+++ b/docs/shopify-dev/analytics-setup/js/app/components/ThirdPartyAnalyticsIntegration.jsx
@@ -6,7 +6,7 @@ import {useEffect} from 'react';
 // [START export]
 export function ThirdPartyAnalyticsIntegration() {
   // [START use]
-  const {subscribe} = useAnalytics();
+  const {subscribe, register} = useAnalytics();
   // [END use]
   // [START register]
   // Register this analytics integration - this will prevent any analytics events
@@ -35,7 +35,10 @@ export function ThirdPartyAnalyticsIntegration() {
 
     // Custom events
     subscribe('custom_checkbox_toggled', (data) => {
-      console.log('ThirdPartyAnalyticsIntegration - Custom checkbox toggled:', data);
+      console.log(
+        'ThirdPartyAnalyticsIntegration - Custom checkbox toggled:',
+        data,
+      );
     });
     // [END subscribe]
 


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/shop/issues-learn/issues/2135

`register` is never destructured, so the snippet as written would throw `ReferenceError: register is not defined at runtime`.

### WHAT is this pull request doing?

Adds register to useAnalytics destructure in ThirdPartyAnalyticsIntegration example

The TS twin file ([.../ts/.../ThirdPartyAnalyticsIntegration.tsx](https://github.com/Shopify/hydrogen/blob/main/docs/shopify-dev/analytics-setup/ts/app/components/ThirdPartyAnalyticsIntegration.tsx)) already has const {subscribe, register} = useAnalytics(); — so this is just a JS-side drift.
- register is part of the useAnalytics() return value — defined in packages/hydrogen/src/analytics-manager/AnalyticsProvider.tsx (AnalyticsContextValueForDoc.register, and included in the context value on line 363).

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset. 
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
