### PR TITLE
Make Oxygen deployment and local-dev flows standalone

### DIFF
--- a/.changeset/lucky-buckets-build.md
+++ b/.changeset/lucky-buckets-build.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add deploy flags and environment variables for configuring Oxygen's client assets directory and worker directory. The worker directory must contain an `index.js` or `index.mjs` entry point.

--- a/.changeset/lucky-buckets-build.md
+++ b/.changeset/lucky-buckets-build.md
@@ -3,3 +3,5 @@
 ---
 
 Add deploy flags and environment variables for configuring Oxygen's client assets directory and worker directory. The worker directory must contain an `index.js` or `index.mjs` entry point.
+
+Deployments now resolve output directories from explicit flags, Vite output directories, then `dist/client` and `dist/server` fallbacks. Custom output deployments and `0.0.0-preview-*` Hydrogen versions default to `node --run build` instead of the Hydrogen build pipeline when no build command is provided.

--- a/.changeset/soft-clouds-serve.md
+++ b/.changeset/soft-clouds-serve.md
@@ -2,4 +2,6 @@
 '@shopify/mini-oxygen': patch
 ---
 
-Make the Oxygen Vite plugin self-sufficient by defaulting builds to `dist` and inferring a compatibility date from the resolved Hydrogen package when one is not provided.
+Make the Oxygen Vite plugin self-sufficient by inferring a compatibility date from the resolved Hydrogen package when one is not provided.
+
+The plugin no longer forces Vite builds into `dist`, preserves configured worker entry IDs for framework adapters, and prepends a clearer Mini Oxygen message when Vite cannot load the configured worker entry.

--- a/.changeset/soft-clouds-serve.md
+++ b/.changeset/soft-clouds-serve.md
@@ -1,7 +1,7 @@
 ---
-'@shopify/mini-oxygen': patch
+'@shopify/mini-oxygen': minor
 ---
 
-Make the Oxygen Vite plugin self-sufficient by inferring a compatibility date from the resolved Hydrogen package when one is not provided.
-
-The plugin no longer forces Vite builds into `dist`. Worker-specific resolve conditions now apply only to the SSR worker environment so browser/client modules continue using Vite's normal client conditions. The dev worker entry no longer exposes helper values as runtime exports.
+- Make the Oxygen Vite plugin self-sufficient by inferring a compatibility date from the resolved Hydrogen package when one is not provided.
+- Worker-specific resolve conditions now apply only to the SSR worker environment so browser/client modules continue using Vite's normal client conditions.
+- `oxygen.json` is now emitted only during SSR builds.

--- a/.changeset/soft-clouds-serve.md
+++ b/.changeset/soft-clouds-serve.md
@@ -4,4 +4,4 @@
 
 Make the Oxygen Vite plugin self-sufficient by inferring a compatibility date from the resolved Hydrogen package when one is not provided.
 
-The plugin no longer forces Vite builds into `dist`, preserves configured worker entry IDs for framework adapters, and prepends a clearer Mini Oxygen message when Vite cannot load the configured worker entry.
+The plugin no longer forces Vite builds into `dist`. Worker-specific resolve conditions now apply only to the SSR worker environment so browser/client modules continue using Vite's normal client conditions. The dev worker entry no longer exposes helper values as runtime exports.

--- a/.changeset/soft-clouds-serve.md
+++ b/.changeset/soft-clouds-serve.md
@@ -5,3 +5,4 @@
 - Make the Oxygen Vite plugin self-sufficient by inferring a compatibility date from the resolved Hydrogen package when one is not provided.
 - Worker-specific resolve conditions now apply only to the SSR worker environment so browser/client modules continue using Vite's normal client conditions.
 - `oxygen.json` is now emitted only during SSR builds.
+- `vite preview` can now run the built Oxygen worker in Mini Oxygen, with an optional `previewEntry` override for custom worker output paths.

--- a/.changeset/soft-clouds-serve.md
+++ b/.changeset/soft-clouds-serve.md
@@ -5,4 +5,5 @@
 - Make the Oxygen Vite plugin self-sufficient by inferring a compatibility date from the resolved Hydrogen package when one is not provided.
 - Worker-specific resolve conditions now apply only to the SSR worker environment so browser/client modules continue using Vite's normal client conditions.
 - `oxygen.json` is now emitted only during SSR builds.
+- The Oxygen Vite plugin now loads Vite environment variables as Mini Oxygen bindings when no env bindings are provided by plugin options or the Hydrogen CLI.
 - `vite preview` can now run the built Oxygen worker in Mini Oxygen, with an optional `previewEntry` override for custom worker output paths.

