### PR TITLE
Use force for upgrade confirmations

### DIFF
--- a/.changeset/hydrogen-upgrade-force.md
+++ b/.changeset/hydrogen-upgrade-force.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Use `--force` to bypass confirmation prompts in `hydrogen upgrade`.

--- a/packages/cli/src/commands/hydrogen/upgrade.test.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.test.ts
@@ -1437,6 +1437,50 @@ describe('upgrade', async () => {
         },
       );
     });
+
+    it('overwrites an existing instructions file without prompting when force is enabled', async () => {
+      await inTemporaryHydrogenRepo(
+        async (appPath) => {
+          const {releases} = await getChangelog();
+
+          const selectedRelease = releases.find(
+            (release) => release.version === '2023.10.0',
+          ) as (typeof releases)[0];
+
+          const resultPath = await generateUpgradeInstructionsFile({
+            appPath,
+            cumulativeRelease: CUMULATIVE_RELEASE,
+            currentVersion: '2023.1.6',
+            selectedRelease,
+          });
+
+          expect(resultPath).toBeDefined();
+
+          const filePath = joinPath(appPath, resultPath!);
+          await writeFile(filePath, 'old instructions');
+          vi.mocked(renderConfirmationPrompt).mockClear();
+
+          await expect(
+            generateUpgradeInstructionsFile({
+              appPath,
+              cumulativeRelease: CUMULATIVE_RELEASE,
+              currentVersion: '2023.1.6',
+              selectedRelease,
+              force: true,
+            }),
+          ).resolves.toEqual(resultPath);
+
+          expect(renderConfirmationPrompt).not.toHaveBeenCalled();
+          await expect(readFile(filePath, 'utf8')).resolves.not.toEqual(
+            'old instructions',
+          );
+        },
+        {
+          cleanGitRepo: true,
+          packageJson: OUTDATED_HYDROGEN_PACKAGE_JSON,
+        },
+      );
+    });
   });
 
   describe('displayDevUpgradeNotice', () => {

--- a/packages/cli/src/commands/hydrogen/upgrade.ts
+++ b/packages/cli/src/commands/hydrogen/upgrade.ts
@@ -131,7 +131,7 @@ type UpgradeOptions = {
 export async function runUpgrade({
   appPath,
   version: targetVersion,
-  force,
+  force = false,
 }: UpgradeOptions) {
   // --version=next is only available when running from monorepo, tests, or CI
   if (targetVersion === 'next') {
@@ -218,11 +218,13 @@ export async function runUpgrade({
       selectedRelease,
     });
 
-    confirmed = await displayConfirmation({
-      cumulativeRelease,
-      selectedRelease,
-      targetVersion,
-    });
+    confirmed =
+      force ||
+      (await displayConfirmation({
+        cumulativeRelease,
+        selectedRelease,
+        targetVersion,
+      }));
   } while (!confirmed);
 
   // Generate a markdown file with upgrade instructions
@@ -231,6 +233,7 @@ export async function runUpgrade({
     cumulativeRelease,
     currentVersion,
     selectedRelease,
+    force,
   });
 
   await upgradeNodeModules({
@@ -1415,11 +1418,13 @@ export async function generateUpgradeInstructionsFile({
   cumulativeRelease,
   currentVersion,
   selectedRelease,
+  force = false,
 }: {
   appPath: string;
   cumulativeRelease: CumulativeRelease;
   currentVersion: string;
   selectedRelease: Release;
+  force?: boolean;
 }) {
   let filename = '';
 
@@ -1501,10 +1506,12 @@ export async function generateUpgradeInstructionsFile({
   if (!(await fileExists(filePath))) {
     await touchFile(filePath);
   } else {
-    const overwriteMdFile = await renderConfirmationPrompt({
-      message: `A previous upgrade instructions file already exists for this version.\nDo you want to overwrite it?`,
-      defaultValue: false,
-    });
+    const overwriteMdFile =
+      force ||
+      (await renderConfirmationPrompt({
+        message: `A previous upgrade instructions file already exists for this version.\nDo you want to overwrite it?`,
+        defaultValue: false,
+      }));
 
     if (overwriteMdFile) {
       await removeFile(`${filePath}.old`);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/22879

`shopify hydrogen upgrade` prompted for upgrade confirmation and could prompt again before overwriting generated upgrade instructions.

### WHAT is this pull request doing?

Uses existing `--force` on `hydrogen upgrade` to skip the upgrade confirmation prompt and overwrite an existing generated instructions file for the target version.

### HOW to test your changes?

Use a Hydrogen project that has an available upgrade. To verify instruction overwrite, make sure the matching `.hydrogen/upgrade-*.md` file already exists before running the command:

```sh
shopify hydrogen upgrade --path ./my-hydrogen-app --version <target-version> --force
```

The command should run without the upgrade confirmation or instruction overwrite confirmation prompts.

### Post-merge steps

None.
