### PR TITLE
Fix package manager detection in `hydrogen upgrade` for monorepos

### DIFF
--- a/.changeset/upgrade-monorepo-package-manager.md
+++ b/.changeset/upgrade-monorepo-package-manager.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix `hydrogen upgrade` package manager detection in monorepos. The command now searches parent directories for a lockfile (such as a pnpm workspace root), so upgrades run with your workspace's package manager instead of falling back to npm.

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -38,13 +38,13 @@ const TEST_VERSION_DEPENDENCY_UPGRADE = '9999.99.99';
 const TEST_VERSION_DEV_DEPENDENCY_UPGRADE = '9999.99.98';
 
 vi.mock('@shopify/cli-kit/node/session');
-vi.mock('@shopify/cli-kit/node/node-package-manager', async () => {
+vi.mock('../../lib/package-managers.js', async () => {
   const original = await vi.importActual<
-    typeof import('@shopify/cli-kit/node/node-package-manager')
-  >('@shopify/cli-kit/node/node-package-manager');
+    typeof import('../../lib/package-managers.js')
+  >('../../lib/package-managers.js');
   return {
     ...original,
-    getPackageManager: vi.fn(() => Promise.resolve('pnpm')),
+    findPackageManagerByLockfile: vi.fn(() => Promise.resolve('pnpm')),
   };
 });
 

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -1,7 +1,7 @@
 import {createRequire} from 'node:module';
 import {tmpdir} from 'node:os';
-import {mkdtemp, readFile, rm} from 'node:fs/promises';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {mkdir, mkdtemp, readFile, rm} from 'node:fs/promises';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {writeFile, fileExists} from '@shopify/cli-kit/node/fs';
 import {joinPath} from '@shopify/cli-kit/node/path';
 import {
@@ -13,9 +13,11 @@ import {
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output';
 import {type PackageJson} from '@shopify/cli-kit/node/node-package-manager';
 import {exec} from '@shopify/cli-kit/node/system';
+import * as system from '@shopify/cli-kit/node/system';
 import {
   buildUpgradeCommandArgs,
   displayConfirmation,
+  displayUpgradeSummary,
   generateUpgradeInstructionsFile,
   getAbsoluteVersion,
   getAvailableUpgrades,
@@ -31,6 +33,7 @@ import {
   getChangelog,
   displayDevUpgradeNotice,
 } from './upgrade.js';
+import * as packageManagers from '../../lib/package-managers.js';
 import {getSkeletonSourceDir} from '../../lib/build.js';
 
 // Test version numbers used to avoid conflicts with duplicate changelog versions
@@ -45,6 +48,19 @@ vi.mock('../../lib/package-managers.js', async () => {
   return {
     ...original,
     findPackageManagerByLockfile: vi.fn(() => Promise.resolve('pnpm')),
+  };
+});
+
+vi.mock('@shopify/cli-kit/node/system', async () => {
+  const original = await vi.importActual<
+    typeof import('@shopify/cli-kit/node/system')
+  >('@shopify/cli-kit/node/system');
+
+  return {
+    ...original,
+    // Delegates to the real exec by default so helpers that drive git keep
+    // working; individual tests override it to capture command invocations.
+    exec: vi.fn(original.exec),
   };
 });
 
@@ -2008,6 +2024,130 @@ describe('upgrade', async () => {
       });
 
       expect(args).toEqual(result);
+    });
+  });
+
+  // Regression coverage for monorepo workspaces, where the lockfile lives at
+  // the workspace root rather than in the app directory. These tests use the
+  // real findPackageManagerByLockfile (not the suite-wide 'pnpm' stub) and
+  // execute the command's task/summary paths end-to-end, so they fail if the
+  // upgrade command stops feeding ancestor-lockfile detection into the
+  // install/remove tasks or the undo instructions.
+  describe('monorepo package manager detection', () => {
+    afterEach(async () => {
+      // Restore the suite-wide stubs for the rest of the file, since the
+      // module-level mock implementations persist across tests.
+      vi.mocked(
+        packageManagers.findPackageManagerByLockfile,
+      ).mockImplementation(() => Promise.resolve('pnpm'));
+      const actualSystem = await vi.importActual<
+        typeof import('@shopify/cli-kit/node/system')
+      >('@shopify/cli-kit/node/system');
+      vi.mocked(system.exec).mockImplementation(actualSystem.exec);
+    });
+
+    async function useRealLockfileDetection() {
+      const {findPackageManagerByLockfile} = await vi.importActual<
+        typeof import('../../lib/package-managers.js')
+      >('../../lib/package-managers.js');
+      vi.mocked(
+        packageManagers.findPackageManagerByLockfile,
+      ).mockImplementation(findPackageManagerByLockfile);
+    }
+
+    it('runs the install and remove tasks with the workspace package manager from an ancestor lockfile', async () => {
+      await useRealLockfileDetection();
+
+      const {releases} = await getChangelog();
+      const selectedRelease = releases.find(
+        (release) => release.version === '2023.10.0',
+      ) as (typeof releases)[0];
+
+      const currentDependencies = {
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON.dependencies,
+        ...OUTDATED_HYDROGEN_PACKAGE_JSON.devDependencies,
+      };
+
+      await inTemporaryDirectory(async (workspaceRoot) => {
+        // Monorepo shape: the only lockfile is at the workspace root and the
+        // Hydrogen app lives in a nested directory with no lockfile of its own.
+        await writeFile(joinPath(workspaceRoot, 'pnpm-lock.yaml'), '');
+        const appPath = joinPath(workspaceRoot, 'apps', 'storefront');
+        await mkdir(appPath, {recursive: true});
+
+        // Capture the package-manager invocation without running a real install.
+        const execSpy = vi
+          .mocked(system.exec)
+          .mockResolvedValue(undefined as never);
+
+        await upgradeNodeModules({
+          appPath,
+          selectedRelease,
+          currentDependencies,
+          // present in currentDependencies, so the removal task is created
+          cumulativeRemoveDependencies: ['@remix-run/react'],
+          cumulativeRemoveDevDependencies: [],
+        });
+
+        // renderTasks is stubbed to a no-op, so run the task callbacks directly.
+        const tasks = vi.mocked(renderTasks).mock.calls.at(-1)?.[0] as Array<{
+          title: string;
+          task: () => Promise<void>;
+        }>;
+
+        const removalTask = tasks.find(
+          (task) => task.title === 'Removing deprecated dependencies',
+        );
+        const upgradeTask = tasks.find(
+          (task) => task.title === 'Upgrading dependencies',
+        );
+
+        await removalTask?.task();
+        await upgradeTask?.task();
+
+        expect(execSpy).toHaveBeenCalledWith(
+          'pnpm',
+          expect.arrayContaining(['remove', '@remix-run/react']),
+          expect.objectContaining({cwd: appPath}),
+        );
+        expect(execSpy).toHaveBeenCalledWith(
+          'pnpm',
+          expect.arrayContaining(['add']),
+          expect.objectContaining({cwd: appPath}),
+        );
+        // Never falls back to npm + --legacy-peer-deps for a pnpm workspace.
+        expect(execSpy).not.toHaveBeenCalledWith(
+          'npm',
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+    });
+
+    it('renders the workspace package manager in the undo instructions for an ancestor lockfile', async () => {
+      await useRealLockfileDetection();
+
+      const {releases} = await getChangelog();
+      const selectedRelease = releases.find(
+        (release) => release.version === '2023.10.0',
+      ) as (typeof releases)[0];
+
+      await inTemporaryDirectory(async (workspaceRoot) => {
+        await writeFile(joinPath(workspaceRoot, 'pnpm-lock.yaml'), '');
+        const appPath = joinPath(workspaceRoot, 'apps', 'storefront');
+        await mkdir(appPath, {recursive: true});
+
+        await displayUpgradeSummary({
+          appPath,
+          currentVersion: '2023.1.6',
+          selectedRelease,
+        });
+
+        const output = outputMock.info();
+        expect(output).toContain('Undo these upgrades?');
+        expect(output).toContain('&& pnpm i`');
+        expect(output).not.toContain('&& npm i`');
+      });
     });
   });
 });

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -23,9 +23,9 @@ import {
 } from '@shopify/cli-kit/node/fs';
 import {
   getDependencies,
-  getPackageManager,
   type PackageJson,
 } from '@shopify/cli-kit/node/node-package-manager';
+import {findPackageManagerByLockfile} from '../../lib/package-managers.js';
 import {exec} from '@shopify/cli-kit/node/system';
 import {AbortError} from '@shopify/cli-kit/node/error';
 import {dirname, joinPath, resolvePath} from '@shopify/cli-kit/node/path';
@@ -1031,7 +1031,7 @@ export async function upgradeNodeModules({
       task: async () => {
         await uninstallNodeModules({
           directory: appPath,
-          packageManager: await getPackageManager(appPath),
+          packageManager: await findPackageManagerByLockfile(appPath),
           args: depsToRemove,
         });
       },
@@ -1053,7 +1053,7 @@ export async function upgradeNodeModules({
     tasks.push({
       title: `Upgrading dependencies`,
       task: async () => {
-        const packageManager = await getPackageManager(appPath);
+        const packageManager = await findPackageManagerByLockfile(appPath);
         const command =
           packageManager === 'npm'
             ? 'install'
@@ -1299,7 +1299,9 @@ async function displayUpgradeSummary({
     ? `You've upgraded Hydrogen ${selectedPinnedVersion} dependencies`
     : `You've upgraded from ${fromToMsg}`;
 
-  const packageManager = await getPackageManager(appPath);
+  const packageManager = resolvePackageManagerName(
+    await findPackageManagerByLockfile(appPath),
+  );
 
   return renderSuccess({
     headline,

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -1256,7 +1256,7 @@ async function promptUpgradeOptions(
 /**
  * Displays a summary of the upgrade and next steps
  */
-async function displayUpgradeSummary({
+export async function displayUpgradeSummary({
   appPath,
   currentVersion,
   selectedRelease,

--- a/packages/cli/src/lib/package-managers.test.ts
+++ b/packages/cli/src/lib/package-managers.test.ts
@@ -1,0 +1,89 @@
+import {describe, it, expect} from 'vitest';
+import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs';
+import {joinPath} from '@shopify/cli-kit/node/path';
+import {findPackageManagerByLockfile} from './package-managers.js';
+
+describe('findPackageManagerByLockfile()', () => {
+  it('detects a lockfile in the directory itself (single-repo)', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writeFile(joinPath(tmpDir, 'pnpm-lock.yaml'), '');
+
+      await expect(findPackageManagerByLockfile(tmpDir)).resolves.toBe('pnpm');
+    });
+  });
+
+  it('walks up to an ancestor lockfile (monorepo workspace root)', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const appDir = joinPath(tmpDir, 'apps', 'storefront');
+      await mkdir(appDir);
+      await writeFile(joinPath(tmpDir, 'pnpm-lock.yaml'), '');
+
+      await expect(findPackageManagerByLockfile(appDir)).resolves.toBe('pnpm');
+    });
+  });
+
+  it('detects yarn workspaces via an ancestor yarn.lock', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const appDir = joinPath(tmpDir, 'apps', 'storefront');
+      await mkdir(appDir);
+      await writeFile(joinPath(tmpDir, 'yarn.lock'), '');
+
+      await expect(findPackageManagerByLockfile(appDir)).resolves.toBe('yarn');
+    });
+  });
+
+  it('detects bun workspaces via an ancestor bun.lockb', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const appDir = joinPath(tmpDir, 'apps', 'storefront');
+      await mkdir(appDir);
+      await writeFile(joinPath(tmpDir, 'bun.lockb'), '');
+
+      await expect(findPackageManagerByLockfile(appDir)).resolves.toBe('bun');
+    });
+  });
+
+  it('prefers the nearest lockfile (app dir beats ancestor)', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const appDir = joinPath(tmpDir, 'apps', 'storefront');
+      await mkdir(appDir);
+      await writeFile(joinPath(tmpDir, 'pnpm-lock.yaml'), '');
+      await writeFile(joinPath(appDir, 'package-lock.json'), '');
+
+      await expect(findPackageManagerByLockfile(appDir)).resolves.toBe('npm');
+    });
+  });
+
+  it('resolves "unknown" when no lockfile exists anywhere', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // stopAt keeps the walk hermetic against lockfiles above the OS temp dir
+      await expect(
+        findPackageManagerByLockfile(tmpDir, {stopAt: tmpDir}),
+      ).resolves.toBe('unknown');
+    });
+  });
+
+  it('detects bun.lock (text-based alternative lockfile)', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writeFile(joinPath(tmpDir, 'bun.lock'), '');
+
+      await expect(findPackageManagerByLockfile(tmpDir)).resolves.toBe('bun');
+    });
+  });
+
+  it('detects npm-shrinkwrap.json (alternative npm lockfile)', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writeFile(joinPath(tmpDir, 'npm-shrinkwrap.json'), '');
+
+      await expect(findPackageManagerByLockfile(tmpDir)).resolves.toBe('npm');
+    });
+  });
+
+  it('matches cli-kit precedence when multiple lockfiles coexist (yarn wins over npm)', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writeFile(joinPath(tmpDir, 'yarn.lock'), '');
+      await writeFile(joinPath(tmpDir, 'package-lock.json'), '');
+
+      await expect(findPackageManagerByLockfile(tmpDir)).resolves.toBe('yarn');
+    });
+  });
+});