--- a/.changeset/soft-clouds-serve.md
+++ b/.changeset/soft-clouds-serve.md
@@ -1,0 +1,5 @@
+---
+'@shopify/mini-oxygen': patch
+---
+
+Make the Oxygen Vite plugin self-sufficient by defaulting builds to `dist` and inferring a compatibility date from the resolved Hydrogen package when one is not provided.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -388,8 +388,26 @@
           "type": "option"
         },
         "build-command": {
-          "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
+          "description": "Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.",
           "name": "build-command",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "assets-dir": {
+          "description": "Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR",
+          "name": "assets-dir",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "worker-dir": {
+          "description": "Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_WORKER_DIR",
+          "name": "worker-dir",
           "required": false,
           "hasDynamicHelp": false,
           "multiple": false,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -106,7 +106,7 @@
     "oclif.manifest.json"
   ],
   "engines": {
-    "node": "^20 || ^22 || ^24"
+    "node": "^22 || ^24"
   },
   "oclif": {
     "commands": "dist/commands",

--- a/packages/cli/src/commands/hydrogen/deploy.test.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.test.ts
@@ -36,6 +36,59 @@ import {
 import {ciPlatform} from '@shopify/cli-kit/node/context/local';
 import {runBuild} from './build.js';
 
+vi.mock('node:module', async () => {
+  const actual =
+    await vi.importActual<typeof import('node:module')>('node:module');
+  const {existsSync} =
+    await vi.importActual<typeof import('node:fs')>('node:fs');
+  const path = await vi.importActual<typeof import('node:path')>('node:path');
+
+  function resolveHydrogenPackageJson(paths: string[]) {
+    for (const startPath of paths) {
+      let currentPath = path.resolve(startPath);
+
+      while (true) {
+        const packageJsonPath = path.join(
+          currentPath,
+          'node_modules',
+          '@shopify',
+          'hydrogen',
+          'package.json',
+        );
+
+        if (existsSync(packageJsonPath)) return packageJsonPath;
+
+        const parentPath = path.dirname(currentPath);
+        if (parentPath === currentPath) break;
+
+        currentPath = parentPath;
+      }
+    }
+
+    throw new Error("Cannot find module '@shopify/hydrogen/package.json'");
+  }
+
+  return {
+    ...actual,
+    createRequire: (filename: string | URL) => {
+      const baseRequire = actual.createRequire(filename);
+      const resolve = Object.assign(
+        (id: string, options?: {paths?: string[]}) => {
+          if (id === '@shopify/hydrogen/package.json' && options?.paths) {
+            return resolveHydrogenPackageJson(options.paths);
+          }
+
+          return baseRequire.resolve(id, options);
+        },
+        {paths: baseRequire.resolve.paths},
+      );
+
+      return Object.assign((id: string) => baseRequire(id), baseRequire, {
+        resolve,
+      });
+    },
+  };
+});
 vi.mock('@shopify/oxygen-cli/deploy');
 vi.mock('@shopify/cli-kit/node/dot-env');
 vi.mock('@shopify/cli-kit/node/fs');

--- a/packages/cli/src/commands/hydrogen/deploy.test.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.test.ts
@@ -18,7 +18,12 @@ import {
 } from '@shopify/cli-kit/node/git';
 import {createRequire} from 'node:module';
 
-import {deploymentLogger, getHydrogenVersion, runDeploy} from './deploy.js';
+import {
+  deploymentLogger,
+  getHydrogenVersion,
+  resolveDeploymentOutputDirs,
+  runDeploy,
+} from './deploy.js';
 import {getOxygenDeploymentData} from '../../lib/get-oxygen-deployment-data.js';
 import {execAsync} from '../../lib/process.js';
 import {createEnvironmentCliChoiceLabel} from '../../lib/common.js';
@@ -159,6 +164,7 @@ describe('deploy', async () => {
   };
 
   beforeEach(async () => {
+    await createHydrogenDependencyPackageJson('2000.1.1');
     process.exit = vi.fn() as any;
     vi.mocked(login).mockResolvedValue({
       session: ADMIN_SESSION,
@@ -182,7 +188,6 @@ describe('deploy', async () => {
       oxygenDeploymentToken: 'some-encoded-token',
       environments: [],
     });
-
     vi.mocked(parseToken).mockReturnValue(mockToken);
   });
 
@@ -209,6 +214,95 @@ describe('deploy', async () => {
       logger: deploymentLogger,
     });
     expect(vi.mocked(renderSuccess)).toHaveBeenCalled;
+  });
+
+  it('calls createDeploy with configured deploy output paths', async () => {
+    const {buildFunction: _, ...hooks} = expectedHooks;
+
+    await runDeploy({
+      ...deployParams,
+      assetsDir: 'custom/client',
+      workerDir: 'custom/server',
+    });
+
+    expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
+      config: {
+        ...expectedConfig,
+        assetsDir: 'custom/client',
+        workerDir: 'custom/server',
+        buildCommand: 'node --run build',
+      },
+      hooks,
+      logger: deploymentLogger,
+    });
+    expect(vi.mocked(runBuild)).not.toHaveBeenCalled();
+  });
+
+  describe('resolveDeploymentOutputDirs', () => {
+    const root = '/project';
+
+    it('uses Vite output dirs when available', async () => {
+      await expect(
+        resolveDeploymentOutputDirs({
+          root,
+          viteConfig: {
+            clientOutDir: '/project/vite/client',
+            serverOutDir: '/project/vite/server',
+          },
+        }),
+      ).resolves.toEqual({
+        assetsDir: 'vite/client',
+        workerDir: 'vite/server',
+      });
+    });
+
+    it('uses configured output paths before Vite output dirs', async () => {
+      await expect(
+        resolveDeploymentOutputDirs({
+          root,
+          viteConfig: {
+            clientOutDir: '/project/vite/client',
+            serverOutDir: '/project/vite/server',
+          },
+          assetsDir: 'custom/client',
+          workerDir: 'custom/server',
+        }),
+      ).resolves.toEqual({
+        assetsDir: 'custom/client',
+        workerDir: 'custom/server',
+      });
+    });
+
+    it('uses configured output paths before fallback output', async () => {
+      await expect(
+        resolveDeploymentOutputDirs({
+          root,
+          assetsDir: 'custom/client',
+        }),
+      ).resolves.toEqual({
+        assetsDir: 'custom/client',
+        workerDir: 'dist/server',
+      });
+    });
+
+    it('falls back to dist output when Vite output is unavailable', async () => {
+      await expect(resolveDeploymentOutputDirs({root})).resolves.toEqual({
+        assetsDir: 'dist/client',
+        workerDir: 'dist/server',
+      });
+    });
+
+    it('uses configured worker dirs as directories', async () => {
+      await expect(
+        resolveDeploymentOutputDirs({
+          root,
+          workerDir: 'custom/server',
+        }),
+      ).resolves.toEqual({
+        assetsDir: 'dist/client',
+        workerDir: 'custom/server',
+      });
+    });
   });
 
   it('calls createDeploy with overridden variables in environment file', async () => {
@@ -676,6 +770,53 @@ describe('deploy', async () => {
       hooks,
       logger: deploymentLogger,
     });
+  });
+
+  it('uses the default build command for Hydrogen preview versions', async () => {
+    const hydrogenVersion = '0.0.0-preview-20260625000000';
+    await createHydrogenDependencyPackageJson(hydrogenVersion);
+
+    const {buildFunction: _, ...hooks} = expectedHooks;
+
+    await runDeploy(deployParams);
+
+    expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
+      config: {
+        ...expectedConfig,
+        buildCommand: 'node --run build',
+        metadata: {
+          ...expectedConfig.metadata,
+          hydrogenVersion,
+        },
+      },
+      hooks,
+      logger: deploymentLogger,
+    });
+    expect(vi.mocked(runBuild)).not.toHaveBeenCalled();
+  });
+
+  it('deploys custom app output with a custom build command and output directories', async () => {
+    const params = {
+      ...deployParams,
+      buildCommand: 'custom-framework build',
+      assetsDir: 'xyz/client',
+      workerDir: 'xyz/server',
+    };
+    const {buildFunction: _, ...hooks} = expectedHooks;
+
+    await runDeploy(params);
+
+    expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
+      config: {
+        ...expectedConfig,
+        assetsDir: 'xyz/client',
+        workerDir: 'xyz/server',
+        buildCommand: 'custom-framework build',
+      },
+      hooks,
+      logger: deploymentLogger,
+    });
+    expect(vi.mocked(runBuild)).not.toHaveBeenCalled();
   });
 
   it('writes a file with JSON content in CI environments', async () => {

--- a/packages/cli/src/commands/hydrogen/deploy.test.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.test.ts
@@ -1,4 +1,6 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
 import {type AdminSession, login} from '../../lib/auth.js';
 import {getStorefronts} from '../../lib/graphql/admin/link-storefront.js';
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env';
@@ -16,7 +18,6 @@ import {
   getLatestGitCommit,
   GitDirectoryNotCleanError,
 } from '@shopify/cli-kit/node/git';
-import {createRequire} from 'node:module';
 
 import {
   deploymentLogger,
@@ -27,7 +28,6 @@ import {
 import {getOxygenDeploymentData} from '../../lib/get-oxygen-deployment-data.js';
 import {execAsync} from '../../lib/process.js';
 import {createEnvironmentCliChoiceLabel} from '../../lib/common.js';
-import {getSkeletonSourceDir} from '../../lib/build.js';
 import {
   CompletedDeployment,
   createDeploy,
@@ -35,7 +35,6 @@ import {
 } from '@shopify/oxygen-cli/deploy';
 import {ciPlatform} from '@shopify/cli-kit/node/context/local';
 import {runBuild} from './build.js';
-import {PackageJson} from 'type-fest';
 
 vi.mock('@shopify/oxygen-cli/deploy');
 vi.mock('@shopify/cli-kit/node/dot-env');
@@ -69,22 +68,35 @@ vi.mock('@shopify/cli-kit/node/git', async () => {
   };
 });
 
-async function createHydrogenDependencyPackageJson(version?: string) {
-  const require = createRequire(import.meta.url);
-  const packageJson: PackageJson = require(
-    require.resolve('@shopify/hydrogen/package.json', {
-      paths: [getSkeletonSourceDir()],
+const tempRoots: string[] = [];
+
+function createAppWithHydrogenVersion(version?: string) {
+  const root = mkdtempSync(`${tmpdir()}/hydrogen-deploy-`);
+  tempRoots.push(root);
+
+  const hydrogenPackageRoot = `${root}/node_modules/@shopify/hydrogen`;
+  mkdirSync(hydrogenPackageRoot, {recursive: true});
+  writeFileSync(
+    `${root}/package.json`,
+    JSON.stringify({
+      dependencies: {
+        '@shopify/hydrogen': version ?? 'workspace:*',
+      },
+    }),
+  );
+  writeFileSync(
+    `${hydrogenPackageRoot}/package.json`,
+    JSON.stringify({
+      name: '@shopify/hydrogen',
+      version,
+      exports: {'./package.json': './package.json'},
     }),
   );
 
-  packageJson.version = version;
-
-  return packageJson;
+  return root;
 }
 
 describe('deploy', async () => {
-  await createHydrogenDependencyPackageJson('2000.1.1');
-
   const ADMIN_SESSION: AdminSession = {
     token: 'abc123',
     storeFqdn: 'my-shop.myshopify.com',
@@ -142,7 +154,6 @@ describe('deploy', async () => {
       url: deployParams.metadataUrl,
       user: deployParams.metadataUser,
       version: deployParams.metadataVersion,
-      hydrogenVersion: '2000.1.1',
     },
     skipVerification: true,
     rootPath: deployParams.path,
@@ -164,7 +175,6 @@ describe('deploy', async () => {
   };
 
   beforeEach(async () => {
-    await createHydrogenDependencyPackageJson('2000.1.1');
     process.exit = vi.fn() as any;
     vi.mocked(login).mockResolvedValue({
       session: ADMIN_SESSION,
@@ -194,6 +204,10 @@ describe('deploy', async () => {
   afterEach(() => {
     vi.resetAllMocks();
     process.exit = originalExit;
+
+    for (const tempRoot of tempRoots.splice(0)) {
+      rmSync(tempRoot, {recursive: true, force: true});
+    }
   });
 
   it('calls getOxygenDeploymentData with the correct parameters', async () => {
@@ -774,15 +788,16 @@ describe('deploy', async () => {
 
   it('uses the default build command for Hydrogen preview versions', async () => {
     const hydrogenVersion = '0.0.0-preview-20260625000000';
-    await createHydrogenDependencyPackageJson(hydrogenVersion);
+    const root = createAppWithHydrogenVersion(hydrogenVersion);
 
     const {buildFunction: _, ...hooks} = expectedHooks;
 
-    await runDeploy(deployParams);
+    await runDeploy({...deployParams, path: root});
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
       config: {
         ...expectedConfig,
+        rootPath: root,
         buildCommand: 'node --run build',
         metadata: {
           ...expectedConfig.metadata,
@@ -796,8 +811,12 @@ describe('deploy', async () => {
   });
 
   it('deploys custom app output with a custom build command and output directories', async () => {
+    const root = mkdtempSync(`${tmpdir()}/hydrogen-deploy-`);
+    tempRoots.push(root);
+
     const params = {
       ...deployParams,
+      path: root,
       buildCommand: 'custom-framework build',
       assetsDir: 'xyz/client',
       workerDir: 'xyz/server',
@@ -809,9 +828,15 @@ describe('deploy', async () => {
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
       config: {
         ...expectedConfig,
+        rootPath: root,
         assetsDir: 'xyz/client',
         workerDir: 'xyz/server',
         buildCommand: 'custom-framework build',
+        metadata: {
+          url: deployParams.metadataUrl,
+          user: deployParams.metadataUser,
+          version: deployParams.metadataVersion,
+        },
       },
       hooks,
       logger: deploymentLogger,
@@ -1135,15 +1160,24 @@ describe('deploy', async () => {
 
   describe('getHydrogenVersion', () => {
     it('returns the version', async () => {
-      const version = await getHydrogenVersion({appPath: deployParams.path});
+      const root = createAppWithHydrogenVersion('2000.1.1');
+
+      const version = getHydrogenVersion({appPath: root});
       expect(version).toBe('2000.1.1');
+    });
+
+    it('returns undefined when Hydrogen is not installed in the app', async () => {
+      const root = mkdtempSync(`${tmpdir()}/hydrogen-deploy-`);
+      tempRoots.push(root);
+
+      expect(getHydrogenVersion({appPath: root})).toBeUndefined();
     });
 
     describe('when there are no version is available', () => {
       it('returns undefined', async () => {
-        await createHydrogenDependencyPackageJson(undefined);
+        const root = createAppWithHydrogenVersion(undefined);
 
-        const version = await getHydrogenVersion({appPath: deployParams.path});
+        const version = getHydrogenVersion({appPath: root});
         expect(version).toBeUndefined();
       });
     });

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -17,7 +17,7 @@ import {
   getLatestGitCommit,
   GitDirectoryNotCleanError,
 } from '@shopify/cli-kit/node/git';
-import {joinPath, relativePath, resolvePath} from '@shopify/cli-kit/node/path';
+import {relativePath, resolvePath} from '@shopify/cli-kit/node/path';
 import {
   renderConfirmationPrompt,
   renderInfo,
@@ -780,7 +780,9 @@ export function getHydrogenVersion({appPath}: {appPath: string}) {
   try {
     const require = createRequire(import.meta.url);
     const packageJson = require(
-      resolvePath(root, 'node_modules', '@shopify', 'hydrogen', 'package.json'),
+      require.resolve('@shopify/hydrogen/package.json', {
+        paths: [root],
+      }),
     ) as PackageJson;
 
     return typeof packageJson.version === 'string'

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -60,6 +60,7 @@ import {packageManagers} from '../../lib/package-managers.js';
 import {setupResourceCleanup} from '../../lib/resource-cleanup.js';
 
 const DEPLOY_OUTPUT_FILE_HANDLE = 'h2_deploy_log.json';
+const DEFAULT_BUILD_COMMAND = 'node --run build';
 
 export const deploymentLogger: Logger = (
   message: string,
@@ -118,7 +119,19 @@ export default class Deploy extends Command {
     }),
     'build-command': Flags.string({
       description:
-        'Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.',
+        'Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.',
+      required: false,
+    }),
+    'assets-dir': Flags.string({
+      description:
+        'Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR',
+      required: false,
+    }),
+    'worker-dir': Flags.string({
+      description:
+        'Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_WORKER_DIR',
       required: false,
     }),
     ...commonFlags.lockfileCheck,
@@ -213,6 +226,8 @@ interface OxygenDeploymentOptions {
   metadataUser?: string;
   metadataVersion?: string;
   entry?: string;
+  assetsDir?: string;
+  workerDir?: string;
 }
 
 interface GitCommit {
@@ -257,10 +272,12 @@ export async function runDeploy(
     jsonOutput,
     path: root,
     shop,
+    assetsDir: assetsDirFlag,
     metadataUrl,
     metadataUser,
     metadataVersion,
     entry: ssrEntry,
+    workerDir: workerDirFlag,
   } = options;
   let {metadataDescription} = options;
 
@@ -465,18 +482,29 @@ export async function runDeploy(
   let workerDir = 'dist/worker';
 
   const isClassicCompiler = await isClassicProject(root);
-
-  if (!isClassicCompiler) {
-    const viteConfig = await getViteConfig(root, ssrEntry).catch(() => null);
-    if (viteConfig) {
-      assetsDir = relativePath(root, viteConfig.clientOutDir);
-      workerDir = relativePath(root, viteConfig.serverOutDir);
-    } else {
-      workerDir = 'dist/server';
-    }
-  }
-
   const metadataHydrogenVersion = await getHydrogenVersion({appPath: root});
+  const shouldUseDefaultBuildCommand =
+    !buildCommand &&
+    !isClassicCompiler &&
+    (assetsDirFlag ||
+      workerDirFlag ||
+      isHydrogenPreviewVersion(metadataHydrogenVersion));
+
+  if (isClassicCompiler) {
+    assetsDir = assetsDirFlag ?? assetsDir;
+    workerDir = workerDirFlag ?? workerDir;
+  } else {
+    const viteConfig = await getViteConfig(root, ssrEntry).catch(() => null);
+    const outputDirs = await resolveDeploymentOutputDirs({
+      root,
+      viteConfig,
+      assetsDir: assetsDirFlag,
+      workerDir: workerDirFlag,
+    });
+
+    assetsDir = outputDirs.assetsDir;
+    workerDir = outputDirs.workerDir;
+  }
 
   const config: DeploymentConfig = {
     assetsDir,
@@ -589,7 +617,7 @@ Continue?`.value,
     },
   };
 
-  if (buildCommand) {
+  if (buildCommand || shouldUseDefaultBuildCommand) {
     if (forceClientSourcemap) {
       console.log('');
       renderInfo({
@@ -598,7 +626,7 @@ Continue?`.value,
         body: 'Client sourcemaps will not be generated.',
       });
     }
-    config.buildCommand = buildCommand;
+    config.buildCommand = buildCommand ?? DEFAULT_BUILD_COMMAND;
   } else {
     hooks.buildFunction = async (
       assetPath: string | undefined,
@@ -698,6 +726,48 @@ Continue?`.value,
     });
 
   return deployPromise;
+}
+
+type DeploymentOutputResolverOptions = {
+  root: string;
+  viteConfig?: {
+    clientOutDir: string;
+    serverOutDir: string;
+  } | null;
+  assetsDir?: string;
+  workerDir?: string;
+};
+
+export async function resolveDeploymentOutputDirs({
+  root,
+  viteConfig,
+  assetsDir,
+  workerDir,
+}: DeploymentOutputResolverOptions): Promise<{
+  assetsDir: string;
+  workerDir: string;
+}> {
+  const fallbackOutputDirs = {
+    assetsDir: 'dist/client',
+    workerDir: 'dist/server',
+  };
+  const viteOutputDirs = viteConfig
+    ? {
+        assetsDir: relativePath(root, viteConfig.clientOutDir),
+        workerDir: relativePath(root, viteConfig.serverOutDir),
+      }
+    : undefined;
+
+  return {
+    assetsDir:
+      assetsDir ?? viteOutputDirs?.assetsDir ?? fallbackOutputDirs.assetsDir,
+    workerDir:
+      workerDir ?? viteOutputDirs?.workerDir ?? fallbackOutputDirs.workerDir,
+  };
+}
+
+function isHydrogenPreviewVersion(version?: string) {
+  return version?.startsWith('0.0.0-preview-') ?? false;
 }
 
 /**

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -8,6 +8,7 @@ import {
   Logger,
   LogLevel,
 } from '@shopify/cli-kit/node/output';
+import {type PackageJson} from '@shopify/cli-kit/node/node-package-manager';
 import {readAndParseDotEnv} from '@shopify/cli-kit/node/dot-env';
 import {AbortError} from '@shopify/cli-kit/node/error';
 import {writeFile} from '@shopify/cli-kit/node/fs';
@@ -482,7 +483,7 @@ export async function runDeploy(
   let workerDir = 'dist/worker';
 
   const isClassicCompiler = await isClassicProject(root);
-  const metadataHydrogenVersion = await getHydrogenVersion({appPath: root});
+  const metadataHydrogenVersion = getHydrogenVersion({appPath: root});
   const shouldUseDefaultBuildCommand =
     !buildCommand &&
     !isClassicCompiler &&
@@ -773,15 +774,19 @@ function isHydrogenPreviewVersion(version?: string) {
 /**
  * Gets the current @shopify/hydrogen version from the package's package.json
  */
-export async function getHydrogenVersion({appPath}: {appPath: string}) {
+export function getHydrogenVersion({appPath}: {appPath: string}) {
   const {root} = getProjectPaths(appPath);
 
-  const require = createRequire(import.meta.url);
-  const {version} = require(
-    require.resolve('@shopify/hydrogen/package.json', {
-      paths: [root],
-    }),
-  );
+  try {
+    const require = createRequire(import.meta.url);
+    const packageJson = require(
+      resolvePath(root, 'node_modules', '@shopify', 'hydrogen', 'package.json'),
+    ) as PackageJson;
 
-  return version;
+    return typeof packageJson.version === 'string'
+      ? packageJson.version
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/cli/src/lib/vite-config.ts
+++ b/packages/cli/src/lib/vite-config.ts
@@ -77,8 +77,12 @@ export async function getViteConfig(
   const {appDirectory, serverBuildFile, routes} =
     getReactRouterOrRemixConfigFromVite(resolvedViteConfig);
 
-  const serverOutDir = resolvedViteConfig.build.outDir;
-  const clientOutDir = serverOutDir.replace(/server$/, 'client');
+  const serverOutDir =
+    resolvedViteConfig.environments.ssr?.build.outDir ??
+    resolvedViteConfig.build.outDir;
+  const clientOutDir =
+    resolvedViteConfig.environments.client?.build.outDir ??
+    serverOutDir.replace(/server$/, 'client');
 
   const rollupOutput = resolvedViteConfig.build.rollupOptions.output;
   const {entryFileNames} =

--- a/packages/mini-oxygen/src/vite/compat-date.test.ts
+++ b/packages/mini-oxygen/src/vite/compat-date.test.ts
@@ -1,0 +1,80 @@
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {tmpdir} from 'node:os';
+import {afterEach, describe, expect, it} from 'vitest';
+import {
+  getCompatibilityDateFromHydrogenVersion,
+  getHydrogenCompatibilityDate,
+} from './compat-date.js';
+
+const tempRoots: string[] = [];
+
+function createRootWithHydrogenPackageJson(source: string) {
+  const root = mkdtempSync(join(tmpdir(), 'mini-oxygen-'));
+  tempRoots.push(root);
+
+  const hydrogenPackageRoot = join(
+    root,
+    'node_modules',
+    '@shopify',
+    'hydrogen',
+  );
+
+  mkdirSync(hydrogenPackageRoot, {recursive: true});
+  writeFileSync(join(root, 'package.json'), JSON.stringify({}));
+  writeFileSync(join(hydrogenPackageRoot, 'package.json'), source);
+
+  return root;
+}
+
+function createRootWithHydrogenVersion(version: string) {
+  return createRootWithHydrogenPackageJson(
+    JSON.stringify({
+      name: '@shopify/hydrogen',
+      version,
+      exports: {'./package.json': './package.json'},
+    }),
+  );
+}
+
+describe('Hydrogen compatibility dates', () => {
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, {recursive: true, force: true});
+    }
+  });
+
+  it('infers the first day of the Hydrogen version month', () => {
+    expect(getCompatibilityDateFromHydrogenVersion('2026.4.4')).toBe(
+      '2026-04-01',
+    );
+    expect(getCompatibilityDateFromHydrogenVersion('2026.10.0-next.0')).toBe(
+      '2026-10-01',
+    );
+  });
+
+  it('uses a fixed compatibility date for non-calver Hydrogen versions', () => {
+    expect(getCompatibilityDateFromHydrogenVersion('0.0.0-next')).toBe(
+      '2026-04-01',
+    );
+    expect(
+      getCompatibilityDateFromHydrogenVersion('0.0.0-next-20260624000000'),
+    ).toBe('2026-04-01');
+    expect(getCompatibilityDateFromHydrogenVersion('4.1.0')).toBe('2026-04-01');
+    expect(getCompatibilityDateFromHydrogenVersion('2026.13.0')).toBe(
+      '2026-04-01',
+    );
+  });
+
+  it('reads the resolved Hydrogen package version from the project root', () => {
+    const root = createRootWithHydrogenVersion('2026.4.4');
+
+    expect(getHydrogenCompatibilityDate(root)).toBe('2026-04-01');
+  });
+
+  it('returns undefined when Hydrogen package metadata cannot be read', () => {
+    const root = createRootWithHydrogenPackageJson('{');
+
+    expect(getHydrogenCompatibilityDate(root)).toBeUndefined();
+  });
+});

--- a/packages/mini-oxygen/src/vite/compat-date.test.ts
+++ b/packages/mini-oxygen/src/vite/compat-date.test.ts
@@ -45,31 +45,40 @@ describe('Hydrogen compatibility dates', () => {
   });
 
   it('infers the first day of the Hydrogen version month', () => {
+    expect(getCompatibilityDateFromHydrogenVersion('2024.10.4')).toBe(
+      '2024-10-01',
+    );
+    expect(getCompatibilityDateFromHydrogenVersion('2025.4.0')).toBe(
+      '2025-04-01',
+    );
+  });
+
+  it('caps inferred compatibility dates at 2025-04-01', () => {
     expect(getCompatibilityDateFromHydrogenVersion('2026.4.4')).toBe(
-      '2026-04-01',
+      '2025-04-01',
     );
     expect(getCompatibilityDateFromHydrogenVersion('2026.10.0-next.0')).toBe(
-      '2026-10-01',
+      '2025-04-01',
     );
   });
 
   it('uses a fixed compatibility date for non-calver Hydrogen versions', () => {
     expect(getCompatibilityDateFromHydrogenVersion('0.0.0-next')).toBe(
-      '2026-04-01',
+      '2025-04-01',
     );
     expect(
       getCompatibilityDateFromHydrogenVersion('0.0.0-next-20260624000000'),
-    ).toBe('2026-04-01');
-    expect(getCompatibilityDateFromHydrogenVersion('4.1.0')).toBe('2026-04-01');
+    ).toBe('2025-04-01');
+    expect(getCompatibilityDateFromHydrogenVersion('4.1.0')).toBe('2025-04-01');
     expect(getCompatibilityDateFromHydrogenVersion('2026.13.0')).toBe(
-      '2026-04-01',
+      '2025-04-01',
     );
   });
 
   it('reads the resolved Hydrogen package version from the project root', () => {
     const root = createRootWithHydrogenVersion('2026.4.4');
 
-    expect(getHydrogenCompatibilityDate(root)).toBe('2026-04-01');
+    expect(getHydrogenCompatibilityDate(root)).toBe('2025-04-01');
   });
 
   it('returns undefined when Hydrogen package metadata cannot be read', () => {

--- a/packages/mini-oxygen/src/vite/compat-date.test.ts
+++ b/packages/mini-oxygen/src/vite/compat-date.test.ts
@@ -45,40 +45,31 @@ describe('Hydrogen compatibility dates', () => {
   });
 
   it('infers the first day of the Hydrogen version month', () => {
-    expect(getCompatibilityDateFromHydrogenVersion('2024.10.4')).toBe(
-      '2024-10-01',
-    );
-    expect(getCompatibilityDateFromHydrogenVersion('2025.4.0')).toBe(
-      '2025-04-01',
-    );
-  });
-
-  it('caps inferred compatibility dates at 2025-04-01', () => {
     expect(getCompatibilityDateFromHydrogenVersion('2026.4.4')).toBe(
-      '2025-04-01',
+      '2026-04-01',
     );
     expect(getCompatibilityDateFromHydrogenVersion('2026.10.0-next.0')).toBe(
-      '2025-04-01',
+      '2026-10-01',
     );
   });
 
   it('uses a fixed compatibility date for non-calver Hydrogen versions', () => {
     expect(getCompatibilityDateFromHydrogenVersion('0.0.0-next')).toBe(
-      '2025-04-01',
+      '2026-04-01',
     );
     expect(
       getCompatibilityDateFromHydrogenVersion('0.0.0-next-20260624000000'),
-    ).toBe('2025-04-01');
-    expect(getCompatibilityDateFromHydrogenVersion('4.1.0')).toBe('2025-04-01');
+    ).toBe('2026-04-01');
+    expect(getCompatibilityDateFromHydrogenVersion('4.1.0')).toBe('2026-04-01');
     expect(getCompatibilityDateFromHydrogenVersion('2026.13.0')).toBe(
-      '2025-04-01',
+      '2026-04-01',
     );
   });
 
   it('reads the resolved Hydrogen package version from the project root', () => {
     const root = createRootWithHydrogenVersion('2026.4.4');
 
-    expect(getHydrogenCompatibilityDate(root)).toBe('2025-04-01');
+    expect(getHydrogenCompatibilityDate(root)).toBe('2026-04-01');
   });
 
   it('returns undefined when Hydrogen package metadata cannot be read', () => {

--- a/packages/mini-oxygen/src/vite/compat-date.ts
+++ b/packages/mini-oxygen/src/vite/compat-date.ts
@@ -2,7 +2,7 @@ import {createRequire} from 'node:module';
 import {resolve} from 'node:path';
 
 const HYDROGEN_PACKAGE = '@shopify/hydrogen/package.json';
-const HYDROGEN_FALLBACK_COMPATIBILITY_DATE = '2026-04-01';
+const HYDROGEN_MAX_COMPATIBILITY_DATE = '2025-04-01';
 
 type HydrogenPackageJson = {
   version?: unknown;
@@ -10,14 +10,18 @@ type HydrogenPackageJson = {
 
 export function getCompatibilityDateFromHydrogenVersion(version: string) {
   const versionMatch = /^(\d{4})\.(\d{1,2})(?:[.-]|$)/.exec(version);
-  if (!versionMatch) return HYDROGEN_FALLBACK_COMPATIBILITY_DATE;
+  if (!versionMatch) return HYDROGEN_MAX_COMPATIBILITY_DATE;
 
   const month = Number(versionMatch[2]);
   if (!Number.isInteger(month) || month < 1 || month > 12) {
-    return HYDROGEN_FALLBACK_COMPATIBILITY_DATE;
+    return HYDROGEN_MAX_COMPATIBILITY_DATE;
   }
 
-  return `${versionMatch[1]}-${String(month).padStart(2, '0')}-01`;
+  const compatibilityDate = `${versionMatch[1]}-${String(month).padStart(2, '0')}-01`;
+
+  return compatibilityDate > HYDROGEN_MAX_COMPATIBILITY_DATE
+    ? HYDROGEN_MAX_COMPATIBILITY_DATE
+    : compatibilityDate;
 }
 
 export function getHydrogenCompatibilityDate(root = process.cwd()) {

--- a/packages/mini-oxygen/src/vite/compat-date.ts
+++ b/packages/mini-oxygen/src/vite/compat-date.ts
@@ -2,7 +2,7 @@ import {createRequire} from 'node:module';
 import {resolve} from 'node:path';
 
 const HYDROGEN_PACKAGE = '@shopify/hydrogen/package.json';
-const HYDROGEN_MAX_COMPATIBILITY_DATE = '2025-04-01';
+const HYDROGEN_FALLBACK_COMPATIBILITY_DATE = '2026-04-01';
 
 type HydrogenPackageJson = {
   version?: unknown;
@@ -10,18 +10,14 @@ type HydrogenPackageJson = {
 
 export function getCompatibilityDateFromHydrogenVersion(version: string) {
   const versionMatch = /^(\d{4})\.(\d{1,2})(?:[.-]|$)/.exec(version);
-  if (!versionMatch) return HYDROGEN_MAX_COMPATIBILITY_DATE;
+  if (!versionMatch) return HYDROGEN_FALLBACK_COMPATIBILITY_DATE;
 
   const month = Number(versionMatch[2]);
   if (!Number.isInteger(month) || month < 1 || month > 12) {
-    return HYDROGEN_MAX_COMPATIBILITY_DATE;
+    return HYDROGEN_FALLBACK_COMPATIBILITY_DATE;
   }
 
-  const compatibilityDate = `${versionMatch[1]}-${String(month).padStart(2, '0')}-01`;
-
-  return compatibilityDate > HYDROGEN_MAX_COMPATIBILITY_DATE
-    ? HYDROGEN_MAX_COMPATIBILITY_DATE
-    : compatibilityDate;
+  return `${versionMatch[1]}-${String(month).padStart(2, '0')}-01`;
 }
 
 export function getHydrogenCompatibilityDate(root = process.cwd()) {

--- a/packages/mini-oxygen/src/vite/compat-date.ts
+++ b/packages/mini-oxygen/src/vite/compat-date.ts
@@ -1,0 +1,35 @@
+import {createRequire} from 'node:module';
+import {resolve} from 'node:path';
+
+const HYDROGEN_PACKAGE = '@shopify/hydrogen/package.json';
+const HYDROGEN_FALLBACK_COMPATIBILITY_DATE = '2026-04-01';
+
+type HydrogenPackageJson = {
+  version?: unknown;
+};
+
+export function getCompatibilityDateFromHydrogenVersion(version: string) {
+  const versionMatch = /^(\d{4})\.(\d{1,2})(?:[.-]|$)/.exec(version);
+  if (!versionMatch) return HYDROGEN_FALLBACK_COMPATIBILITY_DATE;
+
+  const month = Number(versionMatch[2]);
+  if (!Number.isInteger(month) || month < 1 || month > 12) {
+    return HYDROGEN_FALLBACK_COMPATIBILITY_DATE;
+  }
+
+  return `${versionMatch[1]}-${String(month).padStart(2, '0')}-01`;
+}
+
+export function getHydrogenCompatibilityDate(root = process.cwd()) {
+  try {
+    const hydrogenPackageJson = createRequire(resolve(root, 'package.json'))(
+      HYDROGEN_PACKAGE,
+    ) as HydrogenPackageJson;
+
+    return typeof hydrogenPackageJson.version === 'string'
+      ? getCompatibilityDateFromHydrogenVersion(hydrogenPackageJson.version)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/mini-oxygen/src/vite/environment.test.ts
+++ b/packages/mini-oxygen/src/vite/environment.test.ts
@@ -42,6 +42,9 @@ vi.mock('./server-middleware.js', () => ({
   WARMUP_PATHNAME: '/__vite_warmup',
   getViteUrl: mocks.getViteUrl,
   startMiniOxygenRuntime: mocks.startMiniOxygenRuntime,
+}));
+
+vi.mock('./utils.js', () => ({
   toMiniflareRequest: mocks.toMiniflareRequest,
 }));
 

--- a/packages/mini-oxygen/src/vite/environment.ts
+++ b/packages/mini-oxygen/src/vite/environment.ts
@@ -25,6 +25,18 @@ export type MiniOxygenRuntimeOptions = Partial<
     envPromise?: Promise<Record<string, any>>;
   };
 
+type EnvOptions = {
+  env?: Record<string, any>;
+  envPromise?: Promise<Record<string, any>>;
+};
+
+export function hasProvidedEnvBindings(options: EnvOptions) {
+  return (
+    Object.prototype.hasOwnProperty.call(options, 'env') ||
+    Object.prototype.hasOwnProperty.call(options, 'envPromise')
+  );
+}
+
 type RuntimeOptionsResolver = (
   options: MiniOxygenRuntimeOptions,
   viteDevServer: ViteDevServer,
@@ -38,15 +50,23 @@ export function mergeMiniOxygenRuntimeOptions(
   current: MiniOxygenRuntimeOptions,
   next: MiniOxygenRuntimeOptions,
 ): MiniOxygenRuntimeOptions {
-  return {
+  const merged = {
     ...current,
     ...next,
-    env: {...current.env, ...next.env},
-    crossBoundarySetup: [
+  };
+
+  if (hasProvidedEnvBindings(current) || hasProvidedEnvBindings(next)) {
+    merged.env = {...current.env, ...next.env};
+  }
+
+  if (current.crossBoundarySetup || next.crossBoundarySetup) {
+    merged.crossBoundarySetup = [
       ...(current.crossBoundarySetup || []),
       ...(next.crossBoundarySetup || []),
-    ],
-  };
+    ];
+  }
+
+  return merged;
 }
 
 export function createMiniOxygenDevEnvironment(

--- a/packages/mini-oxygen/src/vite/environment.ts
+++ b/packages/mini-oxygen/src/vite/environment.ts
@@ -12,8 +12,8 @@ import {
   WARMUP_PATHNAME,
   getViteUrl,
   startMiniOxygenRuntime,
-  toMiniflareRequest,
 } from './server-middleware.js';
+import {toMiniflareRequest} from './utils.js';
 
 export type MiniOxygenRuntimeOptions = Partial<
   Pick<

--- a/packages/mini-oxygen/src/vite/plugin.test.ts
+++ b/packages/mini-oxygen/src/vite/plugin.test.ts
@@ -3,12 +3,12 @@ import {join} from 'node:path';
 import {tmpdir} from 'node:os';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 import type {Plugin} from 'vite';
-import {oxygen} from './plugin.js';
+import {oxygen, type OxygenPluginOptions} from './plugin.js';
 
 const tempRoots: string[] = [];
 
-function getOxygenPlugin() {
-  return oxygen()[0] as Plugin<{
+function getOxygenPlugin(options?: OxygenPluginOptions) {
+  return oxygen(options)[0] as Plugin<{
     registerPluginOptions(newOptions: {compatibilityDate?: string}): void;
   }>;
 }
@@ -41,7 +41,11 @@ function createRootWithHydrogenVersion(version: string) {
   );
 }
 
-function runConfigHook(plugin: Plugin, config: Record<string, any>) {
+function runConfigHook(
+  plugin: Plugin,
+  config: Record<string, any>,
+  env?: Record<string, any>,
+) {
   if (typeof plugin.config !== 'function') {
     throw new Error('Expected oxygen plugin to expose a config hook.');
   }
@@ -51,6 +55,7 @@ function runConfigHook(plugin: Plugin, config: Record<string, any>) {
     mode: 'production',
     isSsrBuild: false,
     isPreview: false,
+    ...env,
   });
 }
 
@@ -85,12 +90,10 @@ describe('oxygen Vite plugin', () => {
     }
   });
 
-  it('sets the default build output directory when the app does not', () => {
+  it('does not set a default build output directory', () => {
     const plugin = getOxygenPlugin();
 
-    expect(runConfigHook(plugin, {})).toMatchObject({
-      build: {outDir: 'dist'},
-    });
+    expect(runConfigHook(plugin, {})).not.toHaveProperty('build');
   });
 
   it('does not override a user-provided build output directory', () => {
@@ -99,6 +102,17 @@ describe('oxygen Vite plugin', () => {
     expect(
       runConfigHook(plugin, {build: {outDir: 'custom-dist'}}),
     ).not.toHaveProperty('build.outDir');
+  });
+
+  it.each([
+    'virtual:oxygen-framework-entry',
+    '@shopify/oxygen-framework/worker',
+  ])('uses configured entry "%s" for SSR build defaults', (entry) => {
+    const plugin = getOxygenPlugin({entry});
+
+    expect(
+      runConfigHook(plugin, {build: {ssr: true}}, {isSsrBuild: true}),
+    ).toHaveProperty('build.ssr', entry);
   });
 
   it('emits oxygen.json from the installed Hydrogen version', () => {

--- a/packages/mini-oxygen/src/vite/plugin.test.ts
+++ b/packages/mini-oxygen/src/vite/plugin.test.ts
@@ -2,7 +2,26 @@ import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
 import {join} from 'node:path';
 import {tmpdir} from 'node:os';
 import {afterEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('../worker/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../worker/index.js')>();
+
+  return {
+    ...actual,
+    createMiniOxygen: vi.fn(() => ({
+      ready: Promise.resolve({workerUrl: new URL('http://localhost:3000')}),
+      dispatchFetch: vi.fn(),
+      dispose: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('../common/find-port.js', () => ({
+  findPort: vi.fn(async () => 9100),
+}));
+
 import type {Plugin} from 'vite';
+import {createMiniOxygen} from '../worker/index.js';
 import {oxygen, type OxygenPluginOptions} from './plugin.js';
 
 const tempRoots: string[] = [];
@@ -39,6 +58,13 @@ function createRootWithHydrogenVersion(version: string) {
       exports: {'./package.json': './package.json'},
     }),
   );
+}
+
+function createRoot() {
+  const root = mkdtempSync(join(tmpdir(), 'mini-oxygen-'));
+  tempRoots.push(root);
+
+  return root;
 }
 
 function runConfigHook(
@@ -100,8 +126,47 @@ function runConfigEnvironmentHook(plugin: Plugin, name: string) {
   return (plugin.configEnvironment as any)(name);
 }
 
+async function runConfigurePreviewServerHook(
+  plugin: Plugin,
+  {
+    root,
+    clientOutDir = join(root, 'dist/client'),
+  }: {
+    root: string;
+    clientOutDir?: string;
+  },
+) {
+  const hook =
+    typeof plugin.configurePreviewServer === 'function'
+      ? plugin.configurePreviewServer
+      : plugin.configurePreviewServer?.handler;
+
+  if (!hook) {
+    throw new Error(
+      'Expected oxygen plugin to expose a configurePreviewServer hook.',
+    );
+  }
+
+  const previewServer = {
+    config: {
+      root,
+      build: {outDir: clientOutDir},
+      environments: {client: {build: {outDir: clientOutDir}}},
+    },
+    httpServer: {once: vi.fn()},
+    middlewares: {use: vi.fn()},
+  };
+
+  const postHook = await (hook as any)(previewServer);
+  postHook?.();
+
+  return previewServer;
+}
+
 describe('oxygen Vite plugin', () => {
   afterEach(() => {
+    vi.mocked(createMiniOxygen).mockClear();
+
     for (const root of tempRoots.splice(0)) {
       rmSync(root, {recursive: true, force: true});
     }
@@ -209,5 +274,87 @@ describe('oxygen Vite plugin', () => {
     const emitFile = runSsrBuildHooks(plugin, root);
 
     expect(emitFile).not.toHaveBeenCalled();
+  });
+
+  it('uses the server directory next to the Vite client output for preview', async () => {
+    const plugin = getOxygenPlugin();
+    const root = createRoot();
+    const clientOutDir = join(root, 'build/client');
+    const workerFile = join(root, 'build/server/index.js');
+
+    mkdirSync(clientOutDir, {recursive: true});
+    mkdirSync(join(root, 'build/server'), {recursive: true});
+    writeFileSync(workerFile, 'export default {fetch() {}};');
+
+    const previewServer = await runConfigurePreviewServerHook(plugin, {
+      root,
+      clientOutDir,
+    });
+
+    expect(createMiniOxygen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assets: expect.objectContaining({directory: clientOutDir}),
+        workers: [
+          expect.objectContaining({
+            modulesRoot: join(root, 'build/server'),
+            modules: [
+              expect.objectContaining({
+                path: workerFile,
+                contents: 'export default {fetch() {}};',
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(previewServer.middlewares.use).toHaveBeenCalledOnce();
+  });
+
+  it('uses the configured preview entry', async () => {
+    const plugin = getOxygenPlugin({previewEntry: 'custom/worker.mjs'});
+    const root = createRoot();
+    const clientOutDir = join(root, 'dist/client');
+    const workerFile = join(root, 'custom/worker.mjs');
+
+    mkdirSync(clientOutDir, {recursive: true});
+    mkdirSync(join(root, 'custom'), {recursive: true});
+    writeFileSync(workerFile, 'export default {fetch() {}};');
+
+    await runConfigurePreviewServerHook(plugin, {root, clientOutDir});
+
+    expect(createMiniOxygen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workers: [
+          expect.objectContaining({
+            modulesRoot: join(root, 'custom'),
+            modules: [expect.objectContaining({path: workerFile})],
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('falls back to the default dist server entry for preview', async () => {
+    const plugin = getOxygenPlugin();
+    const root = createRoot();
+    const clientOutDir = join(root, 'custom/client');
+    const workerFile = join(root, 'dist/server/index.mjs');
+
+    mkdirSync(clientOutDir, {recursive: true});
+    mkdirSync(join(root, 'dist/server'), {recursive: true});
+    writeFileSync(workerFile, 'export default {fetch() {}};');
+
+    await runConfigurePreviewServerHook(plugin, {root, clientOutDir});
+
+    expect(createMiniOxygen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workers: [
+          expect.objectContaining({
+            modulesRoot: join(root, 'dist/server'),
+            modules: [expect.objectContaining({path: workerFile})],
+          }),
+        ],
+      }),
+    );
   });
 });

--- a/packages/mini-oxygen/src/vite/plugin.test.ts
+++ b/packages/mini-oxygen/src/vite/plugin.test.ts
@@ -83,6 +83,16 @@ function runConfigResolvedHook(plugin: Plugin, root: string) {
   (hook as any)({root});
 }
 
+function runConfigEnvironmentHook(plugin: Plugin, name: string) {
+  if (typeof plugin.configEnvironment !== 'function') {
+    throw new Error(
+      'Expected oxygen plugin to expose a configEnvironment hook.',
+    );
+  }
+
+  return (plugin.configEnvironment as any)(name);
+}
+
 describe('oxygen Vite plugin', () => {
   afterEach(() => {
     for (const root of tempRoots.splice(0)) {
@@ -102,6 +112,28 @@ describe('oxygen Vite plugin', () => {
     expect(
       runConfigHook(plugin, {build: {outDir: 'custom-dist'}}),
     ).not.toHaveProperty('build.outDir');
+  });
+
+  it('does not add worker conditions to the top-level client resolver', () => {
+    const plugin = getOxygenPlugin();
+
+    expect(runConfigHook(plugin, {})).not.toHaveProperty('resolve.conditions');
+  });
+
+  it('adds worker conditions to SSR resolution only', () => {
+    const plugin = getOxygenPlugin();
+
+    const config = runConfigHook(plugin, {});
+    expect(config).toHaveProperty('ssr.resolve.conditions');
+    expect(config.ssr.resolve.conditions).toContain('worker');
+    expect(config.ssr.resolve.conditions).toContain('workerd');
+
+    expect(runConfigEnvironmentHook(plugin, 'client')).toBeUndefined();
+
+    const ssrEnvironmentConfig = runConfigEnvironmentHook(plugin, 'ssr');
+    expect(ssrEnvironmentConfig).toHaveProperty('resolve.conditions');
+    expect(ssrEnvironmentConfig.resolve.conditions).toContain('worker');
+    expect(ssrEnvironmentConfig.resolve.conditions).toContain('workerd');
   });
 
   it.each([

--- a/packages/mini-oxygen/src/vite/plugin.test.ts
+++ b/packages/mini-oxygen/src/vite/plugin.test.ts
@@ -28,7 +28,11 @@ const tempRoots: string[] = [];
 
 function getOxygenPlugin(options?: OxygenPluginOptions) {
   return oxygen(options)[0] as Plugin<{
-    registerPluginOptions(newOptions: {compatibilityDate?: string}): void;
+    registerPluginOptions(newOptions: {
+      compatibilityDate?: string;
+      env?: Record<string, string>;
+      envPromise?: Promise<Record<string, string>>;
+    }): void;
   }>;
 }
 
@@ -150,6 +154,8 @@ async function runConfigurePreviewServerHook(
   const previewServer = {
     config: {
       root,
+      mode: 'development',
+      envDir: root,
       build: {outDir: clientOutDir},
       environments: {client: {build: {outDir: clientOutDir}}},
     },
@@ -163,9 +169,16 @@ async function runConfigurePreviewServerHook(
   return previewServer;
 }
 
+function getLastPreviewBindings() {
+  const options = vi.mocked(createMiniOxygen).mock.calls.at(-1)?.[0] as any;
+
+  return options?.workers?.[0]?.bindings;
+}
+
 describe('oxygen Vite plugin', () => {
   afterEach(() => {
     vi.mocked(createMiniOxygen).mockClear();
+    delete process.env.MINI_OXYGEN_PROCESS_ENV;
 
     for (const root of tempRoots.splice(0)) {
       rmSync(root, {recursive: true, force: true});
@@ -355,6 +368,123 @@ describe('oxygen Vite plugin', () => {
           }),
         ],
       }),
+    );
+  });
+
+  it('loads local Vite env as preview bindings when no env is configured', async () => {
+    const plugin = getOxygenPlugin();
+    const root = createRoot();
+    const clientOutDir = join(root, 'dist/client');
+    const workerFile = join(root, 'dist/server/index.js');
+
+    writeFileSync(join(root, '.env'), 'MINI_OXYGEN_LOCAL_ENV=local\n');
+    mkdirSync(clientOutDir, {recursive: true});
+    mkdirSync(join(root, 'dist/server'), {recursive: true});
+    writeFileSync(workerFile, 'export default {fetch() {}};');
+
+    await runConfigurePreviewServerHook(plugin, {root, clientOutDir});
+
+    expect(getLastPreviewBindings()).toHaveProperty(
+      'MINI_OXYGEN_LOCAL_ENV',
+      'local',
+    );
+  });
+
+  it('does not load Vite env when CLI envPromise is registered', async () => {
+    const plugin = getOxygenPlugin();
+    const root = createRoot();
+    const clientOutDir = join(root, 'dist/client');
+    const workerFile = join(root, 'dist/server/index.js');
+
+    process.env.MINI_OXYGEN_PROCESS_ENV = 'process';
+    writeFileSync(join(root, '.env'), 'MINI_OXYGEN_LOCAL_ENV=local\n');
+    mkdirSync(clientOutDir, {recursive: true});
+    mkdirSync(join(root, 'dist/server'), {recursive: true});
+    writeFileSync(workerFile, 'export default {fetch() {}};');
+    plugin.api?.registerPluginOptions({
+      envPromise: Promise.resolve({MINI_OXYGEN_CLI_ENV: 'cli'}),
+    });
+
+    await runConfigurePreviewServerHook(plugin, {root, clientOutDir});
+
+    expect(getLastPreviewBindings()).toHaveProperty(
+      'MINI_OXYGEN_CLI_ENV',
+      'cli',
+    );
+    expect(getLastPreviewBindings()).not.toHaveProperty(
+      'MINI_OXYGEN_LOCAL_ENV',
+    );
+    expect(getLastPreviewBindings()).not.toHaveProperty(
+      'MINI_OXYGEN_PROCESS_ENV',
+    );
+  });
+
+  it('does not load local Vite env when plugin env is configured', async () => {
+    const plugin = getOxygenPlugin({
+      env: {MINI_OXYGEN_PLUGIN_ENV: 'plugin'},
+    });
+    const root = createRoot();
+    const clientOutDir = join(root, 'dist/client');
+    const workerFile = join(root, 'dist/server/index.js');
+
+    writeFileSync(join(root, '.env'), 'MINI_OXYGEN_LOCAL_ENV=local\n');
+    mkdirSync(clientOutDir, {recursive: true});
+    mkdirSync(join(root, 'dist/server'), {recursive: true});
+    writeFileSync(workerFile, 'export default {fetch() {}};');
+
+    await runConfigurePreviewServerHook(plugin, {root, clientOutDir});
+
+    expect(getLastPreviewBindings()).toHaveProperty(
+      'MINI_OXYGEN_PLUGIN_ENV',
+      'plugin',
+    );
+    expect(getLastPreviewBindings()).not.toHaveProperty(
+      'MINI_OXYGEN_LOCAL_ENV',
+    );
+  });
+
+  it('does not load local Vite env when CLI env is registered', async () => {
+    const plugin = getOxygenPlugin();
+    const root = createRoot();
+    const clientOutDir = join(root, 'dist/client');
+    const workerFile = join(root, 'dist/server/index.js');
+
+    writeFileSync(join(root, '.env'), 'MINI_OXYGEN_LOCAL_ENV=local\n');
+    mkdirSync(clientOutDir, {recursive: true});
+    mkdirSync(join(root, 'dist/server'), {recursive: true});
+    writeFileSync(workerFile, 'export default {fetch() {}};');
+    plugin.api?.registerPluginOptions({
+      env: {MINI_OXYGEN_CLI_ENV: 'cli'},
+    });
+
+    await runConfigurePreviewServerHook(plugin, {root, clientOutDir});
+
+    expect(getLastPreviewBindings()).toHaveProperty(
+      'MINI_OXYGEN_CLI_ENV',
+      'cli',
+    );
+    expect(getLastPreviewBindings()).not.toHaveProperty(
+      'MINI_OXYGEN_LOCAL_ENV',
+    );
+  });
+
+  it('loads local Vite env when registered options do not include env', async () => {
+    const plugin = getOxygenPlugin();
+    const root = createRoot();
+    const clientOutDir = join(root, 'dist/client');
+    const workerFile = join(root, 'dist/server/index.js');
+
+    writeFileSync(join(root, '.env'), 'MINI_OXYGEN_LOCAL_ENV=local\n');
+    mkdirSync(clientOutDir, {recursive: true});
+    mkdirSync(join(root, 'dist/server'), {recursive: true});
+    writeFileSync(workerFile, 'export default {fetch() {}};');
+    plugin.api?.registerPluginOptions({compatibilityDate: '2026-04-01'});
+
+    await runConfigurePreviewServerHook(plugin, {root, clientOutDir});
+
+    expect(getLastPreviewBindings()).toHaveProperty(
+      'MINI_OXYGEN_LOCAL_ENV',
+      'local',
     );
   });
 });

--- a/packages/mini-oxygen/src/vite/plugin.test.ts
+++ b/packages/mini-oxygen/src/vite/plugin.test.ts
@@ -253,7 +253,7 @@ describe('oxygen Vite plugin', () => {
       type: 'asset',
       fileName: 'oxygen.json',
       source: JSON.stringify(
-        {version: 1, compatibility_date: '2025-04-01'},
+        {version: 1, compatibility_date: '2026-04-01'},
         null,
         2,
       ),

--- a/packages/mini-oxygen/src/vite/plugin.test.ts
+++ b/packages/mini-oxygen/src/vite/plugin.test.ts
@@ -253,7 +253,7 @@ describe('oxygen Vite plugin', () => {
       type: 'asset',
       fileName: 'oxygen.json',
       source: JSON.stringify(
-        {version: 1, compatibility_date: '2026-04-01'},
+        {version: 1, compatibility_date: '2025-04-01'},
         null,
         2,
       ),

--- a/packages/mini-oxygen/src/vite/plugin.test.ts
+++ b/packages/mini-oxygen/src/vite/plugin.test.ts
@@ -102,12 +102,16 @@ function runGenerateBundle(plugin: Plugin) {
 
 function runSsrBuildHooks(plugin: Plugin, root: string) {
   runConfigHook(plugin, {}, {isSsrBuild: true});
-  runConfigResolvedHook(plugin, root);
+  runConfigResolvedHook(plugin, root, {build: {ssr: true}});
 
   return runGenerateBundle(plugin);
 }
 
-function runConfigResolvedHook(plugin: Plugin, root: string) {
+function runConfigResolvedHook(
+  plugin: Plugin,
+  root: string,
+  resolvedConfig: Record<string, any> = {},
+) {
   const hook =
     typeof plugin.configResolved === 'function'
       ? plugin.configResolved
@@ -117,7 +121,14 @@ function runConfigResolvedHook(plugin: Plugin, root: string) {
     throw new Error('Expected oxygen plugin to expose a configResolved hook.');
   }
 
-  (hook as any)({root});
+  (hook as any)({
+    root,
+    ...resolvedConfig,
+    build: {
+      ssr: false,
+      ...resolvedConfig.build,
+    },
+  });
 }
 
 function runConfigEnvironmentHook(plugin: Plugin, name: string) {
@@ -260,12 +271,31 @@ describe('oxygen Vite plugin', () => {
     });
   });
 
+  it('emits oxygen.json when the resolved config is an SSR build', () => {
+    const plugin = getOxygenPlugin();
+    const root = createRootWithHydrogenVersion('2026.4.4');
+
+    runConfigHook(plugin, {}, {isSsrBuild: false});
+    runConfigResolvedHook(plugin, root, {build: {ssr: true}});
+    const emitFile = runGenerateBundle(plugin);
+
+    expect(emitFile).toHaveBeenCalledWith({
+      type: 'asset',
+      fileName: 'oxygen.json',
+      source: JSON.stringify(
+        {version: 1, compatibility_date: '2026-04-01'},
+        null,
+        2,
+      ),
+    });
+  });
+
   it('uses explicit compatibility dates before inferred dates', () => {
     const plugin = getOxygenPlugin();
     const root = createRootWithHydrogenVersion('2026.4.4');
 
     runConfigHook(plugin, {}, {isSsrBuild: true});
-    runConfigResolvedHook(plugin, root);
+    runConfigResolvedHook(plugin, root, {build: {ssr: true}});
     plugin.api?.registerPluginOptions({compatibilityDate: '2025-04-01'});
     const emitFile = runGenerateBundle(plugin);
 

--- a/packages/mini-oxygen/src/vite/plugin.test.ts
+++ b/packages/mini-oxygen/src/vite/plugin.test.ts
@@ -70,6 +70,13 @@ function runGenerateBundle(plugin: Plugin) {
   return emitFile;
 }
 
+function runSsrBuildHooks(plugin: Plugin, root: string) {
+  runConfigHook(plugin, {}, {isSsrBuild: true});
+  runConfigResolvedHook(plugin, root);
+
+  return runGenerateBundle(plugin);
+}
+
 function runConfigResolvedHook(plugin: Plugin, root: string) {
   const hook =
     typeof plugin.configResolved === 'function'
@@ -147,12 +154,22 @@ describe('oxygen Vite plugin', () => {
     ).toHaveProperty('build.ssr', entry);
   });
 
-  it('emits oxygen.json from the installed Hydrogen version', () => {
+  it('does not emit oxygen.json during client builds', () => {
     const plugin = getOxygenPlugin();
     const root = createRootWithHydrogenVersion('2026.4.4');
 
+    runConfigHook(plugin, {}, {isSsrBuild: false});
     runConfigResolvedHook(plugin, root);
     const emitFile = runGenerateBundle(plugin);
+
+    expect(emitFile).not.toHaveBeenCalled();
+  });
+
+  it('emits oxygen.json from the installed Hydrogen version during SSR builds', () => {
+    const plugin = getOxygenPlugin();
+    const root = createRootWithHydrogenVersion('2026.4.4');
+
+    const emitFile = runSsrBuildHooks(plugin, root);
 
     expect(emitFile).toHaveBeenCalledWith({
       type: 'asset',
@@ -169,6 +186,7 @@ describe('oxygen Vite plugin', () => {
     const plugin = getOxygenPlugin();
     const root = createRootWithHydrogenVersion('2026.4.4');
 
+    runConfigHook(plugin, {}, {isSsrBuild: true});
     runConfigResolvedHook(plugin, root);
     plugin.api?.registerPluginOptions({compatibilityDate: '2025-04-01'});
     const emitFile = runGenerateBundle(plugin);
@@ -188,8 +206,7 @@ describe('oxygen Vite plugin', () => {
     const plugin = getOxygenPlugin();
     const root = createRootWithHydrogenPackageJson('{');
 
-    runConfigResolvedHook(plugin, root);
-    const emitFile = runGenerateBundle(plugin);
+    const emitFile = runSsrBuildHooks(plugin, root);
 
     expect(emitFile).not.toHaveBeenCalled();
   });

--- a/packages/mini-oxygen/src/vite/plugin.test.ts
+++ b/packages/mini-oxygen/src/vite/plugin.test.ts
@@ -1,0 +1,150 @@
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {tmpdir} from 'node:os';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import type {Plugin} from 'vite';
+import {oxygen} from './plugin.js';
+
+const tempRoots: string[] = [];
+
+function getOxygenPlugin() {
+  return oxygen()[0] as Plugin<{
+    registerPluginOptions(newOptions: {compatibilityDate?: string}): void;
+  }>;
+}
+
+function createRootWithHydrogenPackageJson(source: string) {
+  const root = mkdtempSync(join(tmpdir(), 'mini-oxygen-'));
+  tempRoots.push(root);
+
+  const hydrogenPackageRoot = join(
+    root,
+    'node_modules',
+    '@shopify',
+    'hydrogen',
+  );
+
+  mkdirSync(hydrogenPackageRoot, {recursive: true});
+  writeFileSync(join(root, 'package.json'), JSON.stringify({}));
+  writeFileSync(join(hydrogenPackageRoot, 'package.json'), source);
+
+  return root;
+}
+
+function createRootWithHydrogenVersion(version: string) {
+  return createRootWithHydrogenPackageJson(
+    JSON.stringify({
+      name: '@shopify/hydrogen',
+      version,
+      exports: {'./package.json': './package.json'},
+    }),
+  );
+}
+
+function runConfigHook(plugin: Plugin, config: Record<string, any>) {
+  if (typeof plugin.config !== 'function') {
+    throw new Error('Expected oxygen plugin to expose a config hook.');
+  }
+
+  return (plugin.config as any)(config, {
+    command: 'build',
+    mode: 'production',
+    isSsrBuild: false,
+    isPreview: false,
+  });
+}
+
+function runGenerateBundle(plugin: Plugin) {
+  if (typeof plugin.generateBundle !== 'function') {
+    throw new Error('Expected oxygen plugin to expose a generateBundle hook.');
+  }
+
+  const emitFile = vi.fn();
+  plugin.generateBundle.call({emitFile} as any, {} as any, {} as any, false);
+
+  return emitFile;
+}
+
+function runConfigResolvedHook(plugin: Plugin, root: string) {
+  const hook =
+    typeof plugin.configResolved === 'function'
+      ? plugin.configResolved
+      : plugin.configResolved?.handler;
+
+  if (!hook) {
+    throw new Error('Expected oxygen plugin to expose a configResolved hook.');
+  }
+
+  (hook as any)({root});
+}
+
+describe('oxygen Vite plugin', () => {
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, {recursive: true, force: true});
+    }
+  });
+
+  it('sets the default build output directory when the app does not', () => {
+    const plugin = getOxygenPlugin();
+
+    expect(runConfigHook(plugin, {})).toMatchObject({
+      build: {outDir: 'dist'},
+    });
+  });
+
+  it('does not override a user-provided build output directory', () => {
+    const plugin = getOxygenPlugin();
+
+    expect(
+      runConfigHook(plugin, {build: {outDir: 'custom-dist'}}),
+    ).not.toHaveProperty('build.outDir');
+  });
+
+  it('emits oxygen.json from the installed Hydrogen version', () => {
+    const plugin = getOxygenPlugin();
+    const root = createRootWithHydrogenVersion('2026.4.4');
+
+    runConfigResolvedHook(plugin, root);
+    const emitFile = runGenerateBundle(plugin);
+
+    expect(emitFile).toHaveBeenCalledWith({
+      type: 'asset',
+      fileName: 'oxygen.json',
+      source: JSON.stringify(
+        {version: 1, compatibility_date: '2026-04-01'},
+        null,
+        2,
+      ),
+    });
+  });
+
+  it('uses explicit compatibility dates before inferred dates', () => {
+    const plugin = getOxygenPlugin();
+    const root = createRootWithHydrogenVersion('2026.4.4');
+
+    runConfigResolvedHook(plugin, root);
+    plugin.api?.registerPluginOptions({compatibilityDate: '2025-04-01'});
+    const emitFile = runGenerateBundle(plugin);
+
+    expect(emitFile).toHaveBeenCalledWith({
+      type: 'asset',
+      fileName: 'oxygen.json',
+      source: JSON.stringify(
+        {version: 1, compatibility_date: '2025-04-01'},
+        null,
+        2,
+      ),
+    });
+  });
+
+  it('does not emit oxygen.json when resolved Hydrogen metadata cannot be read', () => {
+    const plugin = getOxygenPlugin();
+    const root = createRootWithHydrogenPackageJson('{');
+
+    runConfigResolvedHook(plugin, root);
+    const emitFile = runGenerateBundle(plugin);
+
+    expect(emitFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mini-oxygen/src/vite/plugin.ts
+++ b/packages/mini-oxygen/src/vite/plugin.ts
@@ -1,7 +1,8 @@
-import {defaultClientConditions} from 'vite';
+import {defaultClientConditions, loadEnv} from 'vite';
 import type {Plugin} from 'vite';
 import {
   createMiniOxygenDevEnvironment,
+  hasProvidedEnvBindings,
   type MiniOxygenDevEnvironment,
   type MiniOxygenRuntimeOptions,
   mergeMiniOxygenRuntimeOptions,
@@ -57,12 +58,25 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
     const entry =
       runtimeOptions.entry ?? pluginOptions.entry ?? DEFAULT_SSR_ENTRY;
     const remoteEnv = await Promise.resolve(runtimeOptions.envPromise);
+    const fallbackEnv =
+      !hasProvidedEnvBindings(pluginOptions) &&
+      !hasProvidedEnvBindings(runtimeOptions)
+        ? loadEnv(viteDevServer.config.mode, viteDevServer.config.envDir, '')
+        : undefined;
+
+    const env = Object.assign(
+      {},
+      fallbackEnv,
+      remoteEnv,
+      runtimeOptions.env,
+      pluginOptions.env,
+    );
 
     return {
       entry,
       viteDevServer,
       crossBoundarySetup: runtimeOptions.crossBoundarySetup,
-      env: {...remoteEnv, ...runtimeOptions.env, ...pluginOptions.env},
+      env,
       debug: runtimeOptions.debug ?? pluginOptions.debug ?? false,
       inspectorPort:
         runtimeOptions.inspectorPort ?? pluginOptions.inspectorPort,

--- a/packages/mini-oxygen/src/vite/plugin.ts
+++ b/packages/mini-oxygen/src/vite/plugin.ts
@@ -10,6 +10,7 @@ import {
   setupOxygenMiddleware,
   type MiniOxygenViteOptions,
 } from './server-middleware.js';
+import {getHydrogenCompatibilityDate} from './compat-date.js';
 
 // Note: Vite resolves extensions like .js or .ts automatically.
 const DEFAULT_SSR_ENTRY = './server';
@@ -40,6 +41,7 @@ export type {MiniOxygenDevEnvironment};
 export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
   let apiOptions: OxygenApiOptions = {};
   let miniOxygenEnvironment: MiniOxygenDevEnvironment | undefined;
+  let root = process.cwd();
 
   const resolveMiniOxygenOptions = async (
     runtimeOptions: MiniOxygenRuntimeOptions,
@@ -59,7 +61,9 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
         runtimeOptions.inspectorPort ?? pluginOptions.inspectorPort,
       requestHook: runtimeOptions.requestHook,
       entryPointErrorHandler: runtimeOptions.entryPointErrorHandler,
-      compatibilityDate: runtimeOptions.compatibilityDate,
+      compatibilityDate:
+        runtimeOptions.compatibilityDate ??
+        getHydrogenCompatibilityDate(viteDevServer.config.root),
       logRequestLine:
         // Give priority to the plugin option over the CLI option here,
         // since the CLI one is just a default, not a user-provided flag.
@@ -76,8 +80,26 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
     {
       name: 'oxygen:main',
       config(config, env) {
+        const build = {
+          ...(!config.build?.outDir && {outDir: 'dist'}),
+          // When building, the CLI will set the `ssr` option to `true`
+          // if no --entry flag is passed for the default SSR entry file.
+          // Replace it here with a default value.
+          ...(env.isSsrBuild &&
+            config.build?.ssr && {
+              ssr:
+                config.build?.ssr === true
+                  ? // No --entry flag passed by the user, use the
+                    // option passed to the plugin or the default value
+                    (pluginOptions.entry ?? DEFAULT_SSR_ENTRY)
+                  : // --entry flag passed by the user, keep it
+                    config.build?.ssr,
+            }),
+        };
+
         return {
           appType: 'custom',
+          ...(Object.keys(build).length > 0 && {build}),
           resolve: {
             conditions: ['worker', 'workerd', ...defaultClientConditions],
           },
@@ -88,22 +110,10 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
               conditions: ['worker', 'workerd', ...defaultClientConditions],
             },
           },
-          // When building, the CLI will set the `ssr` option to `true`
-          // if no --entry flag is passed for the default SSR entry file.
-          // Replace it here with a default value.
-          ...(env.isSsrBuild &&
-            config.build?.ssr && {
-              build: {
-                ssr:
-                  config.build?.ssr === true
-                    ? // No --entry flag passed by the user, use the
-                      // option passed to the plugin or the default value
-                      (pluginOptions.entry ?? DEFAULT_SSR_ENTRY)
-                    : // --entry flag passed by the user, keep it
-                      config.build?.ssr,
-              },
-            }),
         };
+      },
+      configResolved(resolvedConfig) {
+        root = resolvedConfig.root;
       },
       configEnvironment(name) {
         if (name !== 'ssr') return;
@@ -145,17 +155,20 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
         },
       },
       generateBundle() {
-        if (apiOptions.compatibilityDate) {
-          if (!/^\d{4}-\d{2}-\d{2}$/.test(apiOptions.compatibilityDate)) {
+        const compatibilityDate =
+          apiOptions.compatibilityDate ?? getHydrogenCompatibilityDate(root);
+
+        if (compatibilityDate) {
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(compatibilityDate)) {
             throw new Error(
-              `Invalid compatibility date "${apiOptions.compatibilityDate}"`,
+              `Invalid compatibility date "${compatibilityDate}"`,
             );
           }
 
           const oxygenJsonFile = 'oxygen.json';
           const oxygenJsonContent = {
             version: 1,
-            compatibility_date: apiOptions.compatibilityDate,
+            compatibility_date: compatibilityDate,
           };
 
           this.emitFile({

--- a/packages/mini-oxygen/src/vite/plugin.ts
+++ b/packages/mini-oxygen/src/vite/plugin.ts
@@ -14,6 +14,7 @@ import {getHydrogenCompatibilityDate} from './compat-date.js';
 
 // Note: Vite resolves extensions like .js or .ts automatically.
 const DEFAULT_SSR_ENTRY = './server';
+const workerConditions = ['worker', 'workerd', ...defaultClientConditions];
 
 export type OxygenPluginOptions = Partial<
   Pick<
@@ -99,14 +100,11 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
         return {
           appType: 'custom',
           ...(Object.keys(build).length > 0 && {build}),
-          resolve: {
-            conditions: ['worker', 'workerd', ...defaultClientConditions],
-          },
           ssr: {
             noExternal: true,
             target: 'webworker',
             resolve: {
-              conditions: ['worker', 'workerd', ...defaultClientConditions],
+              conditions: workerConditions,
             },
           },
         };
@@ -119,7 +117,7 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
 
         return {
           resolve: {
-            conditions: ['worker', 'workerd', ...defaultClientConditions],
+            conditions: workerConditions,
           },
           dev: {
             createEnvironment(name, config) {

--- a/packages/mini-oxygen/src/vite/plugin.ts
+++ b/packages/mini-oxygen/src/vite/plugin.ts
@@ -81,7 +81,6 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
       name: 'oxygen:main',
       config(config, env) {
         const build = {
-          ...(!config.build?.outDir && {outDir: 'dist'}),
           // When building, the CLI will set the `ssr` option to `true`
           // if no --entry flag is passed for the default SSR entry file.
           // Replace it here with a default value.

--- a/packages/mini-oxygen/src/vite/plugin.ts
+++ b/packages/mini-oxygen/src/vite/plugin.ts
@@ -11,6 +11,10 @@ import {
   type MiniOxygenViteOptions,
 } from './server-middleware.js';
 import {getHydrogenCompatibilityDate} from './compat-date.js';
+import {
+  setupOxygenPreviewServer,
+  type OxygenPreviewOptions,
+} from './preview.js';
 
 // Note: Vite resolves extensions like .js or .ts automatically.
 const DEFAULT_SSR_ENTRY = './server';
@@ -21,7 +25,8 @@ export type OxygenPluginOptions = Partial<
     MiniOxygenViteOptions,
     'entry' | 'env' | 'inspectorPort' | 'logRequestLine' | 'debug'
   >
->;
+> &
+  OxygenPreviewOptions;
 
 type OxygenApiOptions = MiniOxygenRuntimeOptions;
 
@@ -152,6 +157,16 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
               () => apiOptions.entryPointErrorHandler,
             );
           };
+        },
+      },
+      configurePreviewServer: {
+        order: 'pre',
+        async handler(previewServer) {
+          return setupOxygenPreviewServer(
+            previewServer,
+            pluginOptions,
+            apiOptions,
+          );
         },
       },
       generateBundle() {

--- a/packages/mini-oxygen/src/vite/plugin.ts
+++ b/packages/mini-oxygen/src/vite/plugin.ts
@@ -101,8 +101,6 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
     {
       name: 'oxygen:main',
       config(config, env) {
-        isSsrBuild = Boolean(env.isSsrBuild);
-
         const build = {
           // When building, the CLI will set the `ssr` option to `true`
           // if no --entry flag is passed for the default SSR entry file.
@@ -133,6 +131,7 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
       },
       configResolved(resolvedConfig) {
         root = resolvedConfig.root;
+        isSsrBuild = Boolean(resolvedConfig.build.ssr);
       },
       configEnvironment(name) {
         if (name !== 'ssr') return;

--- a/packages/mini-oxygen/src/vite/plugin.ts
+++ b/packages/mini-oxygen/src/vite/plugin.ts
@@ -43,6 +43,7 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
   let apiOptions: OxygenApiOptions = {};
   let miniOxygenEnvironment: MiniOxygenDevEnvironment | undefined;
   let root = process.cwd();
+  let isSsrBuild = false;
 
   const resolveMiniOxygenOptions = async (
     runtimeOptions: MiniOxygenRuntimeOptions,
@@ -81,6 +82,8 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
     {
       name: 'oxygen:main',
       config(config, env) {
+        isSsrBuild = Boolean(env.isSsrBuild);
+
         const build = {
           // When building, the CLI will set the `ssr` option to `true`
           // if no --entry flag is passed for the default SSR entry file.
@@ -152,6 +155,8 @@ export function oxygen(pluginOptions: OxygenPluginOptions = {}): Plugin[] {
         },
       },
       generateBundle() {
+        if (!isSsrBuild) return;
+
         const compatibilityDate =
           apiOptions.compatibilityDate ?? getHydrogenCompatibilityDate(root);
 

--- a/packages/mini-oxygen/src/vite/preview.ts
+++ b/packages/mini-oxygen/src/vite/preview.ts
@@ -1,0 +1,218 @@
+import {existsSync} from 'node:fs';
+import {readFile} from 'node:fs/promises';
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from 'node:path';
+import type {PreviewServer, ResolvedConfig} from 'vite';
+import type {MiniOxygenRuntimeOptions} from './environment.js';
+import {getHydrogenCompatibilityDate} from './compat-date.js';
+import {
+  createMiniOxygen,
+  defaultLogRequestLine,
+  type RequestHook,
+} from '../worker/index.js';
+import {findPort} from '../common/find-port.js';
+import {pipeFromWeb, toMiniflareRequest, toWeb} from './utils.js';
+
+const DEFAULT_PREVIEW_ENTRY = 'dist/server/index.js';
+const DEFAULT_PREVIEW_ENTRY_FILES = ['index.js', 'index.mjs'];
+const DEFAULT_PREVIEW_ASSETS_PORT = 9100;
+
+export type OxygenPreviewOptions = {
+  /**
+   * Built worker module used by `vite preview`.
+   * Defaults to the detected server output entry, then dist/server/index.js.
+   */
+  previewEntry?: string;
+};
+
+type PreviewRuntimePluginOptions = OxygenPreviewOptions &
+  Partial<
+    Pick<
+      MiniOxygenRuntimeOptions,
+      'env' | 'inspectorPort' | 'logRequestLine' | 'debug'
+    >
+  >;
+
+export async function setupOxygenPreviewServer(
+  previewServer: PreviewServer,
+  pluginOptions: PreviewRuntimePluginOptions,
+  apiOptions: MiniOxygenRuntimeOptions,
+) {
+  const previewRuntime = await createOxygenPreviewRuntime(
+    previewServer,
+    pluginOptions,
+    apiOptions,
+  );
+
+  previewServer.httpServer.once('close', () => {
+    void previewRuntime.dispose();
+  });
+
+  return () => {
+    previewServer.middlewares.use(
+      async function o2HandlePreviewWorkerRequest(req, res, next) {
+        try {
+          const response = await previewRuntime.dispatchFetch(
+            toMiniflareRequest(toWeb(req)),
+          );
+
+          await pipeFromWeb(
+            new Response(response.body as ReadableStream | null, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: Array.from(response.headers.entries()),
+            }),
+            res,
+          );
+        } catch (error) {
+          next(error);
+        }
+      },
+    );
+  };
+}
+
+async function createOxygenPreviewRuntime(
+  previewServer: PreviewServer,
+  pluginOptions: PreviewRuntimePluginOptions,
+  apiOptions: MiniOxygenRuntimeOptions,
+) {
+  const {root} = previewServer.config;
+  const {assetsDir, workerFile} = resolvePreviewOutputPaths(
+    previewServer.config,
+    pluginOptions.previewEntry,
+  );
+
+  if (!existsSync(assetsDir)) {
+    throw new Error(
+      `No Oxygen preview client assets were found at "${formatPath(
+        root,
+        assetsDir,
+      )}". Run your build before starting \`vite preview\`.`,
+    );
+  }
+
+  if (!existsSync(workerFile)) {
+    throw new Error(
+      pluginOptions.previewEntry
+        ? `No Oxygen preview worker entry was found at "${formatPath(
+            root,
+            workerFile,
+          )}". Check \`oxygen({ previewEntry })\` or run your build before starting \`vite preview\`.`
+        : `No Oxygen preview worker entry was found. Configure \`oxygen({ previewEntry })\` or build a worker at "${DEFAULT_PREVIEW_ENTRY}".`,
+    );
+  }
+
+  const remoteEnv = await Promise.resolve(apiOptions.envPromise);
+  const compatibilityDate =
+    apiOptions.compatibilityDate ?? getHydrogenCompatibilityDate(root);
+  const requestHook = getPreviewRequestHook(pluginOptions, apiOptions);
+
+  const previewRuntime = createMiniOxygen({
+    debug: apiOptions.debug ?? pluginOptions.debug ?? false,
+    inspectorPort: apiOptions.inspectorPort ?? pluginOptions.inspectorPort,
+    assets: {
+      directory: assetsDir,
+      port: await findPort(DEFAULT_PREVIEW_ASSETS_PORT),
+    },
+    ...(requestHook !== undefined && {requestHook}),
+    workers: [
+      {
+        name: 'preview',
+        modulesRoot: dirname(workerFile),
+        modules: [
+          {
+            type: 'ESModule',
+            path: workerFile,
+            contents: await readFile(workerFile, 'utf8'),
+          },
+        ],
+        bindings: {
+          ...remoteEnv,
+          ...apiOptions.env,
+          ...pluginOptions.env,
+        },
+        ...(compatibilityDate && {compatibilityDate}),
+      },
+    ],
+  });
+
+  await previewRuntime.ready;
+
+  return previewRuntime;
+}
+
+function resolvePreviewOutputPaths(
+  config: ResolvedConfig,
+  previewEntry?: string,
+) {
+  const root = config.root;
+  const clientOutDir = resolveFromRoot(
+    root,
+    config.environments.client?.build.outDir ?? config.build.outDir,
+  );
+
+  if (previewEntry) {
+    return {
+      assetsDir: clientOutDir,
+      workerFile: resolveFromRoot(root, previewEntry),
+    };
+  }
+
+  const workerDirs = [
+    basename(clientOutDir) === 'client'
+      ? join(dirname(clientOutDir), 'server')
+      : undefined,
+    resolve(root, 'dist/server'),
+  ].filter((dir, index, dirs): dir is string => {
+    return Boolean(dir && dirs.indexOf(dir) === index);
+  });
+
+  for (const workerDir of workerDirs) {
+    for (const entryFile of DEFAULT_PREVIEW_ENTRY_FILES) {
+      const workerFile = join(workerDir, entryFile);
+      if (existsSync(workerFile)) {
+        return {assetsDir: clientOutDir, workerFile};
+      }
+    }
+  }
+
+  return {
+    assetsDir: clientOutDir,
+    workerFile: resolve(root, DEFAULT_PREVIEW_ENTRY),
+  };
+}
+
+function resolveFromRoot(root: string, path: string) {
+  return isAbsolute(path) ? path : resolve(root, path);
+}
+
+function formatPath(root: string, path: string) {
+  const relativePath = relative(root, path);
+  return relativePath && !relativePath.startsWith('..') ? relativePath : path;
+}
+
+function getPreviewRequestHook(
+  pluginOptions: PreviewRuntimePluginOptions,
+  apiOptions: MiniOxygenRuntimeOptions,
+): RequestHook | null | undefined {
+  const requestHook = apiOptions.requestHook;
+  const logRequestLine =
+    pluginOptions.logRequestLine ?? apiOptions.logRequestLine;
+
+  if (!requestHook) return logRequestLine;
+  if (logRequestLine === null) return requestHook;
+
+  return async (info) => {
+    await Promise.all([
+      requestHook(info),
+      (logRequestLine ?? defaultLogRequestLine)(info),
+    ]);
+  };
+}

--- a/packages/mini-oxygen/src/vite/preview.ts
+++ b/packages/mini-oxygen/src/vite/preview.ts
@@ -8,8 +8,11 @@ import {
   relative,
   resolve,
 } from 'node:path';
-import type {PreviewServer, ResolvedConfig} from 'vite';
-import type {MiniOxygenRuntimeOptions} from './environment.js';
+import {loadEnv, type PreviewServer, type ResolvedConfig} from 'vite';
+import {
+  hasProvidedEnvBindings,
+  type MiniOxygenRuntimeOptions,
+} from './environment.js';
 import {getHydrogenCompatibilityDate} from './compat-date.js';
 import {
   createMiniOxygen,
@@ -110,6 +113,19 @@ async function createOxygenPreviewRuntime(
   }
 
   const remoteEnv = await Promise.resolve(apiOptions.envPromise);
+  const fallbackEnv =
+    !hasProvidedEnvBindings(pluginOptions) &&
+    !hasProvidedEnvBindings(apiOptions)
+      ? loadEnv(previewServer.config.mode, previewServer.config.envDir, '')
+      : undefined;
+
+  const env = Object.assign(
+    {},
+    fallbackEnv,
+    remoteEnv,
+    apiOptions.env,
+    pluginOptions.env,
+  );
   const compatibilityDate =
     apiOptions.compatibilityDate ?? getHydrogenCompatibilityDate(root);
   const requestHook = getPreviewRequestHook(pluginOptions, apiOptions);
@@ -133,11 +149,7 @@ async function createOxygenPreviewRuntime(
             contents: await readFile(workerFile, 'utf8'),
           },
         ],
-        bindings: {
-          ...remoteEnv,
-          ...apiOptions.env,
-          ...pluginOptions.env,
-        },
+        bindings: env,
         ...(compatibilityDate && {compatibilityDate}),
       },
     ],

--- a/packages/mini-oxygen/src/vite/server-middleware.ts
+++ b/packages/mini-oxygen/src/vite/server-middleware.ts
@@ -11,7 +11,6 @@ import {
   type RequestHook,
   defaultLogRequestLine,
 } from '../worker/index.js';
-import {Request as MiniflareRequest} from 'miniflare';
 import type {OnlyBindings, OnlyServices} from '../worker/utils.js';
 import {pipeFromWeb, toWeb} from './utils.js';
 import {
@@ -229,20 +228,6 @@ export function getViteUrl(viteDevServer: ViteDevServer) {
   }
 
   return viteUrl;
-}
-
-export function toMiniflareRequest(request: Request): MiniflareRequest {
-  // Set the X-Forwarded-Host header to the original host as the `Host` header inside a Worker will contain the workerd host
-  const host = request.headers.get('Host');
-  if (host) {
-    request.headers.set('X-Forwarded-Host', host);
-  }
-  return new MiniflareRequest(request.url, {
-    method: request.method,
-    headers: [['accept-encoding', 'identity'], ...request.headers],
-    body: request.body as any,
-    duplex: 'half',
-  });
 }
 
 async function handleViteInvokeRequest(

--- a/packages/mini-oxygen/src/vite/utils.test.ts
+++ b/packages/mini-oxygen/src/vite/utils.test.ts
@@ -1,7 +1,7 @@
 import {describe, it, expect, vi} from 'vitest';
 import {Readable, Writable} from 'node:stream';
 import {IncomingMessage, ServerResponse} from 'node:http';
-import {pipeFromWeb, toWeb, toURL} from './utils.js';
+import {pipeFromWeb, toMiniflareRequest, toWeb, toURL} from './utils.js';
 import * as nodeFetchServer from '@mjackson/node-fetch-server';
 
 // Mock the sendResponse function from @mjackson/node-fetch-server
@@ -84,6 +84,21 @@ describe('utils', () => {
 
       const webReq = toWeb(nodeReq);
       expect(webReq.body).toBeNull();
+    });
+  });
+
+  describe('toMiniflareRequest', () => {
+    it('should preserve the original host in X-Forwarded-Host', () => {
+      const request = new Request('http://localhost/test', {
+        headers: {host: 'original.example.com'},
+      });
+
+      const miniflareRequest = toMiniflareRequest(request);
+
+      expect(miniflareRequest.headers.get('x-forwarded-host')).toBe(
+        'original.example.com',
+      );
+      expect(miniflareRequest.headers.get('accept-encoding')).toBe('identity');
     });
   });
 

--- a/packages/mini-oxygen/src/vite/utils.ts
+++ b/packages/mini-oxygen/src/vite/utils.ts
@@ -2,6 +2,7 @@ import type {ServerResponse, IncomingMessage} from 'node:http';
 import path from 'node:path';
 import {Readable} from 'node:stream';
 import {sendResponse} from '@mjackson/node-fetch-server';
+import {Request as MiniflareRequest} from 'miniflare';
 
 /**
  * Creates a fully qualified URL from a Node request or a string.
@@ -45,4 +46,18 @@ export function pipeFromWeb(webResponse: Response, res: ServerResponse) {
   // The sendResponse function from @mjackson/node-fetch-server properly handles
   // streaming responses, including turbo-stream responses from React Router.
   return sendResponse(res, webResponse);
+}
+
+export function toMiniflareRequest(request: Request): MiniflareRequest {
+  // Set the X-Forwarded-Host header to the original host as the `Host` header inside a Worker will contain the workerd host
+  const host = request.headers.get('Host');
+  if (host) {
+    request.headers.set('X-Forwarded-Host', host);
+  }
+  return new MiniflareRequest(request.url, {
+    method: request.method,
+    headers: [['accept-encoding', 'identity'], ...request.headers],
+    body: request.body as any,
+    duplex: 'half',
+  });
 }

--- a/packages/mini-oxygen/src/vite/worker-entry-errors.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry-errors.ts
@@ -1,0 +1,1 @@
+export const MISSING_SSR_ENTRY_ERROR = 'No Oxygen worker entry was found.';

--- a/packages/mini-oxygen/src/vite/worker-entry-errors.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry-errors.ts
@@ -1,1 +1,0 @@
-export const MISSING_SSR_ENTRY_ERROR = 'No Oxygen worker entry was found.';

--- a/packages/mini-oxygen/src/vite/worker-entry.test.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry.test.ts
@@ -15,8 +15,6 @@ vi.mock('vite/module-runner', () => ({
 import * as workerEntryModule from './worker-entry.js';
 import workerEntry, {type ViteEnv} from './worker-entry.js';
 
-const MISSING_SSR_ENTRY_ERROR = 'No Oxygen worker entry was found.';
-
 function createEnv(entry: string): ViteEnv {
   return {
     __VITE_INVOKE_MODULE: {fetch: vi.fn()},
@@ -59,7 +57,7 @@ describe('worker entry', () => {
 
     const body = await dispatchWithEntrypointError('./server', error);
 
-    expect(body).toContain(MISSING_SSR_ENTRY_ERROR);
+    expect(body).toContain('No Oxygen worker entry was found.');
     expect(body).toContain('oxygen({ entry: "./server" })');
     expect(body).toContain(viteError);
   });
@@ -71,7 +69,7 @@ describe('worker entry', () => {
 
     const body = await dispatchWithEntrypointError(entry, error);
 
-    expect(body).toContain(MISSING_SSR_ENTRY_ERROR);
+    expect(body).toContain('No Oxygen worker entry was found.');
     expect(body).toContain(
       'oxygen({ entry: "virtual:oxygen-framework-entry" })',
     );
@@ -83,7 +81,7 @@ describe('worker entry', () => {
 
     const body = await dispatchWithEntrypointError('./server', error);
 
-    expect(body).not.toContain(MISSING_SSR_ENTRY_ERROR);
+    expect(body).not.toContain('No Oxygen worker entry was found.');
     expect(body).toContain(error.message);
   });
 
@@ -96,7 +94,7 @@ describe('worker entry', () => {
 
     const body = await dispatchWithEntrypointError('./server', error);
 
-    expect(body).not.toContain(MISSING_SSR_ENTRY_ERROR);
+    expect(body).not.toContain('No Oxygen worker entry was found.');
     expect(body).toContain(error.message);
   });
 });

--- a/packages/mini-oxygen/src/vite/worker-entry.test.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry.test.ts
@@ -14,7 +14,8 @@ vi.mock('vite/module-runner', () => ({
 
 import * as workerEntryModule from './worker-entry.js';
 import workerEntry, {type ViteEnv} from './worker-entry.js';
-import {MISSING_SSR_ENTRY_ERROR} from './worker-entry-errors.js';
+
+const MISSING_SSR_ENTRY_ERROR = 'No Oxygen worker entry was found.';
 
 function createEnv(entry: string): ViteEnv {
   return {

--- a/packages/mini-oxygen/src/vite/worker-entry.test.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry.test.ts
@@ -1,0 +1,98 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  importModule: vi.fn(),
+}));
+
+vi.mock('vite/module-runner', () => ({
+  EvaluatedModuleNode: class {},
+  ModuleRunner: vi.fn(() => ({
+    import: mocks.importModule,
+  })),
+  ssrModuleExportsKey: Symbol.for('ssrModuleExportsKey'),
+}));
+
+import workerEntry, {
+  MISSING_SSR_ENTRY_ERROR,
+  type ViteEnv,
+} from './worker-entry.js';
+
+function createEnv(entry: string): ViteEnv {
+  return {
+    __VITE_INVOKE_MODULE: {fetch: vi.fn()},
+    __VITE_RUNTIME_EXECUTE_URL: entry,
+    __VITE_WARMUP_PATHNAME: '/__vite_warmup',
+    __VITE_SETUP_ENV: vi.fn(),
+    __VITE_UNSAFE_EVAL: {
+      eval: vi.fn(),
+      newFunction: vi.fn(),
+      newAsyncFunction: vi.fn(),
+    },
+  };
+}
+
+async function dispatchWithEntrypointError(entry: string, error: Error) {
+  mocks.importModule.mockRejectedValueOnce(error);
+
+  const response = await workerEntry.fetch(
+    new Request('http://localhost/products'),
+    createEnv(entry),
+    {} as ExecutionContext,
+  );
+
+  return response.text();
+}
+
+describe('worker entry', () => {
+  beforeEach(() => {
+    mocks.importModule.mockReset();
+  });
+
+  it('returns a clear Mini Oxygen error when the default entry is missing', async () => {
+    const viteError =
+      'Failed to load url ./server (resolved id: ./server). Does the file exist?';
+    const error = new Error(viteError);
+
+    const body = await dispatchWithEntrypointError('./server', error);
+
+    expect(body).toContain(MISSING_SSR_ENTRY_ERROR);
+    expect(body).toContain('oxygen({ entry: "./server" })');
+    expect(body).toContain(viteError);
+  });
+
+  it('returns a clear Mini Oxygen error when a configured entry is missing', async () => {
+    const entry = 'virtual:oxygen-framework-entry';
+    const viteError = `Failed to load url ${entry} (resolved id: ${entry}). Does the file exist?`;
+    const error = new Error(viteError);
+
+    const body = await dispatchWithEntrypointError(entry, error);
+
+    expect(body).toContain(MISSING_SSR_ENTRY_ERROR);
+    expect(body).toContain(
+      'oxygen({ entry: "virtual:oxygen-framework-entry" })',
+    );
+    expect(body).toContain(viteError);
+  });
+
+  it('keeps server entry runtime errors unchanged', async () => {
+    const error = new Error('The default entry failed after it loaded.');
+
+    const body = await dispatchWithEntrypointError('./server', error);
+
+    expect(body).not.toContain(MISSING_SSR_ENTRY_ERROR);
+    expect(body).toContain(error.message);
+  });
+
+  it('ignores server mentions outside the error headline', async () => {
+    const error = new Error('The default entry failed after it loaded.');
+    error.stack = [
+      'Error: The default entry failed after it loaded.',
+      "    at import('./server')",
+    ].join('\n');
+
+    const body = await dispatchWithEntrypointError('./server', error);
+
+    expect(body).not.toContain(MISSING_SSR_ENTRY_ERROR);
+    expect(body).toContain(error.message);
+  });
+});

--- a/packages/mini-oxygen/src/vite/worker-entry.test.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry.test.ts
@@ -12,10 +12,9 @@ vi.mock('vite/module-runner', () => ({
   ssrModuleExportsKey: Symbol.for('ssrModuleExportsKey'),
 }));
 
-import workerEntry, {
-  MISSING_SSR_ENTRY_ERROR,
-  type ViteEnv,
-} from './worker-entry.js';
+import * as workerEntryModule from './worker-entry.js';
+import workerEntry, {type ViteEnv} from './worker-entry.js';
+import {MISSING_SSR_ENTRY_ERROR} from './worker-entry-errors.js';
 
 function createEnv(entry: string): ViteEnv {
   return {
@@ -46,6 +45,10 @@ async function dispatchWithEntrypointError(entry: string, error: Error) {
 describe('worker entry', () => {
   beforeEach(() => {
     mocks.importModule.mockReset();
+  });
+
+  it('only exposes the worker handler at runtime', () => {
+    expect(Object.keys(workerEntryModule)).toEqual(['default']);
   });
 
   it('returns a clear Mini Oxygen error when the default entry is missing', async () => {

--- a/packages/mini-oxygen/src/vite/worker-entry.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry.ts
@@ -31,7 +31,6 @@ export interface ViteEnv {
 }
 
 const O2_PREFIX = '[o2:runtime]';
-const MISSING_SSR_ENTRY_ERROR = 'No Oxygen worker entry was found.';
 
 type ViteInvokePayload = {
   name: string;
@@ -197,7 +196,7 @@ function fetchEntryModule(env: ViteEnv) {
     const message = error.message ?? error.stack?.split('\n')[0];
 
     if (message && message.includes(env.__VITE_RUNTIME_EXECUTE_URL)) {
-      const missingEntryMessage = `${MISSING_SSR_ENTRY_ERROR} Use \`oxygen({ entry: "${env.__VITE_RUNTIME_EXECUTE_URL}" })\` in Vite or make sure the entry module exists.`;
+      const missingEntryMessage = `No Oxygen worker entry was found. Use \`oxygen({ entry: "${env.__VITE_RUNTIME_EXECUTE_URL}" })\` in Vite or make sure the entry module exists.`;
       errorResponseBody = `${missingEntryMessage}\n\n${errorResponseBody}`;
     }
 

--- a/packages/mini-oxygen/src/vite/worker-entry.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry.ts
@@ -15,7 +15,6 @@ import {
 import type {HotPayload} from 'vite';
 import type {Response} from 'miniflare';
 import {withRequestHook} from '../worker/handler.js';
-import {MISSING_SSR_ENTRY_ERROR} from './worker-entry-errors.js';
 
 export interface ViteEnv {
   __VITE_INVOKE_MODULE: {fetch: typeof fetch};
@@ -32,6 +31,7 @@ export interface ViteEnv {
 }
 
 const O2_PREFIX = '[o2:runtime]';
+const MISSING_SSR_ENTRY_ERROR = 'No Oxygen worker entry was found.';
 
 type ViteInvokePayload = {
   name: string;

--- a/packages/mini-oxygen/src/vite/worker-entry.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry.ts
@@ -15,6 +15,7 @@ import {
 import type {HotPayload} from 'vite';
 import type {Response} from 'miniflare';
 import {withRequestHook} from '../worker/handler.js';
+import {MISSING_SSR_ENTRY_ERROR} from './worker-entry-errors.js';
 
 export interface ViteEnv {
   __VITE_INVOKE_MODULE: {fetch: typeof fetch};
@@ -31,7 +32,6 @@ export interface ViteEnv {
 }
 
 const O2_PREFIX = '[o2:runtime]';
-export const MISSING_SSR_ENTRY_ERROR = 'No Oxygen worker entry was found.';
 
 type ViteInvokePayload = {
   name: string;

--- a/packages/mini-oxygen/src/vite/worker-entry.ts
+++ b/packages/mini-oxygen/src/vite/worker-entry.ts
@@ -31,6 +31,7 @@ export interface ViteEnv {
 }
 
 const O2_PREFIX = '[o2:runtime]';
+export const MISSING_SSR_ENTRY_ERROR = 'No Oxygen worker entry was found.';
 
 type ViteInvokePayload = {
   name: string;
@@ -192,14 +193,19 @@ function fetchEntryModule(env: ViteEnv) {
       default: {fetch: ExportedHandlerFetchHandler};
     }>
   ).catch((error: Error) => {
+    let errorResponseBody = error.stack ?? error.message ?? 'Internal error';
+    const message = error.message ?? error.stack?.split('\n')[0];
+
+    if (message && message.includes(env.__VITE_RUNTIME_EXECUTE_URL)) {
+      const missingEntryMessage = `${MISSING_SSR_ENTRY_ERROR} Use \`oxygen({ entry: "${env.__VITE_RUNTIME_EXECUTE_URL}" })\` in Vite or make sure the entry module exists.`;
+      errorResponseBody = `${missingEntryMessage}\n\n${errorResponseBody}`;
+    }
+
     return {
-      errorResponse: new globalThis.Response(
-        error?.stack ?? error?.message ?? 'Internal error',
-        {
-          status: 503,
-          statusText: 'executeEntrypoint error',
-        },
-      ),
+      errorResponse: new globalThis.Response(errorResponseBody, {
+        status: 503,
+        statusText: 'executeEntrypoint error',
+      }),
     };
   });
 }


### PR DESCRIPTION
## Summary
- make the Mini Oxygen Vite plugin infer compatibility dates and work without Hydrogen plugin coordination
- support standalone Oxygen deploy output resolution and configurable deploy output directories
- add Mini Oxygen Vite preview runtime and Vite env fallback when CLI/plugin env is not provided

## Validation
- pnpm --dir packages/mini-oxygen run typecheck
- pnpm --dir packages/mini-oxygen exec vitest run src/vite/plugin.test.ts src/vite/environment.test.ts src/vite/utils.test.ts --test-timeout=60000
- pnpm --dir packages/mini-oxygen run build

## Testing

Check this[ other branch](https://github.com/Shopify/hydrogen/pull/3820) to test these changes in the skeleton template. Test also without those changes to ensure it works without breaking changes.