### PR TITLE
Fix preview release npm publish path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.version.outputs.PREVIEW_VERSION
-        run: npm publish packages/hydrogen --tag preview --access public --provenance
+        run: npm publish ./packages/hydrogen --tag preview --access public --provenance
         env:
           NPM_TOKEN: '' # Empty string forces OIDC authentication
 


### PR DESCRIPTION
## Summary

Fixes the preview release workflow by publishing `./packages/hydrogen` instead of `packages/hydrogen`.

Without the explicit `./`, npm interprets `packages/hydrogen` as a GitHub shorthand package spec and tries to resolve `ssh://git@github.com/packages/hydrogen.git`, causing the preview publish step to fail. NPM doc mentions about it [here](https://docs.npmjs.com/cli/v11/commands/npm-publish#:~:text=If%20either%20(a)%20or%20(b)%20is%20specified%20as%20a%20relative%20path%2C%20it%20should%20begin%20with%20an%20explicit%20./%20prefix.) too.