--- a/packages/cli/src/lib/package-managers.ts
+++ b/packages/cli/src/lib/package-managers.ts
@@ -1,3 +1,5 @@
+import {fileExists} from '@shopify/cli-kit/node/fs';
+import {dirname, joinPath, resolvePath} from '@shopify/cli-kit/node/path';
 import {
   type Lockfile,
   type PackageManager as Name,
@@ -34,3 +36,49 @@ export const packageManagers: PackageManager[] = [
     installCommand: 'bun install --frozen-lockfile',
   },
 ];
+
+// Matches cli-kit's lockfile precedence (yarn, pnpm, bun, npm) so the
+// tie-break is unchanged when multiple lockfiles coexist in one directory.
+const lockfileDetectionOrder: Name[] = ['yarn', 'pnpm', 'bun', 'npm'];
+
+/**
+ * Detects the package manager by searching for a known lockfile in
+ * `directory` and, if none is found there, each ancestor directory in turn.
+ * Monorepo workspaces keep the lockfile at the workspace root rather than in
+ * each app directory, so checking only the app directory misses it. The
+ * nearest lockfile wins, preserving single-repo behavior. Returns 'unknown'
+ * when no lockfile exists up to `options.stopAt` (or the filesystem root).
+ */
+export async function findPackageManagerByLockfile(
+  directory: string,
+  options?: {stopAt?: string},
+): Promise<Name> {
+  let currentDirectory = resolvePath(directory);
+  const stopAt = options?.stopAt ? resolvePath(options.stopAt) : undefined;
+
+  for (;;) {
+    for (const name of lockfileDetectionOrder) {
+      const packageManager = packageManagers.find((pm) => pm.name === name);
+      if (!packageManager) continue;
+
+      const lockfiles = [
+        packageManager.lockfile,
+        ...(packageManager.alternativeLockfiles ?? []),
+      ];
+
+      for (const lockfile of lockfiles) {
+        if (await fileExists(joinPath(currentDirectory, lockfile))) {
+          return packageManager.name;
+        }
+      }
+    }
+
+    if (currentDirectory === stopAt) break;
+
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) break;
+    currentDirectory = parentDirectory;
+  }
+
+  return 'unknown';
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3793

