### PR TITLE
Publish preview releases with changesets prerelease mode

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,12 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0-next.6/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "preview",
   "updateInternalDependencies": "patch",
-  "ignore": ["@shopify/hydrogen-example-*", "hydrogen"]
+  "ignore": ["@shopify/hydrogen-example-*", "hydrogen", "@shopify/storefront-e2e"],
+  "format": false
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,5 @@
+{
+  "mode": "pre",
+  "tag": "preview",
+  "changesets": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
         # release job publishes a plain version to the latest dist-tag
         run: jq -e '.mode == "pre" and .tag == "preview"' .changeset/pre.json
 
+      - name: Changesets check
+        run: node scripts/assert-no-major-changesets.ts
+
       - name: Lint
         run: pnpm run lint:ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Format check
         run: pnpm run format:check
 
+      - name: Ensure prerelease mode
+        # Catch a deleted or exited pre.json at PR time; without it the
+        # release job publishes a plain version to the latest dist-tag
+        run: jq -e '.mode == "pre" and .tag == "preview"' .changeset/pre.json
+
       - name: Lint
         run: pnpm run lint:ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,11 @@ jobs:
         # releases published from main
         run: jq -e '.mode == "pre" and .tag == "preview"' .changeset/pre.json
 
+      - name: Ensure no major changesets
+        # Preview releases move only the -preview.<n> suffix; a major
+        # changeset would move the base version off 2026.10.0
+        run: node scripts/assert-no-major-changesets.ts
+
       - name: Build packages
         run: pnpm run build:pkgs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+# This file must be named release.yml: npm's Trusted Publishing configuration
+# for our packages allows a single workflow filename, shared across branches.
+name: Release
+
+on:
+  push:
+    branches: [preview]
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  # Queue runs instead of cancelling: a cancel that lands between npm
+  # publish and tag creation strands state a rerun cannot rebuild
+  cancel-in-progress: false
+
+jobs:
+  preview-release:
+    name: Preview Release
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'shopify'
+    permissions:
+      contents: write # push the version branch and create git tags
+      pull-requests: write # open and update the version PR
+      id-token: write # generate an ID token for npm Trusted Publishing
+    env:
+      npm_config_registry: https://registry.npmjs.org/
+      TURBO_TELEMETRY_DISABLED: "1"
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Changesets needs full history to generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Ensure prerelease mode
+        # Without pre.json, changeset publish would push a non-prerelease
+        # version to the npm latest dist-tag, hijacking it from the real
+        # releases published from main
+        run: jq -e '.mode == "pre" and .tag == "preview"' .changeset/pre.json
+
+      - name: Build packages
+        run: pnpm run build:pkgs
+
+      - name: Create preview release PR or publish
+        id: changesets
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+        with:
+          version: pnpm changeset version
+          publish: pnpm changeset publish
+          commit: "[ci] preview release"
+          title: "[ci] preview release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          # Satisfies the action's npmrc check without configuring a real
+          # token; publishing authenticates via OIDC trusted publishing
+          NPM_TOKEN: ""

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   sortTailwindcss: true,
   sortPackageJson: true,
   ignorePatterns: [
+    ".changeset/pre.json",
     "dist/**",
     "build/**",
     ".next/**",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "format:check": "oxfmt --check",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "pnpm run build:pkgs && changeset publish --tag preview",
     "test": "pnpm run test:scripts && turbo run test",
     "test:scripts": "node --test scripts/*.test.ts",
     "test:benchmark-harness": "tsc -p scripts/storefront-benchmark-harness/tsconfig.json && node --test scripts/storefront-benchmark-harness/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.3",
     "@changesets/cli": "3.0.0-next.8",
+    "@changesets/parse": "1.0.0-next.7",
     "@types/node": "^25.8.0",
     "lefthook": "^2.1.6",
     "oxfmt": "^0.47.0",

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/hydrogen",
-  "version": "0.0.1",
+  "version": "2026.10.0-preview.0",
   "description": "Framework-agnostic Shopify storefront SDK and agent skills.",
   "license": "MIT",
   "author": "Shopify",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@changesets/cli':
         specifier: 3.0.0-next.8
         version: 3.0.0-next.8
+      '@changesets/parse':
+        specifier: 1.0.0-next.7
+        version: 1.0.0-next.7
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
@@ -3825,15 +3828,6 @@ packages:
       vite:
         optional: true
 
-  '@shopify/mini-oxygen@4.2.0':
-    resolution: {integrity: sha512-hViJ+9J3KDsQjH5qLrQwJEtZkKbzc/HOhWE+Z/zSuHVn6YD1ITkkp0g6pqoJ3aFoR1OqvRji0oZAHTNCgyNlqA==}
-    engines: {node: ^22 || ^24}
-    peerDependencies:
-      vite: ^6.2.1 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
-
   '@shopify/oxygen-workers-types@4.2.0':
     resolution: {integrity: sha512-iBc+pK5CfLSrF+Wl6WBYsPdJubSii78EWI/YVzGpr9/gKYVRHMsW2t+kOvY9Vg6BOytF0dB5B4hYkCLH3cAY/g==}
 
@@ -5859,9 +5853,6 @@ packages:
     resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==, tarball: https://registry.npmjs.org/globby/-/globby-16.2.0.tgz}
     engines: {node: '>=20'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==, tarball: https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz}
     engines: {node: '>= 0.4'}
@@ -6314,10 +6305,6 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==, tarball: https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz}
-
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz}
@@ -8410,23 +8397,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==, tarball: https://registry.npmjs.org/trough/-/trough-2.2.0.tgz}
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
-
   ts-log@3.0.2:
     resolution: {integrity: sha512-esq6hx2lM66sQV1YcFkIYTqrWWabmqBqobKHyn1CswdI5FgfQhkmiKiRWVGBNlIbdjBxEIkNvMIwLKKPgRYZLQ==, tarball: https://registry.npmjs.org/ts-log/-/ts-log-3.0.2.tgz}
     engines: {node: '>=20', npm: '>=10'}
-
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   tsdown@0.21.10:
     resolution: {integrity: sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==, tarball: https://registry.npmjs.org/tsdown/-/tsdown-0.21.10.tgz}
@@ -8879,11 +8852,6 @@ packages:
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0
       vue: ^3.5.0
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==, tarball: https://registry.npmjs.org/vite/-/vite-6.4.2.tgz}
@@ -9569,7 +9537,7 @@ snapshots:
 
   '@astrojs/yaml2ts@0.2.3':
     dependencies:
-      yaml: 2.8.4
+      yaml: 2.9.0
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -12537,26 +12505,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@shopify/mini-oxygen@4.2.0(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@mjackson/node-fetch-server': 0.7.0
-      body-parser: 1.20.4
-      connect: 3.7.0
-      get-port: 7.2.0
-      miniflare: 3.20250310.1
-      mrmime: 2.0.0
-      source-map: 0.7.6
-      source-map-support: 0.5.21
-      stack-trace: 1.0.0
-      undici: 7.24.0
-      ws: 8.20.0
-    optionalDependencies:
-      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@shopify/oxygen-workers-types@4.2.0': {}
 
   '@simple-git/args-pathspec@1.0.3': {}
@@ -12943,16 +12891,19 @@ snapshots:
     dependencies:
       xdg-app-paths: 5.5.1
       zod: 4.1.11
+    optional: true
 
   '@vercel/cli-exec@1.0.0':
     dependencies:
       execa: 5.1.1
+    optional: true
 
   '@vercel/functions@3.7.4(ws@8.20.0)':
     dependencies:
       '@vercel/oidc': 3.7.1
     optionalDependencies:
       ws: 8.20.0
+    optional: true
 
   '@vercel/nft@1.5.0(rollup@4.60.3)':
     dependencies:
@@ -12978,6 +12929,7 @@ snapshots:
       '@vercel/cli-config': 0.2.0
       '@vercel/cli-exec': 1.0.0
       jose: 5.10.0
+    optional: true
 
   '@vinxi/listhen@1.5.6':
     dependencies:
@@ -14951,8 +14903,6 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
-  globrex@0.1.2: {}
-
   gopd@1.2.0: {}
 
   gql.tada@1.9.2(graphql@16.13.2)(typescript@5.9.3):
@@ -15404,7 +15354,8 @@ snapshots:
 
   jju@1.4.0: {}
 
-  jose@5.10.0: {}
+  jose@5.10.0:
+    optional: true
 
   js-beautify@1.15.4:
     dependencies:
@@ -15434,11 +15385,6 @@ snapshots:
     optional: true
 
   json-parse-even-better-errors@2.3.1: {}
-
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1:
     optional: true
@@ -16756,7 +16702,8 @@ snapshots:
       word-wrap: 1.2.5
     optional: true
 
-  os-paths@4.4.0: {}
+  os-paths@4.4.0:
+    optional: true
 
   outvariant@1.4.3: {}
 
@@ -18226,13 +18173,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-algebra@2.0.0: {}
-
   ts-log@3.0.2: {}
-
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
 
   tsdown@0.21.10(@arethetypeswrong/core@0.18.3)(typescript@5.9.3):
     dependencies:
@@ -18857,16 +18798,6 @@ snapshots:
       vite: 8.0.10(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       vue: 3.5.33(typescript@5.9.3)
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.10(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
@@ -19260,10 +19191,12 @@ snapshots:
     dependencies:
       os-paths: 4.4.0
       xdg-portable: 7.3.0
+    optional: true
 
   xdg-portable@7.3.0:
     dependencies:
       os-paths: 4.4.0
+    optional: true
 
   xxhash-wasm@1.1.0: {}
 
@@ -19363,7 +19296,8 @@ snapshots:
 
   zod@3.22.3: {}
 
-  zod@4.1.11: {}
+  zod@4.1.11:
+    optional: true
 
   zod@4.4.3: {}
 

--- a/scripts/assert-no-major-changesets.ts
+++ b/scripts/assert-no-major-changesets.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseChangesetFile } from "@changesets/parse";
+
+const PREVIEW_PACKAGE = "@shopify/hydrogen";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const changesetDir = resolve(__dirname, "..", ".changeset");
+
+const offenders: string[] = [];
+
+for (const file of readdirSync(changesetDir)) {
+  if (!file.endsWith(".md") || file === "README.md") continue;
+
+  const { releases } = parseChangesetFile(readFileSync(join(changesetDir, file), "utf8"));
+
+  for (const release of releases) {
+    if (release.name === PREVIEW_PACKAGE && release.type === "major") {
+      offenders.push(`  .changeset/${file}: ${release.name} is ${release.type}`);
+    }
+  }
+}
+
+if (offenders.length > 0) {
+  console.error(
+    `Preview releases only move the -preview.<n> suffix, and a major bump would move the base version. Change these to patch or minor:`,
+  );
+  console.error(offenders.join("\n"));
+  process.exit(1);
+}


### PR DESCRIPTION
## TL;DR

Pushes to `preview` now run a changesets release flow that publishes `@shopify/hydrogen@2026.10.0-preview.<n>` to the `preview` npm dist-tag.

## What and why

Previously, cutting a preview release meant manually dispatching main's `release.yml`, which checked out this branch and published a one-off `0.0.0-preview-<sha>-<timestamp>` version. No changelog, no version PR, no record of what shipped in each cut.

This PR adds the same changesets flow main uses, adapted for this branch:

- **New `release.yml`** (this branch had no release workflow): on every push to `preview`, the changesets action either updates a `[ci] preview release` version PR from pending changesets or, when that PR merges, publishes to npm via OIDC. The file has to keep the `release.yml` name because npm's Trusted Publishing config allows a single workflow filename, shared across branches.
- **Changesets prerelease mode**: the committed `.changeset/pre.json` makes every version come out as `-preview.<n>` and makes `changeset publish` target the `preview` dist-tag instead of `latest`.
- **Version pinning**: `packages/hydrogen` starts at `2026.10.0-preview.0`. Patch changesets complete the prerelease back to the same `2026.10.0` base and only increment the counter, so cuts publish `2026.10.0-preview.1`, `.2`, and so on — sorting below the eventual real `2026.10.0`. CI and the release workflow both run `scripts/assert-no-major-changesets.ts` to reject major changesets — the only bump type that can move the base off `2026.10.0`. Minor changesets are safe: the base's patch component is 0, so semver *completes* the prerelease back to `2026.10.0` instead of bumping (verified empirically, including accumulation across cuts). The pending minor changeset on `preview` (`hydrogen-error-reporting-policy`) is expected to pass.

## Reviewer notes

- The changeset config changes are load-bearing: `format: false` (changesets v3 auto-detects oxfmt and feeds it changelog markdown, which hard-fails `changeset version`), `@shopify/storefront-e2e` in `ignore` (it's a workspace dependent of hydrogen and would get version churn on every cut), and `baseBranch: preview`.
- The release job and CI both refuse to run outside prerelease mode. Without `.changeset/pre.json`, `changeset publish` would push a plain version to the `latest` dist-tag and hijack it from the real releases on main — the CI check catches a deleted or exited `pre.json` on the PR that breaks it, instead of after merge.
- The committed `-preview.0` never publishes (versioning increments before each cut), so the first published version is `2026.10.0-preview.1`. This is intentional.
- This can't be tophatted before merge since the workflow only triggers on pushes to `preview`. The changeset behavior (prerelease numbering, the oxfmt failure, dependent bumps, non-patch rejection) was all verified locally against the v3 CLI this branch uses.
- `preview` has several pending changesets (one minor), so the first version PR appears as soon as this merges — still `2026.10.0-preview.1`. Merging that version PR publishes for real.
- The lockfile diff goes beyond adding `@changesets/parse`: `pnpm install` also pruned genuinely orphaned entries (e.g. `@shopify/mini-oxygen@4.2.0`, `vite-tsconfig-paths`) left behind by earlier manifest changes.

Companion PR that removes the old dispatch job from main: https://github.com/Shopify/hydrogen/pull/3889


