### PR TITLE
Improve MiniOxygen debugger connections

### DIFF
--- a/.changeset/bright-tools-connect.md
+++ b/.changeset/bright-tools-connect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Use the IPv4 loopback address in local debugger instructions.

--- a/.changeset/tidy-tools-debug.md
+++ b/.changeset/tidy-tools-debug.md
@@ -1,6 +1,5 @@
 ---
-'@shopify/cli-hydrogen': patch
 '@shopify/mini-oxygen': patch
 ---
 
-Restrict MiniOxygen inspector access to trusted local debugger clients.
+Improve the reliability of local debugger connections.

--- a/.changeset/tidy-tools-debug.md
+++ b/.changeset/tidy-tools-debug.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/mini-oxygen': patch
+---
+
+Restrict MiniOxygen inspector access to trusted local debugger clients.

--- a/packages/cli/src/lib/dev-shared.ts
+++ b/packages/cli/src/lib/dev-shared.ts
@@ -117,7 +117,7 @@ export function getDebugBannerLine(publicInspectorPort: number) {
   )}.\nAttach a ${outputToken.link(
     colors.yellow(isVSCode ? 'VSCode debugger' : 'debugger'),
     debuggingDocsLink,
-  )} or open DevTools in http://localhost:${String(publicInspectorPort)}.`
+  )} or open DevTools in http://127.0.0.1:${String(publicInspectorPort)}.`
     .value;
 }
 

