### PR TITLE
fix(skills): align hydrogen skills with Claude best practices

### DIFF
--- a/packages/hydrogen/skills/hydrogen-analytics/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-analytics/SKILL.md
@@ -15,7 +15,7 @@ Hydrogen's analytics bus owns the event API, event normalization, and consent-ga
 
 Before wiring route events, check whether this skill has a reference file for the app's framework in `references/`. If one exists, read it and use that framework's route-change and lifecycle primitives. If there is no matching reference, keep the core singleton below and adapt page-view, product-view, collection-view, search-view, and cart tracking to the app's own route lifecycle.
 
-Key consent setup: Shopify Customer Privacy controls destination delivery in production. Raw subscribers can observe events before consent; destinations receive only consent-allowed replay. Do not override `canTrack` to always `true` in production.
+Prerequisite: analytics depends on the same-origin SFAPI proxy (see `hydrogen-request-handlers`) so the browser can observe tracking values from Storefront API responses. Without it, analytics falls back to deprecated JavaScript-visible cookies and session continuity into checkout breaks — treat it as incomplete until the proxy is wired. Key consent setup: Shopify Customer Privacy controls destination delivery in production. Raw subscribers can observe events before consent; destinations receive only consent-allowed replay. Do not override `canTrack` to always `true` in production.
 
 ## Core Pattern
 

--- a/packages/hydrogen/skills/hydrogen-analytics/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-analytics/SKILL.md
@@ -15,7 +15,7 @@ Hydrogen's analytics bus owns the event API, event normalization, and consent-ga
 
 Before wiring route events, check whether this skill has a reference file for the app's framework in `references/`. If one exists, read it and use that framework's route-change and lifecycle primitives. If there is no matching reference, keep the core singleton below and adapt page-view, product-view, collection-view, search-view, and cart tracking to the app's own route lifecycle.
 
-For full setup details and consent nuance, also read `../hydrogen-setup/references/analytics.md`.
+Key consent setup: Shopify Customer Privacy controls destination delivery in production. Raw subscribers can observe events before consent; destinations receive only consent-allowed replay. Do not override `canTrack` to always `true` in production.
 
 ## Core Pattern
 

--- a/packages/hydrogen/skills/hydrogen-cart-drawer/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-cart-drawer/SKILL.md
@@ -22,7 +22,7 @@ Before building the cart drawer, these must be in place:
 
 ---
 
-## 2. What you're building
+## 2. Drawer structure
 
 The drawer has three layout zones (header / body / footer):
 
@@ -195,7 +195,7 @@ This opens the drawer only after the mutation succeeds. Keep validation and canc
 
 Native: Escape and the back gesture (fires `cancel` then `close`). App-provided: the explicit close `<button>` in the header (`aria-label="Close cart"`). Backdrop (light dismiss) requires `<dialog closedby="any">`.
 
-`closedby="any"` is the least compatible part of this pattern. Older browsers and Safari versions that have not shipped `closedby` will ignore the attribute, so the drawer will still close from Escape and the explicit close button, but backdrop click will not close it. Do not provide a polyfill for `closedby` unless the app explicitly requires backdrop click support in those browsers.
+`closedby="any"` is the least compatible part of this pattern. Browsers without `closedby` support will ignore the attribute, so the drawer will still close from Escape and the explicit close button, but backdrop click will not close it. Do not provide a polyfill for `closedby` unless the app explicitly requires backdrop click support in those browsers.
 
 If an app does require that polyfill, use a pointerdown-plus-click guard on the `<dialog>` itself: record whether `pointerdown` started on the dialog backdrop, then close only when the following `click` also targets the dialog. Do not close on a plain `click.self` alone, because a drag that starts inside the drawer and ends on the backdrop can produce an accidental close.
 

--- a/packages/hydrogen/skills/hydrogen-cart-ui/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-cart-ui/SKILL.md
@@ -181,15 +181,9 @@ Each `CartErrorGroup` contains `{ userErrors: CartUserError[], warnings: CartWar
 
 ## Anti-patterns
 
-- **Client-computed totals.** Multiplying quantity by unit price drifts from the true total when discounts, taxes, or rounding apply. Always use server-provided amounts.
 - **Hand-rolled framework cart state.** If the skill has a matching framework reference, use its provider/hooks/helpers. Otherwise, use the core store directly instead of duplicating cart data in component state or custom reducers.
 - **Client-seeded `/cart` page.** Mounting `CartProvider` with no `initialData` (or reading the cart only through a `"use client"` `useCart` hook) leaves the SSR HTML empty, so the `/cart` page cannot render the server cart. Read the cart in the server data path and pass `initialData`. Use resolved `initialData` when strict no-JS live cart HTML is required; use promise `initialData` when the framework can stream and hydrated cart content is wrapped in Suspense.
-- **Disabling controls during pending.** The store's abort-controller pattern makes rapid interactions safe. Disabling controls makes the cart feel sluggish and punishes fast users.
-- **One form for all lines.** Each line needs its own identity — its own form. A shared form creates ambiguous intent when multiple submit buttons exist.
 - **Quantity as text only.** Rendering quantity as a `<span>` with only plus/minus buttons breaks the set-quantity path and the no-JS fallback. Use a real input wired with `register("quantity", { value, interactive: true })`.
 - **Plus/minus-only line forms.** Increase/decrease/remove buttons do not replace `register("set")` and the interactive quantity input. Omitting them breaks the form invariant even if hydrated clicks appear to work.
 - **Drawer-specific line form drift.** The cart drawer may have a different layout from the `/cart` page, but its line item forms must keep the same Hydrogen form contract. Prefer sharing line item form components between the page and drawer.
 - **Banner-only errors.** A line-level error displayed far from the line it refers to is effectively invisible. Show inline first; promote to the banner only when there's no inline target.
-- **Confirmed-looking pending values.** Showing full-opacity values for in-flight data misleads the user into thinking the data is settled. Always visually distinguish unconfirmed state.
-- **Disabling note save.** The save control is never disabled — it remains interactive even when there's nothing to save (draft matches store) or while a save is in-flight. When there's nothing to save, clicking does nothing. During flight, show a pending indicator.
-- **Blocking navigation during pending.** Cart mutations resolve in the background. Confirmation dialogs on route change frustrate users.

--- a/packages/hydrogen/skills/hydrogen-collection-browser/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-collection-browser/SKILL.md
@@ -56,7 +56,7 @@ Use `parseCollectionParams(searchParams)` before Storefront API queries. Pass pa
 - Keep the search term in `q`.
 - Use a collection handle like `search:${term}` so a new term rebuilds the browse store and does not carry old filters.
 - Keep `q` as a hidden input inside the filter/sort form.
-- Map unsupported search sorts back to `RELEVANCE`; only `PRICE` uses `reverse` in the current examples.
+- Map unsupported search sorts back to `RELEVANCE`; only `PRICE` uses `reverse`.
 - Empty search terms should return an empty product list and no filters rather than querying Storefront API.
 - The search input is uncontrolled (`defaultValue={term}`) so the no-JS GET submit works; add `key={term}` so navigation (e.g. "Clear search" → `/search`) resets it. Safe because `term` changes only on submit/navigation, not while typing — do **not** put `key={term}` on a controlled input that updates the term per keystroke (focus loss).
 

--- a/packages/hydrogen/skills/hydrogen-markets/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-markets/SKILL.md
@@ -113,8 +113,6 @@ export function getMarketFromRequest(request: Request): Market {
 }
 ```
 
