### PR TITLE
Remove the manual preview release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,9 @@ on:
       # Example: If we are currently on 2025-07, add 2025-01 here to do a back-fix
       # release for the 2025-01 CalVer branch
       - 2025-01
-  workflow_dispatch:
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && 'preview' || github.ref_name }}
+  group: release-${{ github.ref_name }}
   cancel-in-progress: true
 
 permissions:
@@ -226,89 +225,6 @@ jobs:
       - name: Publish to npm
         if: steps.version.outputs.NEXT_VERSION
         run: pnpm run changeset -- publish --tag next
-        env:
-          NPM_TOKEN: '' # Empty string forces OIDC authentication
-
-  # ============================================
-  # PREVIEW RELEASE (manual dispatch, publishes preview branch)
-  # ============================================
-  preview-release:
-    name: Preview Release
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'shopify' && github.event_name == 'workflow_dispatch' && (github.ref_name == 'main' || github.ref_name == 'preview')
-    permissions:
-      contents: read
-      id-token: write # enable generation of an ID token for publishing
-    outputs:
-      PREVIEW_VERSION: ${{ steps.version.outputs.PREVIEW_VERSION }}
-    steps:
-      - name: ⬇️ Checkout preview branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-        with:
-          ref: preview
-          fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
-        with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
-          node-version: 24 # Needed for npm@11 for Trusted Publishing
-
-      - name: Install the packages
-        run: pnpm install --frozen-lockfile
-
-      - name: 🔢 Compute preview version
-        id: version
-        run: |
-          # get latest commit sha from the checked out preview branch
-          SHA=$(git rev-parse HEAD)
-          # get first 7 characters of sha
-          SHORT_SHA=${SHA::7}
-          TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
-          PREVIEW_VERSION=0.0.0-preview-${SHORT_SHA}-${TIMESTAMP}
-          # set output so it can be used in other jobs
-          echo "PREVIEW_VERSION=${PREVIEW_VERSION}" >> $GITHUB_OUTPUT
-
-      - name: ⤴️ Set preview version
-        if: steps.version.outputs.PREVIEW_VERSION
-        run: |
-          node <<'EOF'
-          const fs = require('fs');
-          const packageJsonPath = 'packages/hydrogen/package.json';
-          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-          packageJson.version = process.env.PREVIEW_VERSION;
-          fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
-          console.log(`Set ${packageJson.name} to ${packageJson.version}`);
-          EOF
-        env:
-          PREVIEW_VERSION: ${{ steps.version.outputs.PREVIEW_VERSION }}
-
-      - name: ✅ Check format, lint, types and tests
-        if: steps.version.outputs.PREVIEW_VERSION
-        run: pnpm run check
-
-      - name: 🏗 Build packages
-        if: steps.version.outputs.PREVIEW_VERSION
-        run: pnpm run build:pkgs
-
-      - name: Test OIDC Token
-        if: steps.version.outputs.PREVIEW_VERSION
-        run: |
-          TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm" | jq -r '.value')
-          [ -n "$TOKEN" ] && echo "✅ OIDC working" || exit 1
-
-      - name: Publish to npm
-        if: steps.version.outputs.PREVIEW_VERSION
-        run: npm publish ./packages/hydrogen --tag preview --access public --provenance
         env:
           NPM_TOKEN: '' # Empty string forces OIDC authentication
 


### PR DESCRIPTION
The preview branch is getting its own changesets-based release flow in https://github.com/Shopify/hydrogen/pull/3888, which publishes proper `2026.10.0-preview.<n>` versions on push. That replaces the manual dispatch path here, where cutting a preview meant dispatching this workflow from main so it could check out the preview branch and publish a one-off `0.0.0-preview-<sha>-<timestamp>` version.

This PR removes the dispatch job, the `workflow_dispatch` trigger, and the concurrency special-case that existed only for it. The production, next, back-fix, and template compile jobs are untouched.