When a Hydrogen app lives inside a monorepo workspace (pnpm/yarn/bun), the lockfile sits at the workspace root — not in the app directory. `hydrogen upgrade` detects the package manager with cli-kit's `getPackageManager(appPath)`, which only checks that single directory for a lockfile before falling back to npm. The result: the upgrade runs `npm install --legacy-peer-deps` inside a pnpm workspace, which fails on `workspace:` protocol dependencies (or pollutes the app dir with a stray `package-lock.json`), and the final "Undo these upgrades?" message prints `npm i` instead of the workspace's package manager.

### WHAT is this pull request doing?

- Adds `findPackageManagerByLockfile(directory, options?)` to `packages/cli/src/lib/package-managers.ts`: walks up from the app directory looking for a known lockfile, built on the existing `packageManagers` metadata table (including alternative lockfiles such as `bun.lock` and `npm-shrinkwrap.json`).
  - **Nearest lockfile wins** — a lockfile in the app directory itself beats any ancestor, so single-repo behavior is unchanged.
  - **Same-directory tie-break matches cli-kit's precedence** (yarn → pnpm → bun → npm), so projects with multiple lockfiles in one directory behave exactly as before.
  - **No lockfile anywhere** → returns `'unknown'`, preserving the existing npm + `--legacy-peer-deps` fallback path untouched.
