### PR TITLE
Add DOM.Iterable to hydrogen-react tsconfig lib

### DIFF
--- a/.changeset/fix-hydrogen-react-dom-iterable-lib.md
+++ b/.changeset/fix-hydrogen-react-dom-iterable-lib.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen-react": patch
+---
+
+Add `DOM.Iterable` to `lib` in `tsconfig.json` so `URLSearchParams` (and other DOM iterables) type-check correctly, and remove the workaround `@ts-ignore` and `eslint-disable` lines in `useSelectedOptionInUrlParam`.

--- a/packages/hydrogen-react/src/useSelectedOptionInUrlParam.tsx
+++ b/packages/hydrogen-react/src/useSelectedOptionInUrlParam.tsx
@@ -12,15 +12,8 @@ export function useSelectedOptionInUrlParam(
     );
     const currentSearchParams = new URLSearchParams(window.location.search);
 
-    // ts ignoring the URLSearchParams not iterable error for now
-    // https://stackoverflow.com/questions/72522489/urlsearchparams-not-accepting-string#answer-72522838
-    // TODO: update ts lib
     const combinedSearchParams = new URLSearchParams({
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       ...Object.fromEntries(currentSearchParams),
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       ...Object.fromEntries(optionsSearchParams),
     });
 

--- a/packages/hydrogen-react/tsconfig.json
+++ b/packages/hydrogen-react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["DOM", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
### WHY are these changes introduced?

The `packages/hydrogen-react/tsconfig.json` `lib` setting was `["DOM", "ESNext"]`, which is missing `DOM.Iterable`. Without it, the type definitions for `URLSearchParams`, `FormData`, `Headers`, `NodeList`, and similar DOM iterables do not expose their `[Symbol.iterator]` method, so iterating them (or spreading them into `Object.fromEntries`) does not type-check.

This forced a workaround in `useSelectedOptionInUrlParam.tsx`: two `@ts-ignore` directives plus matching `eslint-disable` comments, alongside an outdated `TODO: update ts lib`. The root `tsconfig.json` at the monorepo root already sets `lib: ["DOM", "DOM.Iterable", "ESNext"]`, so this brings the package into line with the rest of the workspace.

### WHAT is this pull request doing?

- Adds `DOM.Iterable` to the `lib` array in `packages/hydrogen-react/tsconfig.json`.
- Removes the `@ts-ignore` / `eslint-disable` workaround and the stale `TODO` comment in `useSelectedOptionInUrlParam.tsx`. The runtime behaviour is unchanged.
- Adds a patch changeset.

### HOW to test your changes?

From the repo root after `pnpm install`:

```
cd packages/hydrogen-react
pnpm run typecheck:code
```

`tsc --noEmit` passes with the workaround removed.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation