### PR TITLE
fix: add an explicit ~ alias in the Hydrogen skeleton

### DIFF
--- a/.changeset/fix-js-template-app-alias.md
+++ b/.changeset/fix-js-template-app-alias.md
@@ -1,0 +1,9 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Add an explicit `~` app alias to new Hydrogen projects.
+
+JavaScript projects use `jsconfig.json`, which is not reliably covered by Vite's native `resolve.tsconfigPaths` behavior. New projects now define Hydrogen's `~/` import convention directly in the Vite config so imports like `~/assets/favicon.svg` work in both TypeScript and JavaScript projects.

--- a/cookbook/llms/express.prompt.md
+++ b/cookbook/llms/express.prompt.md
@@ -2525,13 +2525,20 @@ Configure Vite for Express deployment with Node.js module externalization
 #### File: /vite.config.ts
 
 ```diff
-@@ -5,13 +5,15 @@ import {reactRouter} from '@react-router/dev/vite';
- import tsconfigPaths from 'vite-tsconfig-paths';
-
+@@ -1,11 +1,10 @@
+ import {fileURLToPath} from 'node:url';
+ import {defineConfig} from 'vite';
+ import {hydrogen} from '@shopify/hydrogen/vite';
+-import {oxygen} from '@shopify/mini-oxygen/vite';
+ import {reactRouter} from '@react-router/dev/vite';
+ 
  export default defineConfig({
--  plugins: [hydrogen(), oxygen(), reactRouter(), tsconfigPaths()],
-+  plugins: [hydrogen(), reactRouter(), tsconfigPaths()],
-   build: {
+-  plugins: [hydrogen(), oxygen(), reactRouter()],
++  plugins: [hydrogen(), reactRouter()],
+   resolve: {
+     alias: {
+       // Vite's native tsconfig path resolver does not cover JavaScript
+@@ -18,8 +17,10 @@ export default defineConfig({
      // Allow a strict Content-Security-Policy
      // without inlining assets as base64:
      assetsInlineLimit: 0,
@@ -2542,7 +2549,7 @@ Configure Vite for Express deployment with Node.js module externalization
      optimizeDeps: {
        /**
         * Include dependencies here if they throw CJS<>ESM errors.
-@@ -23,10 +25,7 @@ export default defineConfig({
+@@ -31,14 +32,7 @@ export default defineConfig({
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */

--- a/cookbook/llms/multipass.prompt.md
+++ b/cookbook/llms/multipass.prompt.md
@@ -3688,7 +3688,7 @@ Configure Vite for crypto polyfills
 #### File: /vite.config.ts
 
 ~~~diff
-@@ -29,6 +29,7 @@ export default defineConfig({
+@@ -35,6 +35,7 @@ export default defineConfig({
          'react-router > set-cookie-parser',
          'react-router > cookie',
          'react-router',

--- a/cookbook/llms/partytown.prompt.md
+++ b/cookbook/llms/partytown.prompt.md
@@ -679,7 +679,7 @@ Configure Vite to exclude Partytown library from build optimization.
 #### File: /vite.config.ts
 
 ~~~diff
-@@ -29,6 +29,7 @@ export default defineConfig({
+@@ -35,6 +35,7 @@ export default defineConfig({
          'react-router > set-cookie-parser',
          'react-router > cookie',
          'react-router',

--- a/cookbook/recipes/express/README.md
+++ b/cookbook/recipes/express/README.md
@@ -2608,20 +2608,23 @@ Configure Vite for Express deployment with Node.js module externalization
 #### File: [vite.config.ts](https://github.com/Shopify/hydrogen/blob/14d09107663313bae8eac3c701b90a7bc49819e4/templates/skeleton/vite.config.ts)
 
 ~~~diff
-index a1702446..058b559d 100644
+index 2c36cdf92..5557213f 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
-@@ -1,16 +1,17 @@
+@@ -1,11 +1,10 @@
+ import {fileURLToPath} from 'node:url';
  import {defineConfig} from 'vite';
  import {hydrogen} from '@shopify/hydrogen/vite';
 -import {oxygen} from '@shopify/mini-oxygen/vite';
  import {reactRouter} from '@react-router/dev/vite';
- import tsconfigPaths from 'vite-tsconfig-paths';
-
+ 
  export default defineConfig({
--  plugins: [hydrogen(), oxygen(), reactRouter(), tsconfigPaths()],
-+  plugins: [hydrogen(), reactRouter(), tsconfigPaths()],
-   build: {
+-  plugins: [hydrogen(), oxygen(), reactRouter()],
++  plugins: [hydrogen(), reactRouter()],
+   resolve: {
+     alias: {
+       // Vite's native tsconfig path resolver does not cover JavaScript
+@@ -18,8 +17,10 @@ export default defineConfig({
      // Allow a strict Content-Security-Policy
      // without inlining assets as base64:
      assetsInlineLimit: 0,
@@ -2632,7 +2635,7 @@ index a1702446..058b559d 100644
      optimizeDeps: {
        /**
         * Include dependencies here if they throw CJS<>ESM errors.
-@@ -23,10 +24,7 @@ export default defineConfig({
+@@ -31,14 +32,7 @@ export default defineConfig({
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */

--- a/cookbook/recipes/express/patches/vite.config.ts.63904f.patch
+++ b/cookbook/recipes/express/patches/vite.config.ts.63904f.patch
@@ -1,17 +1,20 @@
-index 050b6ed7..ef18f2fc 100644
+index 2c36cdf92..5557213f 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
-@@ -1,17 +1,18 @@
+@@ -1,11 +1,10 @@
+ import {fileURLToPath} from 'node:url';
  import {defineConfig} from 'vite';
  import {hydrogen} from '@shopify/hydrogen/vite';
 -import {oxygen} from '@shopify/mini-oxygen/vite';
  import {reactRouter} from '@react-router/dev/vite';
- import tsconfigPaths from 'vite-tsconfig-paths';
-
+ 
  export default defineConfig({
--  plugins: [hydrogen(), oxygen(), reactRouter(), tsconfigPaths()],
-+  plugins: [hydrogen(), reactRouter(), tsconfigPaths()],
-   build: {
+-  plugins: [hydrogen(), oxygen(), reactRouter()],
++  plugins: [hydrogen(), reactRouter()],
+   resolve: {
+     alias: {
+       // Vite's native tsconfig path resolver does not cover JavaScript
+@@ -18,8 +17,10 @@ export default defineConfig({
      // Allow a strict Content-Security-Policy
      // without inlining assets as base64:
      assetsInlineLimit: 0,
@@ -22,7 +25,7 @@ index 050b6ed7..ef18f2fc 100644
      optimizeDeps: {
        /**
         * Include dependencies here if they throw CJS<>ESM errors.
-@@ -23,14 +24,7 @@ export default defineConfig({
+@@ -31,14 +32,7 @@ export default defineConfig({
         * Include 'example-dep' in the array below.
         * @see https://vitejs.dev/config/dep-optimization-options
         */

--- a/cookbook/recipes/multipass/README.md
+++ b/cookbook/recipes/multipass/README.md
@@ -3753,10 +3753,10 @@ Configure Vite for crypto polyfills
 #### File: [vite.config.ts](https://github.com/Shopify/hydrogen/blob/1040066d20b52667756fd1ebffd8607602a735b4/templates/skeleton/vite.config.ts)
 
 ~~~diff
-index d19b14dc4..550d63a11 100644
+index 2c36cdf92..85b0b5eb 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
-@@ -29,6 +29,7 @@ export default defineConfig({
+@@ -35,6 +35,7 @@ export default defineConfig({
          'react-router > set-cookie-parser',
          'react-router > cookie',
          'react-router',

--- a/cookbook/recipes/multipass/patches/vite.config.ts.8b5b9b.patch
+++ b/cookbook/recipes/multipass/patches/vite.config.ts.8b5b9b.patch
@@ -1,7 +1,7 @@
-index d19b14dc4..550d63a11 100644
+index 2c36cdf92..85b0b5eb 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
-@@ -29,6 +29,7 @@ export default defineConfig({
+@@ -35,6 +35,7 @@ export default defineConfig({
          'react-router > set-cookie-parser',
          'react-router > cookie',
          'react-router',

--- a/cookbook/recipes/partytown/README.md
+++ b/cookbook/recipes/partytown/README.md
@@ -686,10 +686,10 @@ Configure Vite to exclude Partytown library from build optimization.
 #### File: [vite.config.ts](https://github.com/Shopify/hydrogen/blob/1040066d20b52667756fd1ebffd8607602a735b4/templates/skeleton/vite.config.ts)
 
 ~~~diff
-index d19b14dc4..38670eb6a 100644
+index 2c36cdf92..0c6f115c 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
-@@ -29,6 +29,7 @@ export default defineConfig({
+@@ -35,6 +35,7 @@ export default defineConfig({
          'react-router > set-cookie-parser',
          'react-router > cookie',
          'react-router',

--- a/cookbook/recipes/partytown/patches/vite.config.ts.8b5b9b.patch
+++ b/cookbook/recipes/partytown/patches/vite.config.ts.8b5b9b.patch
@@ -1,7 +1,7 @@
-index d19b14dc4..38670eb6a 100644
+index 2c36cdf92..0c6f115c 100644
 --- a/templates/skeleton/vite.config.ts
 +++ b/templates/skeleton/vite.config.ts
-@@ -29,6 +29,7 @@ export default defineConfig({
+@@ -35,6 +35,7 @@ export default defineConfig({
          'react-router > set-cookie-parser',
          'react-router > cookie',
          'react-router',

--- a/templates/skeleton/vite.config.ts
+++ b/templates/skeleton/vite.config.ts
@@ -1,3 +1,4 @@
+import {fileURLToPath} from 'node:url';
 import {defineConfig} from 'vite';
 import {hydrogen} from '@shopify/hydrogen/vite';
 import {oxygen} from '@shopify/mini-oxygen/vite';
@@ -6,6 +7,11 @@ import {reactRouter} from '@react-router/dev/vite';
 export default defineConfig({
   plugins: [hydrogen(), oxygen(), reactRouter()],
   resolve: {
+    alias: {
+      // Vite's native tsconfig path resolver does not cover JavaScript
+      // projects that use jsconfig.json, so define Hydrogen's app alias here.
+      '~': fileURLToPath(new URL('./app', import.meta.url)),
+    },
     tsconfigPaths: true,
   },
   build: {


### PR DESCRIPTION
### WHY are these changes introduced?

Before the upgrade, Hydrogen projects relied on the `vite-tsconfig-paths` plugin to resolve `~/` imports from `tsconfig.json` / `jsconfig.json`.

With the Vite 8 upgrade, we removed that plugin because Vite 8 introduced native support for path aliases via:

```js
resolve: {
  tsconfigPaths: true,
}
```

So TypeScript Hydrogen projects continue to work, while JavaScript quickstart projects can fail to resolve `~/` imports.

PR #3823 fixed a real MiniOxygen issue: it made sure Vite’s `resolve.tsconfigPaths` setting is passed into the MiniOxygen SSR environment.

However, even when the config is passed correctly, Vite’s native resolver still does not resolve `~/` imports reliably for JavaScript projects using `jsconfig.json`.

### WHAT is this pull request doing?

Add this to generated project `vite.config`:

```js
resolve: {
  alias: {
    '~': fileURLToPath(new URL('./app', import.meta.url)),
  },
  tsconfigPaths: true,
}
```

### HOW to test your changes?
- Start a new project using `pnpm create @shopify/hydrogen@latest`
- Select Javascript
- Start the app -> you should see error
- Now in the `vite.config` add the alias
- Re-run and you app and you should see it working

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset. 
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation