### PR TITLE
Add env pull yes confirmation flag

### DIFF
--- a/.changeset/hydrogen-env-pull-yes.md
+++ b/.changeset/hydrogen-env-pull-yes.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add a `--yes` confirmation bypass to `hydrogen env pull`.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -762,6 +762,13 @@
           "name": "force",
           "allowNo": false,
           "type": "boolean"
+        },
+        "yes": {
+          "description": "Automatically confirm changes to the local .env file.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_YES",
+          "name": "yes",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,

--- a/packages/cli/src/commands/hydrogen/env/pull.test.ts
+++ b/packages/cli/src/commands/hydrogen/env/pull.test.ts
@@ -282,6 +282,19 @@ describe('pullVariables', () => {
         });
       });
     });
+
+    describe('and --yes is enabled', () => {
+      it('does not prompt the user to confirm', async () => {
+        await inTemporaryDirectory(async (tmpDir) => {
+          const filePath = joinPath(tmpDir, envFile);
+          await writeFile(filePath, 'EXISTING_TOKEN=1');
+
+          await runEnvPull({path: tmpDir, yes: true, envFile});
+
+          expect(renderConfirmationPrompt).not.toHaveBeenCalled();
+        });
+      });
+    });
   });
 
   describe('environment variable quoting', () => {

--- a/packages/cli/src/commands/hydrogen/env/pull.ts
+++ b/packages/cli/src/commands/hydrogen/env/pull.ts
@@ -1,4 +1,5 @@
 import {diffLines} from 'diff';
+import {Flags} from '@oclif/core';
 import Command from '@shopify/cli-kit/node/base-command';
 import {
   renderConfirmationPrompt,
@@ -73,6 +74,10 @@ export default class EnvPull extends Command {
     ...commonFlags.envFile,
     ...commonFlags.path,
     ...commonFlags.force,
+    yes: Flags.boolean({
+      description: 'Automatically confirm changes to the local .env file.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_YES',
+    }),
   };
 
   async run(): Promise<void> {
@@ -87,6 +92,7 @@ interface EnvPullOptions {
   envFile: string;
   force?: boolean;
   path?: string;
+  yes?: boolean;
 }
 
 export async function runEnvPull({
@@ -95,6 +101,7 @@ export async function runEnvPull({
   path: root = process.cwd(),
   envFile,
   force,
+  yes = false,
 }: EnvPullOptions) {
   const [{session, config}, cliCommand] = await Promise.all([
     login(root),
@@ -160,7 +167,7 @@ export async function runEnvPull({
     fetchedEnv[key] = isSecret ? `""` : quoteEnvValue(value);
   });
 
-  if ((await fileExists(dotEnvPath)) && !force) {
+  if ((await fileExists(dotEnvPath)) && !force && !yes) {
     const existingEnv = await readFile(dotEnvPath);
     const patchedEnv = patchEnvFile(existingEnv, fetchedEnv);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/22877

`shopify hydrogen env pull` only had `--force` for skipping local `.env` merge confirmation, which was unclear for agent confirmation flows.

### WHAT is this pull request doing?

Adds `--yes` to `hydrogen env pull` as an explicit confirmation flag for writing local environment changes.

### HOW to test your changes?

Use a linked Hydrogen project with an existing local `.env` file:

```sh
shopify hydrogen env list --path ./my-hydrogen-app
shopify hydrogen env pull --path ./my-hydrogen-app --env preview --yes
```

The pull command should update the local env file without the merge confirmation prompt.

### Post-merge steps

None.
