### PR TITLE
Add Hydrogen primitives package metadata

### DIFF
--- a/.changeset/fuzzy-wolves-signal.md
+++ b/.changeset/fuzzy-wolves-signal.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Expose package metadata listing the Hydrogen classic CLI commands disabled for this package.

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -101,5 +101,26 @@
     "react": {
       "optional": true
     }
+  },
+  "shopify": {
+    "cli": {
+      "disabledCommands": [
+        "hydrogen:build",
+        "hydrogen:check",
+        "hydrogen:codegen",
+        "hydrogen:debug:cpu",
+        "hydrogen:dev",
+        "hydrogen:g",
+        "hydrogen:generate:route",
+        "hydrogen:generate:routes",
+        "hydrogen:preview",
+        "hydrogen:setup",
+        "hydrogen:setup:css",
+        "hydrogen:setup:markets",
+        "hydrogen:setup:vite",
+        "hydrogen:shortcut",
+        "hydrogen:upgrade"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Adds package-owned Shopify CLI compatibility metadata to the preview `@shopify/hydrogen` package:

```json
"shopify": {
  "cli": {
    "disabledCommands": [
      "hydrogen:build",
      "hydrogen:check",
      "hydrogen:codegen",
      "hydrogen:debug:cpu",
      "hydrogen:dev",
      "hydrogen:g",
      "hydrogen:generate:route",
      "hydrogen:generate:routes",
      "hydrogen:preview",
      "hydrogen:setup",
      "hydrogen:setup:css",
      "hydrogen:setup:markets",
      "hydrogen:setup:vite",
      "hydrogen:shortcut",
      "hydrogen:upgrade"
    ]
  }
}
```

The values are canonical Oclif command IDs, so `shopify hydrogen setup vite` is represented as `hydrogen:setup:vite`.

This list covers the Hydrogen classic lifecycle and project-management commands that this package does not support. Shopify integration commands are intentionally omitted and remain available. The matching CLI consumer is in https://github.com/Shopify/hydrogen/pull/3846.

## Validation

```bash
pnpm exec oxfmt --check packages/hydrogen/package.json .changeset/fuzzy-wolves-signal.md
git diff --check origin/preview...HEAD
```