--- a/packages/mini-oxygen/src/worker/devtools.test.ts
+++ b/packages/mini-oxygen/src/worker/devtools.test.ts
@@ -1,0 +1,335 @@
+import {once} from 'node:events';
+import {request} from 'node:http';
+import getPort, {portNumbers} from 'get-port';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {WebSocket, type ClientOptions, type RawData} from 'ws';
+import {createInspectorProxy, type InspectorProxy} from './devtools.js';
+import type {InspectorConnection} from './inspector.js';
+import {createMiniOxygen} from './index.js';
+
+const inspectorProxies: InspectorProxy[] = [];
+
+afterEach(async () => {
+  await Promise.all(inspectorProxies.splice(0).map((proxy) => proxy.close()));
+});
+
+describe('MiniOxygen inspector proxy', () => {
+  it('listens on IPv4 loopback and advertises loopback URLs', async () => {
+    const {port, proxy} = await startInspectorProxy();
+    const address = await proxy.ready;
+
+    expect(address).toMatchObject({address: '127.0.0.1', family: 'IPv4'});
+
+    const response = await fetch(`http://127.0.0.1:${port}/json`);
+    const [target] = (await response.json()) as Array<{
+      webSocketDebuggerUrl: string;
+      devtoolsFrontendUrl: string;
+    }>;
+
+    expect(target).toMatchObject({
+      webSocketDebuggerUrl: `ws://127.0.0.1:${port}/ws`,
+      devtoolsFrontendUrl: expect.stringContaining(`ws=127.0.0.1:${port}/ws`),
+    });
+  });
+
+  it('rejects HTTP requests with a non-loopback Host', async () => {
+    const {port} = await startInspectorProxy();
+    const response = await makeHttpRequest(port, '/json', {
+      Host: 'attacker.example',
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('only exposes source maps to allowed browser origins', async () => {
+    const {port} = await startInspectorProxy();
+
+    const rejected = await makeHttpRequest(port, '/__index.js.map', {
+      Origin: 'https://attacker.example',
+    });
+    expect(rejected.statusCode).toBe(403);
+
+    const allowed = await makeHttpRequest(port, '/__index.js.map', {
+      Origin: 'devtools://devtools',
+    });
+    expect(allowed.statusCode).toBe(404);
+    expect(allowed.headers['access-control-allow-origin']).toBe(
+      'devtools://devtools',
+    );
+  });
+
+  it('allows Chrome DevTools and VSCode debugger connections', async () => {
+    const {port} = await startInspectorProxy();
+    const url = `ws://127.0.0.1:${port}/ws`;
+
+    const localDevTools = await openWebSocket(url, {
+      origin: `http://127.0.0.1:${port}`,
+      headers: {'User-Agent': 'Mozilla/5.0'},
+    });
+    await closeWebSocket(localDevTools);
+
+    const chromeDevTools = await openWebSocket(url, {
+      origin: 'devtools://devtools',
+      headers: {'User-Agent': 'Mozilla/5.0'},
+    });
+    await closeWebSocket(chromeDevTools);
+
+    // VSCode sends neither Origin nor User-Agent.
+    const vscode = await openWebSocket(url);
+    await closeWebSocket(vscode);
+  });
+
+  it('rejects untrusted browser origins and Host headers', async () => {
+    const {port} = await startInspectorProxy();
+    const url = `ws://127.0.0.1:${port}/ws`;
+
+    await expect(
+      rejectedWebSocketStatus(url, {
+        origin: 'https://attacker.example',
+        headers: {'User-Agent': 'Mozilla/5.0'},
+      }),
+    ).resolves.toBe(401);
+
+    await expect(
+      rejectedWebSocketStatus(url, {
+        headers: {'User-Agent': 'Mozilla/5.0'},
+      }),
+    ).resolves.toBe(401);
+
+    await expect(
+      rejectedWebSocketStatus(url, {
+        headers: {Host: 'attacker.example'},
+      }),
+    ).resolves.toBe(401);
+  });
+
+  it('proxies CDP to a real workerd inspector without exposing it to untrusted origins', async () => {
+    const inspectorPort = await findInspectorPort();
+    const miniOxygen = createMiniOxygen({
+      debug: true,
+      inspectorPort,
+      requestHook: null,
+      workers: [
+        {
+          name: 'test',
+          modules: true,
+          script: `export default {
+            fetch(_request, env) {
+              globalThis.__miniOxygenInspectorTestSecret = env.TEST_SECRET;
+              debugger;
+              return new Response('ok');
+            }
+          }`,
+          bindings: {TEST_SECRET: 'inspector-secret'},
+        },
+      ],
+    });
+
+    try {
+      const {workerUrl} = await withTimeout(
+        miniOxygen.ready,
+        'MiniOxygen readiness',
+      );
+
+      await expect(
+        withTimeout(
+          rejectedWebSocketStatus(`ws://127.0.0.1:${inspectorPort}/ws`, {
+            origin: 'https://attacker.example',
+            headers: {'User-Agent': 'Mozilla/5.0'},
+          }),
+          'untrusted WebSocket rejection',
+        ),
+      ).resolves.toBe(401);
+
+      const debuggerWs = await withTimeout(
+        openWebSocket(`ws://127.0.0.1:${inspectorPort}/ws`, {
+          origin: `http://127.0.0.1:${inspectorPort}`,
+          headers: {'User-Agent': 'Mozilla/5.0'},
+        }),
+        'trusted WebSocket connection',
+      );
+
+      const workerPaused = waitForCdpEvent(
+        debuggerWs,
+        'Debugger.paused',
+        () => true,
+      );
+      await withTimeout(
+        sendCdpCommand(debuggerWs, 1, 'Debugger.enable'),
+        'Debugger.enable',
+      );
+      const workerRequest = fetch(workerUrl);
+      const {callFrames} = await withTimeout(workerPaused, 'worker pause');
+      const [{callFrameId}] = callFrames as Array<{callFrameId: string}>;
+      const result = await withTimeout(
+        sendCdpCommand(debuggerWs, 2, 'Debugger.evaluateOnCallFrame', {
+          callFrameId,
+          expression: 'globalThis.__miniOxygenInspectorTestSecret',
+          returnByValue: true,
+        }),
+        'Debugger.evaluateOnCallFrame',
+      );
+
+      expect(result).toMatchObject({
+        result: {type: 'string', value: 'inspector-secret'},
+      });
+      await withTimeout(
+        sendCdpCommand(debuggerWs, 3, 'Debugger.resume'),
+        'Debugger.resume',
+      );
+      await withTimeout(workerRequest, 'worker request');
+      await withTimeout(closeWebSocket(debuggerWs), 'debugger close');
+    } finally {
+      await withTimeout(miniOxygen.dispose(), 'MiniOxygen disposal');
+    }
+  });
+});
+
+async function startInspectorProxy() {
+  const port = await findInspectorPort();
+  const proxy = createInspectorProxy(port, createMockInspectorConnection());
+  inspectorProxies.push(proxy);
+  await proxy.ready;
+
+  return {port, proxy};
+}
+
+function findInspectorPort() {
+  return getPort({
+    host: '127.0.0.1',
+    port: portNumbers(9229, 9329),
+  });
+}
+
+function createMockInspectorConnection() {
+  const ws = Object.assign(new EventTarget(), {
+    url: 'ws://127.0.0.1:1234/ws',
+    readyState: WebSocket.OPEN,
+    send: vi.fn(),
+  });
+
+  return {ws, sourceMapPath: undefined} as unknown as InspectorConnection;
+}
+
+function makeHttpRequest(
+  port: number,
+  path: string,
+  headers: Record<string, string>,
+) {
+  return new Promise<{
+    statusCode: number | undefined;
+    headers: Record<string, string | string[] | undefined>;
+  }>((resolve, reject) => {
+    const req = request(
+      {hostname: '127.0.0.1', port, path, headers},
+      (response) => {
+        response.resume();
+        resolve({
+          statusCode: response.statusCode,
+          headers: response.headers,
+        });
+      },
+    );
+    req.once('error', reject);
+    req.end();
+  });
+}
+
+function openWebSocket(url: string, options?: ClientOptions) {
+  return new Promise<WebSocket>((resolve, reject) => {
+    const ws = new WebSocket(url, options);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+  });
+}
+
+async function closeWebSocket(ws: WebSocket) {
+  ws.close();
+  await once(ws, 'close');
+}
+
+function rejectedWebSocketStatus(url: string, options: ClientOptions) {
+  return new Promise<number | undefined>((resolve, reject) => {
+    const ws = new WebSocket(url, options);
+    ws.once('error', () => {});
+    ws.once('open', () => {
+      ws.close();
+      reject(new Error('Expected the WebSocket upgrade to be rejected'));
+    });
+    ws.once('unexpected-response', (_request, response) => {
+      response.resume();
+      resolve(response.statusCode);
+    });
+  });
+}
+
+function sendCdpCommand(
+  ws: WebSocket,
+  id: number,
+  method: string,
+  params?: Record<string, unknown>,
+) {
+  return new Promise<Record<string, unknown>>((resolve, reject) => {
+    const onMessage = (data: RawData) => {
+      const message = JSON.parse(data.toString()) as {
+        id?: number;
+        result?: Record<string, unknown>;
+        error?: {message: string};
+      };
+
+      if (message.id !== id) return;
+      ws.off('message', onMessage);
+
+      if (message.error) {
+        reject(new Error(message.error.message));
+      } else {
+        resolve(message.result ?? {});
+      }
+    };
+
+    ws.on('message', onMessage);
+    ws.send(JSON.stringify({id, method, params}));
+  });
+}
+
+function waitForCdpEvent(
+  ws: WebSocket,
+  method: string,
+  predicate: (params: Record<string, unknown>) => boolean,
+) {
+  return new Promise<Record<string, unknown>>((resolve) => {
+    const onMessage = (data: RawData) => {
+      const message = JSON.parse(data.toString()) as {
+        method?: string;
+        params?: Record<string, unknown>;
+      };
+      const params = message.params ?? {};
+
+      if (message.method !== method || !predicate(params)) return;
+      ws.off('message', onMessage);
+      resolve(params);
+    };
+
+    ws.on('message', onMessage);
+  });
+}
+
+function withTimeout<T>(promise: Promise<T>, label: string) {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`${label} timed out`)),
+      5_000,
+    );
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/mini-oxygen/src/worker/devtools.ts
+++ b/packages/mini-oxygen/src/worker/devtools.ts
@@ -5,7 +5,8 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from 'node:http';
-import {WebSocketServer, type WebSocket, type MessageEvent} from 'ws';
+import type {AddressInfo} from 'node:net';
+import {WebSocket, WebSocketServer, type MessageEvent} from 'ws';
 import type {Protocol} from 'devtools-protocol';
 import {request} from 'undici';
 import type {
@@ -17,6 +18,16 @@ import type {
 const CFW_DEVTOOLS = 'https://devtools.devprod.cloudflare.dev';
 const FAVICON_URL =
   'https://cdn.shopify.com/s/files/1/0598/4822/8886/files/favicon.svg';
+const INSPECTOR_HOST = '127.0.0.1';
+const ALLOWED_INSPECTOR_HOSTNAMES = new Set([
+  INSPECTOR_HOST,
+  '[::1]',
+  'localhost',
+]);
+const ALLOWED_INSPECTOR_ORIGINS = new Set([
+  CFW_DEVTOOLS,
+  'devtools://devtools',
+]);
 
 export type InspectorProxy = ReturnType<typeof createInspectorProxy>;
 
@@ -51,10 +62,16 @@ export function createInspectorProxy(
 
   const sourceMapPath = newInspectorConnection.sourceMapPath;
   const sourceMapPathname = '/__index.js.map';
-  const sourceMapURL = `http://localhost:${port}${sourceMapPathname}`;
+  const sourceMapURL = `http://${INSPECTOR_HOST}:${port}${sourceMapPathname}`;
 
   // Create the proxy server used when running with `--debug` flag:
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    if (!isAllowedInspectorHost(req.headers.host)) {
+      res.statusCode = 403;
+      res.end('Forbidden');
+      return;
+    }
+
     // Remove query params. E.g. `/json/list?for_tab`
     const [url = '/', queryString = ''] = req.url?.split('?') || [];
 
@@ -72,7 +89,7 @@ export function createInspectorProxy(
       case '/json/list':
         {
           res.setHeader('Content-Type', 'application/json');
-          const localHost = `localhost:${port}/ws`;
+          const localHost = `${INSPECTOR_HOST}:${port}/ws`;
           const devtoolsFrontendUrl = `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=${localHost}`;
           const devtoolsFrontendUrlCompat = `devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=${localHost}`;
 
@@ -97,12 +114,19 @@ export function createInspectorProxy(
         // Handle proxied sourcemaps. This is only used when serving
         // a built application in h2:preview or classic project dev.
         // h2:dev with Vite uses inlined sourcemaps instead.
+        if (!isAllowedInspectorOrigin(req.headers.origin)) {
+          res.statusCode = 403;
+          res.end('Forbidden');
+          return;
+        }
+
         res.setHeader('Content-Type', 'text/plain');
         res.setHeader('Cache-Control', 'no-store');
         res.setHeader(
           'Access-Control-Allow-Origin',
           req.headers.origin ?? 'devtools://devtools',
         );
+        res.setHeader('Vary', 'Origin');
 
         if (sourceMapPath) {
           res.end(readFileSync(sourceMapPath, 'utf-8'));
@@ -121,7 +145,7 @@ export function createInspectorProxy(
           res.statusCode = 302;
           res.setHeader(
             'Location',
-            `/?experiments=true&v8only=true&debugger=true&ws=localhost:${port}/ws`,
+            `/?experiments=true&v8only=true&debugger=true&ws=${INSPECTOR_HOST}:${port}/ws`,
           );
           res.end();
         } else {
@@ -160,8 +184,25 @@ export function createInspectorProxy(
     }
   });
 
-  const wsServer = new WebSocketServer({server, clientTracking: true});
-  server.listen(port);
+  const wsServer = new WebSocketServer({
+    server,
+    clientTracking: true,
+    verifyClient: ({req}: {req: IncomingMessage}) =>
+      isAllowedInspectorHost(req.headers.host) &&
+      isAllowedInspectorWebSocketOrigin(
+        req.headers.origin,
+        req.headers['user-agent'],
+      ),
+  });
+  const ready = new Promise<AddressInfo>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+
+    server.once('error', onError);
+    server.listen(port, INSPECTOR_HOST, () => {
+      server.off('error', onError);
+      resolve(server.address() as AddressInfo);
+    });
+  });
 
   /**
    * Buffer inspector messages when there is no debugger connected.
@@ -179,21 +220,43 @@ export function createInspectorProxy(
 
       ws.close(1013, 'Too many clients; only one can be connected at a time');
     } else {
-      // Ensure debugger is restarted in workerd before connecting
-      // a new client to receive `Debugger.scriptParsed` events.
-      inspector.ws.send(
-        JSON.stringify({id: 100_000_000, method: 'Debugger.disable'}),
-      );
-
       debuggerWs?.removeEventListener('message', sendMessageToInspector);
       debuggerWs = ws;
+
+      const inspectorWs = inspector.ws;
+      const pendingDebuggerMessages: MessageEvent[] = [];
+      const bufferDebuggerMessage = (event: MessageEvent) =>
+        pendingDebuggerMessages.push(event);
+      const startForwardingToInspector = () => {
+        if (debuggerWs !== ws || ws.readyState !== WebSocket.OPEN) return;
+
+        // Ensure debugger is restarted in workerd before connecting
+        // a new client to receive `Debugger.scriptParsed` events.
+        inspectorWs.send(
+          JSON.stringify({id: 100_000_000, method: 'Debugger.disable'}),
+        );
+
+        debuggerWs.removeEventListener('message', bufferDebuggerMessage);
+        debuggerWs.addEventListener('message', sendMessageToInspector);
+        pendingDebuggerMessages.forEach(sendMessageToInspector);
+      };
+
+      if (inspectorWs.readyState === WebSocket.OPEN) {
+        startForwardingToInspector();
+      } else {
+        debuggerWs.addEventListener('message', bufferDebuggerMessage);
+        inspectorWs.addEventListener('open', startForwardingToInspector, {
+          once: true,
+        });
+      }
 
       // This user-agent is, so far, unique to DevTools in the browser.
       isDevToolsInBrowser = /mozilla/i.test(req.headers['user-agent'] ?? '');
 
-      debuggerWs.addEventListener('message', sendMessageToInspector);
       debuggerWs.addEventListener('close', () => {
         debuggerWs?.removeEventListener('message', sendMessageToInspector);
+        debuggerWs?.removeEventListener('message', bufferDebuggerMessage);
+        inspectorWs.removeEventListener('open', startForwardingToInspector);
         debuggerWs = undefined;
       });
 
@@ -260,6 +323,18 @@ export function createInspectorProxy(
   }
 
   return {
+    ready,
+
+    async close() {
+      await ready;
+      wsServer.clients.forEach((client) => client.terminate());
+
+      await new Promise<void>((resolve) => wsServer.close(() => resolve()));
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    },
+
     // Every time workerd is restarted (e.g. env var change, etc.),
     // the inspector connection needs to be re-established.
     updateInspectorConnection(newConnection: InspectorConnection) {
@@ -267,6 +342,44 @@ export function createInspectorProxy(
       onInspectorConnection();
     },
   };
+}
+
+function isAllowedInspectorHost(hostHeader: string | undefined) {
+  if (!hostHeader) return false;
+
+  try {
+    const hostname = new URL(`http://${hostHeader}`).hostname.toLowerCase();
+    return ALLOWED_INSPECTOR_HOSTNAMES.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+function isAllowedInspectorOrigin(originHeader: string | undefined) {
+  if (!originHeader) return true;
+  if (ALLOWED_INSPECTOR_ORIGINS.has(originHeader)) return true;
+
+  try {
+    const origin = new URL(originHeader);
+
+    return (
+      (origin.protocol === 'http:' || origin.protocol === 'https:') &&
+      ALLOWED_INSPECTOR_HOSTNAMES.has(origin.hostname.toLowerCase())
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isAllowedInspectorWebSocketOrigin(
+  originHeader: string | undefined,
+  userAgentHeader: string | undefined,
+) {
+  // VSCode's debugger sends neither header. Browser connections always send a
+  // User-Agent, so only non-browser clients may omit Origin.
+  if (!originHeader) return !userAgentHeader;
+
+  return isAllowedInspectorOrigin(originHeader);
 }
 
 function enhanceDevToolsEvent(event: MessageEvent, sourceMapUrl: string) {

--- a/packages/mini-oxygen/src/worker/index.ts
+++ b/packages/mini-oxygen/src/worker/index.ts
@@ -139,7 +139,9 @@ export function createMiniOxygen({
     }
   }
 
-  let reconnect: ReturnType<typeof createInspectorConnector> | undefined;
+  let inspectorConnector:
+    | ReturnType<typeof createInspectorConnector>
+    | undefined;
 
   const ready = mf.ready.then(async (workerUrl) => {
     const [privateInspectorUrl, publicInspectorPort] = await Promise.all([
@@ -149,7 +151,7 @@ export function createMiniOxygen({
         : undefined,
     ]);
 
-    reconnect = createInspectorConnector({
+    inspectorConnector = createInspectorConnector({
       sourceMapPath,
       publicInspectorPort,
       privateInspectorPort: Number(privateInspectorUrl.port),
@@ -159,7 +161,7 @@ export function createMiniOxygen({
         ROUTING_WORKER_NAME,
     });
 
-    await reconnect();
+    await inspectorConnector.reconnect();
 
     return {
       workerUrl,
@@ -198,7 +200,7 @@ export function createMiniOxygen({
         workers: miniflareOptions.workers,
       });
 
-      await reconnect?.(() =>
+      await inspectorConnector?.reconnect(() =>
         mf.setOptions(
           buildMiniflareOptions(
             {...miniflareOptions, ...newOptions},
@@ -211,7 +213,7 @@ export function createMiniOxygen({
     async dispose() {
       assetsServer?.closeAllConnections();
       assetsServer?.close();
-      await reconnect?.close();
+      await inspectorConnector?.close();
       await mf.dispose();
       isDisposed = true;
     },

--- a/packages/mini-oxygen/src/worker/index.ts
+++ b/packages/mini-oxygen/src/worker/index.ts
@@ -139,7 +139,7 @@ export function createMiniOxygen({
     }
   }
 
-  let reconnect: ReturnType<typeof createInspectorConnector>;
+  let reconnect: ReturnType<typeof createInspectorConnector> | undefined;
 
   const ready = mf.ready.then(async (workerUrl) => {
     const [privateInspectorUrl, publicInspectorPort] = await Promise.all([
@@ -198,7 +198,7 @@ export function createMiniOxygen({
         workers: miniflareOptions.workers,
       });
 
-      await reconnect(() =>
+      await reconnect?.(() =>
         mf.setOptions(
           buildMiniflareOptions(
             {...miniflareOptions, ...newOptions},
@@ -211,6 +211,7 @@ export function createMiniOxygen({
     async dispose() {
       assetsServer?.closeAllConnections();
       assetsServer?.close();
+      await reconnect?.close();
       await mf.dispose();
       isDisposed = true;
     },

--- a/packages/mini-oxygen/src/worker/inspector.ts
+++ b/packages/mini-oxygen/src/worker/inspector.ts
@@ -402,9 +402,12 @@ function connectToInspector({inspectorUrl, sourceMapPath}: InspectorOptions) {
       if (!isClosed()) {
         try {
           ws.removeAllListeners();
+          // Closing while the connection is still being established emits an
+          // asynchronous error, so keep a listener around to consume it.
+          ws.once('error', () => {});
           ws.close();
-        } catch (err) {
-          // Closing before the websocket is ready will throw an error.
+        } catch {
+          // Ignore synchronous close errors from a connection state race.
         }
       }
 

--- a/packages/mini-oxygen/src/worker/inspector.ts
+++ b/packages/mini-oxygen/src/worker/inspector.ts
@@ -72,7 +72,7 @@ export function createInspectorConnector(options: {
   let inspectorConnection: InspectorConnection | undefined;
   let inspectorProxy: InspectorProxy | undefined;
 
-  return async (onBeforeConnect?: () => void | Promise<void>) => {
+  const reconnect = async (onBeforeConnect?: () => void | Promise<void>) => {
     inspectorConnection?.close();
 
     inspectorUrl ??= await findInspectorUrl(
@@ -97,9 +97,19 @@ export function createInspectorConnector(options: {
           options.publicInspectorPort,
           inspectorConnection,
         );
+        await inspectorProxy.ready;
       }
     }
   };
+
+  return Object.assign(reconnect, {
+    async close() {
+      inspectorConnection?.close();
+      await inspectorProxy?.close();
+      inspectorConnection = undefined;
+      inspectorProxy = undefined;
+    },
+  });
 }
 
 /**

--- a/packages/mini-oxygen/src/worker/inspector.ts
+++ b/packages/mini-oxygen/src/worker/inspector.ts
@@ -60,7 +60,7 @@ export interface ErrorProperties {
  *    the main Node.js process, so that we can display them in the terminal.
  *
  * @param options - Options for the inspector.
- * @returns A function to reconnect to the inspector.
+ * @returns A connector for reconnecting to and closing the inspector.
  */
 export function createInspectorConnector(options: {
   privateInspectorPort: number;
@@ -72,44 +72,44 @@ export function createInspectorConnector(options: {
   let inspectorConnection: InspectorConnection | undefined;
   let inspectorProxy: InspectorProxy | undefined;
 
-  const reconnect = async (onBeforeConnect?: () => void | Promise<void>) => {
-    inspectorConnection?.close();
-
-    inspectorUrl ??= await findInspectorUrl(
-      options.privateInspectorPort,
-      options.workerName,
-    );
-
-    await onBeforeConnect?.();
-
-    inspectorConnection = connectToInspector({
-      inspectorUrl,
-      sourceMapPath: options.sourceMapPath,
-    });
-
-    addInspectorConsoleLogger(inspectorConnection);
-
-    if (options.publicInspectorPort) {
-      if (inspectorProxy) {
-        inspectorProxy.updateInspectorConnection(inspectorConnection);
-      } else {
-        inspectorProxy = createInspectorProxy(
-          options.publicInspectorPort,
-          inspectorConnection,
-        );
-        await inspectorProxy.ready;
-      }
-    }
-  };
-
-  return Object.assign(reconnect, {
+  return {
     async close() {
       inspectorConnection?.close();
       await inspectorProxy?.close();
       inspectorConnection = undefined;
       inspectorProxy = undefined;
     },
-  });
+
+    async reconnect(onBeforeConnect?: () => void | Promise<void>) {
+      inspectorConnection?.close();
+
+      inspectorUrl ??= await findInspectorUrl(
+        options.privateInspectorPort,
+        options.workerName,
+      );
+
+      await onBeforeConnect?.();
+
+      inspectorConnection = connectToInspector({
+        inspectorUrl,
+        sourceMapPath: options.sourceMapPath,
+      });
+
+      addInspectorConsoleLogger(inspectorConnection);
+
+      if (options.publicInspectorPort) {
+        if (inspectorProxy) {
+          inspectorProxy.updateInspectorConnection(inspectorConnection);
+        } else {
+          inspectorProxy = createInspectorProxy(
+            options.publicInspectorPort,
+            inspectorConnection,
+          );
+          await inspectorProxy.ready;
+        }
+      }
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Improve the reliability of local debugger connections to MiniOxygen.

### WHAT is this pull request doing?

Uses the IPv4 loopback address consistently, clarifies the inspector connector lifecycle, and adds debugger connection coverage.

### HOW to test your changes?

`pnpm --filter @shopify/mini-oxygen test`