### PR TITLE
feat: cart fragment override type support

### DIFF
--- a/.changeset/typed-custom-cart-fragments.md
+++ b/.changeset/typed-custom-cart-fragments.md
@@ -1,5 +1,8 @@
 ---
 '@shopify/hydrogen': patch
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
 ---
 
 Add generic cart result typing to `createCartHandler` so custom cart fragments can use their generated fragment types.

--- a/.changeset/typed-custom-cart-fragments.md
+++ b/.changeset/typed-custom-cart-fragments.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Add generic cart result typing to `createCartHandler` so custom cart fragments can use their generated fragment types.

--- a/cookbook/recipes/custom-cart-method/patches/context.ts.c15041.patch
+++ b/cookbook/recipes/custom-cart-method/patches/context.ts.c15041.patch
@@ -1,7 +1,7 @@
 index 692d5ae17..c2dc8b338 100644
 --- a/templates/skeleton/app/lib/context.ts
 +++ b/templates/skeleton/app/lib/context.ts
-@@ -1,6 +1,15 @@
+@@ -1,7 +1,16 @@
 -import {createHydrogenContext} from '@shopify/hydrogen';
 +import {
 +  createHydrogenContext,
@@ -12,6 +12,7 @@ index 692d5ae17..c2dc8b338 100644
  import {AppSession} from '~/lib/session';
 -import {CART_QUERY_FRAGMENT} from '~/lib/fragments';
 +import {CART_QUERY_FRAGMENT, PRODUCT_VARIANT_QUERY} from '~/lib/fragments';
+ import type {CartApiQueryFragment} from 'storefrontapi.generated';
 +import type {
 +  SelectedOptionInput,
 +  CartLineUpdateInput,
@@ -19,11 +20,11 @@ index 692d5ae17..c2dc8b338 100644
  
  // Define the additional context object
  const additionalContext = {
-@@ -16,6 +25,15 @@ type AdditionalContextType = typeof additionalContext;
- 
- declare global {
-   interface HydrogenAdditionalContext extends AdditionalContextType {}
-+  
+@@ -21,6 +30,15 @@
+   // Augment HydrogenCustomCartFragment with the codegen'd cart fragment type so
+   // that context.cart.get() and all cart mutations return the extended cart type.
+   interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
++
 +  // @description Augment the cart with custom methods for variant selection
 +  interface HydrogenCustomCartMethods {
 +    updateLineByOptions: (
@@ -35,7 +36,7 @@ index 692d5ae17..c2dc8b338 100644
  }
  
  /**
-@@ -40,7 +58,8 @@ export async function createHydrogenRouterContext(
+@@ -45,7 +63,8 @@
      AppSession.init(request, [env.SESSION_SECRET]),
    ]);
  
@@ -45,7 +46,7 @@ index 692d5ae17..c2dc8b338 100644
      {
        env,
        request,
-@@ -51,6 +70,33 @@ export async function createHydrogenRouterContext(
+@@ -56,6 +75,33 @@
        i18n: {language: 'EN', country: 'US'},
        cart: {
          queryFragment: CART_QUERY_FRAGMENT,

--- a/cookbook/recipes/markets/patches/context.ts.c15041.patch
+++ b/cookbook/recipes/markets/patches/context.ts.c15041.patch
@@ -1,15 +1,15 @@
 index 692d5ae17..7373ebca2 100644
 --- a/templates/skeleton/app/lib/context.ts
 +++ b/templates/skeleton/app/lib/context.ts
-@@ -1,6 +1,7 @@
- import {createHydrogenContext} from '@shopify/hydrogen';
+@@ -2,6 +2,7 @@
  import {AppSession} from '~/lib/session';
  import {CART_QUERY_FRAGMENT} from '~/lib/fragments';
+ import type {CartApiQueryFragment} from 'storefrontapi.generated';
 +import {getLocaleFromRequest} from './i18n';
  
  // Define the additional context object
  const additionalContext = {
-@@ -40,6 +41,8 @@ export async function createHydrogenRouterContext(
+@@ -45,6 +46,8 @@
      AppSession.init(request, [env.SESSION_SECRET]),
    ]);
  
@@ -18,7 +18,7 @@ index 692d5ae17..7373ebca2 100644
    const hydrogenContext = createHydrogenContext(
      {
        env,
-@@ -47,8 +50,7 @@ export async function createHydrogenRouterContext(
+@@ -52,8 +55,7 @@
        cache,
        waitUntil,
        session,

--- a/cookbook/recipes/third-party-api/patches/context.ts.c15041.patch
+++ b/cookbook/recipes/third-party-api/patches/context.ts.c15041.patch
@@ -1,11 +1,12 @@
 index 692d5ae17..0635384ad 100644
 --- a/templates/skeleton/app/lib/context.ts
 +++ b/templates/skeleton/app/lib/context.ts
-@@ -1,25 +1,10 @@
- import {createHydrogenContext} from '@shopify/hydrogen';
+@@ -2,29 +2,10 @@
  import {AppSession} from '~/lib/session';
  import {CART_QUERY_FRAGMENT} from '~/lib/fragments';
--
+ import type {CartApiQueryFragment} from 'storefrontapi.generated';
++import {createRickAndMortyClient} from '~/lib/createRickAndMortyClient.server';
+ 
 -// Define the additional context object
 -const additionalContext = {
 -  // Additional context for custom properties, CMS clients, 3P SDKs, etc.
@@ -20,16 +21,19 @@ index 692d5ae17..0635384ad 100644
 -
 -declare global {
 -  interface HydrogenAdditionalContext extends AdditionalContextType {}
+-
+-  // Augment HydrogenCustomCartFragment with the codegen'd cart fragment type so
+-  // that context.cart.get() and all cart mutations return the extended cart type.
+-  interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
 -}
-+import {createRickAndMortyClient} from '~/lib/createRickAndMortyClient.server';
- 
+-
  /**
 - * Creates Hydrogen context for React Router 7.9.x
 + * Creates Hydrogen context for React Router 7.9.x with third-party API support
   * Returns HydrogenRouterContextProvider with hybrid access patterns
   * */
  export async function createHydrogenRouterContext(
-@@ -40,6 +25,19 @@ export async function createHydrogenRouterContext(
+@@ -45,6 +26,19 @@
      AppSession.init(request, [env.SESSION_SECRET]),
    ]);
  
@@ -49,7 +53,7 @@ index 692d5ae17..0635384ad 100644
    const hydrogenContext = createHydrogenContext(
      {
        env,
-@@ -58,3 +56,12 @@ export async function createHydrogenRouterContext(
+@@ -63,3 +57,13 @@
  
    return hydrogenContext;
  }
@@ -61,5 +65,5 @@ index 692d5ae17..0635384ad 100644
 +
 +declare global {
 +  interface HydrogenAdditionalContext extends AdditionalContextType {}
++  interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
 +}
-\ No newline at end of file

--- a/packages/cli/src/lib/setups/i18n/replacers.test.ts
+++ b/packages/cli/src/lib/setups/i18n/replacers.test.ts
@@ -59,6 +59,7 @@ describe('i18n replacers', () => {
         "import { createHydrogenContext } from "@shopify/hydrogen";
         import { AppSession } from "~/lib/session";
         import { CART_QUERY_FRAGMENT } from "~/lib/fragments";
+        import type { CartApiQueryFragment } from "storefrontapi.generated";
         import { getLocaleFromRequest } from "~/lib/i18n";
 
         // Define the additional context object
@@ -75,6 +76,10 @@ describe('i18n replacers', () => {
 
         declare global {
           interface HydrogenAdditionalContext extends AdditionalContextType {}
+
+          // Augment HydrogenCustomCartFragment with the codegen'd cart fragment type so
+          // that context.cart.get() and all cart mutations return the extended cart type.
+          interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
         }
 
         /**

--- a/packages/hydrogen/react-router.d.ts
+++ b/packages/hydrogen/react-router.d.ts
@@ -7,7 +7,6 @@ import type {
   HydrogenEnv,
   HydrogenCart,
 } from './src/index';
-import type {Cart} from '@shopify/hydrogen-react/storefront-api-types';
 
 // Extensible interface for additional context properties (CMS clients, 3P SDKs, etc.)
 // Users can augment this interface in their own code to add custom properties
@@ -33,38 +32,14 @@ declare global {
   }
 
   /**
-   * Extensible interface for typing cart results with a custom cart fragment.
-   * Augment this interface with your codegen'd fragment type to get full type
-   * safety on `context.cart.get()` and all cart mutations.
-   *
-   * @example
-   * ```ts
-   * // In app/lib/context.ts
-   * import type {CartApiQueryFragment} from 'storefrontapi.generated';
-   *
-   * declare global {
-   *   interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
-   * }
-   * ```
-   */
-  interface HydrogenCustomCartFragment {}
-
-  /**
    * The cart type used for `context.cart` in route files.
    *
-   * Uses `HydrogenCustomCartFragment & Cart` rather than a conditional type so
-   * the intersection is computed lazily at each use site — avoiding issues where
-   * conditional types in `.d.ts` files get evaluated before `declare global`
-   * augmentations from module files are merged.
-   *
-   * - Default (no augmentation): `{} & Cart` = `Cart` — identical to before.
-   * - With augmentation: `CartApiQueryFragment & Cart` — includes all Cart
-   *   fields plus any custom fields added to the fragment.
+   * `HydrogenCart`'s default type parameter already includes
+   * `HydrogenCustomCartFragment & Cart`, so no explicit intersection is needed
+   * here. The augmentable `HydrogenCustomCartFragment` interface is declared
+   * in `cart/queries/cart-types.ts`.
    */
-  type HydrogenCartWithFragment = HydrogenCart<
-    HydrogenCustomCartFragment & Cart
-  > &
-    HydrogenCustomCartMethods;
+  type HydrogenCartWithFragment = HydrogenCart & HydrogenCustomCartMethods;
 }
 
 declare module 'react-router' {

--- a/packages/hydrogen/react-router.d.ts
+++ b/packages/hydrogen/react-router.d.ts
@@ -7,6 +7,7 @@ import type {
   HydrogenEnv,
   HydrogenCart,
 } from './src/index';
+import type {Cart} from '@shopify/hydrogen-react/storefront-api-types';
 
 // Extensible interface for additional context properties (CMS clients, 3P SDKs, etc.)
 // Users can augment this interface in their own code to add custom properties
@@ -49,13 +50,21 @@ declare global {
   interface HydrogenCustomCartFragment {}
 
   /**
-   * Resolves to `HydrogenCart<HydrogenCustomCartFragment>` when the merchant
-   * has augmented `HydrogenCustomCartFragment`, otherwise falls back to the
-   * default `HydrogenCart` (typed with the base Storefront API `Cart`).
+   * The cart type used for `context.cart` in route files.
+   *
+   * Uses `HydrogenCustomCartFragment & Cart` rather than a conditional type so
+   * the intersection is computed lazily at each use site — avoiding issues where
+   * conditional types in `.d.ts` files get evaluated before `declare global`
+   * augmentations from module files are merged.
+   *
+   * - Default (no augmentation): `{} & Cart` = `Cart` — identical to before.
+   * - With augmentation: `CartApiQueryFragment & Cart` — includes all Cart
+   *   fields plus any custom fields added to the fragment.
    */
-  type HydrogenCartWithFragment = keyof HydrogenCustomCartFragment extends never
-    ? HydrogenCart & HydrogenCustomCartMethods
-    : HydrogenCart<HydrogenCustomCartFragment> & HydrogenCustomCartMethods;
+  type HydrogenCartWithFragment = HydrogenCart<
+    HydrogenCustomCartFragment & Cart
+  > &
+    HydrogenCustomCartMethods;
 }
 
 declare module 'react-router' {

--- a/packages/hydrogen/react-router.d.ts
+++ b/packages/hydrogen/react-router.d.ts
@@ -30,6 +30,32 @@ declare global {
     //   updateLineByOptions: (productId: string, selectedOptions: SelectedOptionInput[], line: CartLineUpdateInput) => Promise<CartQueryDataReturn>;
     // }
   }
+
+  /**
+   * Extensible interface for typing cart results with a custom cart fragment.
+   * Augment this interface with your codegen'd fragment type to get full type
+   * safety on `context.cart.get()` and all cart mutations.
+   *
+   * @example
+   * ```ts
+   * // In app/lib/context.ts
+   * import type {CartApiQueryFragment} from 'storefrontapi.generated';
+   *
+   * declare global {
+   *   interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
+   * }
+   * ```
+   */
+  interface HydrogenCustomCartFragment {}
+
+  /**
+   * Resolves to `HydrogenCart<HydrogenCustomCartFragment>` when the merchant
+   * has augmented `HydrogenCustomCartFragment`, otherwise falls back to the
+   * default `HydrogenCart` (typed with the base Storefront API `Cart`).
+   */
+  type HydrogenCartWithFragment = keyof HydrogenCustomCartFragment extends never
+    ? HydrogenCart & HydrogenCustomCartMethods
+    : HydrogenCart<HydrogenCustomCartFragment> & HydrogenCustomCartMethods;
 }
 
 declare module 'react-router' {
@@ -37,7 +63,7 @@ declare module 'react-router' {
   interface RouterContextProvider extends HydrogenAdditionalContext {
     // Standard Hydrogen context properties from HydrogenRouterContextProvider
     storefront: HydrogenRouterContextProvider['storefront'];
-    cart: HydrogenCart & HydrogenCustomCartMethods;
+    cart: HydrogenCartWithFragment;
     customerAccount: HydrogenRouterContextProvider['customerAccount'];
     env: HydrogenRouterContextProvider['env'];
     session: HydrogenRouterContextProvider['session'];
@@ -48,7 +74,7 @@ declare module 'react-router' {
   interface AppLoadContext extends HydrogenAdditionalContext {
     // Standard Hydrogen context properties from HydrogenRouterContextProvider
     storefront: HydrogenRouterContextProvider['storefront'];
-    cart: HydrogenCart & HydrogenCustomCartMethods;
+    cart: HydrogenCartWithFragment;
     customerAccount: HydrogenRouterContextProvider['customerAccount'];
     env: HydrogenRouterContextProvider['env'];
     session: HydrogenRouterContextProvider['session'];

--- a/packages/hydrogen/src/cart/createCartHandler.test.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.test.ts
@@ -401,6 +401,45 @@ describe('createCartHandler', () => {
     expect(result.cart).toHaveProperty('id', 'c1-new-cart-id');
   });
 
+  it('function updateBuyerIdentity returns cart create errors when cart is not created', async () => {
+    const storefront = {
+      ...mockCreateStorefrontClient(),
+      mutate: vi.fn().mockResolvedValueOnce({
+        cartCreate: {
+          cart: null,
+          userErrors: [{message: 'Cannot create cart'}],
+        },
+      }),
+    } as unknown as Storefront;
+    const cart = getCartHandler({storefront});
+
+    const result = await cart.updateBuyerIdentity({
+      companyLocationId: 'gid://shopify/CompanyLocation/1',
+    });
+
+    expect(result.cart).toBeNull();
+    expect(result.userErrors?.[0]).toHaveProperty(
+      'message',
+      'Cannot create cart',
+    );
+  });
+
+  it('function create throws when a returned cart is missing id', async () => {
+    const storefront = {
+      ...mockCreateStorefrontClient(),
+      mutate: vi.fn().mockResolvedValueOnce({
+        cartCreate: {
+          cart: {totalQuantity: 0},
+        },
+      }),
+    } as unknown as Storefront;
+    const cart = getCartHandler({storefront});
+
+    await expect(cart.create({})).rejects.toThrow(
+      'Cart created but response is missing a valid `id` field.',
+    );
+  });
+
   it('function updateNote has a working default implementation', async () => {
     const cart = getCartHandler({cartId: 'c1-123'});
 

--- a/packages/hydrogen/src/cart/createCartHandler.test.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.test.ts
@@ -9,7 +9,8 @@ import {
   mockCreateCustomerAccountClient,
   mockCreateStorefrontClient,
 } from './cart-test-helper';
-import {Storefront} from '../storefront';
+import type {Storefront, StorefrontApiErrors} from '../storefront';
+import type {CartQueryDataReturn} from './queries/cart-types';
 
 type MockCarthandler = {
   cartId?: string;
@@ -18,6 +19,17 @@ type MockCarthandler = {
   customMethods?: Record<string, Function>;
   buyerIdentity?: CartBuyerIdentityInput;
   storefront?: Storefront;
+};
+
+type CustomCart = {
+  id: string;
+  checkoutUrl: string;
+  totalQuantity: number;
+  customField?: string;
+};
+
+type ExtraCartGetVariables = {
+  customVariable?: string;
 };
 
 function getCartHandler(options: MockCarthandler = {}) {
@@ -75,6 +87,73 @@ describe('createCartHandler', () => {
 
     expectTypeOf(cart).toEqualTypeOf<HydrogenCartCustom<{foo: () => 'bar'}>>;
     expect(Object.keys(cart)).toHaveLength(22);
+    expect(cart.foo()).toBe('bar');
+  });
+
+  it('can type cart methods with a custom cart fragment type', () => {
+    const cart = createCartHandler<CustomCart>({
+      storefront: mockCreateStorefrontClient(),
+      getCartId: () => undefined,
+      setCartId: () => new Headers(),
+      cartQueryFragment: 'cartQueryFragmentOverride',
+      cartMutateFragment: 'cartMutateFragmentOverride',
+    });
+
+    expectTypeOf(cart).toEqualTypeOf<HydrogenCart<CustomCart>>();
+    expectTypeOf<Awaited<ReturnType<typeof cart.get>>>().toEqualTypeOf<
+      (CustomCart & {errors?: StorefrontApiErrors}) | null
+    >();
+    expectTypeOf<Awaited<ReturnType<typeof cart.create>>>().toEqualTypeOf<
+      CartQueryDataReturn<CustomCart>
+    >();
+    expectTypeOf<Awaited<ReturnType<typeof cart.addLines>>>().toEqualTypeOf<
+      CartQueryDataReturn<CustomCart>
+    >();
+  });
+
+  it('can type custom cart get variables', () => {
+    const cart = createCartHandler<CustomCart, ExtraCartGetVariables>({
+      storefront: mockCreateStorefrontClient(),
+      getCartId: () => undefined,
+      setCartId: () => new Headers(),
+      cartQueryFragment: 'cartQueryFragmentOverride',
+    });
+
+    expectTypeOf<Parameters<typeof cart.get>[0]>().toMatchTypeOf<
+      ExtraCartGetVariables | undefined
+    >();
+
+    if (false) {
+      void cart.get({customVariable: 'value'});
+      // @ts-expect-error customVariable must be a string.
+      void cart.get({customVariable: 123});
+    }
+  });
+
+  it('can combine custom cart typing with custom methods', () => {
+    const cart = createCartHandler<
+      CustomCart,
+      ExtraCartGetVariables,
+      {foo: () => 'bar'}
+    >({
+      storefront: mockCreateStorefrontClient(),
+      getCartId: () => undefined,
+      setCartId: () => new Headers(),
+      cartQueryFragment: 'cartQueryFragmentOverride',
+      cartMutateFragment: 'cartMutateFragmentOverride',
+      customMethods: {
+        foo() {
+          return 'bar';
+        },
+      },
+    });
+
+    expectTypeOf(cart).toEqualTypeOf<
+      HydrogenCartCustom<{foo: () => 'bar'}, CustomCart, ExtraCartGetVariables>
+    >();
+    expectTypeOf<Awaited<ReturnType<typeof cart.get>>>().toEqualTypeOf<
+      (CustomCart & {errors?: StorefrontApiErrors}) | null
+    >();
     expect(cart.foo()).toBe('bar');
   });
 

--- a/packages/hydrogen/src/cart/createCartHandler.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.ts
@@ -308,7 +308,13 @@ export function createCartHandler<
           'Ensure your cart query fragment includes the `id` field.',
       );
     }
-    cartId = result?.cart?.id;
+    cartId =
+      result?.cart &&
+      typeof result.cart === 'object' &&
+      'id' in result.cart &&
+      typeof result.cart.id === 'string'
+        ? result.cart.id
+        : undefined;
 
     return result;
   };

--- a/packages/hydrogen/src/cart/createCartHandler.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.ts
@@ -299,6 +299,7 @@ export function createCartHandler<
 
     if (
       !result?.cart ||
+      typeof result.cart !== 'object' ||
       !('id' in result.cart) ||
       typeof result.cart.id !== 'string'
     ) {

--- a/packages/hydrogen/src/cart/createCartHandler.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.ts
@@ -100,7 +100,10 @@ type CartHandlerOptionsWithRequiredCustom<
   customMethods: TCustomMethods;
 };
 
-export type HydrogenCart<TCart = Cart, TGetExtraVariables = {}> = {
+export type HydrogenCart<
+  TCart = HydrogenCustomCartFragment & Cart,
+  TGetExtraVariables = {},
+> = {
   get: CartGetFunction<TCart, TGetExtraVariables>;
   getCartId: () => string | undefined;
   setCartId: (cartId: string) => Headers;
@@ -219,13 +222,13 @@ export type HydrogenCart<TCart = Cart, TGetExtraVariables = {}> = {
 
 export type HydrogenCartCustom<
   TCustomMethods extends CustomMethodsBase,
-  TCart = Cart,
+  TCart = HydrogenCustomCartFragment & Cart,
   TGetExtraVariables = {},
 > = Omit<HydrogenCart<TCart, TGetExtraVariables>, keyof TCustomMethods> &
   TCustomMethods;
 export type CartHandlerReturn<
   TCustomMethods extends CustomMethodsBase,
-  TCart = Cart,
+  TCart = HydrogenCustomCartFragment & Cart,
   TGetExtraVariables = {},
 > =
   | HydrogenCartCustom<TCustomMethods, TCart, TGetExtraVariables>

--- a/packages/hydrogen/src/cart/createCartHandler.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.ts
@@ -298,17 +298,17 @@ export function createCartHandler<
     const result = await _cartCreate(...args);
 
     if (
-      !result?.cart ||
-      typeof result.cart !== 'object' ||
-      !('id' in result.cart) ||
-      typeof result.cart.id !== 'string'
+      result?.cart &&
+      (typeof result.cart !== 'object' ||
+        !('id' in result.cart) ||
+        typeof result.cart.id !== 'string')
     ) {
       throw new Error(
         '[h2:error:createCartHandler] Cart created but response is missing a valid `id` field. ' +
           'Ensure your cart query fragment includes the `id` field.',
       );
     }
-    cartId = result.cart.id;
+    cartId = result?.cart?.id;
 
     return result;
   };

--- a/packages/hydrogen/src/cart/createCartHandler.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.ts
@@ -73,7 +73,10 @@ import {
   type CartDeliveryAddressesReplaceFunction,
   cartDeliveryAddressesReplaceDefault,
 } from './queries/cartDeliveryAddressesReplaceDefault';
-import type {CartBuyerIdentityInput} from '@shopify/hydrogen-react/storefront-api-types';
+import type {
+  Cart,
+  CartBuyerIdentityInput,
+} from '@shopify/hydrogen-react/storefront-api-types';
 
 export type CartHandlerOptions = {
   storefront: Storefront;
@@ -91,25 +94,28 @@ export type CartHandlerOptionsWithCustom<
 > = CartHandlerOptions & {
   customMethods?: TCustomMethods;
 };
+type CartHandlerOptionsWithRequiredCustom<
+  TCustomMethods extends CustomMethodsBase,
+> = CartHandlerOptions & {
+  customMethods: TCustomMethods;
+};
 
-export type HydrogenCart = {
-  get: ReturnType<typeof cartGetDefault>;
+export type HydrogenCart<TCart = Cart, TGetExtraVariables = {}> = {
+  get: CartGetFunction<TCart, TGetExtraVariables>;
   getCartId: () => string | undefined;
   setCartId: (cartId: string) => Headers;
-  create: ReturnType<typeof cartCreateDefault>;
-  addLines: ReturnType<typeof cartLinesAddDefault>;
-  updateLines: ReturnType<typeof cartLinesUpdateDefault>;
-  removeLines: ReturnType<typeof cartLinesRemoveDefault>;
-  updateDiscountCodes: ReturnType<typeof cartDiscountCodesUpdateDefault>;
-  updateGiftCardCodes: ReturnType<typeof cartGiftCardCodesUpdateDefault>;
-  addGiftCardCodes: ReturnType<typeof cartGiftCardCodesAddDefault>;
-  removeGiftCardCodes: ReturnType<typeof cartGiftCardCodesRemoveDefault>;
-  updateBuyerIdentity: ReturnType<typeof cartBuyerIdentityUpdateDefault>;
-  updateNote: ReturnType<typeof cartNoteUpdateDefault>;
-  updateSelectedDeliveryOption: ReturnType<
-    typeof cartSelectedDeliveryOptionsUpdateDefault
-  >;
-  updateAttributes: ReturnType<typeof cartAttributesUpdateDefault>;
+  create: CartCreateFunction<TCart>;
+  addLines: CartLinesAddFunction<TCart>;
+  updateLines: CartLinesUpdateFunction<TCart>;
+  removeLines: CartLinesRemoveFunction<TCart>;
+  updateDiscountCodes: CartDiscountCodesUpdateFunction<TCart>;
+  updateGiftCardCodes: CartGiftCardCodesUpdateFunction<TCart>;
+  addGiftCardCodes: CartGiftCardCodesAddFunction<TCart>;
+  removeGiftCardCodes: CartGiftCardCodesRemoveFunction<TCart>;
+  updateBuyerIdentity: CartBuyerIdentityUpdateFunction<TCart>;
+  updateNote: CartNoteUpdateFunction<TCart>;
+  updateSelectedDeliveryOption: CartSelectedDeliveryOptionsUpdateFunction<TCart>;
+  updateAttributes: CartAttributesUpdateFunction<TCart>;
   setMetafields: ReturnType<typeof cartMetafieldsSetDefault>;
   deleteMetafield: ReturnType<typeof cartMetafieldDeleteDefault>;
   /**
@@ -133,7 +139,7 @@ export type HydrogenCart = {
    *   { someOptionalParam: 'value' }
    * );
    */
-  addDeliveryAddresses: ReturnType<typeof cartDeliveryAddressesAddDefault>;
+  addDeliveryAddresses: CartDeliveryAddressesAddFunction<TCart>;
   /**
    * Removes delivery addresses from the cart.
    *
@@ -150,9 +156,7 @@ export type HydrogenCart = {
    * { someOptionalParam: 'value' });
    */
 
-  removeDeliveryAddresses: ReturnType<
-    typeof cartDeliveryAddressesRemoveDefault
-  >;
+  removeDeliveryAddresses: CartDeliveryAddressesRemoveFunction<TCart>;
   /**
   * Updates delivery addresses in the cart.
   *
@@ -186,9 +190,7 @@ export type HydrogenCart = {
       }
     ],{ someOptionalParam: 'value' });
   */
-  updateDeliveryAddresses: ReturnType<
-    typeof cartDeliveryAddressesUpdateDefault
-  >;
+  updateDeliveryAddresses: CartDeliveryAddressesUpdateFunction<TCart>;
   /**
    * Replaces all delivery addresses on the cart.
    *
@@ -212,26 +214,44 @@ export type HydrogenCart = {
    *   }
    * ], { someOptionalParam: 'value' });
    */
-  replaceDeliveryAddresses: ReturnType<
-    typeof cartDeliveryAddressesReplaceDefault
-  >;
+  replaceDeliveryAddresses: CartDeliveryAddressesReplaceFunction<TCart>;
 };
 
 export type HydrogenCartCustom<
-  TCustomMethods extends Partial<HydrogenCart> & CustomMethodsBase,
-> = Omit<HydrogenCart, keyof TCustomMethods> & TCustomMethods;
-export type CartHandlerReturn<TCustomMethods extends CustomMethodsBase> =
-  | HydrogenCartCustom<TCustomMethods>
-  | HydrogenCart;
+  TCustomMethods extends CustomMethodsBase,
+  TCart = Cart,
+  TGetExtraVariables = {},
+> = Omit<HydrogenCart<TCart, TGetExtraVariables>, keyof TCustomMethods> &
+  TCustomMethods;
+export type CartHandlerReturn<
+  TCustomMethods extends CustomMethodsBase,
+  TCart = Cart,
+  TGetExtraVariables = {},
+> =
+  | HydrogenCartCustom<TCustomMethods, TCart, TGetExtraVariables>
+  | HydrogenCart<TCart, TGetExtraVariables>;
 
 /** @publicDocs */
-export function createCartHandler(options: CartHandlerOptions): HydrogenCart;
 export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
-  options: CartHandlerOptionsWithCustom<TCustomMethods>,
+  options: CartHandlerOptionsWithRequiredCustom<TCustomMethods>,
 ): HydrogenCartCustom<TCustomMethods>;
-export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
+export function createCartHandler<TCart = Cart, TGetExtraVariables = {}>(
+  options: CartHandlerOptions,
+): HydrogenCart<TCart, TGetExtraVariables>;
+export function createCartHandler<
+  TCart,
+  TGetExtraVariables,
+  TCustomMethods extends CustomMethodsBase,
+>(
+  options: CartHandlerOptionsWithRequiredCustom<TCustomMethods>,
+): HydrogenCartCustom<TCustomMethods, TCart, TGetExtraVariables>;
+export function createCartHandler<
+  TCart = Cart,
+  TGetExtraVariables = {},
+  TCustomMethods extends CustomMethodsBase = CustomMethodsBase,
+>(
   options: CartHandlerOptions | CartHandlerOptionsWithCustom<TCustomMethods>,
-): CartHandlerReturn<TCustomMethods> {
+): CartHandlerReturn<TCustomMethods, TCart, TGetExtraVariables> {
   const {
     getCartId: _getCartId,
     setCartId,
@@ -253,9 +273,9 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
     customerAccount,
   };
 
-  const _cartCreate = cartCreateDefault(mutateOptions);
+  const _cartCreate = cartCreateDefault<TCart>(mutateOptions);
 
-  const cartCreate: CartCreateFunction = async function (...args) {
+  const cartCreate: CartCreateFunction<TCart> = async function (...args) {
     // Default buyerIdentity to what is passed into the handler
     // Only override if buyerIdentity is passed directly to the method
     args[0].buyerIdentity = {
@@ -264,12 +284,12 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
     };
 
     const result = await _cartCreate(...args);
-    cartId = result?.cart?.id;
+    cartId = (result?.cart as {id?: string} | undefined)?.id;
     return result;
   };
 
-  const methods: HydrogenCart = {
-    get: cartGetDefault({
+  const methods: HydrogenCart<TCart, TGetExtraVariables> = {
+    get: cartGetDefault<TCart, TGetExtraVariables>({
       storefront,
       customerAccount,
       getCartId,
@@ -290,14 +310,14 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
       });
 
       return cartId || optionalParams?.cartId
-        ? await cartLinesAddDefault(mutateOptions)(lines, optionalParams)
+        ? await cartLinesAddDefault<TCart>(mutateOptions)(lines, optionalParams)
         : await cartCreate({lines, buyerIdentity}, optionalParams);
     },
-    updateLines: cartLinesUpdateDefault(mutateOptions),
-    removeLines: cartLinesRemoveDefault(mutateOptions),
+    updateLines: cartLinesUpdateDefault<TCart>(mutateOptions),
+    removeLines: cartLinesRemoveDefault<TCart>(mutateOptions),
     updateDiscountCodes: async (discountCodes, optionalParams) => {
       return cartId || optionalParams?.cartId
-        ? await cartDiscountCodesUpdateDefault(mutateOptions)(
+        ? await cartDiscountCodesUpdateDefault<TCart>(mutateOptions)(
             discountCodes,
             optionalParams,
           )
@@ -305,17 +325,17 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
     },
     updateGiftCardCodes: async (giftCardCodes, optionalParams) => {
       return cartId || optionalParams?.cartId
-        ? await cartGiftCardCodesUpdateDefault(mutateOptions)(
+        ? await cartGiftCardCodesUpdateDefault<TCart>(mutateOptions)(
             giftCardCodes,
             optionalParams,
           )
         : await cartCreate({giftCardCodes}, optionalParams);
     },
-    addGiftCardCodes: cartGiftCardCodesAddDefault(mutateOptions),
-    removeGiftCardCodes: cartGiftCardCodesRemoveDefault(mutateOptions),
+    addGiftCardCodes: cartGiftCardCodesAddDefault<TCart>(mutateOptions),
+    removeGiftCardCodes: cartGiftCardCodesRemoveDefault<TCart>(mutateOptions),
     updateBuyerIdentity: async (buyerIdentity, optionalParams) => {
       return cartId || optionalParams?.cartId
-        ? await cartBuyerIdentityUpdateDefault(mutateOptions)(
+        ? await cartBuyerIdentityUpdateDefault<TCart>(mutateOptions)(
             buyerIdentity,
             optionalParams,
           )
@@ -323,14 +343,17 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
     },
     updateNote: async (note, optionalParams) => {
       return cartId || optionalParams?.cartId
-        ? await cartNoteUpdateDefault(mutateOptions)(note, optionalParams)
+        ? await cartNoteUpdateDefault<TCart>(mutateOptions)(
+            note,
+            optionalParams,
+          )
         : await cartCreate({note}, optionalParams);
     },
     updateSelectedDeliveryOption:
-      cartSelectedDeliveryOptionsUpdateDefault(mutateOptions),
+      cartSelectedDeliveryOptionsUpdateDefault<TCart>(mutateOptions),
     updateAttributes: async (attributes, optionalParams) => {
       return cartId || optionalParams?.cartId
-        ? await cartAttributesUpdateDefault(mutateOptions)(
+        ? await cartAttributesUpdateDefault<TCart>(mutateOptions)(
             attributes,
             optionalParams,
           )
@@ -342,14 +365,18 @@ export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
             metafields,
             optionalParams,
           )
-        : await cartCreate({metafields}, optionalParams);
+        : ((await cartCreate({metafields}, optionalParams)) as Awaited<
+            ReturnType<CartMetafieldsSetFunction>
+          >);
     },
     deleteMetafield: cartMetafieldDeleteDefault(mutateOptions),
-    addDeliveryAddresses: cartDeliveryAddressesAddDefault(mutateOptions),
-    removeDeliveryAddresses: cartDeliveryAddressesRemoveDefault(mutateOptions),
-    updateDeliveryAddresses: cartDeliveryAddressesUpdateDefault(mutateOptions),
+    addDeliveryAddresses: cartDeliveryAddressesAddDefault<TCart>(mutateOptions),
+    removeDeliveryAddresses:
+      cartDeliveryAddressesRemoveDefault<TCart>(mutateOptions),
+    updateDeliveryAddresses:
+      cartDeliveryAddressesUpdateDefault<TCart>(mutateOptions),
     replaceDeliveryAddresses:
-      cartDeliveryAddressesReplaceDefault(mutateOptions),
+      cartDeliveryAddressesReplaceDefault<TCart>(mutateOptions),
   };
 
   if ('customMethods' in options) {

--- a/packages/hydrogen/src/cart/createCartHandler.ts
+++ b/packages/hydrogen/src/cart/createCartHandler.ts
@@ -77,6 +77,11 @@ import type {
   Cart,
   CartBuyerIdentityInput,
 } from '@shopify/hydrogen-react/storefront-api-types';
+import type {
+  CartOptionalInput,
+  CartQueryDataReturn,
+  MetafieldWithoutOwnerId,
+} from './queries/cart-types';
 
 export type CartHandlerOptions = {
   storefront: Storefront;
@@ -119,7 +124,10 @@ export type HydrogenCart<
   updateNote: CartNoteUpdateFunction<TCart>;
   updateSelectedDeliveryOption: CartSelectedDeliveryOptionsUpdateFunction<TCart>;
   updateAttributes: CartAttributesUpdateFunction<TCart>;
-  setMetafields: ReturnType<typeof cartMetafieldsSetDefault>;
+  setMetafields: (
+    metafields: MetafieldWithoutOwnerId[],
+    optionalParams?: CartOptionalInput,
+  ) => Promise<CartQueryDataReturn | CartQueryDataReturn<TCart>>;
   deleteMetafield: ReturnType<typeof cartMetafieldDeleteDefault>;
   /**
    * Adds delivery addresses to the cart.
@@ -238,9 +246,10 @@ export type CartHandlerReturn<
 export function createCartHandler<TCustomMethods extends CustomMethodsBase>(
   options: CartHandlerOptionsWithRequiredCustom<TCustomMethods>,
 ): HydrogenCartCustom<TCustomMethods>;
-export function createCartHandler<TCart = Cart, TGetExtraVariables = {}>(
-  options: CartHandlerOptions,
-): HydrogenCart<TCart, TGetExtraVariables>;
+export function createCartHandler<
+  TCart = HydrogenCustomCartFragment & Cart,
+  TGetExtraVariables = {},
+>(options: CartHandlerOptions): HydrogenCart<TCart, TGetExtraVariables>;
 export function createCartHandler<
   TCart,
   TGetExtraVariables,
@@ -249,7 +258,7 @@ export function createCartHandler<
   options: CartHandlerOptionsWithRequiredCustom<TCustomMethods>,
 ): HydrogenCartCustom<TCustomMethods, TCart, TGetExtraVariables>;
 export function createCartHandler<
-  TCart = Cart,
+  TCart = HydrogenCustomCartFragment & Cart,
   TGetExtraVariables = {},
   TCustomMethods extends CustomMethodsBase = CustomMethodsBase,
 >(
@@ -287,7 +296,19 @@ export function createCartHandler<
     };
 
     const result = await _cartCreate(...args);
-    cartId = (result?.cart as {id?: string} | undefined)?.id;
+
+    if (
+      !result?.cart ||
+      !('id' in result.cart) ||
+      typeof result.cart.id !== 'string'
+    ) {
+      throw new Error(
+        '[h2:error:createCartHandler] Cart created but response is missing a valid `id` field. ' +
+          'Ensure your cart query fragment includes the `id` field.',
+      );
+    }
+    cartId = result.cart.id;
+
     return result;
   };
 
@@ -368,9 +389,7 @@ export function createCartHandler<
             metafields,
             optionalParams,
           )
-        : ((await cartCreate({metafields}, optionalParams)) as Awaited<
-            ReturnType<CartMetafieldsSetFunction>
-          >);
+        : await cartCreate({metafields}, optionalParams);
     },
     deleteMetafield: cartMetafieldDeleteDefault(mutateOptions),
     addDeliveryAddresses: cartDeliveryAddressesAddDefault<TCart>(mutateOptions),

--- a/packages/hydrogen/src/cart/queries/cart-types.ts
+++ b/packages/hydrogen/src/cart/queries/cart-types.ts
@@ -13,6 +13,29 @@ import type {
 import type {StorefrontApiErrors, Storefront} from '../../storefront';
 import {CustomerAccount} from '../../customer/types';
 
+declare global {
+  /**
+   * Extensible interface for typing cart results with a custom cart fragment.
+   * Augment this interface with your codegen'd fragment type to get full type
+   * safety on every cart operation — whether accessed via `context.cart`,
+   * `createCartHandler`, or `createHydrogenContext`.
+   *
+   * When empty (the default), `HydrogenCustomCartFragment & Cart` collapses
+   * to `Cart`, so existing behaviour is unchanged.
+   *
+   * @example
+   * ```ts
+   * // In app/lib/context.ts
+   * import type {CartApiQueryFragment} from 'storefrontapi.generated';
+   *
+   * declare global {
+   *   interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
+   * }
+   * ```
+   */
+  interface HydrogenCustomCartFragment {}
+}
+
 export type CartOptionalInput = {
   /**
    * The cart id.

--- a/packages/hydrogen/src/cart/queries/cart-types.ts
+++ b/packages/hydrogen/src/cart/queries/cart-types.ts
@@ -67,12 +67,12 @@ export type CartQueryOptions = {
   customerAccount?: CustomerAccount;
 };
 
-export type CartReturn = Cart & {
+export type CartReturn<TCart = Cart> = TCart & {
   errors?: StorefrontApiErrors;
 };
 
-export type CartQueryData = {
-  cart: Cart;
+export type CartQueryData<TCart = Cart> = {
+  cart: TCart;
   userErrors?:
     | CartUserError[]
     | MetafieldsSetUserError[]
@@ -80,11 +80,11 @@ export type CartQueryData = {
   warnings?: CartWarning[];
 };
 
-export type CartQueryDataReturn = CartQueryData & {
+export type CartQueryDataReturn<TCart = Cart> = CartQueryData<TCart> & {
   errors?: StorefrontApiErrors;
 };
 
-export type CartQueryReturn<T> = (
+export type CartQueryReturn<T, TCart = Cart> = (
   requiredParams: T,
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryData>;
+) => Promise<CartQueryData<TCart>>;

--- a/packages/hydrogen/src/cart/queries/cartAttributesUpdateDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartAttributesUpdateDefault.ts
@@ -18,19 +18,20 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartAttributesUpdateFunction = (
-  attributes: AttributeInput[],
-  optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+export type CartAttributesUpdateFunction<TCart = CartQueryDataReturn['cart']> =
+  (
+    attributes: AttributeInput[],
+    optionalParams?: CartOptionalInput,
+  ) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartAttributesUpdateDefault(
-  options: CartQueryOptions,
-): CartAttributesUpdateFunction {
+export function cartAttributesUpdateDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartAttributesUpdateFunction<TCart> {
   return async (attributes, optionalParams) => {
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartAttributesUpdate, errors} = await options.storefront.mutate<{
-      cartAttributesUpdate: CartQueryData;
+      cartAttributesUpdate: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(
       CART_ATTRIBUTES_UPDATE_MUTATION(options.cartFragment, {

--- a/packages/hydrogen/src/cart/queries/cartBuyerIdentityUpdateDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartBuyerIdentityUpdateDefault.ts
@@ -18,15 +18,17 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartBuyerIdentityUpdateFunction = (
+export type CartBuyerIdentityUpdateFunction<
+  TCart = CartQueryDataReturn['cart'],
+> = (
   buyerIdentity: CartBuyerIdentityInput,
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartBuyerIdentityUpdateDefault(
-  options: CartQueryOptions,
-): CartBuyerIdentityUpdateFunction {
+export function cartBuyerIdentityUpdateDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartBuyerIdentityUpdateFunction<TCart> {
   return async (buyerIdentity, optionalParams) => {
     if (buyerIdentity.companyLocationId && options.customerAccount) {
       options.customerAccount.setBuyer({
@@ -40,7 +42,7 @@ export function cartBuyerIdentityUpdateDefault(
 
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartBuyerIdentityUpdate, errors} = await options.storefront.mutate<{
-      cartBuyerIdentityUpdate: CartQueryData;
+      cartBuyerIdentityUpdate: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(
       CART_BUYER_IDENTITY_UPDATE_MUTATION(options.cartFragment, {

--- a/packages/hydrogen/src/cart/queries/cartCreateDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartCreateDefault.ts
@@ -18,15 +18,15 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartCreateFunction = (
+export type CartCreateFunction<TCart = CartQueryDataReturn['cart']> = (
   input: CartInput,
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartCreateDefault(
+export function cartCreateDefault<TCart = CartQueryDataReturn['cart']>(
   options: CartQueryOptions,
-): CartCreateFunction {
+): CartCreateFunction<TCart> {
   return async (input, optionalParams) => {
     const buyer = options.customerAccount
       ? await options.customerAccount.getBuyer()
@@ -35,7 +35,7 @@ export function cartCreateDefault(
     const {buyerIdentity, ...restOfInput} = input;
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartCreate, errors} = await options.storefront.mutate<{
-      cartCreate: CartQueryData;
+      cartCreate: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(CART_CREATE_MUTATION(options.cartFragment, {includeVisitorConsent}), {
       variables: {

--- a/packages/hydrogen/src/cart/queries/cartDeliveryAddressesAddDefault.tsx
+++ b/packages/hydrogen/src/cart/queries/cartDeliveryAddressesAddDefault.tsx
@@ -18,10 +18,12 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartDeliveryAddressesAddFunction = (
+export type CartDeliveryAddressesAddFunction<
+  TCart = CartQueryDataReturn['cart'],
+> = (
   addresses: Array<CartSelectableAddressInput>,
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /**
  * Adds delivery addresses to the cart.
@@ -45,16 +47,16 @@ export type CartDeliveryAddressesAddFunction = (
  * );
  * @publicDocs
  */
-export function cartDeliveryAddressesAddDefault(
-  options: CartQueryOptions,
-): CartDeliveryAddressesAddFunction {
+export function cartDeliveryAddressesAddDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartDeliveryAddressesAddFunction<TCart> {
   return async (
     addresses: Array<CartSelectableAddressInput>,
     optionalParams,
   ) => {
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartDeliveryAddressesAdd, errors} = await options.storefront.mutate<{
-      cartDeliveryAddressesAdd: CartQueryData;
+      cartDeliveryAddressesAdd: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(
       CART_DELIVERY_ADDRESSES_ADD_MUTATION(options.cartFragment, {

--- a/packages/hydrogen/src/cart/queries/cartDeliveryAddressesRemoveDefault.tsx
+++ b/packages/hydrogen/src/cart/queries/cartDeliveryAddressesRemoveDefault.tsx
@@ -18,10 +18,12 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartDeliveryAddressesRemoveFunction = (
+export type CartDeliveryAddressesRemoveFunction<
+  TCart = CartQueryDataReturn['cart'],
+> = (
   addressIds: Array<Scalars['ID']['input']> | Array<string>,
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /**
  * Removes delivery addresses from the cart.
@@ -40,9 +42,9 @@ export type CartDeliveryAddressesRemoveFunction = (
  * { someOptionalParam: 'value' });
  * @publicDocs
  */
-export function cartDeliveryAddressesRemoveDefault(
-  options: CartQueryOptions,
-): CartDeliveryAddressesRemoveFunction {
+export function cartDeliveryAddressesRemoveDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartDeliveryAddressesRemoveFunction<TCart> {
   return async (
     addressIds: Array<Scalars['ID']['input']> | string[],
     optionalParams,
@@ -50,7 +52,7 @@ export function cartDeliveryAddressesRemoveDefault(
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartDeliveryAddressesRemove, errors} =
       await options.storefront.mutate<{
-        cartDeliveryAddressesRemove: CartQueryData;
+        cartDeliveryAddressesRemove: CartQueryData<TCart>;
         errors: StorefrontApiErrors;
       }>(
         CART_DELIVERY_ADDRESSES_REMOVE_MUTATION(options.cartFragment, {

--- a/packages/hydrogen/src/cart/queries/cartDeliveryAddressesReplaceDefault.tsx
+++ b/packages/hydrogen/src/cart/queries/cartDeliveryAddressesReplaceDefault.tsx
@@ -12,10 +12,12 @@ import type {
   CartQueryOptions,
 } from './cart-types';
 
-export type CartDeliveryAddressesReplaceFunction = (
+export type CartDeliveryAddressesReplaceFunction<
+  TCart = CartQueryDataReturn['cart'],
+> = (
   addresses: Array<CartSelectableAddressInput>,
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /**
  * Replaces all delivery addresses on the cart.
@@ -43,16 +45,16 @@ export type CartDeliveryAddressesReplaceFunction = (
  * );
  * @publicDocs
  */
-export function cartDeliveryAddressesReplaceDefault(
-  options: CartQueryOptions,
-): CartDeliveryAddressesReplaceFunction {
+export function cartDeliveryAddressesReplaceDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartDeliveryAddressesReplaceFunction<TCart> {
   return async (
     addresses: Array<CartSelectableAddressInput>,
     optionalParams,
   ) => {
     const {cartDeliveryAddressesReplace, errors} =
       await options.storefront.mutate<{
-        cartDeliveryAddressesReplace: CartQueryData;
+        cartDeliveryAddressesReplace: CartQueryData<TCart>;
         errors: StorefrontApiErrors;
       }>(CART_DELIVERY_ADDRESSES_REPLACE_MUTATION(options.cartFragment), {
         variables: {

--- a/packages/hydrogen/src/cart/queries/cartDeliveryAddressesUpdateDefault.tsx
+++ b/packages/hydrogen/src/cart/queries/cartDeliveryAddressesUpdateDefault.tsx
@@ -18,10 +18,12 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartDeliveryAddressesUpdateFunction = (
+export type CartDeliveryAddressesUpdateFunction<
+  TCart = CartQueryDataReturn['cart'],
+> = (
   addresses: Array<CartSelectableAddressUpdateInput>,
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /**
  * Updates delivery addresses in the cart.
@@ -62,9 +64,9 @@ export type CartDeliveryAddressesUpdateFunction = (
   ],{ someOptionalParam: 'value' });
  * @publicDocs
  */
-export function cartDeliveryAddressesUpdateDefault(
-  options: CartQueryOptions,
-): CartDeliveryAddressesUpdateFunction {
+export function cartDeliveryAddressesUpdateDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartDeliveryAddressesUpdateFunction<TCart> {
   return async (
     addresses: Array<CartSelectableAddressUpdateInput>,
     optionalParams,
@@ -72,7 +74,7 @@ export function cartDeliveryAddressesUpdateDefault(
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartDeliveryAddressesUpdate, errors} =
       await options.storefront.mutate<{
-        cartDeliveryAddressesUpdate: CartQueryData;
+        cartDeliveryAddressesUpdate: CartQueryData<TCart>;
         errors: StorefrontApiErrors;
       }>(
         CART_DELIVERY_ADDRESSES_UPDATE_MUTATION(options.cartFragment, {

--- a/packages/hydrogen/src/cart/queries/cartDiscountCodesUpdateDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartDiscountCodesUpdateDefault.ts
@@ -17,15 +17,17 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartDiscountCodesUpdateFunction = (
+export type CartDiscountCodesUpdateFunction<
+  TCart = CartQueryDataReturn['cart'],
+> = (
   discountCodes: string[],
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartDiscountCodesUpdateDefault(
-  options: CartQueryOptions,
-): CartDiscountCodesUpdateFunction {
+export function cartDiscountCodesUpdateDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartDiscountCodesUpdateFunction<TCart> {
   return async (discountCodes, optionalParams) => {
     // Ensure the discount codes are unique
     const uniqueCodes = discountCodes.filter((value, index, array) => {
@@ -34,7 +36,7 @@ export function cartDiscountCodesUpdateDefault(
 
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartDiscountCodesUpdate, errors} = await options.storefront.mutate<{
-      cartDiscountCodesUpdate: CartQueryData;
+      cartDiscountCodesUpdate: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(
       CART_DISCOUNT_CODE_UPDATE_MUTATION(options.cartFragment, {

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.ts
@@ -89,6 +89,7 @@ export function cartGetDefault<TCart = Cart, TExtraVariables = {}>({
     if (
       isCustomerLoggedIn &&
       cart &&
+      typeof cart === 'object' &&
       'checkoutUrl' in cart &&
       typeof cart.checkoutUrl === 'string'
     ) {

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.ts
@@ -14,7 +14,7 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-type CartGetProps = {
+export type CartGetProps<TExtraVariables = {}> = {
   /**
    * The cart ID.
    * @default cart.getCartId();
@@ -49,11 +49,11 @@ type CartGetProps = {
    * When provided, consent is encoded into the cart's checkoutUrl via the _cs parameter.
    */
   visitorConsent?: VisitorConsent;
-};
+} & TExtraVariables;
 
-export type CartGetFunction = (
-  cartInput?: CartGetProps,
-) => Promise<CartReturn | null>;
+export type CartGetFunction<TCart = Cart, TExtraVariables = {}> = (
+  cartInput?: CartGetProps<TExtraVariables>,
+) => Promise<CartReturn<TCart> | null>;
 
 type CartGetOptions = CartQueryOptions & {
   /**
@@ -63,13 +63,13 @@ type CartGetOptions = CartQueryOptions & {
 };
 
 /** @publicDocs */
-export function cartGetDefault({
+export function cartGetDefault<TCart = Cart, TExtraVariables = {}>({
   storefront,
   customerAccount,
   getCartId,
   cartFragment,
-}: CartGetOptions): CartGetFunction {
-  return async (cartInput?: CartGetProps) => {
+}: CartGetOptions): CartGetFunction<TCart, TExtraVariables> {
+  return async (cartInput?: CartGetProps<TExtraVariables>) => {
     const cartId = cartInput?.cartId ?? getCartId();
 
     if (!cartId) return null;
@@ -77,7 +77,7 @@ export function cartGetDefault({
     const includeVisitorConsent = shouldIncludeVisitorConsent(cartInput);
     const [isCustomerLoggedIn, {cart, errors}] = await Promise.all([
       customerAccount ? customerAccount.isLoggedIn() : false,
-      storefront.query<{cart: Cart | null}>(
+      storefront.query<{cart: TCart | null}>(
         CART_QUERY(cartFragment, {includeVisitorConsent}),
         {
           variables: {cartId, ...cartInput},
@@ -86,10 +86,15 @@ export function cartGetDefault({
       ),
     ]);
 
-    if (isCustomerLoggedIn && cart?.checkoutUrl) {
-      const finalCheckoutUrl = new URL(cart.checkoutUrl);
+    const cartWithCheckoutUrl = cart as
+      | (TCart & {checkoutUrl?: string})
+      | null
+      | undefined;
+
+    if (isCustomerLoggedIn && cartWithCheckoutUrl?.checkoutUrl) {
+      const finalCheckoutUrl = new URL(cartWithCheckoutUrl.checkoutUrl);
       finalCheckoutUrl.searchParams.set('logged_in', 'true');
-      cart.checkoutUrl = finalCheckoutUrl.toString();
+      cartWithCheckoutUrl.checkoutUrl = finalCheckoutUrl.toString();
     }
 
     return cart || errors ? formatAPIResult(cart, errors) : null;

--- a/packages/hydrogen/src/cart/queries/cartGetDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGetDefault.ts
@@ -86,15 +86,15 @@ export function cartGetDefault<TCart = Cart, TExtraVariables = {}>({
       ),
     ]);
 
-    const cartWithCheckoutUrl = cart as
-      | (TCart & {checkoutUrl?: string})
-      | null
-      | undefined;
-
-    if (isCustomerLoggedIn && cartWithCheckoutUrl?.checkoutUrl) {
-      const finalCheckoutUrl = new URL(cartWithCheckoutUrl.checkoutUrl);
+    if (
+      isCustomerLoggedIn &&
+      cart &&
+      'checkoutUrl' in cart &&
+      typeof cart.checkoutUrl === 'string'
+    ) {
+      const finalCheckoutUrl = new URL(cart.checkoutUrl);
       finalCheckoutUrl.searchParams.set('logged_in', 'true');
-      cartWithCheckoutUrl.checkoutUrl = finalCheckoutUrl.toString();
+      Object.assign(cart, {checkoutUrl: finalCheckoutUrl.toString()});
     }
 
     return cart || errors ? formatAPIResult(cart, errors) : null;

--- a/packages/hydrogen/src/cart/queries/cartGiftCardCodeUpdateDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGiftCardCodeUpdateDefault.ts
@@ -17,10 +17,12 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartGiftCardCodesUpdateFunction = (
+export type CartGiftCardCodesUpdateFunction<
+  TCart = CartQueryDataReturn['cart'],
+> = (
   giftCardCodes: string[],
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /**
  * Updates (replaces) gift card codes in the cart.
@@ -35,13 +37,13 @@ export type CartGiftCardCodesUpdateFunction = (
  * await updateGiftCardCodes(['SUMMER2025', 'WELCOME10']);
  * @publicDocs
  */
-export function cartGiftCardCodesUpdateDefault(
-  options: CartQueryOptions,
-): CartGiftCardCodesUpdateFunction {
+export function cartGiftCardCodesUpdateDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartGiftCardCodesUpdateFunction<TCart> {
   return async (giftCardCodes, optionalParams) => {
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartGiftCardCodesUpdate, errors} = await options.storefront.mutate<{
-      cartGiftCardCodesUpdate: CartQueryData;
+      cartGiftCardCodesUpdate: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(
       CART_GIFT_CARD_CODE_UPDATE_MUTATION(options.cartFragment, {

--- a/packages/hydrogen/src/cart/queries/cartGiftCardCodesAddDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGiftCardCodesAddDefault.ts
@@ -11,10 +11,11 @@ import type {
   CartQueryOptions,
 } from './cart-types';
 
-export type CartGiftCardCodesAddFunction = (
-  giftCardCodes: string[],
-  optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+export type CartGiftCardCodesAddFunction<TCart = CartQueryDataReturn['cart']> =
+  (
+    giftCardCodes: string[],
+    optionalParams?: CartOptionalInput,
+  ) => Promise<CartQueryDataReturn<TCart>>;
 
 /**
  * Adds gift card codes to the cart without replacing existing ones.
@@ -30,12 +31,12 @@ export type CartGiftCardCodesAddFunction = (
  * await addGiftCardCodes(['SUMMER2025', 'WELCOME10']);
  * @publicDocs
  */
-export function cartGiftCardCodesAddDefault(
-  options: CartQueryOptions,
-): CartGiftCardCodesAddFunction {
+export function cartGiftCardCodesAddDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartGiftCardCodesAddFunction<TCart> {
   return async (giftCardCodes, optionalParams) => {
     const {cartGiftCardCodesAdd, errors} = await options.storefront.mutate<{
-      cartGiftCardCodesAdd: CartQueryData;
+      cartGiftCardCodesAdd: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(CART_GIFT_CARD_CODES_ADD_MUTATION(options.cartFragment), {
       variables: {

--- a/packages/hydrogen/src/cart/queries/cartGiftCardCodesRemoveDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartGiftCardCodesRemoveDefault.ts
@@ -17,19 +17,21 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartGiftCardCodesRemoveFunction = (
+export type CartGiftCardCodesRemoveFunction<
+  TCart = CartQueryDataReturn['cart'],
+> = (
   appliedGiftCardIds: string[],
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartGiftCardCodesRemoveDefault(
-  options: CartQueryOptions,
-): CartGiftCardCodesRemoveFunction {
+export function cartGiftCardCodesRemoveDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartGiftCardCodesRemoveFunction<TCart> {
   return async (appliedGiftCardIds, optionalParams) => {
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartGiftCardCodesRemove, errors} = await options.storefront.mutate<{
-      cartGiftCardCodesRemove: CartQueryData;
+      cartGiftCardCodesRemove: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(
       CART_GIFT_CARD_CODES_REMOVE_MUTATION(options.cartFragment, {

--- a/packages/hydrogen/src/cart/queries/cartLinesAddDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartLinesAddDefault.ts
@@ -18,19 +18,19 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartLinesAddFunction = (
+export type CartLinesAddFunction<TCart = CartQueryDataReturn['cart']> = (
   lines: Array<CartLineInput>,
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartLinesAddDefault(
+export function cartLinesAddDefault<TCart = CartQueryDataReturn['cart']>(
   options: CartQueryOptions,
-): CartLinesAddFunction {
+): CartLinesAddFunction<TCart> {
   return async (lines, optionalParams) => {
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartLinesAdd, errors} = await options.storefront.mutate<{
-      cartLinesAdd: CartQueryData;
+      cartLinesAdd: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(CART_LINES_ADD_MUTATION(options.cartFragment, {includeVisitorConsent}), {
       variables: {

--- a/packages/hydrogen/src/cart/queries/cartLinesRemoveDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartLinesRemoveDefault.ts
@@ -18,21 +18,21 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartLinesRemoveFunction = (
+export type CartLinesRemoveFunction<TCart = CartQueryDataReturn['cart']> = (
   lineIds: string[],
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartLinesRemoveDefault(
+export function cartLinesRemoveDefault<TCart = CartQueryDataReturn['cart']>(
   options: CartQueryOptions,
-): CartLinesRemoveFunction {
+): CartLinesRemoveFunction<TCart> {
   return async (lineIds, optionalParams) => {
     throwIfLinesAreOptimistic('removeLines', lineIds);
 
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartLinesRemove, errors} = await options.storefront.mutate<{
-      cartLinesRemove: CartQueryData;
+      cartLinesRemove: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(
       CART_LINES_REMOVE_MUTATION(options.cartFragment, {includeVisitorConsent}),

--- a/packages/hydrogen/src/cart/queries/cartLinesUpdateDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartLinesUpdateDefault.ts
@@ -19,21 +19,21 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartLinesUpdateFunction = (
+export type CartLinesUpdateFunction<TCart = CartQueryDataReturn['cart']> = (
   lines: CartLineUpdateInput[],
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartLinesUpdateDefault(
+export function cartLinesUpdateDefault<TCart = CartQueryDataReturn['cart']>(
   options: CartQueryOptions,
-): CartLinesUpdateFunction {
+): CartLinesUpdateFunction<TCart> {
   return async (lines, optionalParams) => {
     throwIfLinesAreOptimistic('updateLines', lines);
 
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartLinesUpdate, errors} = await options.storefront.mutate<{
-      cartLinesUpdate: CartQueryData;
+      cartLinesUpdate: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(
       CART_LINES_UPDATE_MUTATION(options.cartFragment, {includeVisitorConsent}),

--- a/packages/hydrogen/src/cart/queries/cartNoteUpdateDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartNoteUpdateDefault.ts
@@ -17,19 +17,19 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartNoteUpdateFunction = (
+export type CartNoteUpdateFunction<TCart = CartQueryDataReturn['cart']> = (
   note: string,
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartNoteUpdateDefault(
+export function cartNoteUpdateDefault<TCart = CartQueryDataReturn['cart']>(
   options: CartQueryOptions,
-): CartNoteUpdateFunction {
+): CartNoteUpdateFunction<TCart> {
   return async (note, optionalParams) => {
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartNoteUpdate, errors} = await options.storefront.mutate<{
-      cartNoteUpdate: CartQueryData;
+      cartNoteUpdate: CartQueryData<TCart>;
       errors: StorefrontApiErrors;
     }>(
       CART_NOTE_UPDATE_MUTATION(options.cartFragment, {includeVisitorConsent}),

--- a/packages/hydrogen/src/cart/queries/cartSelectedDeliveryOptionsUpdateDefault.ts
+++ b/packages/hydrogen/src/cart/queries/cartSelectedDeliveryOptionsUpdateDefault.ts
@@ -18,20 +18,22 @@ import {
   shouldIncludeVisitorConsent,
 } from './cart-query-helpers';
 
-export type CartSelectedDeliveryOptionsUpdateFunction = (
+export type CartSelectedDeliveryOptionsUpdateFunction<
+  TCart = CartQueryDataReturn['cart'],
+> = (
   selectedDeliveryOptions: CartSelectedDeliveryOptionInput[],
   optionalParams?: CartOptionalInput,
-) => Promise<CartQueryDataReturn>;
+) => Promise<CartQueryDataReturn<TCart>>;
 
 /** @publicDocs */
-export function cartSelectedDeliveryOptionsUpdateDefault(
-  options: CartQueryOptions,
-): CartSelectedDeliveryOptionsUpdateFunction {
+export function cartSelectedDeliveryOptionsUpdateDefault<
+  TCart = CartQueryDataReturn['cart'],
+>(options: CartQueryOptions): CartSelectedDeliveryOptionsUpdateFunction<TCart> {
   return async (selectedDeliveryOptions, optionalParams) => {
     const includeVisitorConsent = shouldIncludeVisitorConsent(optionalParams);
     const {cartSelectedDeliveryOptionsUpdate, errors} =
       await options.storefront.mutate<{
-        cartSelectedDeliveryOptionsUpdate: CartQueryData;
+        cartSelectedDeliveryOptionsUpdate: CartQueryData<TCart>;
         errors: StorefrontApiErrors;
       }>(
         CART_SELECTED_DELIVERY_OPTIONS_UPDATE_MUTATION(options.cartFragment, {

--- a/packages/hydrogen/src/cart/types.augmentation.test.ts
+++ b/packages/hydrogen/src/cart/types.augmentation.test.ts
@@ -1,0 +1,46 @@
+import {describe, it, expectTypeOf} from 'vitest';
+import type {Cart} from '@shopify/hydrogen-react/storefront-api-types';
+import type {HydrogenCart} from './createCartHandler';
+import type {CartReturn, CartQueryDataReturn} from './queries/cart-types';
+
+declare global {
+  interface HydrogenCustomCartFragment {
+    giftMessage?: {key: string; value: string} | null;
+  }
+}
+
+describe('HydrogenCustomCartFragment global augmentation', () => {
+  it('default HydrogenCart picks up augmented fields on get()', () => {
+    type DefaultCart = HydrogenCart;
+    type GetResult = Awaited<ReturnType<DefaultCart['get']>>;
+
+    expectTypeOf<NonNullable<GetResult>>().toHaveProperty('giftMessage');
+    expectTypeOf<NonNullable<GetResult>>().toHaveProperty('id');
+    expectTypeOf<NonNullable<GetResult>>().toHaveProperty('checkoutUrl');
+  });
+
+  it('default HydrogenCart picks up augmented fields on create()', () => {
+    type DefaultCart = HydrogenCart;
+    type CreateResult = Awaited<ReturnType<DefaultCart['create']>>;
+
+    expectTypeOf<CreateResult['cart']>().toHaveProperty('giftMessage');
+    expectTypeOf<CreateResult['cart']>().toHaveProperty('id');
+  });
+
+  it('default HydrogenCart picks up augmented fields on addLines()', () => {
+    type DefaultCart = HydrogenCart;
+    type AddLinesResult = Awaited<ReturnType<DefaultCart['addLines']>>;
+
+    expectTypeOf<AddLinesResult['cart']>().toHaveProperty('giftMessage');
+    expectTypeOf<AddLinesResult['cart']>().toHaveProperty('id');
+  });
+
+  it('augmented fields coexist with standard Cart fields', () => {
+    type DefaultCart = HydrogenCart;
+    type GetResult = NonNullable<Awaited<ReturnType<DefaultCart['get']>>>;
+
+    expectTypeOf<GetResult>().toMatchTypeOf<
+      Cart & {giftMessage?: {key: string; value: string} | null}
+    >();
+  });
+});

--- a/packages/hydrogen/src/createHydrogenContext.ts
+++ b/packages/hydrogen/src/createHydrogenContext.ts
@@ -235,7 +235,9 @@ export function createHydrogenContext<
     setCartId: cartOptions.setId || cartSetIdDefault(),
     cartQueryFragment: cartOptions.queryFragment,
     cartMutateFragment: cartOptions.mutateFragment,
-    customMethods: cartOptions.customMethods,
+    ...(cartOptions.customMethods && {
+      customMethods: cartOptions.customMethods,
+    }),
     buyerIdentity,
 
     // defaults

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -57,7 +57,11 @@ export {cartAttributesUpdateDefault} from './cart/queries/cartAttributesUpdateDe
 export {cartBuyerIdentityUpdateDefault} from './cart/queries/cartBuyerIdentityUpdateDefault';
 export {cartCreateDefault} from './cart/queries/cartCreateDefault';
 export {cartDiscountCodesUpdateDefault} from './cart/queries/cartDiscountCodesUpdateDefault';
-export {cartGetDefault} from './cart/queries/cartGetDefault';
+export {
+  cartGetDefault,
+  type CartGetFunction,
+  type CartGetProps,
+} from './cart/queries/cartGetDefault';
 export {cartGiftCardCodesAddDefault} from './cart/queries/cartGiftCardCodesAddDefault';
 export {cartGiftCardCodesRemoveDefault} from './cart/queries/cartGiftCardCodesRemoveDefault';
 export {cartGiftCardCodesUpdateDefault} from './cart/queries/cartGiftCardCodeUpdateDefault';

--- a/packages/hydrogen/src/index.ts
+++ b/packages/hydrogen/src/index.ts
@@ -57,11 +57,7 @@ export {cartAttributesUpdateDefault} from './cart/queries/cartAttributesUpdateDe
 export {cartBuyerIdentityUpdateDefault} from './cart/queries/cartBuyerIdentityUpdateDefault';
 export {cartCreateDefault} from './cart/queries/cartCreateDefault';
 export {cartDiscountCodesUpdateDefault} from './cart/queries/cartDiscountCodesUpdateDefault';
-export {
-  cartGetDefault,
-  type CartGetFunction,
-  type CartGetProps,
-} from './cart/queries/cartGetDefault';
+export {cartGetDefault} from './cart/queries/cartGetDefault';
 export {cartGiftCardCodesAddDefault} from './cart/queries/cartGiftCardCodesAddDefault';
 export {cartGiftCardCodesRemoveDefault} from './cart/queries/cartGiftCardCodesRemoveDefault';
 export {cartGiftCardCodesUpdateDefault} from './cart/queries/cartGiftCardCodeUpdateDefault';

--- a/packages/hydrogen/src/types.test.ts
+++ b/packages/hydrogen/src/types.test.ts
@@ -8,6 +8,8 @@ import type {RouterContextProvider} from 'react-router';
 import type {Storefront} from './storefront';
 import type {CustomerAccount} from './customer/types';
 import type {HydrogenCart} from './cart/createCartHandler';
+import type {CartReturn} from './cart/queries/cart-types';
+import type {Cart} from '@shopify/hydrogen-react/storefront-api-types';
 
 describe('Type augmentations', () => {
   describe('HydrogenRouterContextProvider', () => {
@@ -146,6 +148,36 @@ describe('Type augmentations', () => {
       // Since this is a type-level test, we just verify the import compiles
       type TestImport = import('./index').HydrogenRouterContextProvider;
       expectTypeOf<TestImport>().not.toBeNever();
+    });
+  });
+
+  describe('HydrogenCustomCartFragment', () => {
+    it('should default to empty object so HydrogenCart collapses to Cart', () => {
+      // When HydrogenCustomCartFragment is not augmented (empty {}),
+      // {} & Cart collapses to Cart — the default behaviour is unchanged.
+      type DefaultCart = HydrogenCart;
+      type CartWithExplicitDefault = HydrogenCart<Cart>;
+
+      // Both should have the same cart-related methods
+      expectTypeOf<DefaultCart>().toHaveProperty('get');
+      expectTypeOf<DefaultCart>().toHaveProperty('addLines');
+      expectTypeOf<CartWithExplicitDefault>().toHaveProperty('get');
+      expectTypeOf<CartWithExplicitDefault>().toHaveProperty('addLines');
+    });
+
+    it('should allow augmentation to add custom fields to cart return types', () => {
+      // Simulates what happens when a consumer augments
+      // HydrogenCustomCartFragment with their codegen'd fragment type
+      type CustomFragment = Cart & {
+        giftMessage?: {key: string; value: string} | null;
+      };
+      type CustomCart = HydrogenCart<CustomFragment>;
+
+      // get() should return CartReturn<CustomFragment> | null
+      type GetResult = Awaited<ReturnType<CustomCart['get']>>;
+      expectTypeOf<NonNullable<GetResult>>().toHaveProperty('giftMessage');
+      expectTypeOf<NonNullable<GetResult>>().toHaveProperty('id');
+      expectTypeOf<NonNullable<GetResult>>().toHaveProperty('checkoutUrl');
     });
   });
 

--- a/templates/skeleton/app/lib/context.ts
+++ b/templates/skeleton/app/lib/context.ts
@@ -1,6 +1,7 @@
 import {createHydrogenContext} from '@shopify/hydrogen';
 import {AppSession} from '~/lib/session';
 import {CART_QUERY_FRAGMENT} from '~/lib/fragments';
+import type {CartApiQueryFragment} from 'storefrontapi.generated';
 
 // Define the additional context object
 const additionalContext = {
@@ -16,6 +17,10 @@ type AdditionalContextType = typeof additionalContext;
 
 declare global {
   interface HydrogenAdditionalContext extends AdditionalContextType {}
+
+  // Augment HydrogenCustomCartFragment with the codegen'd cart fragment type so
+  // that context.cart.get() and all cart mutations return the extended cart type.
+  interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Merchants who customize their cart GraphQL fragment (via `cartQueryFragment` / `cartMutateFragment`) couldn't get TypeScript to recognize the extra fields they added. They'd fetch metafields, custom attributes, or other additional data at runtime, but the return type was always the base `Cart` — so accessing those fields gave a TypeScript error even though the data was there. Attempts to address #2440

### WHAT is this pull request doing?

**Adds a `TCart` generic to `createCartHandler` and all cart query functions** so the return type of every cart operation reflects the actual shape of the cart fragment being used.

Also introduces a new **`HydrogenCustomCartFragment` augmentable global interface** (in `react-router.d.ts`) that threads the type through to `context.cart` in route files without requiring any changes to how `createHydrogenContext` is called. When empty (the default), behaviour is identical to before. When extended with a codegen'd fragment type, all cart methods automatically return the extended type.

### Example of what a dev might do
Here's that section rewritten with an inline copyable example:

**1. Add the field to your cart fragment in `app/lib/fragments.ts`:**
```graphql
fragment CartApiQuery on Cart {
  # ...existing fields...
  foobar: metafields(identifiers: [{namespace: "custom", key: "gift_message"}]) {
    key
    value
  }
}
```

**2. Run codegen to regenerate your types:**
```bash
npm run codegen
```

**3. Augment `HydrogenCustomCartFragment` in `app/lib/context.ts`:**
```typescript
import type {CartApiQueryFragment} from 'storefrontapi.generated';

declare global {
  interface HydrogenAdditionalContext extends AdditionalContextType {}

  // Add this — wires your codegen'd fragment type into context.cart
  interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
}
```

All cart methods in every route file now reflect the extended type:

```typescript
// In any route loader or action:
const cart = await context.cart.get();

// Before (without HydrogenCustomCartFragment augmentation):
cart?.foobar // ❌ Property 'metafields' does not exist on type 'Cart'

// After:
cart?.foobar // ✅ Array<Maybe<{ key: string; value: string }>> | null
```

### HOW to test your changes?

1. In the skeleton template
2. In `app/lib/fragments.ts`, add a field to `CART_QUERY_FRAGMENT` that doesn't exist on the base `Cart` type (e.g. `foobar: metafields`)
3. Run `pnpm run codegen` — the generated `CartApiQueryFragment` in `storefrontapi.generated.d.ts` will include the new field
4. In `app/lib/context.ts`, add inside the existing `declare global` block:
   ```typescript
   interface HydrogenCustomCartFragment extends CartApiQueryFragment {}
   ```
5. In any route loader, access `context.cart.get()` and verify TypeScript now autocompletes and accepts the new field
6. Remove the augmentation and verify TypeScript no longer knows about the field (confirms the default is unchanged)

To verify no regression for existing users: skip step 4 entirely and confirm `context.cart` still types correctly with the base `Cart` fields.

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation