### PR TITLE
fix: Rename check command class from GenerateRoute to Check

### DIFF
--- a/.changeset/fix-check-class-name.md
+++ b/.changeset/fix-check-class-name.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Fix the `check` command class name from `GenerateRoute` to `Check` — a copy-paste error that caused confusion in stack traces and developer tooling.

--- a/packages/cli/src/commands/hydrogen/check.ts
+++ b/packages/cli/src/commands/hydrogen/check.ts
@@ -11,7 +11,7 @@ import {
 
 import {Args} from '@oclif/core';
 
-export default class GenerateRoute extends Command {
+export default class Check extends Command {
   static descriptionWithMarkdown = `Checks whether your Hydrogen app includes a set of standard Shopify routes.`;
 
   static description =
@@ -31,7 +31,7 @@ export default class GenerateRoute extends Command {
   };
 
   async run(): Promise<void> {
-    const {flags, args} = await this.parse(GenerateRoute);
+    const {flags, args} = await this.parse(Check);
     const directory = flags.path ? resolvePath(flags.path) : process.cwd();
 
     if (args.resource === 'routes') {


### PR DESCRIPTION
## Summary

Fixes #3696

In `packages/cli/src/commands/hydrogen/check.ts`, the class was named `GenerateRoute` instead of `Check` — a copy-paste error from when the file was created based on `generate/route.ts`.

While oclif uses file-based routing so the class name does not affect command resolution, it appears incorrectly in stack traces and causes confusion for developers maintaining the code.

## Changes

- Renamed class from `GenerateRoute` to `Check` (line 14)
- Updated `this.parse(GenerateRoute)` to `this.parse(Check)` (line 34)
- Added a changeset for `@shopify/cli-hydrogen` patch bump

## Verification

- The `index.ts` already imports this class as `Check` (`import Check from './commands/hydrogen/check.js'`), confirming the intended name
- The only external export used by tests is `runCheckRoutes`, which is unchanged
- No functional behavior change — class name is purely cosmetic in oclif's file-based routing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)