-This keeps market selection at the server boundary. Product queries, collection queries, cart queries, and checkout URLs all become market-aware when they use `@inContext`.
-
 ---
 
 ## Per-Market Domains
@@ -135,8 +133,6 @@ export function getMarketFromRequest(request: Request): Market {
   return MARKET_BY_HOST[host] ?? DEFAULT_MARKET;
 }
 ```
-
-This is the cleanest option when SEO, legal entities, or merchant operations require distinct domains. The storefront does not need a visible market prefix in the path because the host already carries the market.
 
 ---
 

--- a/packages/hydrogen/skills/hydrogen-predictive-search/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-predictive-search/SKILL.md
@@ -104,7 +104,7 @@ Use the route-handler form for browser-backed autocomplete. Use `makePredictiveS
 - Keep debounce in the client store; do not add ad-hoc debounce in components unless there is a separate UX reason.
 - Prefer additive fragments over full query overrides.
 - Return empty UI for blank terms rather than querying Storefront API.
-- The modal is a native `<dialog>` opened with `showModal()`. For backdrop-dismiss and `closedby`, follow `hydrogen-cart-drawer`'s `references/accessibility.md` — do not reimplement (use the pointerdown guard from that reference, not a bare click handler).
+- The modal is a native `<dialog>` opened with `showModal()`. For backdrop-dismiss, use `closedby="any"` where supported. For browsers without `closedby` support, use a pointerdown-plus-click guard: record whether `pointerdown` started on the dialog backdrop, then close only when the following `click` also targets the dialog. Do not close on a plain `click.self` alone — a drag that starts inside and ends on the backdrop can produce an accidental close.
 
 ## Verify
 

