### PR TITLE
Preserve actionable build errors during h2 deploy

### DIFF
--- a/.changeset/deploy-preserve-build-error.md
+++ b/.changeset/deploy-preserve-build-error.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Preserve actionable build errors during `h2 deploy`. When the build step fails (for example, when the `vite` package is missing from the project), the original error and its guidance are now surfaced instead of being wrapped into a generic "Build function failed with error" message and reported as an uncaught crash.

--- a/packages/cli/src/commands/hydrogen/deploy.test.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.test.ts
@@ -833,6 +833,37 @@ describe('deploy', async () => {
     });
   });
 
+  it('surfaces the original build error instead of the wrapped deploy error', async () => {
+    // The kind of actionable error `runBuild` throws when the project is
+    // missing its `vite` dependency (via `importVite`).
+    const buildError = new AbortError(
+      "Could not find the 'vite' package in your project.",
+      'Hydrogen uses Vite to run this command.',
+      [
+        'Install your project dependencies (for example, by running `npm install`) and try again.',
+      ],
+    );
+    vi.mocked(runBuild).mockRejectedValueOnce(buildError);
+
+    // Simulate how `@shopify/oxygen-cli` wraps a failing `buildFunction` into a
+    // generic, non-AbortError error before rejecting the deploy promise.
+    vi.mocked(createDeploy).mockImplementationOnce(async (options) => {
+      try {
+        await options.hooks?.buildFunction?.('some-cool-asset-path');
+      } catch (error) {
+        throw new Error(
+          `Build function failed with error: ${(error as Error).message}`,
+        );
+      }
+
+      return {url: 'https://a-lovely-deployment.com'};
+    });
+
+    // The original AbortError (with its next steps) is surfaced, not the
+    // wrapped generic error that would be reported as an uncaught crash.
+    await expect(runDeploy(deployParams)).rejects.toBe(buildError);
+  });
+
   it('passes a build command to createDeploy when the build-command flag is used', async () => {
     const params = {
       ...deployParams,

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -584,6 +584,7 @@ Continue?`.value,
   );
 
   let deployError: AbortError | null = null;
+  let buildError: Error | null = null;
   let resolveDeploy: () => void;
   let rejectDeploy: (reason?: AbortError) => void;
   const deployPromise = new Promise<void>((resolve, reject) => {
@@ -633,23 +634,34 @@ Continue?`.value,
     hooks.buildFunction = async (
       assetPath: string | undefined,
     ): Promise<void> => {
-      outputInfo(
-        outputContent`${colors.whiteBright('Building project...')}`.value,
-      );
+      try {
+        outputInfo(
+          outputContent`${colors.whiteBright('Building project...')}`.value,
+        );
 
-      if (isClassicCompiler) {
-        throw new AbortError(REMIX_COMPILER_ERROR_MESSAGE);
+        if (isClassicCompiler) {
+          throw new AbortError(REMIX_COMPILER_ERROR_MESSAGE);
+        }
+
+        await runBuild({
+          directory: root,
+          assetPath,
+          lockfileCheck,
+          sourcemap: true,
+          forceClientSourcemap,
+          useCodegen: false,
+          entry: ssrEntry,
+        });
+      } catch (error) {
+        // `@shopify/oxygen-cli` wraps any error thrown by `buildFunction` into a
+        // generic Error ("Build function failed with error: ..."). That drops the
+        // original error's actionable next steps and, because it's no longer an
+        // AbortError, cli-kit reports it as an uncaught crash. Capture the original
+        // here so it can be surfaced instead of the wrapped error (see the reject
+        // below).
+        buildError = error as Error;
+        throw error;
       }
-
-      await runBuild({
-        directory: root,
-        assetPath,
-        lockfileCheck,
-        sourcemap: true,
-        forceClientSourcemap,
-        useCodegen: false,
-        entry: ssrEntry,
-      });
     };
   }
 
@@ -724,7 +736,7 @@ Continue?`.value,
       resolveDeploy();
     })
     .catch((error) => {
-      rejectDeploy(deployError || error);
+      rejectDeploy(deployError || buildError || error);
     });
 
   return deployPromise;

--- a/packages/cli/src/commands/hydrogen/deploy.ts
+++ b/packages/cli/src/commands/hydrogen/deploy.ts
@@ -653,12 +653,7 @@ Continue?`.value,
           entry: ssrEntry,
         });
       } catch (error) {
-        // `@shopify/oxygen-cli` wraps any error thrown by `buildFunction` into a
-        // generic Error ("Build function failed with error: ..."). That drops the
-        // original error's actionable next steps and, because it's no longer an
-        // AbortError, cli-kit reports it as an uncaught crash. Capture the original
-        // here so it can be surfaced instead of the wrapped error (see the reject
-        // below).
+        // Capture the original error so it can be surfaced later, before oxygen-cli wraps it.
         buildError = error as Error;
         throw error;
       }


### PR DESCRIPTION
Resiliency issue: shop/issues#63530

### WHY are these changes introduced?

`h2 deploy` runs the build through the `hooks.buildFunction` callback, which calls `runBuild()` → `importVite()`. When the project is missing its `vite` dependency, `importVite()` throws a well-formed `AbortError` with actionable next steps (`Install your project dependencies (for example, by running \`npm install\`) and try again.`).

However, that callback is handed to `createDeploy()` from `@shopify/oxygen-cli`, which **catches and re-wraps** any error thrown by `buildFunction` into a generic `Error`: `Build function failed with error: ...`. By the time deploy.ts's terminal `.catch` runs, `deployError` is `null` (it's only set by deployment hooks, not build failures), so the deploy rejects with that wrapped generic error.

Two consequences:
- The original error's actionable next steps are lost — the merchant just sees `Build function failed with error: Error: Could not find the 'vite' package in your project.`
- Because it's no longer an `AbortError`, `@shopify/cli-kit` treats it as an *unexpected* error and reports it as an uncaught crash instead of a handled, actionable message.

**Alternative considered:** fixing the wrapping in `@shopify/oxygen-cli` itself (so it preserves `AbortError`s). That's the more general fix but lives in a separate package/release; this PR is a self-contained fix on the Hydrogen side.

### WHAT is this pull request doing?

Captures the original error thrown by the `buildFunction` hook (before oxygen-cli wraps it) and prefers it over the wrapped error when rejecting the deploy:

- New `buildError` capture variable alongside `deployError`.
- `hooks.buildFunction` body wrapped in try/catch that records the original error and re-throws.
- Terminal reject changed to `rejectDeploy(deployError || buildError || error)`.

The success path is unchanged (`buildError` stays `null`; the `.catch` only runs on failure). This improves **every** build-hook failure path, surfacing the original error instead of oxygen-cli's generic wrapper:
- Missing `vite` and the classic-compiler error are `AbortError`s, so they now render with their next steps and are no longer reported as crashes.
- Other (non-`AbortError`) build failures — e.g. a genuine Vite build error — are still reported as crashes by cli-kit, but now surface the original build error message rather than the opaque `Build function failed with error: ...` wrapper.

### HOW to test your changes?

```
cd packages/cli
SHOPIFY_UNIT_TEST=1 npx vitest run src/commands/hydrogen/deploy.test.ts
```

Added a regression test — `surfaces the original build error instead of the wrapped deploy error` — that mocks `runBuild` to throw the missing-`vite` `AbortError`, mocks `createDeploy` to wrap it the way oxygen-cli does, and asserts `runDeploy` rejects with the **original** `AbortError` rather than the wrapped generic error. Verified the test fails without the fix and passes with it. All 47 tests in the file pass.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
