### PR TITLE
fix(hydrogen): call cart selector hook unconditionally in useOptionalCart

### DIFF
--- a/.changeset/few-bags-share.md
+++ b/.changeset/few-bags-share.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+call cart selector hook unconditionally in useOptionalCart

--- a/packages/hydrogen/src/react/cart.tsx
+++ b/packages/hydrogen/src/react/cart.tsx
@@ -140,18 +140,19 @@ export function useOptionalCart<TData extends CartData = CartData, S = unknown>(
   isEqual?: (a: S, b: S) => boolean,
 ): S | undefined {
   const store = useOptionalCartStore();
-  if (!store) return undefined;
   return useCartSelector(store, selector, isEqual);
 }
 
 function useCartSelector<TData extends CartData = CartData, S = unknown>(
-  store: CartStore,
+  store: CartStore | null,
   selector: (state: CartState<TData>) => S,
   isEqual?: (a: S, b: S) => boolean,
-): S {
+): S | undefined {
   const cachedRef = useRef<{ state: unknown; selector: typeof selector; value: S } | null>(null);
 
   const getSnapshot = () => {
+    if (!store) return undefined;
+
     const state = store.getState() as CartState<TData>;
 
     if (
@@ -173,7 +174,13 @@ function useCartSelector<TData extends CartData = CartData, S = unknown>(
     return next;
   };
 
-  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
+  const subscribe = store ? store.subscribe : noopSubscribe;
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+function noopSubscribe(): () => void {
+  return () => {};
 }
 
 export function useCartForm() {

--- a/packages/hydrogen/src/react/cart.tsx
+++ b/packages/hydrogen/src/react/cart.tsx
@@ -174,13 +174,7 @@ function useCartSelector<TData extends CartData = CartData, S = unknown>(
     return next;
   };
 
-  const subscribe = store ? store.subscribe : noopSubscribe;
-
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-}
-
-function noopSubscribe(): () => void {
-  return () => {};
+  return useSyncExternalStore(store?.subscribe ?? (() => () => {}), getSnapshot, getSnapshot);
 }
 
 export function useCartForm() {


### PR DESCRIPTION
### WHY are these changes introduced?

`useOptionalCart` called the `useCartSelector` hook *after* an early
`return undefined` when rendered outside a `<CartProvider>`. That makes a
hook run conditionally, violating the Rules of Hooks: the number/order of
hooks changes between renders depending on whether a provider is present,
which can corrupt React's hook state and crash in dev.

### WHAT is this pull request doing?

- `useOptionalCart` now always calls `useCartSelector`, passing a
  possibly-`null` store instead of returning early.
- `useCartSelector` accepts `CartStore | null`: `getSnapshot` returns
  `undefined` when there's no store, and it subscribes via a no-op
  `subscribe` so `useRef`/`useSyncExternalStore` always run in the same
  order.
- `useCart` continues to cast the result with `as S`, preserving the
  non-optional return type; `useOptionalCart` returns `S | undefined`.

No behavioral change for consumers inside a provider.

### HOW to test your changes?

From `packages/hydrogen`:

```bash
pnpm test        # vitest — src/react/cart.test.tsx (26/26 passing)
pnpm typecheck