- Replaces the three `getPackageManager(appPath)` call sites in `upgrade.ts` (dependency removal, dependency upgrade, and the undo-instructions message) with the new helper. The undo message is additionally wrapped in `resolvePackageManagerName()` so it can never render the literal string `unknown`.
- Migrates the `upgrade.test.ts` package-manager mock to the new module and adds 9 unit tests covering: single-repo detection, monorepo ancestor detection (pnpm/yarn/bun), nearest-wins precedence, no-lockfile fallback, alternative lockfiles, and the same-directory tie-break order.
- Adds a changeset (patch bump for `@shopify/cli-hydrogen`).

Out of scope (left untouched, happy to follow up): the same single-directory detection pattern exists in `build.ts`, `setup/css.ts`, `setup/vite.ts`, and `lib/shell.ts`.

### HOW to test your changes?

Unit tests:

```bash
pnpm --filter @shopify/cli-hydrogen test src/lib/package-managers.test.ts src/commands/hydrogen/upgrade.test.ts
```

Manual end-to-end:

1. Create a pnpm workspace (`pnpm-workspace.yaml` with `packages: ['apps/*']`) containing a Hydrogen app at `apps/storefront` pinned to an older Hydrogen version. Run `pnpm install` from the root (single `pnpm-lock.yaml` at the root, no lockfile in the app dir) and commit.
2. Build this branch's CLI (`pnpm --filter @shopify/cli-hydrogen build`) and run the upgrade against the app directory.
3. Observe: the "Upgrading dependencies" task runs `pnpm add …` (previously `npm install --legacy-peer-deps`), no `package-lock.json` appears in the app dir, the root `pnpm-lock.yaml` updates, and the closing undo message reads `… && pnpm i`.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — the walk-up loop uses cli-kit's `resolvePath`/`dirname`/`joinPath` and terminates when `dirname(dir) === dir`, which holds at filesystem roots on both POSIX (`/`) and Windows drive roots (`C:\`)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation — n/a: behavior fix with no doc pages affected; the changeset carries the user-facing release note
