### PR TITLE
Allow shared example secrets/config to be sourced from env vars

### DIFF
--- a/examples/shared/config.ts
+++ b/examples/shared/config.ts
@@ -34,9 +34,16 @@ const hydrogenPreviewStore = {
   shopId: "gid://shopify/Shop/55145660472",
 } as const;
 
+function readEnv(key: string): string | undefined {
+  if (typeof process === "undefined" || !process.env) return undefined;
+  const value = process.env[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
 export const storefrontConfig = {
-  storeDomain: hydrogenPreviewStore.storeDomain,
-  publicStorefrontToken: hydrogenPreviewStore.publicStorefrontToken,
+  storeDomain: readEnv("PUBLIC_STORE_DOMAIN") ?? hydrogenPreviewStore.storeDomain,
+  publicStorefrontToken:
+    readEnv("PUBLIC_STOREFRONT_API_TOKEN") ?? hydrogenPreviewStore.publicStorefrontToken,
   i18n: { country: "US", language: "EN" },
 } satisfies StorefrontConfigShape;
 

--- a/examples/shared/private-env.ts
+++ b/examples/shared/private-env.ts
@@ -7,15 +7,16 @@ type SharedSecrets = Record<string, string>;
 export function getPrivateStorefrontToken(): string {
   const token = getSharedSecret(PRIVATE_STOREFRONT_TOKEN_KEY);
   if (!token) {
-    throw new Error(
-      `${PRIVATE_STOREFRONT_TOKEN_KEY} is required for SSR requests. ` +
-        `Run "pnpm run examples:secrets:decrypt" to create examples/shared/secrets.ts.`,
-    );
+    throw new Error(`Missing ${PRIVATE_STOREFRONT_TOKEN_KEY} is required for SSR requests.`);
   }
   return token;
 }
 
 export function getSharedSecret(key: string): string | undefined {
-  const value = (secrets as SharedSecrets)[key];
-  return typeof value === "string" && value ? value : undefined;
+  const fromSecrets = (secrets as SharedSecrets)[key];
+  if (typeof fromSecrets === "string" && fromSecrets) return fromSecrets;
+
+  if (typeof process === "undefined" || !process.env) return undefined;
+  const fromEnv = process.env[key];
+  return typeof fromEnv === "string" && fromEnv ? fromEnv : undefined;
 }


### PR DESCRIPTION
## What

Updates the shared example helpers so the storefront token and config can be supplied via environment variables, falling back to the existing committed/decrypted values when env vars aren't set.

- `examples/shared/config.ts`: add a small `readEnv()` helper and source `storeDomain` / `publicStorefrontToken` from `PUBLIC_STORE_DOMAIN` / `PUBLIC_STOREFRONT_API_TOKEN` when present, falling back to the `hydrogen-preview` defaults.
- `examples/shared/private-env.ts`: `getSharedSecret()` now falls back to `process.env[key]` when the value isn't found in the decrypted `secrets` module, so the private token can be provided via env. Simplified the missing-token error message accordingly.

## Why

Lets the shared examples run with credentials injected through the environment (e.g. in CI or hosted deployments) without requiring the EJSON secrets file to be decrypted locally, while keeping the existing committed defaults working out of the box.

## Notes

Scope is limited to the two `examples/shared/*` files — no behavior change when env vars are unset.