--- a/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
@@ -54,7 +54,7 @@ const redirect = await handleShopifyRedirects({
 - Pass registered handler groups explicitly, for example `handlers: [cartHandlers, customerAccountHandlers]`.
 - `handleShopifyRoutes` applies request-context response headers before returning matched Hydrogen route responses.
 - Link and submit to Customer Account routes (`/account/login`, `/account/authorize`, `/account/refresh`, `/account/logout`) with plain HTML `<a>`/`<form>`, never the framework's client-side navigation component (`<Form>`/`<Link>` in React Router, `next/link` in Next.js, `NuxtLink` in Nuxt). The login and logout handlers return raw HTTP redirects to external Shopify URLs, which client-nav cannot process.
-- Apps authoring Customer Account API documents use the same packed Hydrogen TypeScript plugin as Storefront API documents. See `hydrogen-storefront-client/references/query-validation.md` for the exact config. Applies to every framework.
+- Apps authoring Customer Account API documents use the same packed Hydrogen TypeScript plugin as Storefront API documents. Add `@shopify/hydrogen/ts-plugin` to `tsconfig.json` `compilerOptions.plugins` and chain `hydrogen gql check` into a package script. Applies to every framework.
 - For framework-routed responses, commit session headers once at the final response boundary, append those headers, then call `requestContext.applyResponseHeaders(response.headers)` so SFAPI cookies, `Server-Timing`, tracking fallback headers, and personalized-response cache safety survive.
 - Wire this in production runtime code, not dev-only hooks. Only GraphiQL is dev-only.
 

--- a/packages/hydrogen/skills/hydrogen-setup/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-setup/SKILL.md
@@ -15,7 +15,7 @@ Follow these instructions in order to set up Hydrogen in an existing or new repo
 
 Assume the deterministic Hydrogen setup command has already installed `@shopify/hydrogen` and copied the packaged skills into the app. Do not redo package installation or skill copying from this LLM skill.
 
-Master build checklist (an at-a-glance index of the ordered steps below; each step has full detail in its own section):
+Master build checklist:
 
 ```
 - [ ] Inspect the app (package.json at app root)
@@ -45,7 +45,7 @@ Read `package.json` in the current directory. If it does not exist, stop and tel
 
 ## Detect The Framework
 
-Use LLM judgment for this step. Inspect dependencies, configuration files, server entry points, route directories, and existing request lifecycle code. Identify whether the app has a framework that can run server code and expose request handlers, middleware, loaders, server functions, or route handlers.
+Inspect dependencies, configuration files, server entry points, route directories, and existing request lifecycle code. Identify whether the app has a framework that can run server code and expose request handlers, middleware, loaders, server functions, or route handlers.
 
 After detecting the framework, check `references/` for a matching framework reference file. Normalize likely framework or binding names to lowercase kebab-case and read the matching file before making framework-specific setup choices. If no matching reference exists, continue from the generic instructions here and follow the app's existing conventions.
 
@@ -53,13 +53,10 @@ Do not hard block just because no reference file exists. Continue when the app h
 
 ## Use Standard Environment Names
 
-Use these canonical environment variable names throughout the app:
+Use canonical environment variable names throughout the app. For Storefront API variables, see `hydrogen-storefront-client` for the canonical list.
 
-- `PUBLIC_STORE_DOMAIN` for the Shopify store domain.
-- `PUBLIC_STOREFRONT_API_TOKEN` for the public Storefront API token.
-- `PRIVATE_STOREFRONT_API_TOKEN` for the private Storefront API token.
-- `PUBLIC_STOREFRONT_ID` for analytics `storefrontId`; use `"0"` when the app does not have a storefront ID.
-- `PUBLIC_CHECKOUT_DOMAIN` for app-level checkout-domain configuration such as CSP setup. Checkout buttons should use the cart's `checkoutUrl`.
+Customer Account API variables (documented here only):
+
 - `SHOP_ID` for the numeric Shopify shop ID string used by Customer Account API.
 - `PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID` for Customer Account OAuth.
 - `CUSTOMER_ACCOUNT_SESSION_SECRET` for encrypted cookie examples. Prefer opaque server-side sessions in production apps.

--- a/packages/hydrogen/skills/hydrogen-setup/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-setup/SKILL.md
@@ -55,9 +55,9 @@ Do not hard block just because no reference file exists. Continue when the app h
 
 Use canonical environment variable names throughout the app. For Storefront API variables, see `hydrogen-storefront-client` for the canonical list.
 
-Customer Account API variables (documented here only):
+Also documented here:
 
-- `SHOP_ID` for the numeric Shopify shop ID string used by Customer Account API.
+- `SHOP_ID` for the numeric Shopify shop ID string. Required by Shopify runtime scripts (`ShopifyScripts`) for every storefront, and by Customer Account API.
 - `PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID` for Customer Account OAuth.
 - `CUSTOMER_ACCOUNT_SESSION_SECRET` for encrypted cookie examples. Prefer opaque server-side sessions in production apps.
 

--- a/packages/hydrogen/skills/hydrogen-setup/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-setup/SKILL.md
@@ -53,10 +53,13 @@ Do not hard block just because no reference file exists. Continue when the app h
 
 ## Use Standard Environment Names
 
-Use canonical environment variable names throughout the app. For Storefront API variables, see `hydrogen-storefront-client` for the canonical list.
+Use these canonical environment variable names throughout the app (kept in sync with `hydrogen-storefront-client`):
 
-Also documented here:
-
+- `PUBLIC_STORE_DOMAIN` for the Shopify store domain.
+- `PUBLIC_STOREFRONT_API_TOKEN` for the public Storefront API token.
+- `PRIVATE_STOREFRONT_API_TOKEN` for the private Storefront API token.
+- `PUBLIC_STOREFRONT_ID` for analytics `storefrontId`; use `"0"` when the app does not have a storefront ID.
+- `PUBLIC_CHECKOUT_DOMAIN` for app-level checkout-domain configuration such as CSP setup. Checkout links should come from cart data, usually `cart.checkoutUrl`.
 - `SHOP_ID` for the numeric Shopify shop ID string. Required by Shopify runtime scripts (`ShopifyScripts`) for every storefront, and by Customer Account API.
 - `PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID` for Customer Account OAuth.
 - `CUSTOMER_ACCOUNT_SESSION_SECRET` for encrypted cookie examples. Prefer opaque server-side sessions in production apps.

--- a/packages/hydrogen/skills/hydrogen-smoke-test/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-smoke-test/SKILL.md
@@ -25,7 +25,7 @@ Static checks:
 - [ ] Formatting check, if distinct from the fixer
 
 Request handlers:
-- [ ] POST /api/<api-version>/graphql.json returns Storefront API JSON, not the framework 404
+- [ ] POST /api/{api-version}/graphql.json returns Storefront API JSON, not the framework 404
 - [ ] GET /api/cart returns cart handler JSON (no cart cookie -> {cart: null})
 - [ ] GET /admin redirects to the configured shop/admin domain
 - [ ] Unknown path returns framework 404 unless a Shopify URL redirect matches
@@ -89,10 +89,10 @@ Run the app's available scripts:
 
 ## Request Handlers
 
-Replace `<port>` with the running app port:
+Replace `<port>` with the running app port, and `{api-version}` with the Storefront API version configured by the app:
 
 ```bash
-curl -i -X POST http://localhost:<port>/api/<api-version>/graphql.json \
+curl -i -X POST http://localhost:<port>/api/{api-version}/graphql.json \
   -H "content-type: application/json" \
   -H "X-Shopify-Storefront-Access-Token: <public-token>" \
   -d '{"query":"{ shop { name } }"}'
@@ -100,7 +100,7 @@ curl -i -X POST http://localhost:<port>/api/<api-version>/graphql.json \
 
 Expected: Storefront API JSON, not the framework 404.
 
-Use the Storefront API version configured by the app. The SFAPI proxy forwards the incoming public token header; it does not inject a token from server config.
+The SFAPI proxy forwards the incoming public token header; it does not inject a token from server config.
 
 ```bash
 curl -i http://localhost:<port>/api/cart

--- a/packages/hydrogen/skills/hydrogen-smoke-test/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-smoke-test/SKILL.md
@@ -25,7 +25,7 @@ Static checks:
 - [ ] Formatting check, if distinct from the fixer
 
 Request handlers:
-- [ ] POST /api/{api-version}/graphql.json returns Storefront API JSON, not the framework 404
+- [ ] POST /api/<api-version>/graphql.json returns Storefront API JSON, not the framework 404
 - [ ] GET /api/cart returns cart handler JSON (no cart cookie -> {cart: null})
 - [ ] GET /admin redirects to the configured shop/admin domain
 - [ ] Unknown path returns framework 404 unless a Shopify URL redirect matches
@@ -63,7 +63,7 @@ Collection and search:
 Analytics:
 - [ ] Page view fires on initial load and client navigations
 - [ ] Product/collection/search/cart view events fire once per route data change
-- [ ] analytics.updateCart(cart) runs when confirmed cart data changes, and the cart query includes updatedAt
+- [ ] trackCartAnalytics(cart) runs when confirmed cart data changes, and the cart query includes updatedAt
 - [ ] No browser module reads private env variables
 - [ ] Production does not override canTrack to always true
 
@@ -92,7 +92,7 @@ Run the app's available scripts:
 Replace `<port>` with the running app port:
 
 ```bash
-curl -i -X POST http://localhost:<port>/api/2026-04/graphql.json \
+curl -i -X POST http://localhost:<port>/api/<api-version>/graphql.json \
   -H "content-type: application/json" \
   -H "X-Shopify-Storefront-Access-Token: <public-token>" \
   -d '{"query":"{ shop { name } }"}'
@@ -100,7 +100,7 @@ curl -i -X POST http://localhost:<port>/api/2026-04/graphql.json \
 
 Expected: Storefront API JSON, not the framework 404.
 
-Use the Storefront API version configured by the app when it differs from `2026-04`. The SFAPI proxy forwards the incoming public token header; it does not inject a token from server config.
+Use the Storefront API version configured by the app. The SFAPI proxy forwards the incoming public token header; it does not inject a token from server config.
 
 ```bash
 curl -i http://localhost:<port>/api/cart

--- a/packages/hydrogen/skills/hydrogen-storefront-client/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/SKILL.md
@@ -244,7 +244,7 @@ const { data } = await client.graphql(PRODUCTS, {
 
 User-provided values take precedence over auto-injected ones.
 
-### Where does request state go?
+### Request state storage
 
 `requestContext` is passed at client creation so request-scoped cookies, request-group IDs, response-header capture, personalized-response cache safety, and request aborts are centralized. Use one Shopify request context for Storefront and Customer Account clients in the same request. Per-call `signal` is optional when you need additional cancellation:
 
@@ -261,7 +261,7 @@ Read `references/caching.md` to cache catalog reads across sub-requests on Oxyge
 
 ## Error handling
 
-**Transport errors throw. GraphQL errors are returned.** This is the key mental model:
+**Transport errors throw. GraphQL errors are returned.**
 
 ```ts
 import { StorefrontApiError, StorefrontTimeoutError } from "@shopify/hydrogen";

--- a/packages/hydrogen/skills/hydrogen-variant-form/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-variant-form/SKILL.md
@@ -242,16 +242,9 @@ Pass `allowedOptionNames` to filter search params to only known product option n
 
 ## Anti-patterns
 
-- **Hiding option values based on selection.** Showing only "compatible" values for the current selection collapses the option matrix and prevents exploration. Always show all values; use `exists` and `available` for visual treatment.
-- **Disabling sold-out variants.** Sold-out variants (`available: false`) should be selectable so buyers can see what they would get. Only non-existent combinations (`exists: false`) are truly disabled.
-- **Client-computed prices.** Never compute prices from variant data or option combinations. Always use server-provided `price` / `compareAtPrice` / `priceRange` amounts.
-- **Recreating the store on product prop changes.** Use `hydrate()` instead. Recreating discards the decoded variant cache, the cart subscription, and any user interaction state.
 - **Using reactive effects on state to sync selection to URL.** The `selectOption` return value provides the selection result synchronously. Reacting to `state.selectedOptions` instead introduces an extra update cycle and can fire with stale values.
 - **Navigating inside same-product option buttons.** Do not destructure `onClick` / `onChange` from `register("optionValue", ...)`, call `navigate()`, and then call the registered handler manually. This bypasses the provider `onSelect` contract and can navigate from stale or invalid data.
 - **Button-/onClick-only same-product option values.** A same-product option value rendered as `<button onClick={selectOption}>` with no `href` is dead without JavaScript — a no-JS shopper cannot switch variants and is stuck on the default. Render it as a GET link to the option URL and let the registered handler enhance it; the `href` is the progressive-enhancement fallback.
-- **Calling `selectOption` for combined-listing values.** When `value.handle` differs from the current product's handle, the value belongs to a different product. Use a navigation element (anchor or link component) for full navigation — `selectOption` only understands the current product's matrix.
 - **Using raw anchors when the framework has a client-side link component.** Raw `<a>` tags lose client-router behavior such as scroll preservation, pending navigation state, prefetching, and route transitions. Use the app's established link component unless raw anchors are the framework convention.
-- **Checking only `selectedVariant !== null` for add-to-cart.** This misses two constraints: the variant must be `availableForSale`, and `product.requiresSellingPlan` must not be `true`. Use `canAddToCart()`.
 - **Putting variant selection inside the add-to-cart form.** Variant selection is button/link interactions that update store state. The add-to-cart form submits `merchandiseId` and `quantity` to the cart. Mixing them creates ambiguous form semantics and breaks progressive enhancement.
 - **Ignoring `errors` state after form submission.** Cart user errors, warnings, and network errors are surfaced reactively on the store state. Failing to display these leaves the buyer with no feedback when something goes wrong.
-- **Manually computing `selectedVariant` from `options`.** Use `state.selectedVariant` directly — it is derived and kept in sync automatically. The older pattern of `options[0].values.find(v => v.selected)?.variant` is unnecessary.

--- a/templates/nextjs/.agents/skills/hydrogen-analytics/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-analytics/SKILL.md
@@ -15,7 +15,7 @@ Hydrogen's analytics bus owns the event API, event normalization, and consent-ga
 
 Before wiring route events, check whether this skill has a reference file for the app's framework in `references/`. If one exists, read it and use that framework's route-change and lifecycle primitives. If there is no matching reference, keep the core singleton below and adapt page-view, product-view, collection-view, search-view, and cart tracking to the app's own route lifecycle.
 
-For full setup details and consent nuance, also read `../hydrogen-setup/references/analytics.md`.
+Prerequisite: analytics depends on the same-origin SFAPI proxy (see `hydrogen-request-handlers`) so the browser can observe tracking values from Storefront API responses. Without it, analytics falls back to deprecated JavaScript-visible cookies and session continuity into checkout breaks — treat it as incomplete until the proxy is wired. Key consent setup: Shopify Customer Privacy controls destination delivery in production. Raw subscribers can observe events before consent; destinations receive only consent-allowed replay. Do not override `canTrack` to always `true` in production.
 
 ## Core Pattern
 

--- a/templates/nextjs/.agents/skills/hydrogen-cart-drawer/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-cart-drawer/SKILL.md
@@ -22,7 +22,7 @@ Before building the cart drawer, these must be in place:
 
 ---
 
-## 2. What you're building
+## 2. Drawer structure
 
 The drawer has three layout zones (header / body / footer):
 
@@ -195,7 +195,7 @@ This opens the drawer only after the mutation succeeds. Keep validation and canc
 
 Native: Escape and the back gesture (fires `cancel` then `close`). App-provided: the explicit close `<button>` in the header (`aria-label="Close cart"`). Backdrop (light dismiss) requires `<dialog closedby="any">`.
 
-`closedby="any"` is the least compatible part of this pattern. Older browsers and Safari versions that have not shipped `closedby` will ignore the attribute, so the drawer will still close from Escape and the explicit close button, but backdrop click will not close it. Do not provide a polyfill for `closedby` unless the app explicitly requires backdrop click support in those browsers.
+`closedby="any"` is the least compatible part of this pattern. Browsers without `closedby` support will ignore the attribute, so the drawer will still close from Escape and the explicit close button, but backdrop click will not close it. Do not provide a polyfill for `closedby` unless the app explicitly requires backdrop click support in those browsers.
 
 If an app does require that polyfill, use a pointerdown-plus-click guard on the `<dialog>` itself: record whether `pointerdown` started on the dialog backdrop, then close only when the following `click` also targets the dialog. Do not close on a plain `click.self` alone, because a drag that starts inside the drawer and ends on the backdrop can produce an accidental close.
 

--- a/templates/nextjs/.agents/skills/hydrogen-cart-ui/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-cart-ui/SKILL.md
@@ -181,15 +181,9 @@ Each `CartErrorGroup` contains `{ userErrors: CartUserError[], warnings: CartWar
 
 ## Anti-patterns
 
-- **Client-computed totals.** Multiplying quantity by unit price drifts from the true total when discounts, taxes, or rounding apply. Always use server-provided amounts.
 - **Hand-rolled framework cart state.** If the skill has a matching framework reference, use its provider/hooks/helpers. Otherwise, use the core store directly instead of duplicating cart data in component state or custom reducers.
 - **Client-seeded `/cart` page.** Mounting `CartProvider` with no `initialData` (or reading the cart only through a `"use client"` `useCart` hook) leaves the SSR HTML empty, so the `/cart` page cannot render the server cart. Read the cart in the server data path and pass `initialData`. Use resolved `initialData` when strict no-JS live cart HTML is required; use promise `initialData` when the framework can stream and hydrated cart content is wrapped in Suspense.
-- **Disabling controls during pending.** The store's abort-controller pattern makes rapid interactions safe. Disabling controls makes the cart feel sluggish and punishes fast users.
-- **One form for all lines.** Each line needs its own identity — its own form. A shared form creates ambiguous intent when multiple submit buttons exist.
 - **Quantity as text only.** Rendering quantity as a `<span>` with only plus/minus buttons breaks the set-quantity path and the no-JS fallback. Use a real input wired with `register("quantity", { value, interactive: true })`.
 - **Plus/minus-only line forms.** Increase/decrease/remove buttons do not replace `register("set")` and the interactive quantity input. Omitting them breaks the form invariant even if hydrated clicks appear to work.
 - **Drawer-specific line form drift.** The cart drawer may have a different layout from the `/cart` page, but its line item forms must keep the same Hydrogen form contract. Prefer sharing line item form components between the page and drawer.
 - **Banner-only errors.** A line-level error displayed far from the line it refers to is effectively invisible. Show inline first; promote to the banner only when there's no inline target.
-- **Confirmed-looking pending values.** Showing full-opacity values for in-flight data misleads the user into thinking the data is settled. Always visually distinguish unconfirmed state.
-- **Disabling note save.** The save control is never disabled — it remains interactive even when there's nothing to save (draft matches store) or while a save is in-flight. When there's nothing to save, clicking does nothing. During flight, show a pending indicator.
-- **Blocking navigation during pending.** Cart mutations resolve in the background. Confirmation dialogs on route change frustrate users.

--- a/templates/nextjs/.agents/skills/hydrogen-collection-browser/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-collection-browser/SKILL.md
@@ -56,7 +56,7 @@ Use `parseCollectionParams(searchParams)` before Storefront API queries. Pass pa
 - Keep the search term in `q`.
 - Use a collection handle like `search:${term}` so a new term rebuilds the browse store and does not carry old filters.
 - Keep `q` as a hidden input inside the filter/sort form.
-- Map unsupported search sorts back to `RELEVANCE`; only `PRICE` uses `reverse` in the current examples.
+- Map unsupported search sorts back to `RELEVANCE`; only `PRICE` uses `reverse`.
 - Empty search terms should return an empty product list and no filters rather than querying Storefront API.
 - The search input is uncontrolled (`defaultValue={term}`) so the no-JS GET submit works; add `key={term}` so navigation (e.g. "Clear search" → `/search`) resets it. Safe because `term` changes only on submit/navigation, not while typing — do **not** put `key={term}` on a controlled input that updates the term per keystroke (focus loss).
 

--- a/templates/nextjs/.agents/skills/hydrogen-markets/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-markets/SKILL.md
@@ -113,8 +113,6 @@ export function getMarketFromRequest(request: Request): Market {
 }
 ```
 
-This keeps market selection at the server boundary. Product queries, collection queries, cart queries, and checkout URLs all become market-aware when they use `@inContext`.
-
 ---
 
 ## Per-Market Domains
@@ -135,8 +133,6 @@ export function getMarketFromRequest(request: Request): Market {
   return MARKET_BY_HOST[host] ?? DEFAULT_MARKET;
 }
 ```
-
-This is the cleanest option when SEO, legal entities, or merchant operations require distinct domains. The storefront does not need a visible market prefix in the path because the host already carries the market.
 
 ---
 

--- a/templates/nextjs/.agents/skills/hydrogen-predictive-search/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-predictive-search/SKILL.md
@@ -104,7 +104,7 @@ Use the route-handler form for browser-backed autocomplete. Use `makePredictiveS
 - Keep debounce in the client store; do not add ad-hoc debounce in components unless there is a separate UX reason.
 - Prefer additive fragments over full query overrides.
 - Return empty UI for blank terms rather than querying Storefront API.
-- The modal is a native `<dialog>` opened with `showModal()`. For backdrop-dismiss and `closedby`, follow `hydrogen-cart-drawer`'s `references/accessibility.md` — do not reimplement (use the pointerdown guard from that reference, not a bare click handler).
+- The modal is a native `<dialog>` opened with `showModal()`. For backdrop-dismiss, use `closedby="any"` where supported. For browsers without `closedby` support, use a pointerdown-plus-click guard: record whether `pointerdown` started on the dialog backdrop, then close only when the following `click` also targets the dialog. Do not close on a plain `click.self` alone — a drag that starts inside and ends on the backdrop can produce an accidental close.
 
 ## Verify
 

--- a/templates/nextjs/.agents/skills/hydrogen-request-handlers/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-request-handlers/SKILL.md
@@ -54,7 +54,7 @@ const redirect = await handleShopifyRedirects({
 - Pass registered handler groups explicitly, for example `handlers: [cartHandlers, customerAccountHandlers]`.
 - `handleShopifyRoutes` applies request-context response headers before returning matched Hydrogen route responses.
 - Link and submit to Customer Account routes (`/account/login`, `/account/authorize`, `/account/refresh`, `/account/logout`) with plain HTML `<a>`/`<form>`, never the framework's client-side navigation component (`<Form>`/`<Link>` in React Router, `next/link` in Next.js, `NuxtLink` in Nuxt). The login and logout handlers return raw HTTP redirects to external Shopify URLs, which client-nav cannot process.
-- Apps authoring Customer Account API documents use the same packed Hydrogen TypeScript plugin as Storefront API documents. See `hydrogen-storefront-client/references/query-validation.md` for the exact config. Applies to every framework.
+- Apps authoring Customer Account API documents use the same packed Hydrogen TypeScript plugin as Storefront API documents. Add `@shopify/hydrogen/ts-plugin` to `tsconfig.json` `compilerOptions.plugins` and chain `hydrogen gql check` into a package script. Applies to every framework.
 - For framework-routed responses, commit session headers once at the final response boundary, append those headers, then call `requestContext.applyResponseHeaders(response.headers)` so SFAPI cookies, `Server-Timing`, tracking fallback headers, and personalized-response cache safety survive.
 - Wire this in production runtime code, not dev-only hooks. Only GraphiQL is dev-only.
 

--- a/templates/nextjs/.agents/skills/hydrogen-setup/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-setup/SKILL.md
@@ -15,7 +15,7 @@ Follow these instructions in order to set up Hydrogen in an existing or new repo
 
 Assume the deterministic Hydrogen setup command has already installed `@shopify/hydrogen` and copied the packaged skills into the app. Do not redo package installation or skill copying from this LLM skill.
 
-Master build checklist (an at-a-glance index of the ordered steps below; each step has full detail in its own section):
+Master build checklist:
 
 ```
 - [ ] Inspect the app (package.json at app root)
@@ -45,7 +45,7 @@ Read `package.json` in the current directory. If it does not exist, stop and tel
 
 ## Detect The Framework
 
-Use LLM judgment for this step. Inspect dependencies, configuration files, server entry points, route directories, and existing request lifecycle code. Identify whether the app has a framework that can run server code and expose request handlers, middleware, loaders, server functions, or route handlers.
+Inspect dependencies, configuration files, server entry points, route directories, and existing request lifecycle code. Identify whether the app has a framework that can run server code and expose request handlers, middleware, loaders, server functions, or route handlers.
 
 After detecting the framework, check `references/` for a matching framework reference file. Normalize likely framework or binding names to lowercase kebab-case and read the matching file before making framework-specific setup choices. If no matching reference exists, continue from the generic instructions here and follow the app's existing conventions.
 
@@ -53,14 +53,14 @@ Do not hard block just because no reference file exists. Continue when the app h
 
 ## Use Standard Environment Names
 
-Use these canonical environment variable names throughout the app:
+Use these canonical environment variable names throughout the app (kept in sync with `hydrogen-storefront-client`):
 
 - `PUBLIC_STORE_DOMAIN` for the Shopify store domain.
 - `PUBLIC_STOREFRONT_API_TOKEN` for the public Storefront API token.
 - `PRIVATE_STOREFRONT_API_TOKEN` for the private Storefront API token.
 - `PUBLIC_STOREFRONT_ID` for analytics `storefrontId`; use `"0"` when the app does not have a storefront ID.
-- `PUBLIC_CHECKOUT_DOMAIN` for app-level checkout-domain configuration such as CSP setup. Checkout buttons should use the cart's `checkoutUrl`.
-- `SHOP_ID` for the numeric Shopify shop ID string used by Customer Account API.
+- `PUBLIC_CHECKOUT_DOMAIN` for app-level checkout-domain configuration such as CSP setup. Checkout links should come from cart data, usually `cart.checkoutUrl`.
+- `SHOP_ID` for the numeric Shopify shop ID string. Required by Shopify runtime scripts (`ShopifyScripts`) for every storefront, and by Customer Account API.
 - `PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID` for Customer Account OAuth.
 - `CUSTOMER_ACCOUNT_SESSION_SECRET` for encrypted cookie examples. Prefer opaque server-side sessions in production apps.
 

--- a/templates/nextjs/.agents/skills/hydrogen-smoke-test/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-smoke-test/SKILL.md
@@ -63,7 +63,7 @@ Collection and search:
 Analytics:
 - [ ] Page view fires on initial load and client navigations
 - [ ] Product/collection/search/cart view events fire once per route data change
-- [ ] analytics.updateCart(cart) runs when confirmed cart data changes, and the cart query includes updatedAt
+- [ ] trackCartAnalytics(cart) runs when confirmed cart data changes, and the cart query includes updatedAt
 - [ ] No browser module reads private env variables
 - [ ] Production does not override canTrack to always true
 
@@ -89,10 +89,10 @@ Run the app's available scripts:
 
 ## Request Handlers
 
-Replace `<port>` with the running app port:
+Replace `<port>` with the running app port, and `{api-version}` with the Storefront API version configured by the app:
 
 ```bash
-curl -i -X POST http://localhost:<port>/api/2026-04/graphql.json \
+curl -i -X POST http://localhost:<port>/api/{api-version}/graphql.json \
   -H "content-type: application/json" \
   -H "X-Shopify-Storefront-Access-Token: <public-token>" \
   -d '{"query":"{ shop { name } }"}'
@@ -100,7 +100,7 @@ curl -i -X POST http://localhost:<port>/api/2026-04/graphql.json \
 
 Expected: Storefront API JSON, not the framework 404.
 
-Use the Storefront API version configured by the app when it differs from `2026-04`. The SFAPI proxy forwards the incoming public token header; it does not inject a token from server config.
+The SFAPI proxy forwards the incoming public token header; it does not inject a token from server config.
 
 ```bash
 curl -i http://localhost:<port>/api/cart

--- a/templates/nextjs/.agents/skills/hydrogen-storefront-client/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-storefront-client/SKILL.md
@@ -244,7 +244,7 @@ const { data } = await client.graphql(PRODUCTS, {
 
 User-provided values take precedence over auto-injected ones.
 
-### Where does request state go?
+### Request state storage
 
 `requestContext` is passed at client creation so request-scoped cookies, request-group IDs, response-header capture, personalized-response cache safety, and request aborts are centralized. Use one Shopify request context for Storefront and Customer Account clients in the same request. Per-call `signal` is optional when you need additional cancellation:
 
@@ -261,7 +261,7 @@ Read `references/caching.md` to cache catalog reads across sub-requests on Oxyge
 
 ## Error handling
 
-**Transport errors throw. GraphQL errors are returned.** This is the key mental model:
+**Transport errors throw. GraphQL errors are returned.**
 
 ```ts
 import { StorefrontApiError, StorefrontTimeoutError } from "@shopify/hydrogen";

--- a/templates/nextjs/.agents/skills/hydrogen-variant-form/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-variant-form/SKILL.md
@@ -242,16 +242,9 @@ Pass `allowedOptionNames` to filter search params to only known product option n
 
 ## Anti-patterns
 
-- **Hiding option values based on selection.** Showing only "compatible" values for the current selection collapses the option matrix and prevents exploration. Always show all values; use `exists` and `available` for visual treatment.
-- **Disabling sold-out variants.** Sold-out variants (`available: false`) should be selectable so buyers can see what they would get. Only non-existent combinations (`exists: false`) are truly disabled.
-- **Client-computed prices.** Never compute prices from variant data or option combinations. Always use server-provided `price` / `compareAtPrice` / `priceRange` amounts.
-- **Recreating the store on product prop changes.** Use `hydrate()` instead. Recreating discards the decoded variant cache, the cart subscription, and any user interaction state.
 - **Using reactive effects on state to sync selection to URL.** The `selectOption` return value provides the selection result synchronously. Reacting to `state.selectedOptions` instead introduces an extra update cycle and can fire with stale values.
 - **Navigating inside same-product option buttons.** Do not destructure `onClick` / `onChange` from `register("optionValue", ...)`, call `navigate()`, and then call the registered handler manually. This bypasses the provider `onSelect` contract and can navigate from stale or invalid data.
 - **Button-/onClick-only same-product option values.** A same-product option value rendered as `<button onClick={selectOption}>` with no `href` is dead without JavaScript — a no-JS shopper cannot switch variants and is stuck on the default. Render it as a GET link to the option URL and let the registered handler enhance it; the `href` is the progressive-enhancement fallback.
-- **Calling `selectOption` for combined-listing values.** When `value.handle` differs from the current product's handle, the value belongs to a different product. Use a navigation element (anchor or link component) for full navigation — `selectOption` only understands the current product's matrix.
 - **Using raw anchors when the framework has a client-side link component.** Raw `<a>` tags lose client-router behavior such as scroll preservation, pending navigation state, prefetching, and route transitions. Use the app's established link component unless raw anchors are the framework convention.
-- **Checking only `selectedVariant !== null` for add-to-cart.** This misses two constraints: the variant must be `availableForSale`, and `product.requiresSellingPlan` must not be `true`. Use `canAddToCart()`.
 - **Putting variant selection inside the add-to-cart form.** Variant selection is button/link interactions that update store state. The add-to-cart form submits `merchandiseId` and `quantity` to the cart. Mixing them creates ambiguous form semantics and breaks progressive enhancement.
 - **Ignoring `errors` state after form submission.** Cart user errors, warnings, and network errors are surfaced reactively on the store state. Failing to display these leaves the buyer with no feedback when something goes wrong.
-- **Manually computing `selectedVariant` from `options`.** Use `state.selectedVariant` directly — it is derived and kept in sync automatically. The older pattern of `options[0].values.find(v => v.selected)?.variant` is unnecessary.

--- a/templates/react-router/.agents/skills/hydrogen-analytics/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-analytics/SKILL.md
@@ -15,7 +15,7 @@ Hydrogen's analytics bus owns the event API, event normalization, and consent-ga
 
 Before wiring route events, check whether this skill has a reference file for the app's framework in `references/`. If one exists, read it and use that framework's route-change and lifecycle primitives. If there is no matching reference, keep the core singleton below and adapt page-view, product-view, collection-view, search-view, and cart tracking to the app's own route lifecycle.
 
-For full setup details and consent nuance, also read `../hydrogen-setup/references/analytics.md`.
+Prerequisite: analytics depends on the same-origin SFAPI proxy (see `hydrogen-request-handlers`) so the browser can observe tracking values from Storefront API responses. Without it, analytics falls back to deprecated JavaScript-visible cookies and session continuity into checkout breaks — treat it as incomplete until the proxy is wired. Key consent setup: Shopify Customer Privacy controls destination delivery in production. Raw subscribers can observe events before consent; destinations receive only consent-allowed replay. Do not override `canTrack` to always `true` in production.
 
 ## Core Pattern
 

--- a/templates/react-router/.agents/skills/hydrogen-cart-drawer/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-cart-drawer/SKILL.md
@@ -22,7 +22,7 @@ Before building the cart drawer, these must be in place:
 
 ---
 
-## 2. What you're building
+## 2. Drawer structure
 
 The drawer has three layout zones (header / body / footer):
 
@@ -195,7 +195,7 @@ This opens the drawer only after the mutation succeeds. Keep validation and canc
 
 Native: Escape and the back gesture (fires `cancel` then `close`). App-provided: the explicit close `<button>` in the header (`aria-label="Close cart"`). Backdrop (light dismiss) requires `<dialog closedby="any">`.
 
-`closedby="any"` is the least compatible part of this pattern. Older browsers and Safari versions that have not shipped `closedby` will ignore the attribute, so the drawer will still close from Escape and the explicit close button, but backdrop click will not close it. Do not provide a polyfill for `closedby` unless the app explicitly requires backdrop click support in those browsers.
+`closedby="any"` is the least compatible part of this pattern. Browsers without `closedby` support will ignore the attribute, so the drawer will still close from Escape and the explicit close button, but backdrop click will not close it. Do not provide a polyfill for `closedby` unless the app explicitly requires backdrop click support in those browsers.
 
 If an app does require that polyfill, use a pointerdown-plus-click guard on the `<dialog>` itself: record whether `pointerdown` started on the dialog backdrop, then close only when the following `click` also targets the dialog. Do not close on a plain `click.self` alone, because a drag that starts inside the drawer and ends on the backdrop can produce an accidental close.
 

--- a/templates/react-router/.agents/skills/hydrogen-cart-ui/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-cart-ui/SKILL.md
@@ -181,15 +181,9 @@ Each `CartErrorGroup` contains `{ userErrors: CartUserError[], warnings: CartWar
 
 ## Anti-patterns
 
-- **Client-computed totals.** Multiplying quantity by unit price drifts from the true total when discounts, taxes, or rounding apply. Always use server-provided amounts.
 - **Hand-rolled framework cart state.** If the skill has a matching framework reference, use its provider/hooks/helpers. Otherwise, use the core store directly instead of duplicating cart data in component state or custom reducers.
 - **Client-seeded `/cart` page.** Mounting `CartProvider` with no `initialData` (or reading the cart only through a `"use client"` `useCart` hook) leaves the SSR HTML empty, so the `/cart` page cannot render the server cart. Read the cart in the server data path and pass `initialData`. Use resolved `initialData` when strict no-JS live cart HTML is required; use promise `initialData` when the framework can stream and hydrated cart content is wrapped in Suspense.
-- **Disabling controls during pending.** The store's abort-controller pattern makes rapid interactions safe. Disabling controls makes the cart feel sluggish and punishes fast users.
-- **One form for all lines.** Each line needs its own identity — its own form. A shared form creates ambiguous intent when multiple submit buttons exist.
 - **Quantity as text only.** Rendering quantity as a `<span>` with only plus/minus buttons breaks the set-quantity path and the no-JS fallback. Use a real input wired with `register("quantity", { value, interactive: true })`.
 - **Plus/minus-only line forms.** Increase/decrease/remove buttons do not replace `register("set")` and the interactive quantity input. Omitting them breaks the form invariant even if hydrated clicks appear to work.
 - **Drawer-specific line form drift.** The cart drawer may have a different layout from the `/cart` page, but its line item forms must keep the same Hydrogen form contract. Prefer sharing line item form components between the page and drawer.
 - **Banner-only errors.** A line-level error displayed far from the line it refers to is effectively invisible. Show inline first; promote to the banner only when there's no inline target.
-- **Confirmed-looking pending values.** Showing full-opacity values for in-flight data misleads the user into thinking the data is settled. Always visually distinguish unconfirmed state.
-- **Disabling note save.** The save control is never disabled — it remains interactive even when there's nothing to save (draft matches store) or while a save is in-flight. When there's nothing to save, clicking does nothing. During flight, show a pending indicator.
-- **Blocking navigation during pending.** Cart mutations resolve in the background. Confirmation dialogs on route change frustrate users.

--- a/templates/react-router/.agents/skills/hydrogen-collection-browser/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-collection-browser/SKILL.md
@@ -56,7 +56,7 @@ Use `parseCollectionParams(searchParams)` before Storefront API queries. Pass pa
 - Keep the search term in `q`.
 - Use a collection handle like `search:${term}` so a new term rebuilds the browse store and does not carry old filters.
 - Keep `q` as a hidden input inside the filter/sort form.
-- Map unsupported search sorts back to `RELEVANCE`; only `PRICE` uses `reverse` in the current examples.
+- Map unsupported search sorts back to `RELEVANCE`; only `PRICE` uses `reverse`.
 - Empty search terms should return an empty product list and no filters rather than querying Storefront API.
 - The search input is uncontrolled (`defaultValue={term}`) so the no-JS GET submit works; add `key={term}` so navigation (e.g. "Clear search" → `/search`) resets it. Safe because `term` changes only on submit/navigation, not while typing — do **not** put `key={term}` on a controlled input that updates the term per keystroke (focus loss).
 

--- a/templates/react-router/.agents/skills/hydrogen-markets/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-markets/SKILL.md
@@ -113,8 +113,6 @@ export function getMarketFromRequest(request: Request): Market {
 }
 ```
 
-This keeps market selection at the server boundary. Product queries, collection queries, cart queries, and checkout URLs all become market-aware when they use `@inContext`.
-
 ---
 
 ## Per-Market Domains
@@ -135,8 +133,6 @@ export function getMarketFromRequest(request: Request): Market {
   return MARKET_BY_HOST[host] ?? DEFAULT_MARKET;
 }
 ```
-
-This is the cleanest option when SEO, legal entities, or merchant operations require distinct domains. The storefront does not need a visible market prefix in the path because the host already carries the market.
 
 ---
 

--- a/templates/react-router/.agents/skills/hydrogen-predictive-search/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-predictive-search/SKILL.md
@@ -104,7 +104,7 @@ Use the route-handler form for browser-backed autocomplete. Use `makePredictiveS
 - Keep debounce in the client store; do not add ad-hoc debounce in components unless there is a separate UX reason.
 - Prefer additive fragments over full query overrides.
 - Return empty UI for blank terms rather than querying Storefront API.
-- The modal is a native `<dialog>` opened with `showModal()`. For backdrop-dismiss and `closedby`, follow `hydrogen-cart-drawer`'s `references/accessibility.md` — do not reimplement (use the pointerdown guard from that reference, not a bare click handler).
+- The modal is a native `<dialog>` opened with `showModal()`. For backdrop-dismiss, use `closedby="any"` where supported. For browsers without `closedby` support, use a pointerdown-plus-click guard: record whether `pointerdown` started on the dialog backdrop, then close only when the following `click` also targets the dialog. Do not close on a plain `click.self` alone — a drag that starts inside and ends on the backdrop can produce an accidental close.
 
 ## Verify
 

--- a/templates/react-router/.agents/skills/hydrogen-request-handlers/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-request-handlers/SKILL.md
@@ -54,7 +54,7 @@ const redirect = await handleShopifyRedirects({
 - Pass registered handler groups explicitly, for example `handlers: [cartHandlers, customerAccountHandlers]`.
 - `handleShopifyRoutes` applies request-context response headers before returning matched Hydrogen route responses.
 - Link and submit to Customer Account routes (`/account/login`, `/account/authorize`, `/account/refresh`, `/account/logout`) with plain HTML `<a>`/`<form>`, never the framework's client-side navigation component (`<Form>`/`<Link>` in React Router, `next/link` in Next.js, `NuxtLink` in Nuxt). The login and logout handlers return raw HTTP redirects to external Shopify URLs, which client-nav cannot process.
-- Apps authoring Customer Account API documents use the same packed Hydrogen TypeScript plugin as Storefront API documents. See `hydrogen-storefront-client/references/query-validation.md` for the exact config. Applies to every framework.
+- Apps authoring Customer Account API documents use the same packed Hydrogen TypeScript plugin as Storefront API documents. Add `@shopify/hydrogen/ts-plugin` to `tsconfig.json` `compilerOptions.plugins` and chain `hydrogen gql check` into a package script. Applies to every framework.
 - For framework-routed responses, commit session headers once at the final response boundary, append those headers, then call `requestContext.applyResponseHeaders(response.headers)` so SFAPI cookies, `Server-Timing`, tracking fallback headers, and personalized-response cache safety survive.
 - Wire this in production runtime code, not dev-only hooks. Only GraphiQL is dev-only.
 

--- a/templates/react-router/.agents/skills/hydrogen-setup/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-setup/SKILL.md
@@ -15,7 +15,7 @@ Follow these instructions in order to set up Hydrogen in an existing or new repo
 
 Assume the deterministic Hydrogen setup command has already installed `@shopify/hydrogen` and copied the packaged skills into the app. Do not redo package installation or skill copying from this LLM skill.
 
-Master build checklist (an at-a-glance index of the ordered steps below; each step has full detail in its own section):
+Master build checklist:
 
 ```
 - [ ] Inspect the app (package.json at app root)
@@ -45,7 +45,7 @@ Read `package.json` in the current directory. If it does not exist, stop and tel
 
 ## Detect The Framework
 
-Use LLM judgment for this step. Inspect dependencies, configuration files, server entry points, route directories, and existing request lifecycle code. Identify whether the app has a framework that can run server code and expose request handlers, middleware, loaders, server functions, or route handlers.
+Inspect dependencies, configuration files, server entry points, route directories, and existing request lifecycle code. Identify whether the app has a framework that can run server code and expose request handlers, middleware, loaders, server functions, or route handlers.
 
 After detecting the framework, check `references/` for a matching framework reference file. Normalize likely framework or binding names to lowercase kebab-case and read the matching file before making framework-specific setup choices. If no matching reference exists, continue from the generic instructions here and follow the app's existing conventions.
 
@@ -53,14 +53,14 @@ Do not hard block just because no reference file exists. Continue when the app h
 
 ## Use Standard Environment Names
 
-Use these canonical environment variable names throughout the app:
+Use these canonical environment variable names throughout the app (kept in sync with `hydrogen-storefront-client`):
 
 - `PUBLIC_STORE_DOMAIN` for the Shopify store domain.
 - `PUBLIC_STOREFRONT_API_TOKEN` for the public Storefront API token.
 - `PRIVATE_STOREFRONT_API_TOKEN` for the private Storefront API token.
 - `PUBLIC_STOREFRONT_ID` for analytics `storefrontId`; use `"0"` when the app does not have a storefront ID.
-- `PUBLIC_CHECKOUT_DOMAIN` for app-level checkout-domain configuration such as CSP setup. Checkout buttons should use the cart's `checkoutUrl`.
-- `SHOP_ID` for the numeric Shopify shop ID string used by Customer Account API.
+- `PUBLIC_CHECKOUT_DOMAIN` for app-level checkout-domain configuration such as CSP setup. Checkout links should come from cart data, usually `cart.checkoutUrl`.
+- `SHOP_ID` for the numeric Shopify shop ID string. Required by Shopify runtime scripts (`ShopifyScripts`) for every storefront, and by Customer Account API.
 - `PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID` for Customer Account OAuth.
 - `CUSTOMER_ACCOUNT_SESSION_SECRET` for encrypted cookie examples. Prefer opaque server-side sessions in production apps.
 

--- a/templates/react-router/.agents/skills/hydrogen-smoke-test/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-smoke-test/SKILL.md
@@ -63,7 +63,7 @@ Collection and search:
 Analytics:
 - [ ] Page view fires on initial load and client navigations
 - [ ] Product/collection/search/cart view events fire once per route data change
-- [ ] analytics.updateCart(cart) runs when confirmed cart data changes, and the cart query includes updatedAt
+- [ ] trackCartAnalytics(cart) runs when confirmed cart data changes, and the cart query includes updatedAt
 - [ ] No browser module reads private env variables
 - [ ] Production does not override canTrack to always true
 
@@ -89,10 +89,10 @@ Run the app's available scripts:
 
 ## Request Handlers
 
-Replace `<port>` with the running app port:
+Replace `<port>` with the running app port, and `{api-version}` with the Storefront API version configured by the app:
 
 ```bash
-curl -i -X POST http://localhost:<port>/api/2026-04/graphql.json \
+curl -i -X POST http://localhost:<port>/api/{api-version}/graphql.json \
   -H "content-type: application/json" \
   -H "X-Shopify-Storefront-Access-Token: <public-token>" \
   -d '{"query":"{ shop { name } }"}'
@@ -100,7 +100,7 @@ curl -i -X POST http://localhost:<port>/api/2026-04/graphql.json \
 
 Expected: Storefront API JSON, not the framework 404.
 
-Use the Storefront API version configured by the app when it differs from `2026-04`. The SFAPI proxy forwards the incoming public token header; it does not inject a token from server config.
+The SFAPI proxy forwards the incoming public token header; it does not inject a token from server config.
 
 ```bash
 curl -i http://localhost:<port>/api/cart

--- a/templates/react-router/.agents/skills/hydrogen-storefront-client/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-storefront-client/SKILL.md
@@ -244,7 +244,7 @@ const { data } = await client.graphql(PRODUCTS, {
 
 User-provided values take precedence over auto-injected ones.
 
-### Where does request state go?
+### Request state storage
 
 `requestContext` is passed at client creation so request-scoped cookies, request-group IDs, response-header capture, personalized-response cache safety, and request aborts are centralized. Use one Shopify request context for Storefront and Customer Account clients in the same request. Per-call `signal` is optional when you need additional cancellation:
 
@@ -261,7 +261,7 @@ Read `references/caching.md` to cache catalog reads across sub-requests on Oxyge
 
 ## Error handling
 
-**Transport errors throw. GraphQL errors are returned.** This is the key mental model:
+**Transport errors throw. GraphQL errors are returned.**
 
 ```ts
 import { StorefrontApiError, StorefrontTimeoutError } from "@shopify/hydrogen";

--- a/templates/react-router/.agents/skills/hydrogen-variant-form/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-variant-form/SKILL.md
@@ -242,16 +242,9 @@ Pass `allowedOptionNames` to filter search params to only known product option n
 
 ## Anti-patterns
 
-- **Hiding option values based on selection.** Showing only "compatible" values for the current selection collapses the option matrix and prevents exploration. Always show all values; use `exists` and `available` for visual treatment.
-- **Disabling sold-out variants.** Sold-out variants (`available: false`) should be selectable so buyers can see what they would get. Only non-existent combinations (`exists: false`) are truly disabled.
-- **Client-computed prices.** Never compute prices from variant data or option combinations. Always use server-provided `price` / `compareAtPrice` / `priceRange` amounts.
-- **Recreating the store on product prop changes.** Use `hydrate()` instead. Recreating discards the decoded variant cache, the cart subscription, and any user interaction state.
 - **Using reactive effects on state to sync selection to URL.** The `selectOption` return value provides the selection result synchronously. Reacting to `state.selectedOptions` instead introduces an extra update cycle and can fire with stale values.
 - **Navigating inside same-product option buttons.** Do not destructure `onClick` / `onChange` from `register("optionValue", ...)`, call `navigate()`, and then call the registered handler manually. This bypasses the provider `onSelect` contract and can navigate from stale or invalid data.
 - **Button-/onClick-only same-product option values.** A same-product option value rendered as `<button onClick={selectOption}>` with no `href` is dead without JavaScript — a no-JS shopper cannot switch variants and is stuck on the default. Render it as a GET link to the option URL and let the registered handler enhance it; the `href` is the progressive-enhancement fallback.
-- **Calling `selectOption` for combined-listing values.** When `value.handle` differs from the current product's handle, the value belongs to a different product. Use a navigation element (anchor or link component) for full navigation — `selectOption` only understands the current product's matrix.
 - **Using raw anchors when the framework has a client-side link component.** Raw `<a>` tags lose client-router behavior such as scroll preservation, pending navigation state, prefetching, and route transitions. Use the app's established link component unless raw anchors are the framework convention.
-- **Checking only `selectedVariant !== null` for add-to-cart.** This misses two constraints: the variant must be `availableForSale`, and `product.requiresSellingPlan` must not be `true`. Use `canAddToCart()`.
 - **Putting variant selection inside the add-to-cart form.** Variant selection is button/link interactions that update store state. The add-to-cart form submits `merchandiseId` and `quantity` to the cart. Mixing them creates ambiguous form semantics and breaks progressive enhancement.
 - **Ignoring `errors` state after form submission.** Cart user errors, warnings, and network errors are surfaced reactively on the store state. Failing to display these leaves the buyer with no feedback when something goes wrong.
-- **Manually computing `selectedVariant` from `options`.** Use `state.selectedVariant` directly — it is derived and kept in sync automatically. The older pattern of `options[0].values.find(v => v.selected)?.variant` is unnecessary.


### PR DESCRIPTION
Reference: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices.md

- Fixed a factual bug where the smoke-test checklist referenced an API that doesn't exist
- Removed cross-skill references so skills don't break when installed independently
- Deduplicated content that had already started drifting between files
- Removed tone and time-sensitive language that adds noise without helping agents