### PR TITLE
feat(hydrogen): resolve inbound `?variant=<id>` deep links

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,23 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Resolve inbound `?variant=<id>` deep links to the product URL's option-param form.
+
+Shopify's own surfaces — Liquid storefronts, Shopping feeds, email campaigns, paid ads, and Shop Pay — deep-link to a product with a bare variant id (`/products/shoes?variant=41565182099480`) rather than one search param per option. A storefront that only reads option params (`?Color=Red&Size=M`) silently drops that selection and renders the default variant, so every link a merchant already has in market lands on the wrong variant after migrating to Hydrogen.
+
+Two new exports:
+
+- `getVariantIdParam({ searchParams })` reads the param and normalizes it to a `ProductVariant` GID, returning `null` for anything that isn't one — including GIDs for other resource types, so an untrusted param can't be forwarded into a `node(id:)` lookup for an unrelated object.
+- `handleVariantDeepLink({ request, storefrontClient, routeTemplates, pathPrefix })` resolves the variant and returns a 307 `Response`, or `null` when the request isn't a product URL with a resolvable variant. It mirrors the `handleUrlRedirects` interceptor shape, so it drops into any framework's pre-render hook.
+
+```ts
+const variantRedirect = await handleVariantDeepLink({ request, storefrontClient, routeTemplates });
+if (variantRedirect) return variantRedirect;
+```
+
+Because it goes through `routeTemplates`, apps serving products from a custom path (`/p/:productHandle`) and apps using an i18n `pathPrefix` (`/en-ca/products/…`) work without extra configuration. The redirect preserves unrelated params (`utm_*`, `ref`) so campaign attribution survives, and follows the variant's own product handle so a combined-listing variant lands on the right page.
+
+This is additive: option params remain the canonical URL contract and remain the no-JS mechanism. Unresolvable or stale ids return `null` and render the default variant rather than 404.
+
+Run it before the route renders, not after a 404 like `handleShopifyRedirects` — the product route exists, and only the variant selection needs translating. Running it during rendering can degrade to a client-side redirect that never fires for a shopper with JavaScript disabled.

--- a/examples/hydrogen/server.ts
+++ b/examples/hydrogen/server.ts
@@ -5,6 +5,7 @@ import {
   createShopifyRequestContext,
   handleShopifyRedirects,
   handleShopifyRoutes,
+  handleVariantDeepLink,
 } from "@shopify/hydrogen";
 import { createStorefrontClient } from "@shopify/hydrogen";
 import { createCustomerAccountServerHandlers } from "@shopify/hydrogen/customer-account";
@@ -74,6 +75,25 @@ export default {
         handlers: [cartHandlers, predictiveSearchHandlers, customerAccountHandlers],
       });
       if (shopifyRoute) return shopifyRoute;
