### PR TITLE
Show non-interactive init flags in Hydrogen help

### DIFF
--- a/.changeset/hydrogen-required-noninteractive-help.md
+++ b/.changeset/hydrogen-required-noninteractive-help.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Show which `hydrogen init` flags are required when running non-interactively in command help.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1005,7 +1005,7 @@
           "type": "boolean"
         },
         "path": {
-          "description": "The path to the directory of the new Hydrogen storefront.",
+          "description": "(required if non-interactive) The path to the directory of the new Hydrogen storefront.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
           "name": "path",
           "hasDynamicHelp": false,
@@ -1013,7 +1013,7 @@
           "type": "option"
         },
         "language": {
-          "description": "Sets the template language to use. One of `js` or `ts`.",
+          "description": "(required if non-interactive) Sets the template language to use. One of `js` or `ts`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_LANGUAGE",
           "name": "language",
           "hasDynamicHelp": false,
@@ -1029,21 +1029,21 @@
           "type": "option"
         },
         "install-deps": {
-          "description": "Auto installs dependencies using the active package manager.",
+          "description": "(required if non-interactive) Auto installs dependencies using the active package manager.",
           "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
           "name": "install-deps",
           "allowNo": true,
           "type": "boolean"
         },
         "mock-shop": {
-          "description": "Use mock.shop as the data source for the storefront.",
+          "description": "(required if non-interactive) Use mock.shop as the data source for the storefront.",
           "env": "SHOPIFY_HYDROGEN_FLAG_MOCK_DATA",
           "name": "mock-shop",
           "allowNo": false,
           "type": "boolean"
         },
         "styling": {
-          "description": "Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`, `postcss`, `none`.",
+          "description": "(required if non-interactive) Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`, `postcss`, `none`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_STYLING",
           "name": "styling",
           "hasDynamicHelp": false,
@@ -1051,7 +1051,7 @@
           "type": "option"
         },
         "markets": {
-          "description": "Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
+          "description": "(required if non-interactive) Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_I18N",
           "name": "markets",
           "hasDynamicHelp": false,
@@ -1059,7 +1059,7 @@
           "type": "option"
         },
         "shortcut": {
-          "description": "Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
+          "description": "(required if non-interactive) Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_SHORTCUT",
           "name": "shortcut",
           "allowNo": true,

--- a/packages/cli/src/commands/hydrogen/init.ts
+++ b/packages/cli/src/commands/hydrogen/init.ts
@@ -5,6 +5,7 @@ import {
   commonFlags,
   parseProcessFlags,
   flagsToCamelObject,
+  requiredIfNonInteractive,
 } from '../../lib/flags.js';
 import {checkCurrentCLIVersion} from '../../lib/check-cli-version.js';
 import {
@@ -23,28 +24,37 @@ export default class Init extends Command {
   static description = 'Creates a new Hydrogen storefront.';
   static flags = {
     ...commonFlags.force,
-    path: Flags.string({
-      description: 'The path to the directory of the new Hydrogen storefront.',
-      env: 'SHOPIFY_HYDROGEN_FLAG_PATH',
-    }),
-    language: Flags.string({
-      description: 'Sets the template language to use. One of `js` or `ts`.',
-      choices: Object.keys(LANGUAGES),
-      env: 'SHOPIFY_HYDROGEN_FLAG_LANGUAGE',
-    }),
+    path: requiredIfNonInteractive(
+      Flags.string({
+        description:
+          'The path to the directory of the new Hydrogen storefront.',
+        env: 'SHOPIFY_HYDROGEN_FLAG_PATH',
+      }),
+    ),
+    language: requiredIfNonInteractive(
+      Flags.string({
+        description: 'Sets the template language to use. One of `js` or `ts`.',
+        choices: Object.keys(LANGUAGES),
+        env: 'SHOPIFY_HYDROGEN_FLAG_LANGUAGE',
+      }),
+    ),
     template: Flags.string({
       description:
         'Scaffolds project based on an existing template or example from the Hydrogen repository.',
       env: 'SHOPIFY_HYDROGEN_FLAG_TEMPLATE',
     }),
-    ...commonFlags.installDeps,
-    'mock-shop': Flags.boolean({
-      description: 'Use mock.shop as the data source for the storefront.',
-      env: 'SHOPIFY_HYDROGEN_FLAG_MOCK_DATA',
-    }),
-    ...commonFlags.styling,
-    ...commonFlags.markets,
-    ...commonFlags.shortcut,
+    'install-deps': requiredIfNonInteractive(
+      commonFlags.installDeps['install-deps'],
+    ),
+    'mock-shop': requiredIfNonInteractive(
+      Flags.boolean({
+        description: 'Use mock.shop as the data source for the storefront.',
+        env: 'SHOPIFY_HYDROGEN_FLAG_MOCK_DATA',
+      }),
+    ),
+    styling: requiredIfNonInteractive(commonFlags.styling.styling),
+    markets: requiredIfNonInteractive(commonFlags.markets.markets),
+    shortcut: requiredIfNonInteractive(commonFlags.shortcut.shortcut),
     git: Flags.boolean({
       description: 'Init Git and create initial commits.',
       env: 'SHOPIFY_HYDROGEN_FLAG_GIT',

--- a/packages/cli/src/lib/flags.test.ts
+++ b/packages/cli/src/lib/flags.test.ts
@@ -1,5 +1,10 @@
 import {describe, it, expect} from 'vitest';
-import {flagsToCamelObject, parseProcessFlags} from './flags.js';
+import {Flags} from '@oclif/core';
+import {
+  flagsToCamelObject,
+  parseProcessFlags,
+  requiredIfNonInteractive,
+} from './flags.js';
 
 describe('CLI flag utils', () => {
   it('turns kebab-case flags to camelCase', async () => {
@@ -41,5 +46,16 @@ describe('CLI flag utils', () => {
       installDeps: false,
       language: 'js',
     });
+  });
+
+  it('annotates flags that are required in non-interactive terminals', async () => {
+    const original = Flags.string({description: 'A value used by a prompt.'});
+    const annotated = requiredIfNonInteractive(original);
+
+    expect(annotated).toMatchObject({
+      requiredIfNonInteractive: true,
+      description: '(required if non-interactive) A value used by a prompt.',
+    });
+    expect(original.description).toBe('A value used by a prompt.');
   });
 });

--- a/packages/cli/src/lib/flags.ts
+++ b/packages/cli/src/lib/flags.ts
@@ -187,6 +187,18 @@ export function flagsToCamelObject<T extends Record<string, any>>(obj: T) {
   }, {} as any) as CamelCasedProperties<T>;
 }
 
+export function requiredIfNonInteractive<T extends {description?: string}>(
+  flag: T,
+) {
+  return {
+    ...flag,
+    requiredIfNonInteractive: true,
+    description: ['(required if non-interactive)', flag.description]
+      .filter(Boolean)
+      .join(' '),
+  };
+}
+
 /**
  * Parse process arguments into an object for use in the cli as flags.
  * This is used when starting the init command from create-hydrogen without Oclif.


### PR DESCRIPTION
# TL;DR

Annotates `hydrogen init --help` so agents and other non-interactive runners can see which setup flags need to be provided to avoid prompts.

# Context

Closes https://github.com/shop/issues-develop/issues/22928

`hydrogen init` can prompt for several values during local starter setup. In non-interactive contexts, users and agents discover those requirements only after a failed prompt, then retry with one more flag. The linked issue calls out that this is especially painful for agentic workflows.

Shopify CLI is moving toward a `requiredIfNonInteractive` flag marker. Hydrogen currently consumes `@shopify/cli-kit` from npm, so this PR implements the help annotation locally instead of duplicating BaseCommand parser internals.

# Changes

- Adds a `requiredIfNonInteractive` flag helper in Hydrogen CLI flag utilities.
- The helper prefixes descriptions with `(required if non-interactive)` so Oclif help and the cached manifest surface the requirement.
- The helper clones flag definitions before annotating them, avoiding accidental mutation of shared `commonFlags` used by other commands.
- Applies the annotation to `hydrogen init` flags that answer local starter prompts in unattended runs: `--path`, `--language`, `--install-deps`, `--mock-shop`, `--styling`, `--markets`, and `--shortcut`.
- Regenerates `packages/cli/oclif.manifest.json`.
- Adds a patch changeset for `@shopify/cli-hydrogen`.

# Tophatting

- `pnpm --dir packages/cli exec vitest run src/lib/flags.test.ts --test-timeout=60000`
- `pnpm --dir packages/cli run build`
- `git diff --check`

Also tried `pnpm --dir packages/cli run typecheck`, but it failed before reaching this change because local TypeScript resolution cannot find `@shopify/hydrogen-codegen`; pnpm also reported the current shell as Node 20.19.1 while the package requires Node 22 or 24.

Also tried the broader `src/commands/hydrogen/init.test.ts`; the new helper test passed, but the init project-validity cases failed on existing local environment issues: npm is blocked by minimum dependency age enforcement, and the generated skeleton could not resolve built Hydrogen/MiniOxygen Vite plugin files.
