### PR TITLE
Guard Hydrogen primitives projects from classic CLI commands

### DIFF
--- a/.changeset/clever-lemurs-guard.md
+++ b/.changeset/clever-lemurs-guard.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Read disabled command metadata from @shopify/hydrogen and stop those commands with an actionable error.

--- a/packages/cli/src/hooks/init.ts
+++ b/packages/cli/src/hooks/init.ts
@@ -1,9 +1,13 @@
-import {createRequire} from 'node:module';
 import {spawnSync} from 'node:child_process';
 import type {Hook} from '@oclif/core';
 import {outputDebug, outputNewline} from '@shopify/cli-kit/node/output';
-import {cwd, joinPath, resolvePath} from '@shopify/cli-kit/node/path';
+import {cwd, resolvePath} from '@shopify/cli-kit/node/path';
 import {renderWarning} from '@shopify/cli-kit/node/ui';
+
+import {
+  applyHydrogenCommandPolicy,
+  isHydrogenProject,
+} from '../lib/hydrogen-command-policy.js';
 
 const hook: Hook<'init'> = async function (options) {
   // Check if this is a Hydrogen command to avoid running this
@@ -48,6 +52,10 @@ const hook: Hook<'init'> = async function (options) {
     process.exit(1);
   }
 
+  if (applyHydrogenCommandPolicy({id: options.id, projectPath})) {
+    process.exit(1);
+  }
+
   if (
     commandNeedsVM(options.id, options.argv) &&
     !process.execArgv.includes(EXPERIMENTAL_VM_MODULES_FLAG) &&
@@ -72,23 +80,6 @@ const EXPERIMENTAL_VM_MODULES_FLAG = '--experimental-vm-modules';
 function commandNeedsVM(id = '', argv: string[] = []) {
   // All the commands that rely on MiniOxygen's Node sandbox:
   return id === 'hydrogen:debug:cpu';
-}
-
-function isHydrogenProject(projectPath: string) {
-  try {
-    const require = createRequire(import.meta.url);
-    const {dependencies, scripts} = require(
-      joinPath(projectPath, 'package.json'),
-    );
-
-    return (
-      !!dependencies?.['@shopify/hydrogen'] ||
-      // Diff examples don't have dependencies:
-      !!scripts?.dev?.includes('--diff')
-    );
-  } catch {
-    return false;
-  }
 }
 
 export default hook;

--- a/packages/cli/src/lib/hydrogen-command-policy.test.ts
+++ b/packages/cli/src/lib/hydrogen-command-policy.test.ts
@@ -1,0 +1,169 @@
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {
+  applyHydrogenCommandPolicy,
+  isHydrogenCommandDisabled,
+  isHydrogenProject,
+} from './hydrogen-command-policy.js';
+
+describe('Hydrogen command policy', () => {
+  const outputMock = mockAndCaptureOutput();
+  let projectPath: string;
+
+  beforeEach(() => {
+    outputMock.clear();
+    projectPath = mkdtempSync(join(tmpdir(), 'hydrogen-command-policy-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectPath, {force: true, recursive: true});
+  });
+
+  describe('applyHydrogenCommandPolicy()', () => {
+    it('continues when command id is missing', () => {
+      writeProjectPackageJson({
+        dependencies: {'@shopify/hydrogen': 'workspace:*'},
+      });
+      writeDisabledCommands('hydrogen:dev');
+
+      const isDisabled = applyHydrogenCommandPolicy({projectPath});
+
+      expect(isDisabled).toBe(false);
+      expect(outputMock.output()).toBe('');
+    });
+
+    it('continues when a command is not disabled', () => {
+      writeProjectPackageJson({
+        dependencies: {'@shopify/hydrogen': 'workspace:*'},
+      });
+      writeDisabledCommands('hydrogen:dev');
+
+      const isDisabled = applyHydrogenCommandPolicy({
+        id: 'hydrogen:env:pull',
+        projectPath,
+      });
+
+      expect(isDisabled).toBe(false);
+      expect(outputMock.output()).toBe('');
+    });
+
+    it('blocks commands listed in package metadata with generic guidance', () => {
+      writeProjectPackageJson({
+        dependencies: {'@shopify/hydrogen': 'workspace:*'},
+      });
+      writeDisabledCommands('hydrogen:setup:vite');
+
+      const isDisabled = applyHydrogenCommandPolicy({
+        id: 'hydrogen:setup:vite',
+        projectPath,
+      });
+
+      expect(isDisabled).toBe(true);
+      expect(outputMock.output()).toContain(
+        '`shopify hydrogen setup vite` is not supported by this version of Hydrogen',
+      );
+      expect(outputMock.output()).toContain(
+        'The installed version of @shopify/hydrogen disables this command.',
+      );
+      expect(outputMock.output()).toContain(
+        'Use your framework or package tooling instead.',
+      );
+    });
+  });
+
+  describe('isHydrogenCommandDisabled()', () => {
+    it('reads disabled commands from @shopify/hydrogen package metadata', () => {
+      writeProjectPackageJson({
+        dependencies: {'@shopify/hydrogen': 'workspace:*'},
+      });
+      writeDisabledCommands('hydrogen:setup:vite');
+
+      expect(
+        isHydrogenCommandDisabled(projectPath, 'hydrogen:setup:vite'),
+      ).toBe(true);
+      expect(isHydrogenCommandDisabled(projectPath, 'hydrogen:env:pull')).toBe(
+        false,
+      );
+    });
+
+    it('keeps commands enabled when disabled command metadata is missing', () => {
+      writeProjectPackageJson({
+        dependencies: {'@shopify/hydrogen': '2026.1.0'},
+      });
+      writeHydrogenPackageJson({});
+
+      expect(
+        isHydrogenCommandDisabled(projectPath, 'hydrogen:setup:vite'),
+      ).toBe(false);
+    });
+  });
+
+  describe('isHydrogenProject()', () => {
+    it.each(['dependencies', 'devDependencies', 'peerDependencies'] as const)(
+      'identifies projects declaring @shopify/hydrogen in %s',
+      (dependencyType) => {
+        writeProjectPackageJson({
+          [dependencyType]: {'@shopify/hydrogen': 'workspace:*'},
+        });
+
+        expect(isHydrogenProject(projectPath)).toBe(true);
+      },
+    );
+
+    it('does not identify projects from hoisted @shopify/hydrogen packages alone', () => {
+      const workspacePath = mkdtempSync(
+        join(tmpdir(), 'hydrogen-command-policy-workspace-'),
+      );
+      const nestedProjectPath = join(workspacePath, 'packages', 'not-hydrogen');
+
+      mkdirSync(nestedProjectPath, {recursive: true});
+      writeJson(join(nestedProjectPath, 'package.json'), {
+        name: 'not-hydrogen',
+      });
+      writeHydrogenPackageJson(
+        {shopify: {cli: {disabledCommands: ['hydrogen:setup:vite']}}},
+        join(workspacePath, 'node_modules', '@shopify', 'hydrogen'),
+      );
+
+      try {
+        expect(isHydrogenProject(nestedProjectPath)).toBe(false);
+      } finally {
+        rmSync(workspacePath, {force: true, recursive: true});
+      }
+    });
+  });
+
+  function writeProjectPackageJson(packageJson: Record<string, unknown>) {
+    writeJson(join(projectPath, 'package.json'), packageJson);
+  }
+
+  function writeDisabledCommands(...disabledCommands: string[]) {
+    writeHydrogenPackageJson({shopify: {cli: {disabledCommands}}});
+  }
+
+  function writeHydrogenPackageJson(
+    packageJson: Record<string, unknown>,
+    hydrogenPackagePath = join(
+      projectPath,
+      'node_modules',
+      '@shopify',
+      'hydrogen',
+    ),
+  ) {
+    mkdirSync(hydrogenPackagePath, {recursive: true});
+    writeJson(join(hydrogenPackagePath, 'package.json'), {
+      name: '@shopify/hydrogen',
+      exports: {'./package.json': './package.json'},
+      ...packageJson,
+    });
+  }
+
+  function writeJson(path: string, data: Record<string, unknown>) {
+    writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+  }
+});

--- a/packages/cli/src/lib/hydrogen-command-policy.ts
+++ b/packages/cli/src/lib/hydrogen-command-policy.ts
@@ -1,0 +1,62 @@
+import {createRequire} from 'node:module';
+
+import {outputNewline} from '@shopify/cli-kit/node/output';
+import {joinPath} from '@shopify/cli-kit/node/path';
+import {renderError} from '@shopify/cli-kit/node/ui';
+
+/**
+ * Returns true if the command has been marked as disabled and we've shown an
+ * error to the user.
+ */
+export function applyHydrogenCommandPolicy({
+  id,
+  projectPath,
+}: {
+  id?: string;
+  projectPath: string;
+}) {
+  if (
+    !id ||
+    !isHydrogenProject(projectPath) ||
+    !isHydrogenCommandDisabled(projectPath, id)
+  ) {
+    return false;
+  }
+
+  outputNewline();
+  renderError({
+    headline: `\`shopify ${id.replace(/:/g, ' ')}\` is not supported by this version of Hydrogen`,
+    body: 'The installed version of @shopify/hydrogen disables this command.',
+    nextSteps: ['Use your framework or package tooling instead.'],
+  });
+
+  return true;
+}
+
+export function isHydrogenCommandDisabled(projectPath: string, id: string) {
+  try {
+    const require = createRequire(joinPath(projectPath, 'package.json'));
+    const hydrogenPackageJson = require('@shopify/hydrogen/package.json');
+    const disabledCommands =
+      hydrogenPackageJson?.shopify?.cli?.disabledCommands;
+
+    return Array.isArray(disabledCommands) && disabledCommands.includes(id);
+  } catch {
+    return false;
+  }
+}
+
+export function isHydrogenProject(projectPath: string) {
+  try {
+    const require = createRequire(import.meta.url);
+    const projectPackageJson = require(joinPath(projectPath, 'package.json'));
+
+    return [
+      projectPackageJson?.dependencies,
+      projectPackageJson?.devDependencies,
+      projectPackageJson?.peerDependencies,
+    ].some((dependencies) => !!dependencies?.['@shopify/hydrogen']);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Hydrogen packages can support Shopify integration commands without also supporting Hydrogen classic's app lifecycle commands. The CLI needs that compatibility decision to come from the installed package rather than inferring it from the package shape.

This PR adds a central command policy to the CLI init hook:

- reads `shopify.cli.disabledCommands` from the installed `@shopify/hydrogen/package.json`
- blocks an exact Oclif command ID when the package lists it
- leaves unlisted commands alone, including Shopify integration commands
- shows the same generic error for every disabled command

The disabled command list intentionally lives in the package rather than the CLI. This lets a Hydrogen package change its supported command surface without requiring another command-policy release. The matching metadata for the preview Hydrogen package is in https://github.com/Shopify/hydrogen/pull/3847.

## Tophatting 🎩

From a checkout of this PR:

```bash
pnpm install
pnpm --dir packages/cli run build
pnpm run patch-cli
```

Until the package metadata lands, patch the installed `@shopify/hydrogen/package.json` in the project you want to test:

```bash
node <<'EOF_NODE'
const {createRequire} = require('node:module');
const {readFileSync, writeFileSync} = require('node:fs');

const requireFromProject = createRequire(`${process.cwd()}/package.json`);
const packageJsonPath = requireFromProject.resolve('@shopify/hydrogen/package.json');
const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));

packageJson.shopify = {
  ...packageJson.shopify,
  cli: {
    ...packageJson.shopify?.cli,
    disabledCommands: ['hydrogen:dev', 'hydrogen:setup:vite'],
  },
};

writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
console.log(`Patched ${packageJsonPath}`);
EOF_NODE
```

This only changes the local `node_modules` copy. Reinstalling dependencies removes the patch.

Then run the patched CLI from the Hydrogen checkout:

```bash
pnpm exec shopify hydrogen dev --path /path/to/project
pnpm exec shopify hydrogen setup vite --path /path/to/project
pnpm exec shopify hydrogen env pull --path /path/to/project --help
```

The first two commands should stop with the generic unsupported-command error. `env pull` is not listed in the metadata and should continue to its help output.

## Validation

```bash
pnpm exec prettier --check packages/cli/src/hooks/init.ts packages/cli/src/lib/hydrogen-command-policy.ts packages/cli/src/lib/hydrogen-command-policy.test.ts .changeset/clever-lemurs-guard.md
pnpm exec eslint --no-error-on-unmatched-pattern packages/cli/src/hooks/init.ts packages/cli/src/lib/hydrogen-command-policy.ts packages/cli/src/lib/hydrogen-command-policy.test.ts
SHOPIFY_UNIT_TEST=1 LANG=en-US.UTF-8 pnpm --dir packages/cli exec vitest run --test-timeout=60000 src/lib/hydrogen-command-policy.test.ts
pnpm --dir packages/cli run build
```