+
+      /**
+       * Shopify's own surfaces (Liquid storefronts, Shopping feeds, email, ads,
+       * Shop Pay) deep-link with a bare `?variant=<id>`. Translate it to the
+       * option-param URL the product route reads, before the app renders, so it
+       * stays a real HTTP redirect for a shopper without JavaScript.
+       */
+      const variantRedirect = await handleVariantDeepLink({
+        request: publicRequest,
+        routeTemplates,
+        storefrontClient,
+      });
+      if (variantRedirect) {
+        // Mirrors the `shopifyRoute` early return above: nothing has rendered
+        // yet, so there are no pending session commits to flush — only the
+        // SFAPI response headers need merging.
+        shopifyRequestContext.applyResponseHeaders(variantRedirect.headers);
+        return variantRedirect;
+      }
 
       const routerContext = await createHydrogenRouterContext(
         publicRequest,

--- a/examples/nextjs/proxy.ts
+++ b/examples/nextjs/proxy.ts
@@ -4,6 +4,7 @@ import {
   createShopifyRequestContext,
   createStorefrontClient,
   handleShopifyRoutes,
+  handleVariantDeepLink,
 } from "@shopify/hydrogen";
 import { NextResponse, type NextRequest } from "next/server";
 
@@ -11,6 +12,7 @@ import { cartHandlers } from "@/lib/cart-handlers";
 import { createCustomerSessionManager } from "@/lib/customer-account";
 import { customerSessionHandlers } from "@/lib/customer-session-handlers";
 import { predictiveSearchHandlers } from "@/lib/predictive-search-handlers";
+import { routeTemplates } from "@/lib/route-templates";
 import { MOCK_SHOP_DOMAIN, resolveStorefrontConfig } from "@/lib/storefront-config";
 
 /**
@@ -19,6 +21,13 @@ import { MOCK_SHOP_DOMAIN, resolveStorefrontConfig } from "@/lib/storefront-conf
  * routing — Hydrogen-owned routes (`/api/cart`, `/api/predictive-search`,
  * `/api/{ver}/graphql.json`, `/admin`, …) short-circuit here. Storefront URL
  * redirects run in `app/not-found.tsx` (post-404), never here.
+ *
+ * `?variant=<id>` deep links (Liquid storefronts, Shopping feeds, email, ads,
+ * Shop Pay) are normalized to the PDP's option-param URL here too — distinct
+ * from the admin-configured Storefront URL redirects above, and placed before
+ * framework routing so it stays a real HTTP redirect for no-JS shoppers (F4)
+ * rather than the client-side one a page-level `redirect()` degrades to under
+ * Cache Components.
  *
  * The original request URL is forwarded to Server Components via
  * `requestContext.getForwardedRequestHeaders()` (carries `x-storefront-url` for
@@ -37,8 +46,6 @@ export async function proxy(request: NextRequest) {
     buyerIp,
   });
 
-  const sessionManager = await createCustomerSessionManager(request);
-
   const { storeDomain, privateStorefrontToken } = resolveStorefrontConfig();
 
   const storefrontClient = createStorefrontClient({
@@ -50,6 +57,26 @@ export async function proxy(request: NextRequest) {
       buyerIp,
     },
   });
+
+  // Normalize `?variant=<id>` deep links to the PDP's option-param URL. Runs
+  // ahead of the session manager: a redirected request never reads the session,
+  // so there's no reason to pay its cookie decrypt first.
+  const variantRedirect = await handleVariantDeepLink({
+    request,
+    storefrontClient,
+    routeTemplates,
+  });
+  if (variantRedirect) {
+    // Hydrogen returns a relative `location`, which is what a framework router
+    // wants. Next's proxy resolves the header with `new URL()` and throws on a
+    // relative value, so rebuild it against the request origin here.
+    const location = variantRedirect.headers.get("location") ?? "/";
+    const response = NextResponse.redirect(new URL(location, request.url), variantRedirect.status);
+    requestContext.applyResponseHeaders(response.headers);
+    return response;
+  }
+
+  const sessionManager = await createCustomerSessionManager(request);
 
   // Customer Accounts are only available on a real store (mock.shop has no
   // Customer Account API). Inline the resolved `storeDomain` check rather than

--- a/examples/react-router/app/lib/storefront-middleware.ts
+++ b/examples/react-router/app/lib/storefront-middleware.ts
@@ -6,6 +6,7 @@ import {
   createStorefrontClient,
   handleShopifyRedirects,
   handleShopifyRoutes,
+  handleVariantDeepLink,
   type ShopifyRequestContext,
 } from "@shopify/hydrogen";
 import { createCustomerAccountClient } from "@shopify/hydrogen/customer-account";
@@ -144,6 +145,19 @@ export const storefrontMiddleware: MiddlewareFunction<Response> = async (
   // `Set-Cookie`) and applies SFAPI response headers, so the early-return
   // path needs no further post-processing.
   if (shopifyRoute) return shopifyRoute;
+
+  // Shopify's own surfaces (Liquid storefronts, Shopping feeds, email, ads,
+  // Shop Pay) deep-link with a bare `?variant=<id>`. Translate it to the
+  // option-param URL the product route reads. Runs before `next()` so it stays
+  // a real HTTP redirect for a no-JS shopper (F4).
+  const variantRedirect = await handleVariantDeepLink({
+    request,
+    storefrontClient,
+    routeTemplates,
+  });
+  if (variantRedirect) {
+    return finalizeResponse(requestContext, variantRedirect, sessionManager);
+  }
 
   // Loaders read both clients from context. Handlers don't read context, so
   // this only needs to be set on the framework-router path (after the

--- a/packages/hydrogen/src/core/index.ts
+++ b/packages/hydrogen/src/core/index.ts
@@ -2,6 +2,8 @@ export type { RedirectOptions } from "./handle-shopify-redirects";
 export { createShopifyRouteTemplates } from "./standard-routes/index";
 export type { ShopifyRouteTemplates } from "./standard-routes/index";
 export { handleShopifyRedirects } from "./handle-shopify-redirects";
+export { handleVariantDeepLink } from "./interceptors/variant-deep-link";
+export type { VariantDeepLinkOptions } from "./interceptors/variant-deep-link";
 export { handleShopifyRoutes } from "./handle-shopify-routes";
 export { createShopifyRouteHandler } from "./route-handlers";
 export type {
@@ -178,7 +180,7 @@ export type {
   ValidProductSelectionResult,
   VariantSelectionResult,
 } from "./product";
-export { getSelectedProductOptions } from "./product";
+export { getSelectedProductOptions, getVariantIdParam } from "./product";
 export type {
   ProductInput,
   ProductAddToCartProps,

--- a/packages/hydrogen/src/core/interceptors/variant-deep-link.test.ts
+++ b/packages/hydrogen/src/core/interceptors/variant-deep-link.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createStorefrontClient } from "../../client/client";
+import { createShopifyRequestContext } from "../headers";
+import { createShopifyRouteTemplates } from "../standard-routes/index";
+import { assert } from "../test-utils";
+import { handleVariantDeepLink } from "./variant-deep-link";
+
+const DEFAULT_I18N = { country: "US", language: "EN" } as const;
+const LARGE_VARIANT_GID = "gid://shopify/ProductVariant/43695710437398";
+
+function storefrontClient(request: Request) {
+  return createStorefrontClient({
+    type: "private",
+    requestContext: createShopifyRequestContext({ request, i18n: DEFAULT_I18N }),
+    config: {
+      storeDomain: "test-store.myshopify.com",
+      privateStorefrontToken: "test-private-token",
+      buyerIp: "127.0.0.1",
+    },
+  });
+}
+
+function options(
+  request: Request,
+  overrides: Partial<Parameters<typeof handleVariantDeepLink>[0]> = {},
+): Parameters<typeof handleVariantDeepLink>[0] {
+  return {
+    request,
+    storefrontClient: storefrontClient(request),
+    routeTemplates: createShopifyRouteTemplates({}),
+    ...overrides,
+  };
+}
+
+function variantResponse(handle: string, selectedOptions: Array<{ name: string; value: string }>) {
+  return new Response(JSON.stringify({ data: { node: { product: { handle }, selectedOptions } } }));
+}
+
+describe("handleVariantDeepLink", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ data: { node: null } })));
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("redirects a bare variant id to the option-param URL", async () => {
+    mockFetch.mockResolvedValueOnce(variantResponse("slides", [{ name: "Size", value: "Large" }]));
+
+    const request = new Request("https://my-app.com/products/slides?variant=43695710437398");
+    const result = await handleVariantDeepLink(options(request));
+
+    assert(result, "expected variant deep link redirect");
+    expect(result.status).toBe(307);
+    expect(result.headers.get("location")).toBe("/products/slides?Size=Large");
+  });
+
+  it("accepts a full ProductVariant GID", async () => {
+    mockFetch.mockResolvedValueOnce(variantResponse("slides", [{ name: "Size", value: "Large" }]));
+
+    const url = `https://my-app.com/products/slides?variant=${encodeURIComponent(LARGE_VARIANT_GID)}`;
+    const result = await handleVariantDeepLink(options(new Request(url)));
+
+    assert(result, "expected variant deep link redirect");
+    expect(result.headers.get("location")).toBe("/products/slides?Size=Large");
+  });
+
+  it("preserves unrelated campaign params", async () => {
+    mockFetch.mockResolvedValueOnce(variantResponse("slides", [{ name: "Size", value: "Medium" }]));
+
+    const request = new Request(
+      "https://my-app.com/products/slides?variant=43695710437398&utm_source=google&ref=feed",
+    );
+    const result = await handleVariantDeepLink(options(request));
+
+    assert(result, "expected variant deep link redirect");
+    const location = result.headers.get("location") ?? "";
+    expect(location.startsWith("/products/slides?")).toBe(true);
+    expect(new URLSearchParams(location.split("?")[1])).toEqual(
+      new URLSearchParams({ utm_source: "google", ref: "feed", Size: "Medium" }),
+    );
+  });
+
+  it("follows the variant's own product handle for combined listings", async () => {
+    mockFetch.mockResolvedValueOnce(
+      variantResponse("slides-wide", [{ name: "Width", value: "Wide" }]),
+    );
+
+    const request = new Request("https://my-app.com/products/slides?variant=43695710437398");
+    const result = await handleVariantDeepLink(options(request));
+
+    assert(result, "expected variant deep link redirect");
+    expect(result.headers.get("location")).toBe("/products/slides-wide?Width=Wide");
+  });
+
+  it("omits Shopify's Default Title sentinel for single-variant products", async () => {
+    mockFetch.mockResolvedValueOnce(
+      variantResponse("gift-card", [{ name: "Title", value: "Default Title" }]),
+    );
+
+    const request = new Request("https://my-app.com/products/gift-card?variant=43695710437398");
+    const result = await handleVariantDeepLink(options(request));
+
+    assert(result, "expected variant deep link redirect");
+    expect(result.headers.get("location")).toBe("/products/gift-card");
+  });
+
+  it("honors a custom product route template", async () => {
+    mockFetch.mockResolvedValueOnce(variantResponse("slides", [{ name: "Size", value: "Large" }]));
+
+    const request = new Request("https://my-app.com/p/slides?variant=43695710437398");
+    const result = await handleVariantDeepLink(
+      options(request, {
+        routeTemplates: createShopifyRouteTemplates({ product: "/p/:productHandle" }),
+      }),
+    );
+
+    assert(result, "expected variant deep link redirect");
+    expect(result.headers.get("location")).toBe("/p/slides?Size=Large");
+  });
+
+  it("preserves an i18n path prefix", async () => {
+    mockFetch.mockResolvedValueOnce(variantResponse("slides", [{ name: "Size", value: "Large" }]));
+
+    const request = new Request("https://my-app.com/en-ca/products/slides?variant=43695710437398");
+    const result = await handleVariantDeepLink(options(request, { pathPrefix: "/en-ca" }));
+
+    assert(result, "expected variant deep link redirect");
+    expect(result.headers.get("location")).toBe("/en-ca/products/slides?Size=Large");
+  });
+
+  it("ignores requests without a variant param", async () => {
+    const request = new Request("https://my-app.com/products/slides?Size=Large");
+
+    expect(await handleVariantDeepLink(options(request))).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-product routes carrying a variant param", async () => {
+    const request = new Request("https://my-app.com/cart?variant=43695710437398");
+
+    expect(await handleVariantDeepLink(options(request))).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores a GID for another resource type without querying", async () => {
+    const url = `https://my-app.com/products/slides?variant=${encodeURIComponent("gid://shopify/Customer/1")}`;
+
+    expect(await handleVariantDeepLink(options(new Request(url)))).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("falls through when the variant does not resolve", async () => {
+    const request = new Request("https://my-app.com/products/slides?variant=99999999999999");
+
+    expect(await handleVariantDeepLink(options(request))).toBeNull();
+  });
+});

--- a/packages/hydrogen/src/core/interceptors/variant-deep-link.ts
+++ b/packages/hydrogen/src/core/interceptors/variant-deep-link.ts
@@ -1,0 +1,132 @@
+import type { PrivateStorefrontClient } from "../../client";
+import { gql } from "../../graphql";
+import { getVariantIdParam } from "../product/options";
+import { getStandardRoute, matchStandardRouteUrl } from "../standard-routes";
+import type { ShopifyRouteTemplates } from "../standard-routes";
+import { createRedirectResponse } from "./url-redirects";
+
+const VARIANT_DEEP_LINK_QUERY = gql(`
+  query VariantDeepLink($id: ID!) {
+    node(id: $id) {
+      ... on ProductVariant {
+        product {
+          handle
+        }
+        selectedOptions {
+          name
+          value
+        }
+      }
+    }
+  }
+`);
+
+const VARIANT_PARAM = "variant";
+
+// Shopify's sentinel option for single-variant products. Not a real choice, so
+// it never belongs in a product URL.
+const DEFAULT_OPTION_NAME = "Title";
+const DEFAULT_OPTION_VALUE = "Default Title";
+
+export type VariantDeepLinkOptions = {
+  request: Request;
+  storefrontClient: PrivateStorefrontClient;
+  /**
+   * The app's custom route templates. Used to recognize the incoming product
+   * URL and to build the redirect target, so apps serving products from a
+   * non-standard path (`/p/:productHandle`) work without extra configuration.
+   */
+  routeTemplates?: ShopifyRouteTemplates;
+  /** The active `i18n.pathPrefix`, when the app serves localized paths. */
+  pathPrefix?: string;
+};
+
+/**
+ * Redirects an inbound `?variant=<id>` deep link to the product URL's
+ * option-param form.
+ *
+ * Shopify's own surfaces — Liquid storefronts, Shopping feeds, email campaigns,
+ * paid ads, and Shop Pay — link to a product with a bare variant id
+ * (`/products/shoes?variant=41565182099480`). Hydrogen product pages read
+ * option params (`?Color=Red&Size=M`), so without this those links resolve to
+ * the product's default variant instead of the one the shopper chose.
+ *
+ * Returns a 307 `Response` when the request is a product URL carrying a
+ * resolvable variant id, and `null` otherwise — including for unresolvable or
+ * stale ids, so an outdated link renders the default variant rather than 404.
+ *
+ * Unlike {@link handleShopifyRedirects}, this runs *before* the route renders,
+ * not after a 404: the product route exists, and only the variant selection
+ * needs translating. Run it early enough that the redirect is a real HTTP
+ * response — a redirect issued during rendering can degrade to a client-side
+ * one, which never runs for a shopper with JavaScript disabled.
+ *
+ * The redirect preserves unrelated params (`utm_*`, `ref`) so campaign
+ * attribution survives, and follows the variant's own product handle so a
+ * combined-listing variant lands on the right page.
+ *
+ * @example
+ * ```ts
+ * const variantRedirect = await handleVariantDeepLink({ request, storefrontClient });
+ * if (variantRedirect) return variantRedirect;
+ * ```
+ */
+export async function handleVariantDeepLink({
+  request,
+  storefrontClient,
+  routeTemplates = {},
+  pathPrefix,
+}: VariantDeepLinkOptions): Promise<Response | null> {
+  const url = new URL(request.url);
+
+  // Cheapest guard first: almost no traffic carries a variant param.
+  const variantId = getVariantIdParam({ searchParams: url.searchParams });
+  if (!variantId) return null;
+
+  const match = matchStandardRouteUrl({ url: request.url, routeTemplates, pathPrefix });
+  if (match?.route !== "product") return null;
+
+  const { data, errors } = await storefrontClient.graphql(VARIANT_DEEP_LINK_QUERY, {
+    variables: { id: variantId },
+  });
+
+  if (errors) {
+    console.error("[hydrogen] Variant deep link query failed", errors);
+  }
+
+  const node = data?.node;
+  if (!node || !("selectedOptions" in node)) return null;
+
+  const pathname = getStandardRoute(
+    routeTemplates,
+    "product",
+    { productHandle: node.product.handle },
+    { pathPrefix },
+  );
+
+  const search = buildOptionSearch(url.searchParams, node.selectedOptions);
+
+  // 307, not 308: option values are merchant-editable, so this mapping must not
+  // be cached in shoppers' browsers permanently.
+  return createRedirectResponse(`${pathname}${search}`, 307);
+}
+
+/**
+ * Swaps the variant param for the variant's option params, keeping everything
+ * else so campaign attribution (`utm_*`, `ref`) survives the redirect.
+ */
+function buildOptionSearch(
+  searchParams: URLSearchParams,
+  selectedOptions: ReadonlyArray<{ name: string; value: string }>,
+): string {
+  const params = new URLSearchParams(searchParams);
+  params.delete(VARIANT_PARAM);
+
+  for (const option of selectedOptions) {
+    if (option.name === DEFAULT_OPTION_NAME && option.value === DEFAULT_OPTION_VALUE) continue;
+    params.set(option.name, option.value);
+  }
+
+  const search = params.toString();
+  return search ? `?${search}` : "";
+}

--- a/packages/hydrogen/src/core/product/index.ts
+++ b/packages/hydrogen/src/core/product/index.ts
@@ -13,7 +13,7 @@ export type {
   ValidProductSelectionResult,
   VariantSelectionResult,
 } from "./product-form";
-export { getSelectedProductOptions } from "./options";
+export { getSelectedProductOptions, getVariantIdParam } from "./options";
 export { createProductFormRegister } from "./form";
 export type {
   ProductAddToCartProps,

--- a/packages/hydrogen/src/core/product/options.test.ts
+++ b/packages/hydrogen/src/core/product/options.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getSelectedProductOptions } from "./options";
+import { getSelectedProductOptions, getVariantIdParam } from "./options";
 
 describe("getSelectedProductOptions", () => {
   it("decodes special characters in option names and values", () => {
@@ -29,5 +29,50 @@ describe("getSelectedProductOptions", () => {
     params.set("Size", "M");
 
     expect(getSelectedProductOptions({ searchParams: params, allowedOptionNames: [] })).toEqual([]);
+  });
+});
+
+describe("getVariantIdParam", () => {
+  const gid = "gid://shopify/ProductVariant/41565182099480";
+
+  it("normalizes the bare legacy id Liquid storefronts emit", () => {
+    const params = new URLSearchParams("variant=41565182099480");
+
+    expect(getVariantIdParam({ searchParams: params })).toBe(gid);
+  });
+
+  it("accepts a full Storefront API GID", () => {
+    const params = new URLSearchParams();
+    params.set("variant", gid);
+
+    expect(getVariantIdParam({ searchParams: params })).toBe(gid);
+  });
+
+  it("returns null when the param is absent or empty", () => {
+    expect(getVariantIdParam({ searchParams: new URLSearchParams() })).toBeNull();
+    expect(getVariantIdParam({ searchParams: new URLSearchParams("variant=") })).toBeNull();
+    expect(getVariantIdParam({ searchParams: new URLSearchParams("variant=%20") })).toBeNull();
+  });
+
+  it("rejects GIDs for other resource types so they can't reach node(id:)", () => {
+    const params = new URLSearchParams();
+    params.set("variant", "gid://shopify/Customer/1");
+
+    expect(getVariantIdParam({ searchParams: params })).toBeNull();
+  });
+
+  it("rejects non-numeric and decorated ids", () => {
+    for (const value of ["not-an-id", "41565182099480 OR 1=1", `${gid}?namespace=x`, "-1", "1.5"]) {
+      const params = new URLSearchParams();
+      params.set("variant", value);
+
+      expect(getVariantIdParam({ searchParams: params })).toBeNull();
+    }
+  });
+
+  it("uses the first value when the param repeats", () => {
+    const params = new URLSearchParams("variant=41565182099480&variant=99999999999999");
+
+    expect(getVariantIdParam({ searchParams: params })).toBe(gid);
   });
 });

--- a/packages/hydrogen/src/core/product/options.ts
+++ b/packages/hydrogen/src/core/product/options.ts
@@ -1,3 +1,4 @@
+import { parseGid } from "../utils/parse-gid";
 import type {
   ProductInput,
   ProductOptionValueFrom,
@@ -60,6 +61,52 @@ export function getSelectedProductOptions({
   }
 
   return selectedOptions;
+}
+
+const VARIANT_ID_PARAM = "variant";
+const PRODUCT_VARIANT_GID_PREFIX = "gid://shopify/ProductVariant/";
+
+/**
+ * Reads an inbound `?variant=<id>` search param and normalizes it to a
+ * `ProductVariant` GID.
+ *
+ * Shopify's own surfaces — Liquid storefronts, Shopping feeds, email campaigns,
+ * paid ads, and Shop Pay links — deep-link to a product with a bare variant id
+ * (`/products/shoes?variant=41565182099480`) rather than one param per option.
+ * A storefront that only understands option params (`?Color=Red&Size=M`)
+ * silently drops that selection and renders the default variant, so every link
+ * a merchant already has in market lands on the wrong variant.
+ *
+ * Use this to detect such a link, resolve the variant, and redirect to your
+ * canonical option-param URL. Existing marketing links keep working without
+ * changing the URL contract the product page is built around.
+ *
+ * Returns `null` when the param is absent, empty, or is not a product variant
+ * id — including GIDs for other resource types, so an untrusted param can't be
+ * forwarded into a `node(id:)` lookup for an unrelated object.
+ *
+ * @example
+ * ```ts
+ * const variantId = getVariantIdParam({ searchParams });
+ * if (variantId) {
+ *   // Resolve the variant's selectedOptions, then redirect to the canonical URL.
+ * }
+ * ```
+ */
+export function getVariantIdParam({
+  searchParams,
+}: {
+  searchParams: URLSearchParams;
+}): string | null {
+  const raw = searchParams.get(VARIANT_ID_PARAM)?.trim();
+  if (!raw) return null;
+
+  // Accept both the bare legacy id Liquid emits and a full Storefront API GID.
+  const parsed = parseGid(raw);
+  if (parsed.resource && parsed.resource !== "ProductVariant") return null;
+
+  const bareId = parsed.id || raw;
+  return /^\d+$/.test(bareId) ? `${PRODUCT_VARIANT_GID_PREFIX}${bareId}` : null;
 }
 
 export function getAdjacentAndFirstSelectableVariants<TProduct extends ProductInput>(


### PR DESCRIPTION
TL;DR: Shopify's own surfaces deep-link to products with a bare variant id (`?variant=41565182099480`). Hydrogen product pages only read option params (`?Color=Red&Size=M`), so those links silently render the **default variant** instead of the one the shopper clicked. This adds a framework-agnostic interceptor that resolves the param, and wires it into the three examples.

Liquid storefronts, Shopping feeds, email campaigns, paid ads, and Shop Pay all emit `?variant=<id>` URLs. When a merchant migrates to Hydrogen, every one of those existing links breaks quietly — no error, no 404, just the wrong variant across their whole paid-acquisition surface.

## Before

An inbound link from a Shopping feed or ad:

```
/products/slides?variant=43695710437398   →   renders the default variant (Small)
```

The `variant` param is not an option name, so `getSelectedProductOptions` ignores it and the Storefront query falls back to `selectedOrFirstAvailableVariant`.

## After

```
/products/slides?variant=43695710437398   →   307   →   /products/slides?Size=Large
```

The shopper lands on the variant the link pointed at, and the URL matches what the variant picker itself would have produced.

## What this changes

Two new exports from `@shopify/hydrogen`:

- **`getVariantIdParam({ searchParams })`** — reads the `variant` param and normalizes it to a `ProductVariant` GID, accepting both the bare legacy id Liquid emits and a full GID. Returns `null` for anything that is not a product variant id, including GIDs for other resource types, so an untrusted param cannot be forwarded into a `node(id:)` lookup for an unrelated object. Built on the existing `parseGid`, matching how `shop-pay.ts` already validates variant ids.
- **`handleVariantDeepLink({ request, storefrontClient, routeTemplates, pathPrefix })`** — resolves the variant and returns a 307 `Response`, or `null` when the request is not a product URL with a resolvable variant. Mirrors the `handleUrlRedirects` interceptor shape.

```ts
const variantRedirect = await handleVariantDeepLink({ request, storefrontClient, routeTemplates });
if (variantRedirect) return variantRedirect;
```

Because resolution goes through `routeTemplates`, this works with no extra configuration for apps serving products from a custom path (`/p/:productHandle`) and apps using an i18n `pathPrefix` (`/en-ca/products/…`). The redirect preserves unrelated params (`utm_*`, `ref`) so campaign attribution survives, follows the variant's own product handle so a combined-listing variant lands on the right page, and skips Shopify's `Title` / `Default Title` sentinel so single-variant products do not pick up a meaningless param.

Wired into `examples/nextjs` (in `proxy.ts`), `examples/react-router` (in the storefront middleware), and `examples/hydrogen` (in `server.ts`).

This is **additive**. Option params remain the canonical URL contract and remain the no-JS mechanism described in `engineering.md` §F4. No existing URL behavior changes, and the canonical tag is untouched — variant params still do not affect it (§F10).

### Why it runs before rendering, not after a 404

`handleShopifyRedirects` is wired post-404 everywhere, which is right for admin-configured Storefront URL redirects: those only apply when the route does not exist. This is a different case — the product route exists and returns 200, and only the variant selection needs translating.

It also has to beat rendering. A page-level `redirect()` looks like it works, but under Next.js Cache Components the shell streams before the redirect can set a status, so it degrades to a client-side redirect. Measured in the Next.js example: the `?variant=` URL served **53KB with no add-to-cart**, versus **80KB** at the canonical URL. A shopper with JavaScript disabled following an ad link would land on an unusable page — breaking the very progressive-enhancement requirement this change is meant to respect. Redirecting ahead of framework routing keeps it a real HTTP redirect for everyone.

## Developer impact

Includes a **minor** changeset for `@shopify/hydrogen`. Both exports are additive; nothing existing changes signature or behavior.

One framework note worth knowing when adopting this: Hydrogen returns a relative `location`, which is what a framework router wants, but Next.js's proxy resolves the header with `new URL()` and throws on a relative value. The Next.js example rebuilds it against the request origin — see `examples/nextjs/proxy.ts`.

## UX impact

Shoppers arriving from a Shopify-generated link now see the variant that link referred to, with its correct price, image, and availability, instead of the product default. The address bar is normalized to the option-param form, so sharing or bookmarking produces the same URL the on-page picker would.

Unresolvable ids (a stale variant in an old feed, a malformed param) fall through and render the default variant rather than 404, so an outdated link degrades to today's behavior instead of an error page.

## Out of scope

- **`templates/nextjs` and `templates/react-router`.** Both templates depend on `"@shopify/hydrogen": "preview"` — the published npm package, not the workspace — so they cannot reference `handleVariantDeepLink` until a preview build ships it. Wiring them now would fail their typecheck. They are unchanged here and should follow in the usual "update Hydrogen preview package" pass. The wiring is two lines in each `proxy.ts` / `server.ts`; happy to open that follow-up once this lands and publishes.
- **Caching the variant lookup.** The `node(id:)` query runs per inbound deep link. Worth revisiting if it shows up in practice, but it seemed like the wrong thing to bake in without data.
- **`productInCollection` routes.** Only the `product` route template is matched. Shopify's feeds and ads emit `/products/:handle`, so collection-scoped product URLs with a variant param still render the default variant.

## Risk

- The redirect is **307, not 308**, deliberately: option values are merchant-editable, so this mapping must not be cached in shoppers' browsers permanently.
- It runs on every request in each app's pre-render hook. The variant-param check runs first and is a plain `searchParams.get`, and the Storefront lookup only fires on a product-route URL carrying a well-formed variant id, so ordinary traffic short-circuits before any I/O.
- `examples/hydrogen` is typechecked but **not runtime-verified** — it has no mock.shop fallback and throws on a missing `PRIVATE_STOREFRONT_API_TOKEN` before any of this code runs, so I could not exercise it locally. Its wiring mirrors `examples/react-router`, which is verified. Worth a reviewer with store credentials confirming.
- I inferred the URL-contract intent from `notes/product.md` and `engineering.md`. If maintainers would rather `?variant=` be served directly instead of redirected, `getVariantIdParam` still applies and only the interceptor changes.

## How to Test

1. Run `pnpm install && pnpm build:pkgs`.
2. Run `pnpm dev:next` (or `pnpm dev:rr` for the React Router example).
3. Visit `/products/slides` and note the default selection (Small).
4. Visit `/products/slides?variant=43695710437398`.
5. Confirm the browser lands on `/products/slides?Size=Large`, and that **Large** is the selected option with its price and availability.
6. Visit `/products/slides?variant=43695710404630&utm_source=google&ref=feed`.
7. Confirm you land on `/products/slides?utm_source=google&ref=feed&Size=Medium` — the campaign params survive.
8. Visit `/products/slides?variant=99999999999999` (a stale id) and confirm the page renders the default variant rather than a 404.
9. Visit `/cart?variant=43695710437398` and confirm no redirect happens.
10. Disable JavaScript in your browser and repeat step 4. Confirm you still land on the Large variant with a working add-to-cart form.

Steps 4–9 can also be checked with `curl -sI` to see the `307` and `location` header directly.

Verified against `mock.shop`, so no store credentials are needed for the Next.js and React Router examples.
