### PR TITLE
Add agent-friendly hydrogen init linking flags

### DIFF
--- a/.changeset/hydrogen-init-agent-flags.md
+++ b/.changeset/hydrogen-init-agent-flags.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Add noninteractive Shopify storefront linking flags to `hydrogen init`.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1035,12 +1035,44 @@
           "allowNo": true,
           "type": "boolean"
         },
+        "link": {
+          "description": "Link the storefront to a Shopify account instead of using mock.shop.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_LINK",
+          "exclusive": [
+            "mock-shop"
+          ],
+          "name": "link",
+          "allowNo": false,
+          "type": "boolean"
+        },
         "mock-shop": {
           "description": "Use mock.shop as the data source for the storefront.",
           "env": "SHOPIFY_HYDROGEN_FLAG_MOCK_DATA",
+          "exclusive": [
+            "link"
+          ],
           "name": "mock-shop",
           "allowNo": false,
           "type": "boolean"
+        },
+        "storefront": {
+          "description": "The name of an existing Hydrogen storefront to link.",
+          "env": "SHOPIFY_HYDROGEN_STOREFRONT",
+          "name": "storefront",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "storefront-name": {
+          "description": "The name to use when creating a new Hydrogen storefront.",
+          "env": "SHOPIFY_HYDROGEN_STOREFRONT_NAME",
+          "exclusive": [
+            "storefront"
+          ],
+          "name": "storefront-name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "styling": {
           "description": "Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`, `postcss`, `none`.",

--- a/packages/cli/src/commands/hydrogen/init.test.ts
+++ b/packages/cli/src/commands/hydrogen/init.test.ts
@@ -82,6 +82,45 @@ describe('init', () => {
     });
   });
 
+  it('passes Shopify linking flags to setupTemplate', async () => {
+    vi.mocked(setupTemplate).mockResolvedValueOnce(undefined);
+
+    await runInit({
+      link: true,
+      path: './linked-storefront',
+      storefront: 'Hydrogen',
+    });
+
+    expect(setupTemplate).toHaveBeenCalledWith({
+      git: true,
+      link: true,
+      path: './linked-storefront',
+      storefront: 'Hydrogen',
+    });
+  });
+
+  it('rejects conflicting mock.shop and link flags', async () => {
+    await expect(
+      runInit({
+        mockShop: true,
+        storefrontName: 'New Storefront',
+      }),
+    ).rejects.toThrow('mock-shop');
+
+    expect(setupTemplate).not.toHaveBeenCalled();
+  });
+
+  it('rejects conflicting existing and new storefront flags', async () => {
+    await expect(
+      runInit({
+        storefront: 'Existing Storefront',
+        storefrontName: 'New Storefront',
+      }),
+    ).rejects.toThrow('storefront-name');
+
+    expect(setupTemplate).not.toHaveBeenCalled();
+  });
+
   describe('project validity', () => {
     let tmpDir: string;
 

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -38,9 +38,25 @@ export default class Init extends Command {
       env: 'SHOPIFY_HYDROGEN_FLAG_TEMPLATE',
     }),
     ...commonFlags.installDeps,
+    link: Flags.boolean({
+      description:
+        'Link the storefront to a Shopify account instead of using mock.shop.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_LINK',
+      exclusive: ['mock-shop'],
+    }),
     'mock-shop': Flags.boolean({
       description: 'Use mock.shop as the data source for the storefront.',
       env: 'SHOPIFY_HYDROGEN_FLAG_MOCK_DATA',
+      exclusive: ['link'],
+    }),
+    storefront: Flags.string({
+      description: 'The name of an existing Hydrogen storefront to link.',
+      env: 'SHOPIFY_HYDROGEN_STOREFRONT',
+    }),
+    'storefront-name': Flags.string({
+      description: 'The name to use when creating a new Hydrogen storefront.',
+      env: 'SHOPIFY_HYDROGEN_STOREFRONT_NAME',
+      exclusive: ['storefront'],
     }),
     ...commonFlags.styling,
     ...commonFlags.markets,
@@ -121,6 +137,23 @@ export async function runInit(
     options.shortcut ??= true;
     // TODO: enable Tailwind once v4 is stable
     options.styling ??= 'none';
+  }
+
+  const hasLinkOption =
+    options.link || options.storefront || options.storefrontName;
+
+  if (options.mockShop && hasLinkOption) {
+    throw new AbortError(
+      '`--mock-shop` cannot be used with Shopify storefront linking flags.',
+      'Use either `--mock-shop` or one of `--link`, `--storefront`, or `--storefront-name`.',
+    );
+  }
+
+  if (options.storefront && options.storefrontName) {
+    throw new AbortError(
+      '`--storefront` cannot be used with `--storefront-name`.',
+      'Use `--storefront` to link an existing storefront or `--storefront-name` to create a new one.',
+    );
   }
 
   const showUpgrade = await checkCurrentCLIVersion();

--- a/packages/cli/src/lib/onboarding/common.ts
+++ b/packages/cli/src/lib/onboarding/common.ts
@@ -71,7 +71,10 @@ export type InitOptions = {
   path?: string;
   template?: string;
   language?: Language;
+  link?: boolean;
   mockShop?: boolean;
+  storefront?: string;
+  storefrontName?: string;
   styling?: StylingChoice;
   i18n?: I18nChoice;
   token?: string;
@@ -222,6 +225,13 @@ type StorefrontInfo = {
  */
 export async function handleStorefrontLink(
   controller: AbortController,
+  {
+    storefront: flagStorefront,
+    storefrontName,
+  }: {
+    storefront?: string;
+    storefrontName?: string;
+  } = {},
 ): Promise<StorefrontInfo> {
   enhanceAuthLogs(true);
   const {session, config} = await login();
@@ -229,18 +239,35 @@ export async function handleStorefrontLink(
 
   const storefronts = await getStorefronts(session);
 
-  let selectedStorefront = await handleStorefrontSelection(storefronts);
+  let selectedStorefront: HydrogenStorefront | undefined;
+
+  if (flagStorefront) {
+    selectedStorefront = storefronts.find(
+      ({title}) => title === flagStorefront,
+    );
+
+    if (!selectedStorefront) {
+      throw new AbortError(
+        `Couldn't find ${flagStorefront}`,
+        `Use \`--storefront-name\` to create a new Hydrogen storefront with that name.`,
+      );
+    }
+  } else if (!storefrontName) {
+    selectedStorefront = await handleStorefrontSelection(storefronts);
+  }
 
   let title;
 
   if (selectedStorefront) {
     title = selectedStorefront.title;
   } else {
-    title = await renderTextPrompt({
-      message: 'New storefront name',
-      defaultValue: titleize(config.shopName),
-      abortSignal: controller.signal,
-    });
+    title =
+      storefrontName ??
+      (await renderTextPrompt({
+        message: 'New storefront name',
+        defaultValue: titleize(config.shopName),
+        abortSignal: controller.signal,
+      }));
   }
 
   return {

--- a/packages/cli/src/lib/onboarding/local.test.ts
+++ b/packages/cli/src/lib/onboarding/local.test.ts
@@ -13,6 +13,7 @@ import {renderSelectPrompt} from '@shopify/cli-kit/node/ui';
 import {installNodeModules} from '@shopify/cli-kit/node/node-package-manager';
 import {execAsync} from '../process.js';
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output';
+import {handleStorefrontLink} from './common.js';
 
 describe('local templates', () => {
   const outputMock = mockAndCaptureOutput();
@@ -96,6 +97,69 @@ describe('local templates', () => {
           message: 'Select package manager to install dependencies',
         }),
       );
+    });
+  });
+
+  it('uses the Shopify link flow when init linking flags are provided', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      vi.mocked(handleStorefrontLink).mockResolvedValueOnce({
+        id: 'gid://shopify/HydrogenStorefront/1',
+        title: 'Hydrogen',
+        shop: 'my-shop.myshopify.com',
+        shopName: 'My Shop',
+        email: 'merchant@example.com',
+        session: {
+          token: 'abc123',
+          storeFqdn: 'my-shop.myshopify.com',
+        },
+      });
+
+      await setupTemplate({
+        path: tmpDir,
+        git: false,
+        language: 'ts',
+        link: true,
+        storefront: 'Hydrogen',
+      });
+
+      expect(renderSelectPrompt).not.toHaveBeenCalledWith(
+        expect.objectContaining({message: 'Connect to Shopify'}),
+      );
+      expect(handleStorefrontLink).toHaveBeenCalledWith(expect.anything(), {
+        storefront: 'Hydrogen',
+        storefrontName: undefined,
+      });
+    });
+  });
+
+  it('uses a storefront name flag to create a linked storefront without the connect prompt', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      vi.mocked(handleStorefrontLink).mockResolvedValueOnce({
+        id: 'gid://shopify/HydrogenStorefront/2',
+        title: 'Agent Storefront',
+        shop: 'my-shop.myshopify.com',
+        shopName: 'My Shop',
+        email: 'merchant@example.com',
+        session: {
+          token: 'abc123',
+          storeFqdn: 'my-shop.myshopify.com',
+        },
+      });
+
+      await setupTemplate({
+        path: tmpDir,
+        git: false,
+        language: 'ts',
+        storefrontName: 'Agent Storefront',
+      });
+
+      expect(renderSelectPrompt).not.toHaveBeenCalledWith(
+        expect.objectContaining({message: 'Connect to Shopify'}),
+      );
+      expect(handleStorefrontLink).toHaveBeenCalledWith(expect.anything(), {
+        storefront: undefined,
+        storefrontName: 'Agent Storefront',
+      });
     });
   });
 

