### PR TITLE
fix(e2e): decouple smoke home test from featured collection image

### DIFF
--- a/e2e/specs/smoke/home.spec.ts
+++ b/e2e/specs/smoke/home.spec.ts
@@ -3,7 +3,7 @@ import {test, expect, setTestStore} from '../../fixtures';
 setTestStore('hydrogenPreviewStorefront');
 
 test.describe('Home Page', () => {
-  test('should display hero image, product grid, and no console errors', async ({
+  test('should display featured collection, product grid, and no console errors', async ({
     page,
   }) => {
     const consoleErrors: string[] = [];
@@ -15,12 +15,7 @@ test.describe('Home Page', () => {
 
     await page.goto('/');
 
-    const heroImage = page
-      .getByRole('link')
-      .filter({
-        has: page.getByRole('heading', {level: 1}),
-      })
-      .getByRole('img');
+    const featuredCollectionHeading = page.getByRole('heading', {level: 1});
 
     const productGridImage = page
       .getByRole('region', {name: 'Recommended Products'})
@@ -28,7 +23,7 @@ test.describe('Home Page', () => {
       .first()
       .getByRole('img');
 
-    await expect(heroImage).toBeVisible();
+    await expect(featuredCollectionHeading).toBeVisible();
     await expect(productGridImage).toBeVisible();
 
     expect(consoleErrors).toHaveLength(0);


### PR DESCRIPTION
## Problem

`[smoke] home.spec.ts` was failing on `main` because it asserted the home hero's collection image. The hero is the most-recently-updated collection (`sortKey: UPDATED_AT`) and its image is optional. A bulk collection update in the preview store left every collection tied on `updatedAt`, so the tie now surfaces **Freeride**, which has no image — the hero renders only its heading and the test times out.

## Fix

Assert the collection **heading** (always present) instead of the optional image, per the "Dynamic Store Data" guidance in `e2e/CLAUDE.md`. The product-grid image assertion still covers `Image` rendering.

Test-only; no changeset.