### PR TITLE
Recommend Shopify AI Toolkit in scaffolded storefronts

### DIFF
--- a/.changeset/wise-tools-connect.md
+++ b/.changeset/wise-tools-connect.md
@@ -1,0 +1,7 @@
+---
+'skeleton': patch
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Recommend the Shopify AI Toolkit in newly scaffolded storefronts.

--- a/templates/skeleton/AGENTS.md
+++ b/templates/skeleton/AGENTS.md
@@ -1,0 +1,5 @@
+# Shopify Hydrogen development
+
+This storefront is scaffolded from Shopify's Hydrogen skeleton template. See the README for framework-specific details.
+
+Use the [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai-toolkit) for all Shopify API and platform work. If missing, install it in the agent host per that page (or `npx skills add Shopify/shopify-ai-toolkit --list` for skill-compatible hosts).

--- a/templates/skeleton/CLAUDE.md
+++ b/templates/skeleton/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What

- Add a short, harness-neutral AGENTS.md to the Hydrogen skeleton template.
- Add CLAUDE.md with a link to AGENTS.md, because it's required for Claude.
- Recommend the Shopify AI Toolkit and include the skill-compatible installation command.
- Add the required patch changeset for the skeleton and scaffold packages.

## Why

New Hydrogen storefronts should point coding agents to the maintained Shopify guidance and validation tooling.

Related to https://github.com/shop/issues-develop/issues/22870