### PR TITLE
Update skeleton README for React Router

### DIFF
--- a/templates/skeleton/README.md
+++ b/templates/skeleton/README.md
@@ -1,13 +1,13 @@
 # Hydrogen template: Skeleton
 
-Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dovetail with [Remix](https://remix.run/), Shopify’s full stack web framework. This template contains a **minimal setup** of components, queries and tooling to get started with Hydrogen.
+Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dovetail with [React Router](https://reactrouter.com/), the modern multi-strategy router for React. This template contains a **minimal setup** of components, queries and tooling to get started with Hydrogen.
 
 [Check out Hydrogen docs](https://shopify.dev/custom-storefronts/hydrogen)
-[Get familiar with Remix](https://remix.run/docs/en/v1)
+[Get familiar with React Router](https://reactrouter.com/start/framework/routing)
 
 ## What's included
 
-- Remix
+- React Router
 - Hydrogen
 - Oxygen
 - Vite
@@ -22,7 +22,7 @@ Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dov
 
 **Requirements:**
 
-- Node.js version 18.0.0 or higher
+- Node.js version 22.x or 24.x
 
 ```bash
 npm create @shopify/hydrogen@latest


### PR DESCRIPTION
## What changed
- Replaced remaining Remix wording and links in the skeleton README with React Router equivalents.
- Updated the documented Node.js requirement to match the template package engines: 22.x or 24.x.

## Why
Hydrogen skeleton projects now use React Router 7+, so the generated template README should point developers at current framework terminology and supported runtime versions.

## Testing
- Not run; docs-only change.