### PR TITLE
Correct scripts for preview release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,12 +288,16 @@ jobs:
           fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
           console.log(`Set ${packageJson.name} to ${packageJson.version}`);
           EOF
-          pnpm run version:hydrogen
         env:
           PREVIEW_VERSION: ${{ steps.version.outputs.PREVIEW_VERSION }}
-      - name: ✅ Check
+
+      - name: ✅ Check format, lint, types and tests
         if: steps.version.outputs.PREVIEW_VERSION
         run: pnpm run check
+
+      - name: 🏗 Build packages
+        if: steps.version.outputs.PREVIEW_VERSION
+        run: pnpm run build:pkgs
 
       - name: Test OIDC Token
         if: steps.version.outputs.PREVIEW_VERSION


### PR DESCRIPTION
The preview branch won't include scripts like `hydrogen:version` for now. This PR corrects the scripts called from the release workflow to adapt to the new setup.

Also, `check` doesn't build packages anymore so this adds an explicit step for building.