### PR TITLE
Skip confirmation prompts on deploy with --force

### DIFF
--- a/.changeset/hydrogen-deploy-allow-non-preview.md
+++ b/.changeset/hydrogen-deploy-allow-non-preview.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Skip confirmation before deploying to non-preview environments with `--force`.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -353,7 +353,7 @@
         },
         "force": {
           "char": "f",
-          "description": "Forces a deployment to proceed if there are uncommitted changes in its Git repository.",
+          "description": "Forces a deployment to proceed if there are uncommitted changes in its Git repository, and skips confirmation prompts for non-preview environments.",
           "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
           "name": "force",
           "required": false,

--- a/packages/cli/src/commands/hydrogen/deploy.test.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.test.ts
@@ -201,13 +201,16 @@ describe('deploy', async () => {
     defaultEnvironment: false,
     deploymentUrl: 'https://oxygen.shopifyapps.com',
     deploymentToken: mockToken,
+    environmentTag: undefined,
     generateAuthBypassToken: true,
+    authBypassTokenDuration: undefined,
     verificationMaxDuration: 180,
     metadata: {
       url: deployParams.metadataUrl,
       user: deployParams.metadataUser,
       version: deployParams.metadataVersion,
     },
+    overriddenEnvironmentVariables: undefined,
     skipVerification: true,
     rootPath: deployParams.path,
     skipBuild: false,
@@ -226,6 +229,16 @@ describe('deploy', async () => {
     onUploadFilesComplete: expect.any(Function),
     onUploadFilesError: expect.any(Function),
   };
+
+  function expectDeployConfig({
+    metadata,
+    ...rest
+  }: Record<string, unknown> & {metadata?: Record<string, unknown>}) {
+    return expect.objectContaining({
+      ...rest,
+      ...(metadata ? {metadata: expect.objectContaining(metadata)} : {}),
+    });
+  }
 
   beforeEach(async () => {
     process.exit = vi.fn() as any;
@@ -276,7 +289,7 @@ describe('deploy', async () => {
     await runDeploy(deployParams);
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: expectedConfig,
+      config: expectDeployConfig(expectedConfig),
       hooks: expectedHooks,
       logger: deploymentLogger,
     });
@@ -293,12 +306,12 @@ describe('deploy', async () => {
     });
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: {
+      config: expectDeployConfig({
         ...expectedConfig,
         assetsDir: 'custom/client',
         workerDir: 'custom/server',
         buildCommand: 'node --run build',
-      },
+      }),
       hooks,
       logger: deploymentLogger,
     });
@@ -386,7 +399,7 @@ describe('deploy', async () => {
     });
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: {
+      config: expectDeployConfig({
         ...expectedConfig,
         overriddenEnvironmentVariables: [
           {
@@ -395,7 +408,7 @@ describe('deploy', async () => {
             isSecret: true,
           },
         ],
-      },
+      }),
       hooks: expectedHooks,
       logger: deploymentLogger,
     });
@@ -442,10 +455,10 @@ describe('deploy', async () => {
     });
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: {
+      config: expectDeployConfig({
         ...expectedConfig,
         environmentTag: 'stage-1',
-      },
+      }),
       hooks: expectedHooks,
       logger: deploymentLogger,
     });
@@ -473,10 +486,10 @@ describe('deploy', async () => {
     });
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: {
+      config: expectDeployConfig({
         ...expectedConfig,
         environmentTag: 'stage-1',
-      },
+      }),
       hooks: expectedHooks,
       logger: deploymentLogger,
     });
@@ -497,10 +510,10 @@ describe('deploy', async () => {
     });
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: {
+      config: expectDeployConfig({
         ...expectedConfig,
         environmentTag: 'stage-1',
-      },
+      }),
       hooks: expectedHooks,
       logger: deploymentLogger,
     });
@@ -610,14 +623,14 @@ describe('deploy', async () => {
           body: expect.anything(),
         });
         expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-          config: {
+          config: expectDeployConfig({
             ...expectedConfig,
             environmentTag: 'main',
             metadata: {
               ...expectedConfig.metadata,
               description: '123 with additional changes',
             },
-          },
+          }),
           hooks: expectedHooks,
           logger: deploymentLogger,
         });
@@ -646,14 +659,14 @@ describe('deploy', async () => {
 
           expect(vi.mocked(renderWarning)).not.toHaveBeenCalled;
           expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-            config: {
+            config: expectDeployConfig({
               ...expectedConfig,
               environmentTag: 'main',
               metadata: {
                 ...expectedConfig.metadata,
                 description: 'cool new stuff',
               },
-            },
+            }),
             hooks: expectedHooks,
             logger: deploymentLogger,
           });
