### PR TITLE
Show actionable error when vite is missing in Hydrogen CLI

### DIFF
--- a/.changeset/hydrogen-cli-vite-not-found.md
+++ b/.changeset/hydrogen-cli-vite-not-found.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Show a clear, actionable error when `vite` cannot be found in your project instead of crashing with an unhandled `Cannot find module 'vite'`. This typically happens when a Hydrogen command is run outside the app directory or before installing dependencies; the CLI now explains how to fix it.

--- a/packages/cli/src/lib/import-utils.test.ts
+++ b/packages/cli/src/lib/import-utils.test.ts
@@ -1,0 +1,47 @@
+import {describe, it, expect, vi} from 'vitest';
+import {AbortError} from '@shopify/cli-kit/node/error';
+import {importVite} from './import-utils.js';
+
+// Force `require.resolve('vite', ...)` to fail with MODULE_NOT_FOUND so we can
+// exercise the missing-vite path deterministically, while delegating every
+// other resolution to the real implementation.
+vi.mock('node:module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:module')>();
+
+  return {
+    ...actual,
+    createRequire(filename: string | URL) {
+      const realRequire = actual.createRequire(filename);
+      const wrapped = ((...args: Parameters<typeof realRequire>) =>
+        realRequire(...args)) as NodeRequire;
+      Object.assign(wrapped, realRequire);
+
+      const resolve = ((request: string, options?: {paths?: string[]}) => {
+        if (request === 'vite') {
+          const error = new Error("Cannot find module 'vite'") as Error & {
+            code?: string;
+          };
+          error.code = 'MODULE_NOT_FOUND';
+          throw error;
+        }
+
+        return realRequire.resolve(request, options);
+      }) as NodeRequire['resolve'];
+      resolve.paths = realRequire.resolve.paths.bind(realRequire.resolve);
+      wrapped.resolve = resolve;
+
+      return wrapped;
+    },
+  };
+});
+
+describe('importVite', () => {
+  it('throws a handled AbortError when vite cannot be found in the project', async () => {
+    const promise = importVite('/some/project/root');
+
+    await expect(promise).rejects.toThrowError(AbortError);
+    await expect(promise).rejects.toThrowError(
+      /Could not find the 'vite' package/,
+    );
+  });
+});

--- a/packages/cli/src/lib/import-utils.ts
+++ b/packages/cli/src/lib/import-utils.ts
@@ -1,5 +1,6 @@
 import {createRequire} from 'node:module';
 import {pathToFileURL} from 'node:url';
+import {AbortError} from '@shopify/cli-kit/node/error';
 import {findUpAndReadPackageJson} from '@shopify/cli-kit/node/node-package-manager';
 import {dirname, joinPath} from '@shopify/cli-kit/node/path';
 
@@ -8,10 +9,30 @@ const require = createRequire(import.meta.url);
 export type Vite = typeof import('vite');
 
 export async function importVite(root: string): Promise<Vite> {
-  const vitePath = require.resolve(
-    'vite',
-    process.env.SHOPIFY_UNIT_TEST ? undefined : {paths: [root]},
-  );
+  let vitePath: string;
+
+  try {
+    vitePath = require.resolve(
+      'vite',
+      process.env.SHOPIFY_UNIT_TEST ? undefined : {paths: [root]},
+    );
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error as Error & {code?: string}).code === 'MODULE_NOT_FOUND'
+    ) {
+      throw new AbortError(
+        "Could not find the 'vite' package in your project.",
+        'Hydrogen uses Vite to run this command.',
+        [
+          'Run this command from the root directory of your Hydrogen app.',
+          'Install your project dependencies (for example, by running `npm install`) and try again.',
+        ],
+      );
+    }
+
+    throw error;
+  }
 
   const vitePackageJson = await findUpAndReadPackageJson(vitePath);
 


### PR DESCRIPTION
`importVite()` resolved `vite` from the user's project root and let a raw `MODULE_NOT_FOUND` ("Cannot find module 'vite'") propagate when the package was not installed there (e.g. running a hydrogen command outside the app directory or before installing dependencies). Because it was unhandled, it is reported a crash.

Catch the missing-module case and throw a handled `AbortError` with actionable next steps. Handled errors print cleanly and are not reported as crashes; any other resolution error is re-thrown unchanged.

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset. 
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
