### PR TITLE
Lower perkit sample rate

### DIFF
--- a/.changeset/fuzzy-laws-say.md
+++ b/.changeset/fuzzy-laws-say.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Reduce PerfKit resource timing sampling rate from 100 to 10.

--- a/packages/hydrogen/src/analytics-manager/PerfKit.tsx
+++ b/packages/hydrogen/src/analytics-manager/PerfKit.tsx
@@ -29,7 +29,7 @@ export function PerfKit({shop}: {shop: ShopAnalytics}) {
       'data-storefront-id': shop.hydrogenSubchannelId,
       'data-monorail-region': 'global',
       'data-spa-mode': 'true',
-      'data-resource-timing-sampling-rate': '100',
+      'data-resource-timing-sampling-rate': '10',
     },
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

PerfKit currently collects resource timing data at a higher sampling rate than needed for Hydrogen storefronts. Reducing the sample rate lowers the amount of performance telemetry collected while preserving PerfKit coverage.

### WHAT is this pull request doing?

Updates the PerfKit script configuration to reduce `data-resource-timing-sampling-rate` from `100` to `10`.

Also adds a patch changeset for `@shopify/hydrogen`.

### HOW to test your changes?

No automated tests were added. Existing tests do not currently validate the PerfKit data sampling rate.

To verify manually, inspect the PerfKit script attributes in `packages/hydrogen/src/analytics-manager/PerfKit.tsx` and confirm `data-resource-timing-sampling-rate` is set to `10`.

<img width="792" height="63" alt="image" src="https://github.com/user-attachments/assets/6a03dc35-0c6a-49f5-ac73-f76b0c47b0ed" />


#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation