### PR TITLE
Next.js example: three storefront clients aligned with `use cache`

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -50,7 +50,7 @@ Note: Next.js 16 does **not** cache `fetch` by default — every request to a se
 
 Same shape as the React Router example — every framework port re-invents the same three pieces, so this is the feedback loop into the Hydrogen package in `packages/hydrogen`:
 
-- `storefrontClient.graphql()` in `app/lib/storefront.ts` — now uses `createStorefrontClient` from `@shopify/hydrogen` with `gql.tada` for zero-config type inference. Error normalization and request-id propagation are handled by the core client.
+- `storefrontClient.graphql()` in `app/lib/storefront.ts` (server clients) and `app/lib/public-storefront.ts` (browser-safe public client) — now uses `createStorefrontClient` from `@shopify/hydrogen` with `gql.tada` for zero-config type inference. Error normalization and request-id propagation are handled by the core client.
 - `formatMoney()` in `app/lib/money.ts` — every example needs money formatting from a `MoneyV2`-shaped object.
 - `ProductCard` reads a narrow product shape (`handle`, `title`, `featuredImage`, `priceRange.minVariantPrice`). A core fragment + type for "product card" would let routes share GraphQL fragments instead of re-listing fields.
 - Color swatch mapping (`SWATCHES` in `app/components/ProductDetails.tsx`) is hand-rolled — option-value → swatch metadata is a real merchant problem; the SDK should have an opinion on how to expose it.

--- a/examples/nextjs/app/lib/public-storefront.ts
+++ b/examples/nextjs/app/lib/public-storefront.ts
@@ -1,0 +1,20 @@
+import { storefrontConfig } from "@shared/config";
+import { createStorefrontClient } from "@shopify/hydrogen";
+
+// Browser-safe client: holds only the public access token, which Shopify
+// throttles per client IP, so each shopper gets their own bucket. Use it for
+// interactive client-side fetches from Client Components (e.g. TanStack Query
+// or SWR): predictive search, "load more" pagination, availability polling.
+// Example: a useQuery({ queryFn: () => publicStorefrontClient.graphql(...) }).
+//
+// To authenticate from the browser the token must be inlined into the client
+// bundle via a `NEXT_PUBLIC_*` env var; with the shared config below it falls
+// back to the demo store's public token.
+export const publicStorefrontClient = createStorefrontClient({
+  type: "public",
+  config: {
+    storeDomain: storefrontConfig.storeDomain,
+    i18n: storefrontConfig.i18n,
+    publicStorefrontToken: storefrontConfig.publicStorefrontToken,
+  },
+});

--- a/examples/nextjs/app/lib/storefront.ts
+++ b/examples/nextjs/app/lib/storefront.ts
@@ -6,6 +6,11 @@ import { createStorefrontClient, createStorefrontRequestContext } from "@shopify
 import { headers } from "next/headers";
 import { cache } from "react";
 
+// Accesses the `headers()` request-time API, so it cannot be used inside a
+// `use cache` boundary (https://nextjs.org/docs/app/api-reference/directives/use-cache).
+// To cache data that depends on request-time APIs, use `use cache: private`
+// (https://nextjs.org/docs/app/api-reference/directives/use-cache-private).
+// Example: fetching the buyer's cart or logged-in customer data.
 export const getStorefrontClient = cache(async () => {
   const requestHeaders = await headers();
   const requestContext = createStorefrontRequestContext({ headers: requestHeaders });
@@ -20,4 +25,16 @@ export const getStorefrontClient = cache(async () => {
       requestContext,
     },
   });
+});
+
+// Accesses no request-time APIs, so it can be marked cacheable with `use cache`
+// (https://nextjs.org/docs/app/api-reference/directives/use-cache).
+// Example: rendering non-personalized product, collection, or blog pages.
+export const sharedRateLimitStorefrontClient = createStorefrontClient({
+  type: "private_shared_rate_limit",
+  config: {
+    storeDomain: storefrontConfig.storeDomain,
+    i18n: storefrontConfig.i18n,
+    privateStorefrontToken: getPrivateStorefrontToken(),
+  },
 });


### PR DESCRIPTION
## What

Splits the Next.js example's single storefront client into **three purpose-built clients**, each documented against a specific Next.js `use cache` boundary.

| Client | Location | Token | `use cache` story |
| --- | --- | --- | --- |
| `getStorefrontClient` | `app/lib/storefront.ts` | private (per-request) | Reads `headers()` → **not** cacheable. Use `use cache: private` for buyer cart / logged-in customer data. |
| `sharedRateLimitStorefrontClient` | `app/lib/storefront.ts` | private (shared rate limit) | No request-time APIs → **cacheable** with `use cache`. For non-personalized product / collection / blog pages. |
| `publicStorefrontClient` | `app/lib/public-storefront.ts` | public (per-IP) | Browser-safe. For client-side fetches (predictive search, "load more", availability polling). |

## Why

Next.js 16's `use cache` and `use cache: private` directives draw a hard line between request-time and cacheable data. A single client that always reads `headers()` can never enter a `use cache` boundary. Separating the clients by their data-access pattern lets each route reach for the right one — and surfaces, for the core `@shopify/hydrogen` package, the distinction between buyer-IP, shared-rate-limit, and public token usage.

## Changes

- Add `app/lib/public-storefront.ts` — browser-safe public client.
- Add `sharedRateLimitStorefrontClient` to `app/lib/storefront.ts` for `use cache`-able server fetches.
- Document the `use cache` / `use cache: private` boundary on each client with links to the Next.js docs.
- Update README to reference both the server and browser-safe clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
