### PR TITLE
Add link shop and storefront creation flags

### DIFF
--- a/.changeset/hydrogen-link-create-flags.md
+++ b/.changeset/hydrogen-link-create-flags.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add noninteractive shop and storefront creation flags to `hydrogen link`.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1150,10 +1150,44 @@
           "multiple": false,
           "type": "option"
         },
+        "shop": {
+          "char": "s",
+          "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
+          "env": "SHOPIFY_SHOP",
+          "name": "shop",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "storefront": {
           "description": "The name of a Hydrogen Storefront (e.g. \"Jane's Apparel\")",
           "env": "SHOPIFY_HYDROGEN_STOREFRONT",
+          "exclusive": [
+            "create-storefront",
+            "name"
+          ],
           "name": "storefront",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "create-storefront": {
+          "description": "Create a new Hydrogen storefront.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_CREATE_STOREFRONT",
+          "exclusive": [
+            "storefront"
+          ],
+          "name": "create-storefront",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The name to use when creating a new Hydrogen storefront.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_NAME",
+          "exclusive": [
+            "storefront"
+          ],
+          "name": "name",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"

--- a/packages/cli/src/commands/hydrogen/link.test.ts
+++ b/packages/cli/src/commands/hydrogen/link.test.ts
@@ -94,6 +94,12 @@ describe('link', () => {
     expect(getStorefronts).toHaveBeenCalledWith(ADMIN_SESSION);
   });
 
+  it('logs in with the provided shop when --shop is provided', async () => {
+    await runLink({path: 'my-path', shop: 'other-shop.myshopify.com'});
+
+    expect(login).toHaveBeenCalledWith('my-path', 'other-shop.myshopify.com');
+  });
+
   it('renders a list of choices and forwards the selection to setStorefront', async () => {
     vi.mocked(renderSelectPrompt).mockResolvedValue(
       FULL_SHOPIFY_CONFIG.storefront.id,
@@ -160,6 +166,53 @@ describe('link', () => {
 
       expect(outputMock.info()).toContain(
         `${expectedStorefrontName} is now linked`,
+      );
+    });
+
+    it('skips storefront selection when --create-storefront is provided', async () => {
+      await runLink({createStorefront: true});
+
+      expect(renderSelectPrompt).not.toHaveBeenCalled();
+      expect(renderTextPrompt).toHaveBeenCalledWith({
+        message: expect.stringMatching(/name/i),
+        defaultValue: expect.any(String),
+      });
+    });
+
+    it('uses --name without prompting for selection or name', async () => {
+      await runLink({name: expectedStorefrontName});
+
+      expect(renderSelectPrompt).not.toHaveBeenCalled();
+      expect(renderTextPrompt).not.toHaveBeenCalled();
+      expect(createStorefront).toHaveBeenCalledWith(
+        ADMIN_SESSION,
+        expectedStorefrontName,
+      );
+    });
+
+    it('uses a trimmed name when creating a storefront', async () => {
+      await runLink({name: ` ${expectedStorefrontName} `});
+
+      expect(renderSelectPrompt).not.toHaveBeenCalled();
+      expect(renderTextPrompt).not.toHaveBeenCalled();
+      expect(createStorefront).toHaveBeenCalledWith(
+        ADMIN_SESSION,
+        expectedStorefrontName,
+      );
+    });
+
+    it('treats a blank name as absent', async () => {
+      vi.mocked(renderTextPrompt).mockResolvedValue(expectedStorefrontName);
+
+      await runLink({createStorefront: true, name: '   '});
+
+      expect(renderTextPrompt).toHaveBeenCalledWith({
+        message: expect.stringMatching(/name/i),
+        defaultValue: expect.any(String),
+      });
+      expect(createStorefront).toHaveBeenCalledWith(
+        ADMIN_SESSION,
+        expectedStorefrontName,
       );
     });
 
@@ -234,6 +287,17 @@ describe('link', () => {
 
         expect(outputMock.warn()).toMatch(/Couldn\'t find Does not exist/g);
       });
+    });
+
+    it('rejects storefront creation flags', async () => {
+      await expect(
+        runLink({
+          storefront: 'Hydrogen',
+          name: 'New Storefront',
+        }),
+      ).rejects.toThrow('storefront');
+
+      expect(setStorefront).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/commands/hydrogen/link.ts
+++ b/packages/cli/src/commands/hydrogen/link.ts
@@ -11,7 +11,7 @@ import {
 } from '@shopify/cli-kit/node/ui';
 import {AbortError} from '@shopify/cli-kit/node/error';
 
-import {commonFlags} from '../../lib/flags.js';
+import {commonFlags, flagsToCamelObject} from '../../lib/flags.js';
 import {getStorefronts} from '../../lib/graphql/admin/link-storefront.js';
 import {setStorefront, type ShopifyConfig} from '../../lib/shopify-config.js';
 import {createStorefront} from '../../lib/graphql/admin/create-storefront.js';
@@ -40,37 +40,57 @@ export default class Link extends Command {
   static flags = {
     ...commonFlags.force,
     ...commonFlags.path,
+    ...commonFlags.shop,
     storefront: Flags.string({
       description: 'The name of a Hydrogen Storefront (e.g. "Jane\'s Apparel")',
       env: 'SHOPIFY_HYDROGEN_STOREFRONT',
+      exclusive: ['create-storefront', 'name'],
+    }),
+    'create-storefront': Flags.boolean({
+      description: 'Create a new Hydrogen storefront.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_CREATE_STOREFRONT',
+      exclusive: ['storefront'],
+    }),
+    name: Flags.string({
+      description: 'The name to use when creating a new Hydrogen storefront.',
+      env: 'SHOPIFY_HYDROGEN_FLAG_NAME',
+      exclusive: ['storefront'],
     }),
   };
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Link);
-    await runLink(flags);
+    await runLink(flagsToCamelObject(flags));
   }
 }
 
 export interface LinkStorefrontArguments {
   force?: boolean;
   path?: string;
+  shop?: string;
   storefront?: string;
+  createStorefront?: boolean;
+  name?: string;
 }
 
 export async function runLink({
+  createStorefront: flagCreateStorefront,
   force,
   path: root = process.cwd(),
+  shop,
   storefront: flagStorefront,
+  name,
 }: LinkStorefrontArguments) {
   const [{session, config}, cliCommand] = await Promise.all([
-    login(root),
+    login(root, shop),
     getCliCommand(),
   ]);
 
   const linkedStore = await linkStorefront(root, session, config, {
     force,
+    flagCreateStorefront,
     flagStorefront,
+    storefrontName: name,
     cliCommand,
   });
 
@@ -94,16 +114,29 @@ export async function linkStorefront(
   config: ShopifyConfig,
   {
     force = false,
+    flagCreateStorefront,
     flagStorefront,
+    storefrontName,
     cliCommand,
     storefronts,
   }: {
     force?: boolean;
+    flagCreateStorefront?: boolean;
     flagStorefront?: string;
+    storefrontName?: string;
     cliCommand: string;
     storefronts?: ParsedHydrogenStorefront[];
   },
 ) {
+  storefrontName = storefrontName?.trim() || undefined;
+
+  if (flagStorefront && (flagCreateStorefront || storefrontName)) {
+    throw new AbortError(
+      '`--storefront` cannot be used with storefront creation flags.',
+      'Use `--storefront` to link an existing storefront or `--name` to create a new one.',
+    );
+  }
+
   if (!config.shop) {
     throw new AbortError('No shop found in local config, login first.');
   }
@@ -146,6 +179,13 @@ export async function linkStorefront(
 
       return;
     }
+  } else if (flagCreateStorefront || storefrontName) {
+    selectedStorefront = await createNewStorefront(
+      root,
+      session,
+      storefronts,
+      storefrontName,
+    );
   } else {
     selectedStorefront = await handleStorefrontSelection(storefronts);
 
@@ -167,6 +207,7 @@ async function createNewStorefront(
   root: string,
   session: AdminSession,
   storefronts: ParsedHydrogenStorefront[],
+  storefrontName?: string,
 ) {
   const projectDirectory = basename(root);
   let defaultProjectName = titleize(projectDirectory);
@@ -177,10 +218,12 @@ async function createNewStorefront(
     defaultProjectName = generateRandomName();
   }
 
-  const projectName = await renderTextPrompt({
-    message: 'New storefront name',
-    defaultValue: defaultProjectName,
-  });
+  const projectName =
+    storefrontName ??
+    (await renderTextPrompt({
+      message: 'New storefront name',
+      defaultValue: defaultProjectName,
+    }));
 
   let storefront: HydrogenStorefront | undefined;
   let jobId: string | undefined;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/22878

`shopify hydrogen link` still required prompts to choose the shop and name a new storefront, which blocked noninteractive agent runs after project scaffolding.

### WHAT is this pull request doing?

Adds `--shop`, `--create-storefront`, and `--storefront-name` to `hydrogen link` so agents can select a shop and create or link a storefront without prompts.

### HOW to test your changes?

Use an unlinked Hydrogen project and a development shop:

```sh
shopify hydrogen link --path ./my-hydrogen-app --shop <store>.myshopify.com --storefront "Existing Storefront Name" --force
shopify hydrogen link --path ./my-hydrogen-app --shop <store>.myshopify.com --create-storefront --storefront-name "Agent CLI Test Storefront" --force
```

Both commands should complete without prompting for shop selection, storefront selection, or the new storefront name.

### Post-merge steps

None.
