### PR TITLE
Fix CSP nonce hydration mismatch in ShopifyScripts

### DIFF
--- a/.changeset/shopify-scripts-nonce-hydration.md
+++ b/.changeset/shopify-scripts-nonce-hydration.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix a CSP nonce hydration mismatch warning from `ShopifyScripts`. When a nonce is supplied, browsers hide the parsed script's nonce content attribute (exposing `nonce=""` while retaining the real value on the `.nonce` property), which React reported as an attribute mismatch on the external generated script on every full page load. The generated script tags now suppress this known, benign diff when a nonce is provided, keeping unrelated hydration diagnostics visible.

--- a/packages/hydrogen/src/react/shopify-scripts.tsx
+++ b/packages/hydrogen/src/react/shopify-scripts.tsx
@@ -23,6 +23,13 @@ export function ShopifyScripts(options: ShopifyScriptsProps) {
     getShopifyScriptTags(scriptOptions).tags.map(({ tagName, attributes, innerHTML }, index) =>
       createElement(tagName, {
         key: index,
+        // When a CSP nonce is supplied, the browser hides the parsed script's
+        // nonce content attribute (exposing `nonce=""` while retaining the real
+        // value on the `.nonce` property), which React reports as a hydration
+        // attribute mismatch. Suppress that known, benign diff. Inline scripts
+        // are already covered below via their `innerHTML` branch; this handles
+        // the external (src) generated script.
+        ...(scriptOptions.nonce !== undefined ? { suppressHydrationWarning: true } : {}),
         ...getReactAttributes(attributes),
         ...(innerHTML
           ? {


### PR DESCRIPTION
Browsers hide a parsed script's nonce content attribute (exposing nonce="" while the real value stays on the .nonce property), which React reported as an attribute mismatch on the external generated script on every full page load when a CSP nonce was used. Suppress this known, benign diff for generated script tags when a nonce is supplied. Inline scripts were already covered via their innerHTML branch.

Fixes #3855

<!--
  How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that this PR is addressing. If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### HOW to test your changes?

<!--
  Give as much information for the reviewer to test your changes locally. A thorough step-by-step guide will go along-way.
-->

#### Post-merge steps

<!--
  If changes require post-merge steps, for example merging and publishing [documentation](https://shopify.dev) changes,
  specify it in this section and add the label "includes-post-merge-steps".
  If it doesn't, feel free to remove this section.
-->

#### Checklist

- [ ] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset. 
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<!--
 THANK YOU for your pull request! Members from the Hydrogen team will review these changes and provide feedback as soon as they are available.
-->
