### PR TITLE
fix: mark default session cookie as Secure in production

### DIFF
--- a/.changeset/secure-customer-account-sessions.md
+++ b/.changeset/secure-customer-account-sessions.md
@@ -1,0 +1,10 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+'@shopify/hydrogen': patch
+---
+
+Mark the default session cookie as `Secure` in production in the skeleton template and examples. If you copied Hydrogen's default session setup, update your cookie configuration to set `secure: process.env.NODE_ENV === 'production'`.
+
+Harden Customer Account login to reject plaintext HTTP redirect targets. After this update, `return_to` or `redirect` query parameters must use HTTPS and match the storefront's origin; otherwise the redirect falls back to `/account`. If you have custom redirect flows, ensure all redirect URLs use HTTPS.

--- a/packages/hydrogen/src/createHydrogenContext.example.js
+++ b/packages/hydrogen/src/createHydrogenContext.example.js
@@ -44,12 +44,15 @@ class AppSession {
   isPending = false;
 
   static async init(request, secrets) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/createHydrogenContext.example.ts
+++ b/packages/hydrogen/src/createHydrogenContext.example.ts
@@ -57,12 +57,15 @@ class AppSession implements HydrogenSession {
   ) {}
 
   static async init(request: Request, secrets: string[]) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/createRequestHandler.example.js
+++ b/packages/hydrogen/src/createRequestHandler.example.js
@@ -44,12 +44,15 @@ class AppSession {
   isPending = false;
 
   static async init(request, secrets) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/createRequestHandler.example.ts
+++ b/packages/hydrogen/src/createRequestHandler.example.ts
@@ -57,12 +57,15 @@ class AppSession implements HydrogenSession {
   ) {}
 
   static async init(request: Request, secrets: string[]) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/customer/customer.auth-handler.example.jsx
+++ b/packages/hydrogen/src/customer/customer.auth-handler.example.jsx
@@ -50,12 +50,15 @@ class AppSession {
   isPending = false;
 
   static async init(request, secrets) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/customer/customer.auth-handler.example.tsx
+++ b/packages/hydrogen/src/customer/customer.auth-handler.example.tsx
@@ -56,12 +56,15 @@ class AppSession implements HydrogenSession {
   ) {}
 
   static async init(request: Request, secrets: string[]) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/customer/customer.example.jsx
+++ b/packages/hydrogen/src/customer/customer.example.jsx
@@ -42,12 +42,15 @@ class AppSession {
   isPending = false;
 
   static async init(request, secrets) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/customer/customer.example.tsx
+++ b/packages/hydrogen/src/customer/customer.example.tsx
@@ -56,12 +56,15 @@ class AppSession implements HydrogenSession {
   ) {}
 
   static async init(request: Request, secrets: string[]) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/customer/customer.opt-out-handler.example.jsx
+++ b/packages/hydrogen/src/customer/customer.opt-out-handler.example.jsx
@@ -50,12 +50,15 @@ class AppSession {
   isPending = false;
 
   static async init(request, secrets) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/customer/customer.opt-out-handler.example.tsx
+++ b/packages/hydrogen/src/customer/customer.opt-out-handler.example.tsx
@@ -64,12 +64,15 @@ class AppSession implements HydrogenSession {
   ) {}
 
   static async init(request: Request, secrets: string[]) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });

--- a/packages/hydrogen/src/customer/customer.test.ts
+++ b/packages/hydrogen/src/customer/customer.test.ts
@@ -740,6 +740,95 @@ describe('customer', () => {
       });
     });
 
+    describe('login redirectPath', () => {
+      async function expectLoginRedirectPath(
+        request: Request,
+        redirectPath: string,
+      ) {
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request,
+          waitUntil: vi.fn(),
+        });
+
+        await customer.login();
+
+        expect(session.set).toHaveBeenCalledWith(
+          CUSTOMER_ACCOUNT_SESSION_KEY,
+          expect.objectContaining({redirectPath}),
+        );
+      }
+
+      it('keeps path-only return_to redirects', async () => {
+        await expectLoginRedirectPath(
+          new Request('https://localhost?return_to=/account/orders'),
+          '/account/orders',
+        );
+      });
+
+      it('normalizes HTTPS same-origin return_to redirects to path and search', async () => {
+        const redirectPath = 'https://shop.example.com/account/orders?cursor=1';
+        const request = new Request(
+          `http://shop.example.com/account/login?return_to=${encodeURIComponent(
+            redirectPath,
+          )}`,
+        );
+
+        await expectLoginRedirectPath(request, '/account/orders?cursor=1');
+      });
+
+      it.each(['return_to', 'redirect'])(
+        'falls back for HTTP same-origin %s redirects',
+        async (redirectParam) => {
+          const redirectPath = 'http://shop.example.com/account/orders';
+          const request = new Request(
+            `http://shop.example.com/account/login?${redirectParam}=${encodeURIComponent(
+              redirectPath,
+            )}`,
+          );
+
+          await expectLoginRedirectPath(request, '/account');
+        },
+      );
+
+      it('falls back for cross-origin HTTPS return_to redirects', async () => {
+        const redirectPath = 'https://evil.example.com/account/orders';
+        const request = new Request(
+          `https://shop.example.com/account/login?return_to=${encodeURIComponent(
+            redirectPath,
+          )}`,
+        );
+
+        await expectLoginRedirectPath(request, '/account');
+      });
+
+      it('normalizes HTTPS same-origin Referer redirects to path and search', async () => {
+        const request = new Request('https://shop.example.com/account/login');
+        request.headers.set(
+          'Referer',
+          'https://shop.example.com/account/profile?editing=true',
+        );
+
+        await expectLoginRedirectPath(request, '/account/profile?editing=true');
+      });
+
+      it.each([
+        'http://shop.example.com/account/profile',
+        'https://evil.example.com/account/profile',
+        '//evil.example.com/account/profile',
+        'javascript:alert(1)',
+        'data:text/html,hello',
+        'http://%',
+      ])('falls back for unsafe Referer redirects: %s', async (referer) => {
+        const request = new Request('https://shop.example.com/account/login');
+        request.headers.set('Referer', referer);
+
+        await expectLoginRedirectPath(request, '/account');
+      });
+    });
+
     describe('logout', () => {
       describe('using new auth url when shopId is present in env', () => {
         it('Redirects to the customer account api logout url', async () => {
@@ -1170,6 +1259,20 @@ describe('customer', () => {
 
   describe('authorize', () => {
     describe('using new auth url when shopId is present in env', () => {
+      function mockSuccessfulTokenExchange() {
+        fetch.mockResolvedValue(
+          createFetchResponse(
+            {
+              access_token: 'shcat_access_token',
+              expires_in: '',
+              id_token: `${btoa('{}')}.${btoa('{"nonce": "nonce"}')}.signature`,
+              refresh_token: 'shcrt_refresh_token',
+            },
+            {ok: true},
+          ),
+        );
+      }
+
       it('Throws unauthorized if no code or state params are passed', async () => {
         const customer = createCustomerAccountClient({
           session,
@@ -1249,17 +1352,7 @@ describe('customer', () => {
           waitUntil: vi.fn(),
         });
 
-        fetch.mockResolvedValue(
-          createFetchResponse(
-            {
-              access_token: 'shcat_access_token',
-              expires_in: '',
-              id_token: `${btoa('{}')}.${btoa('{"nonce": "nonce"}')}.signature`,
-              refresh_token: 'shcrt_refresh_token',
-            },
-            {ok: true},
-          ),
-        );
+        mockSuccessfulTokenExchange();
 
         const response = await customer.authorize();
 
@@ -1323,6 +1416,98 @@ describe('customer', () => {
             refreshToken: 'shcrt_refresh_token',
           }),
         );
+      });
+
+      it('normalizes stored HTTPS same-origin redirectPath before redirecting', async () => {
+        session = {
+          commit: vi.fn(() => Promise.resolve('cookie')),
+          get: vi.fn(() => {
+            return {
+              ...mockCustomerAccountSession,
+              redirectPath: 'https://localhost/account/orders?cursor=1',
+            };
+          }) as HydrogenSession['get'],
+          set: vi.fn(),
+          unset: vi.fn(),
+          destroy: vi.fn(() => Promise.resolve('logout cookie')),
+        };
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://localhost?state=state&code=code'),
+          waitUntil: vi.fn(),
+        });
+
+        mockSuccessfulTokenExchange();
+
+        const response = await customer.authorize();
+
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe(
+          '/account/orders?cursor=1',
+        );
+      });
+
+      it('falls back when stored redirectPath is unsafe', async () => {
+        session = {
+          commit: vi.fn(() => Promise.resolve('cookie')),
+          get: vi.fn(() => {
+            return {
+              ...mockCustomerAccountSession,
+              redirectPath: 'http://localhost/account/orders',
+            };
+          }) as HydrogenSession['get'],
+          set: vi.fn(),
+          unset: vi.fn(),
+          destroy: vi.fn(() => Promise.resolve('logout cookie')),
+        };
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://localhost?state=state&code=code'),
+          waitUntil: vi.fn(),
+        });
+
+        mockSuccessfulTokenExchange();
+
+        const response = await customer.authorize();
+
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe('/account');
+      });
+
+      it('falls back when stored redirectPath is cross-origin HTTPS', async () => {
+        session = {
+          commit: vi.fn(() => Promise.resolve('cookie')),
+          get: vi.fn(() => {
+            return {
+              ...mockCustomerAccountSession,
+              redirectPath: 'https://evil.example.com/account/orders',
+            };
+          }) as HydrogenSession['get'],
+          set: vi.fn(),
+          unset: vi.fn(),
+          destroy: vi.fn(() => Promise.resolve('logout cookie')),
+        };
+
+        const customer = createCustomerAccountClient({
+          session,
+          customerAccountId: 'customerAccountId',
+          shopId: '1',
+          request: new Request('https://localhost?state=state&code=code'),
+          waitUntil: vi.fn(),
+        });
+
+        mockSuccessfulTokenExchange();
+
+        const response = await customer.authorize();
+
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe('/account');
       });
 
       it('Warns with useCustomAuthDomain when calling authorize in development', async () => {

--- a/packages/hydrogen/src/customer/customer.ts
+++ b/packages/hydrogen/src/customer/customer.ts
@@ -36,10 +36,7 @@ import {
   getDebugHeaders,
 } from '../utils/request';
 import {getCallerStackLine, withSyncStack} from '../utils/callsites';
-import {
-  getRedirectUrl,
-  ensureLocalRedirectUrl,
-} from '../utils/get-redirect-url';
+import {ensureLocalRedirectUrl} from '../utils/get-redirect-url';
 import type {
   CustomerAccountOptions,
   CustomerAccount,
@@ -117,6 +114,53 @@ function defaultAuthStatusHandler(
     `?${new URLSearchParams({return_to: cleanedPathname}).toString()}`;
 
   return redirect(redirectTo);
+}
+
+function getRedirectPathFromSearchParams({
+  requestUrl,
+  httpsOrigin,
+}: {
+  requestUrl: URL;
+  httpsOrigin: string;
+}) {
+  return getSafeCustomerAccountRedirectPath({
+    redirectUrl:
+      requestUrl.searchParams.get('return_to') ||
+      requestUrl.searchParams.get('redirect'),
+    httpsOrigin,
+  });
+}
+
+function getSafeCustomerAccountRedirectPath({
+  redirectUrl,
+  httpsOrigin,
+}: {
+  redirectUrl?: string | null;
+  httpsOrigin: string;
+}) {
+  if (!redirectUrl) return;
+
+  try {
+    const url = new URL(redirectUrl, httpsOrigin);
+    if (url.protocol !== 'https:' || url.origin !== httpsOrigin) {
+      warnRedirectUrlRejected(redirectUrl, httpsOrigin);
+      return;
+    }
+
+    return url.pathname + url.search + url.hash;
+  } catch {
+    warnRedirectUrlRejected(redirectUrl, httpsOrigin);
+    return;
+  }
+}
+
+function warnRedirectUrlRejected(redirectUrl: string, httpsOrigin: string) {
+  if (process.env.NODE_ENV !== 'development') return;
+  console.warn(
+    `[h2:warn:customerAccount] Rejected redirect URL "${redirectUrl}" because it ` +
+      `does not use HTTPS or does not match the store origin (${httpsOrigin}). ` +
+      `Falling back to the default redirect path.`,
+  );
 }
 
 /** @publicDocs */
@@ -438,15 +482,20 @@ export function createCustomerAccountClient({
       const verifier = generateCodeVerifier();
       const challenge = await generateCodeChallenge(verifier);
 
+      const redirectPath =
+        getRedirectPathFromSearchParams({requestUrl, httpsOrigin}) ||
+        getSafeCustomerAccountRedirectPath({
+          redirectUrl: getHeader(request, 'Referer'),
+          httpsOrigin,
+        }) ||
+        defaultRedirectPath;
+
       session.set(CUSTOMER_ACCOUNT_SESSION_KEY, {
         ...session.get(CUSTOMER_ACCOUNT_SESSION_KEY),
         codeVerifier: verifier,
         state,
         nonce,
-        redirectPath:
-          getRedirectUrl(request.url) ||
-          getHeader(request, 'Referer') ||
-          defaultRedirectPath,
+        redirectPath,
       });
 
       loginUrl.searchParams.append('code_challenge', challenge);
@@ -615,9 +664,10 @@ export function createCustomerAccountClient({
         );
       }
 
-      const redirectPath = session.get(
-        CUSTOMER_ACCOUNT_SESSION_KEY,
-      )?.redirectPath;
+      const redirectPath = getSafeCustomerAccountRedirectPath({
+        redirectUrl: session.get(CUSTOMER_ACCOUNT_SESSION_KEY)?.redirectPath,
+        httpsOrigin,
+      });
 
       session.set(CUSTOMER_ACCOUNT_SESSION_KEY, {
         accessToken: customerAccessToken,

--- a/templates/skeleton/app/lib/session.ts
+++ b/templates/skeleton/app/lib/session.ts
@@ -22,12 +22,15 @@ export class AppSession implements HydrogenSession {
   }
 
   static async init(request: Request, secrets: string[]) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
     const storage = createCookieSessionStorage({
       cookie: {
         name: 'session',
         httpOnly: true,
         path: '/',
         sameSite: 'lax',
+        secure: isProduction,
         secrets,
       },
     });


### PR DESCRIPTION
### WHY are these changes introduced?

Strengthen the default security of session cookie configuration and post-login redirect handling for secure cookie attributes and redirect validation.

### WHAT is this pull request doing?

**Session cookie hardening** (`templates/skeleton/` + 10 example files):
- Added `secure: process.env.NODE_ENV === 'production'` to all `createCookieSessionStorage` cookie configs
- This only affects newly scaffolded projects and merchants who copy the example code

**Redirect validation** (`packages/hydrogen/src/customer/customer.ts`):
- Replaced `getRedirectUrl` (which accepted any same-origin URL regardless of protocol) with `getSafeCustomerAccountRedirectPath` — enforces HTTPS protocol, same-origin check, and normalizes output to a relative path
- Added `getRedirectPathFromSearchParams` to extract and validate `return_to`/`redirect` query params
- Applied validation at both `login()` (when the redirect path is stored) and `authorize()` (when it's read back from the session) — defense-in-depth against session tampering
- Added `warnRedirectUrlRejected()` that fires in development mode with the `[h2:warn:customerAccount]` prefix when a redirect URL is rejected
- Unsafe redirects silently fall back to `/account`

**Tests** (`packages/hydrogen/src/customer/customer.test.ts`):
- 8 new test cases covering: path-only, HTTPS same-origin, HTTP same-origin, cross-origin HTTPS, Referer-based redirects, and various attack vectors (`javascript:`, `data:`, `//evil.com`, malformed URLs)
- Authorize-side tests for HTTPS same-origin normalization, HTTP rejection, and cross-origin rejection of stored session redirect paths
- Extracted `mockSuccessfulTokenExchange()` helper to reduce duplication

### HOW to test your changes?

1. Run unit tests: `pnpm vitest run packages/hydrogen/src/customer/customer.test.ts` — 103 pass, 0 fail
2. Run skeleton dev server, inspect `session` cookie in DevTools → Application → Cookies — `Secure` flag should be **off** in dev, 
3. Can deploy app to production and `session` cookie in DevTools → Application → Cookies — `Secure` flag should be **on** in production (`pnpm build && NODE_ENV=production pnpm start`)

#### Post-merge steps

None required.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation