### PR TITLE
fix(preview): Storefront E2E availability queries

### DIFF
--- a/packages/storefront-e2e/specs/cart/config.ts
+++ b/packages/storefront-e2e/specs/cart/config.ts
@@ -16,7 +16,7 @@ const PRODUCT_VARIANT_COUNT = 10;
 
 const CART_ENABLED_PRODUCTS_QUERY = gql(`
   query CartEnabledProducts($count: Int!, $variantCount: Int!) {
-    products(first: $count, query: "availableForSale:true") {
+    products(first: $count, query: "available_for_sale:true") {
       nodes {
         handle
         requiresSellingPlan

--- a/packages/storefront-e2e/specs/checkout/config.ts
+++ b/packages/storefront-e2e/specs/checkout/config.ts
@@ -16,7 +16,7 @@ const PRODUCT_VARIANT_COUNT = 10;
 
 const CART_ENABLED_PRODUCTS_QUERY = gql(`
   query CheckoutCartEnabledProducts($count: Int!, $variantCount: Int!) {
-    products(first: $count, query: "availableForSale:true") {
+    products(first: $count, query: "available_for_sale:true") {
       nodes {
         handle
         requiresSellingPlan

--- a/packages/storefront-e2e/specs/product-variant/config.ts
+++ b/packages/storefront-e2e/specs/product-variant/config.ts
@@ -16,7 +16,7 @@ const PRODUCT_VARIANT_PATHS = {
 
 const PRODUCT_VARIANTS_QUERY = gql(`
   query ProductVariants($productCount: Int!, $variantCount: Int!) {
-    products(first: $productCount, query: "availableForSale:true") {
+    products(first: $productCount, query: "available_for_sale:true") {
       nodes {
         handle
         title

--- a/packages/storefront-e2e/specs/product/config.ts
+++ b/packages/storefront-e2e/specs/product/config.ts
@@ -16,7 +16,7 @@ const PRODUCT_PATHS = {
 
 const PRODUCTS_IN_STOCK_QUERY = gql(`
   query ProductsInStock($count: Int!, $variantCount: Int!) {
-    products(first: $count, query: "availableForSale:true") {
+    products(first: $count, query: "available_for_sale:true") {
       nodes {
         handle
         title

--- a/packages/storefront-e2e/specs/search/config.ts
+++ b/packages/storefront-e2e/specs/search/config.ts
@@ -17,7 +17,7 @@ const SEARCH_PATHS = {
 
 const SEARCH_PRODUCTS_QUERY = gql(`
   query SearchProducts($count: Int!) {
-    products(first: $count, query: "availableForSale:true") {
+    products(first: $count, query: "available_for_sale:true") {
       nodes {
         title
       }


### PR DESCRIPTION
TL;DR: Use the supported `available_for_sale` search field so Storefront E2E discovery queries only return available products.

## Before

```graphql
products(query: "availableForSale:true")
```

The camelCase field name was not recognised, so availability filtering did not work as expected.

## After

```graphql
products(query: "available_for_sale:true")
```

## What this changes

- Updates product discovery queries for cart, checkout, product, product variant, and search E2E suites.
- Keeps the intended behaviour of selecting products that are available for sale.

[shop/world#965065](https://github.com/shop/world/pull/965065) tracks a separate Storefront API flaw where `available_for_sale` effectively treats any supplied value as `true`. That does not affect this PR's outcome because these queries intentionally pass `true`. The camelCase field name was the reason they were not filtering as expected.

## Developer impact

Repo-local E2E configuration only. No public API or runtime behaviour changes, so no changeset is needed.

## Risk

Low. The queries retain their intended availability constraint and only correct its field name.
