### PR TITLE
Include selectedOptions in add-to-cart event detail

### DIFF
--- a/.changeset/optimistic-cart-selected-options.md
+++ b/.changeset/optimistic-cart-selected-options.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Include the selected variant's `selectedOptions` in the add-to-cart event detail built by the product form. Optimistic cart lines now carry `merchandise.selectedOptions` during the mutation window, so cart line components that render option names (e.g. `Size: Large`) no longer flicker from the variant title to the resolved options when the add-to-cart mutation completes.

--- a/packages/hydrogen/src/core/product/product-form.test.ts
+++ b/packages/hydrogen/src/core/product/product-form.test.ts
@@ -923,12 +923,24 @@ describe("createProductFormStore", () => {
           {
             id: "v-red",
             title: "Red",
+            selectedOptions: [{ name: "Color", value: "Red" }],
             product: { title: undefined },
             image: undefined,
             price: { amount: "10.00", currencyCode: "USD" },
           },
         ],
       });
+    });
+
+    it("includes the variant's selectedOptions so the optimistic line can render option names", async () => {
+      const cartStore = createMockCartStore();
+      const store = createStore(makeSingleOptionProduct(RED), cartStore);
+      const event = new Event("submit") as SubmitEvent;
+
+      await store.handleFormSubmit(event);
+
+      const [, detail] = (cartStore.handleFormSubmit as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(detail.products[0].selectedOptions).toEqual([{ name: "Color", value: "Red" }]);
     });
 
     it("passes undefined eventDetail when no variant is selected", async () => {
@@ -960,6 +972,7 @@ describe("createProductFormStore", () => {
           {
             id: "v-red",
             title: "Red",
+            selectedOptions: [{ name: "Color", value: "Red" }],
             product: { title: "Cozy Shirt" },
             image: { url: "https://cdn.example.com/shirt.jpg", altText: "Red shirt" },
             price: { amount: "10.00", currencyCode: "USD" },

--- a/packages/hydrogen/src/core/product/product-form.ts
+++ b/packages/hydrogen/src/core/product/product-form.ts
@@ -313,6 +313,7 @@ function buildAddToCartDetail<TProduct extends ProductInput>(
       {
         id: selectedVariant.id,
         title: selectedVariant.title,
+        selectedOptions: selectedVariant.selectedOptions,
         product: selectedVariant.product ? { title: selectedVariant.product.title } : undefined,
         image: selectedVariant.image,
         price: selectedVariant.price,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3853

`buildAddToCartDetail` doesn't include the variant's `selectedOptions` when it builds the add-to-cart detail, even though it's already available on the selected variant. The cart store spreads that payload into the optimistic line's `merchandise`, so the optimistic line ends up with no `selectedOptions`.

The effect is a flicker: cart lines that show option names like `Size: Large` have nothing to render during the optimistic window and fall back to the variant title (`Large / Square`), then snap to the real options once the mutation resolves.

### WHAT is this pull request doing?

Adding `selectedOptions` to the product payload in `buildAddToCartDetail`. Nothing else needs to change since the cart store already spreads the whole payload into `merchandise` and `CartLineMerchandise` already has the field. Also updated the existing tests and added one that checks the optimistic detail includes `selectedOptions`.

### HOW to test your changes?

    vitest run src/core/product/product-form.test.ts

All passing.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation