### PR TITLE
Add env push force confirmation flag

### DIFF
--- a/.changeset/hydrogen-env-push-agent-confirm.md
+++ b/.changeset/hydrogen-env-push-agent-confirm.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add `--force` and `--dry-run` flags to `hydrogen env push`.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -805,6 +805,24 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Push environment variable changes without confirmation.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Preview environment variable changes without pushing them.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DRY_RUN",
+          "exclusive": [
+            "force"
+          ],
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/cli/src/commands/hydrogen/env/push.test.ts
+++ b/packages/cli/src/commands/hydrogen/env/push.test.ts
@@ -478,4 +478,94 @@ describe('pushVariables', () => {
       );
     });
   });
+
+  it('does not prompt for diff confirmation when --force is provided', async () => {
+    vi.mocked(getStorefrontEnvVariables).mockResolvedValue({
+      id: SHOPIFY_CONFIG.storefront.id,
+      environmentVariables: [
+        {
+          id: '1',
+          key: 'EXISTING_TOKEN',
+          value: '1',
+          isSecret: false,
+          readOnly: false,
+        },
+        {
+          id: '2',
+          key: 'SECOND_TOKEN',
+          value: '2',
+          isSecret: false,
+          readOnly: false,
+        },
+      ],
+    });
+
+    await inTemporaryDirectory(async (tmpDir) => {
+      const filePath = joinPath(tmpDir, envFile);
+      await writeFile(filePath, 'EXISTING_TOKEN=1\nSECOND_TOKEN=NEW_VALUE');
+      await expect(
+        runEnvPush({
+          path: tmpDir,
+          env: 'preview',
+          envFile,
+          force: true,
+        }),
+      ).resolves.not.toThrow();
+
+      expect(renderConfirmationPrompt).not.toHaveBeenCalled();
+      expect(pushStorefrontEnvVariables).toHaveBeenCalledWith(
+        {storeFqdn: 'my-shop', token: 'abc123'},
+        'gid://shopify/HydrogenStorefront/2',
+        'gid://shopify/HydrogenStorefrontEnvironment/2',
+        [
+          {key: 'EXISTING_TOKEN', value: '1'},
+          {key: 'SECOND_TOKEN', value: 'NEW_VALUE'},
+        ],
+      );
+    });
+  });
+
+  it('renders a diff without pushing when --dry-run is provided', async () => {
+    vi.mocked(getStorefrontEnvVariables).mockResolvedValue({
+      id: SHOPIFY_CONFIG.storefront.id,
+      environmentVariables: [
+        {
+          id: '1',
+          key: 'EXISTING_TOKEN',
+          value: '1',
+          isSecret: false,
+          readOnly: false,
+        },
+        {
+          id: '2',
+          key: 'SECOND_TOKEN',
+          value: '2',
+          isSecret: false,
+          readOnly: false,
+        },
+      ],
+    });
+
+    await inTemporaryDirectory(async (tmpDir) => {
+      const filePath = joinPath(tmpDir, envFile);
+      await writeFile(filePath, 'EXISTING_TOKEN=1\nSECOND_TOKEN=NEW_VALUE');
+      await expect(
+        runEnvPush({
+          path: tmpDir,
+          env: 'preview',
+          envFile,
+          dryRun: true,
+        }),
+      ).resolves.not.toThrow();
+
+      expect(renderConfirmationPrompt).not.toHaveBeenCalled();
+      expect(pushStorefrontEnvVariables).not.toHaveBeenCalled();
+      expect(outputMock.info()).toMatch(/The following changes would be made/);
+      expect(outputMock.info()).toMatch(/Preview/);
+      expect(outputMock.info()).toMatch(/SECOND_TOKEN=NEW_VALUE/);
+      expect(outputMock.info()).toMatch(
+        /No changes were pushed because --dry-run was used/,
+      );
+    });
+  });
 });

--- a/packages/cli/src/commands/hydrogen/env/push.ts
+++ b/packages/cli/src/commands/hydrogen/env/push.ts
@@ -1,4 +1,5 @@
 import Command from '@shopify/cli-kit/node/base-command';
+import {Flags} from '@oclif/core';
 import {diffLines} from 'diff';
 import {commonFlags, flagsToCamelObject} from '../../../lib/flags.js';
 import {login} from '../../../lib/auth.js';
@@ -41,6 +42,16 @@ export default class EnvPush extends Command {
     ...commonFlags.env,
     ...commonFlags.envFile,
     ...commonFlags.path,
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Push environment variable changes without confirmation.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_FORCE',
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Preview environment variable changes without pushing them.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_DRY_RUN',
+      exclusive: ['force'],
+    }),
   };
 
   async run(): Promise<void> {
@@ -50,14 +61,18 @@ export default class EnvPush extends Command {
 }
 
 interface EnvPushOptions {
+  dryRun?: boolean;
   env?: string;
   envFile: string;
+  force?: boolean;
   path?: string;
 }
 
 export async function runEnvPush({
+  dryRun = false,
   env: envHandle,
   envFile,
+  force = false,
   path = process.cwd(),
 }: EnvPushOptions) {
   let validatedEnvironment: Environment;
@@ -181,8 +196,23 @@ export async function runEnvPush({
       body: 'No changes to your environment variables.',
     });
     return;
-  } else {
-    const diff = diffLines(comparableRemoteVars, compareableLocalVars);
+  }
+
+  const diff = diffLines(comparableRemoteVars, compareableLocalVars);
+
+  if (dryRun) {
+    renderInfo({
+      body: outputContent`The following changes would be made to your environment variables for ${
+        validatedEnvironment.name
+      }:
+
+${outputToken.linesDiff(diff)}
+No changes were pushed because --dry-run was used.`.value,
+    });
+    return;
+  }
+
+  if (!force) {
     const confirmPush = await renderConfirmationPrompt({
       confirmationMessage: 'Yes, confirm changes',
       cancellationMessage: 'No, make changes later',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/22875

`shopify hydrogen env push` showed a diff confirmation prompt that agents could not skip.

### WHAT is this pull request doing?

Adds `--force` to `hydrogen env push` so environment variable pushes can proceed without the diff confirmation prompt.

Also, adds `--dry-run` (can't be used with force) to preview the diff without doing any change.

### HOW to test your changes?

Use a linked Hydrogen project with a changed local `.env` file:

```sh
shopify hydrogen env list --path ./my-hydrogen-app
shopify hydrogen env push --path ./my-hydrogen-app --env preview --dry-run
shopify hydrogen env push --path ./my-hydrogen-app --env preview --force
```

The push command should skip the environment variable diff confirmation prompt.

<img width="1647" height="390" alt="dry-run" src="https://github.com/user-attachments/assets/ad42e504-ec63-4756-8e1b-a8b9f6d9c408" />

<img width="1655" height="281" alt="push" src="https://github.com/user-attachments/assets/6c7a89d8-614b-4c88-931c-a9bb74eaa259" />