--- a/packages/cli/src/lib/onboarding/local.ts
+++ b/packages/cli/src/lib/onboarding/local.ts
@@ -45,25 +45,31 @@ export async function setupLocalStarterTemplate(
   options: InitOptions,
   controller: AbortController,
 ) {
-  const templateAction = options.mockShop
-    ? 'mock'
-    : await renderSelectPrompt<'mock' | 'link'>({
-        message: 'Connect to Shopify',
-        choices: [
-          {
-            label:
-              'Use sample data from mock.shop (You can connect a Shopify account later)',
-            value: 'mock',
-          },
-          {label: 'Link your Shopify account', value: 'link'},
-        ],
-        defaultValue: 'mock',
-        abortSignal: controller.signal,
-      });
+  const templateAction =
+    options.link || options.storefront || options.storefrontName
+      ? 'link'
+      : options.mockShop
+        ? 'mock'
+        : await renderSelectPrompt<'mock' | 'link'>({
+            message: 'Connect to Shopify',
+            choices: [
+              {
+                label:
+                  'Use sample data from mock.shop (You can connect a Shopify account later)',
+                value: 'mock',
+              },
+              {label: 'Link your Shopify account', value: 'link'},
+            ],
+            defaultValue: 'mock',
+            abortSignal: controller.signal,
+          });
 
   const storefrontInfo =
     templateAction === 'link'
-      ? await handleStorefrontLink(controller)
+      ? await handleStorefrontLink(controller, {
+          storefront: options.storefront,
+          storefrontName: options.storefrontName,
+        })
       : undefined;
 
   const project = await handleProjectLocation({


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/22874

`shopify hydrogen init` could not fully run noninteractively when an agent needed to link the new project to Shopify instead of mock.shop.

### WHAT is this pull request doing?

Adds `--link`, `--storefront`, and `--storefront-name` to `hydrogen init` so agents can select linked setup, choose an existing storefront, or create a storefront with a provided name.

### HOW to test your changes?

Use a development shop with an existing Hydrogen storefront:

```sh
shopify hydrogen init --path ./agent-init-existing --link --storefront "Existing Storefront Name" --language ts --styling none --markets none --no-install-deps --no-git
shopify hydrogen init --path ./agent-init-new --link --storefront-name "Agent CLI Test Storefront" --language ts --styling none --markets none --no-install-deps --no-git
```

Both commands should complete without the mock-vs-link, storefront selection, or storefront-name prompts.

### Post-merge steps

None.
