### PR TITLE
fix(dev): stop @shopify/hydrogen watch from racing example bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "build": "turbo run build",
     "build:pkgs": "turbo run build --filter='./packages/*'",
-    "dev": "turbo run dev",
+    "dev": "turbo run dev --filter='./examples/*'",
     "dev:pkgs": "turbo run dev --filter='./packages/*'",
-    "dev:rr": "turbo run dev --filter=@shopify/hydrogen-example-react-router...",
-    "dev:next": "turbo run dev --filter=@shopify/hydrogen-example-nextjs...",
+    "dev:rr": "turbo run dev --filter=@shopify/hydrogen-example-react-router",
+    "dev:next": "turbo run dev --filter=@shopify/hydrogen-example-nextjs",
     "dev:hydrogen": "pnpm --dir examples/hydrogen dev",
     "examples:secrets:encrypt": "ejson encrypt examples/shared/secrets.ejson",
     "typecheck": "turbo run typecheck",


### PR DESCRIPTION
## Problem

Running `pnpm dev` (and `pnpm dev:next` / `pnpm dev:rr`) prints a wall of transient errors at startup:

```
Module not found: Can't resolve '@shopify/hydrogen'
  ./examples/nextjs/proxy.ts
  ./examples/nextjs/lib/cart-handlers.ts
  ...
```

The app still serves once startup settles, but it looks broken and is alarming.

## Cause

Those scripts schedule **both** `@shopify/hydrogen#build` (one-shot) **and** `@shopify/hydrogen#dev` (`tsdown --watch`). The watch rewrites `dist/` on startup while the example bundlers (Turbopack, Vite) are reading it, so they momentarily resolve partial/empty module files → "Module not found".

I confirmed:
- It's transient — `dist/` files never disappear (high-frequency polling shows 0 missing); it's mid-write partial reads.
- The watch **alone** causes it even when `@shopify/hydrogen#build` is a turbo cache hit, so serializing build→dev wouldn't fix it. The concurrent watch has to be removed from the examples' dev path.

## Fix

Scope the dev scripts to the examples. Turbo still builds `@shopify/hydrogen` once via `dependsOn: ["^build"]`, but no longer runs its **watch** alongside the examples:

```diff
- "dev": "turbo run dev",
+ "dev": "turbo run dev --filter='./examples/*'",
- "dev:rr": "turbo run dev --filter=@shopify/hydrogen-example-react-router...",
- "dev:next": "turbo run dev --filter=@shopify/hydrogen-example-nextjs...",
+ "dev:rr": "turbo run dev --filter=@shopify/hydrogen-example-react-router",
+ "dev:next": "turbo run dev --filter=@shopify/hydrogen-example-nextjs",
```

`dev:pkgs` still watches `./packages/*` for SDK development — run it alongside an example only when actively editing the SDK. This also makes `pnpm dev` match its README description ("every example's dev server in parallel").

## Trade-off

Editing `@shopify/hydrogen` source no longer hot-rebuilds into a running example under `pnpm dev` (use `pnpm dev:pkgs` for that). A future improvement could restore concurrent SDK-watch + examples by making the SDK build write `dist/` atomically (temp + rename) so bundlers never observe a partial file.

## Verification

Cold (`packages/hydrogen/dist` removed, `.next` and turbo cache cleared):

```
pnpm dev:next
→ 0 module-not-found errors (was 22)
→ @shopify/hydrogen#build runs; @shopify/hydrogen#dev (watch) does not
```

Turbo dry-run confirms `@shopify/hydrogen#build` is still scheduled and `@shopify/hydrogen#dev` is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)