### PR TITLE
cache hardening

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -55,10 +55,6 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
 
       - name: 📥 Install dependencies (root)
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: 📦 Build packages


### PR DESCRIPTION
Removes loose `restore-keys:` prefixes (`${{ runner.os }}-build-`, `${{ runner.os }}-`) from cache lookups in deploy.yml and deploy-examples.yml so the cache is restored only on an exact-match key.