@@ -676,7 +689,7 @@ describe('deploy', async () => {
     await runDeploy(deployParams);
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: {...expectedConfig, environmentTag: 'main'},
+      config: expectDeployConfig({...expectedConfig, environmentTag: 'main'}),
       hooks: expectedHooks,
       logger: deploymentLogger,
     });
@@ -758,11 +771,11 @@ describe('deploy', async () => {
       await runDeploy(deployParams);
 
       expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-        config: {
+        config: expectDeployConfig({
           ...expectedConfig,
           defaultEnvironment: true,
           environmentTag: undefined,
-        },
+        }),
         hooks: expectedHooks,
         logger: deploymentLogger,
       });
@@ -830,10 +843,10 @@ describe('deploy', async () => {
     await runDeploy(params);
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: {
+      config: expectDeployConfig({
         ...expectedConfig,
         buildCommand: 'hocus pocus',
-      },
+      }),
       hooks,
       logger: deploymentLogger,
     });
@@ -848,7 +861,7 @@ describe('deploy', async () => {
     await runDeploy({...deployParams, path: root});
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: {
+      config: expectDeployConfig({
         ...expectedConfig,
         rootPath: root,
         buildCommand: 'node --run build',
@@ -856,7 +869,7 @@ describe('deploy', async () => {
           ...expectedConfig.metadata,
           hydrogenVersion,
         },
-      },
+      }),
       hooks,
       logger: deploymentLogger,
     });
@@ -879,7 +892,7 @@ describe('deploy', async () => {
     await runDeploy(params);
 
     expect(vi.mocked(createDeploy)).toHaveBeenCalledWith({
-      config: {
+      config: expectDeployConfig({
         ...expectedConfig,
         rootPath: root,
         assetsDir: 'xyz/client',
@@ -890,7 +903,7 @@ describe('deploy', async () => {
           user: deployParams.metadataUser,
           version: deployParams.metadataVersion,
         },
-      },
+      }),
       hooks,
       logger: deploymentLogger,
     });
@@ -1074,6 +1087,20 @@ describe('deploy', async () => {
         });
 
         expect(renderConfirmationPrompt).toHaveBeenCalledWith({
+          confirmationMessage: 'Yes, confirm deploy',
+          cancellationMessage: 'No, cancel deploy',
+          message: expect.any(String),
+        });
+      });
+
+      it("doesn't render a user confirmation on deploy when the force flag is provided", async () => {
+        await runDeploy({
+          ...deployParams,
+          env: 'production',
+          force: true,
+        });
+
+        expect(renderConfirmationPrompt).not.toHaveBeenCalledWith({
           confirmationMessage: 'Yes, confirm deploy',
           cancellationMessage: 'No, cancel deploy',
           message: expect.any(String),

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -94,7 +94,7 @@ export default class Deploy extends Command {
     force: Flags.boolean({
       char: 'f',
       description:
-        'Forces a deployment to proceed if there are uncommitted changes in its Git repository.',
+        'Forces a deployment to proceed if there are uncommitted changes in its Git repository, and skips confirmation prompts for non-preview environments.',
       default: false,
       env: 'SHOPIFY_HYDROGEN_FLAG_FORCE',
       required: false,
@@ -266,7 +266,7 @@ export async function runDeploy(
     env: envHandle,
     envBranch,
     environmentFile,
-    force: forceOnUncommittedChanges,
+    force,
     forceClientSourcemap = false,
     noVerify,
     lockfileCheck,
@@ -290,7 +290,7 @@ export async function runDeploy(
       isCleanGit = false;
     }
 
-    if (!forceOnUncommittedChanges && !isCleanGit) {
+    if (!force && !isCleanGit) {
       let errorMessage = 'Uncommitted changes detected';
       let changedFiles = undefined;
 
@@ -540,7 +540,8 @@ export async function runDeploy(
   if (
     !isCI &&
     !config.defaultEnvironment &&
-    (userProvidedEnvironmentTag || userChosenEnvironmentTag)
+    (userProvidedEnvironmentTag || userChosenEnvironmentTag) &&
+    !force
   ) {
     let chosenEnvironment = findEnvironmentByBranchOrThrow(
       deploymentData!.environments!,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/22876

`shopify hydrogen deploy` could still prompt for confirmation before deploying to a non-preview environment.

### WHAT is this pull request doing?

Allows `hydrogen deploy --force`to skip confirmation prompts about deploying to non-preview environments

### HOW to test your changes?

Use a linked Hydrogen project with an available non-preview environment:

```sh
shopify hydrogen deploy --path ./my-hydrogen-app --env production --force
```

The deploy command should proceed without the non-preview deployment confirmation prompt.