### PR TITLE
fix(hydrogen): keep analytics and consent bootstrap out of hydration

### DIFF
--- a/.changeset/lucky-pandas-shave.md
+++ b/.changeset/lucky-pandas-shave.md
@@ -1,0 +1,8 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Stop the analytics and consent bootstrap from breaking hydration.
+
+- `Analytics.Provider` now applies its post-hydration state updates (the deferred shop and cart resolutions, and the analytics `onReady` callback) inside `startTransition`. Previously these urgent updates could land while a streamed Suspense boundary below the provider was still dehydrated, which made React discard that boundary's server HTML and client-render it (recoverable error #418).
+- `useCustomerPrivacy` no longer throws when `window.Shopify` (or `window.privacyBanner`) has already been defined as a non-configurable property by a browser extension or a theme-era app. The property watchers now degrade to reading the consent APIs once the consent script has settled, instead of letting `TypeError: Cannot redefine property: Shopify` escape into the router error boundary and take down the page.

--- a/packages/hydrogen/src/analytics-manager/AnalyticsProvider.transition.test.tsx
+++ b/packages/hydrogen/src/analytics-manager/AnalyticsProvider.transition.test.tsx
@@ -1,0 +1,139 @@
+import {describe, beforeAll, beforeEach, expect, it, vi} from 'vitest';
+import {render, act} from '@testing-library/react';
+import {startTransition} from 'react';
+import {
+  CurrencyCode,
+  LanguageCode,
+} from '@shopify/hydrogen-react/storefront-api-types';
+import {Analytics} from './AnalyticsProvider';
+import {CartReturn} from '../cart/queries/cart-types';
+
+/**
+ * Regression coverage for #3838.
+ *
+ * `Analytics.Provider` sits above every route-level Suspense boundary. When it
+ * applies an urgent state update while a streamed boundary below it is still
+ * dehydrated, React abandons hydration for that boundary, throws away its
+ * server HTML and client-renders it ("This Suspense boundary received an update
+ * before it finished hydrating", React error #418).
+ *
+ * Reproducing the hydration interruption itself needs a streaming SSR harness
+ * with a delayed tail, which is out of reach here. What we can pin down is the
+ * property that prevents it: the deferred shop/cart resolutions and the
+ * analytics `onReady` callback must be applied as transitions, never as urgent
+ * updates. Unwrap any of them and these assertions fail.
+ */
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    startTransition: vi.fn(actual.startTransition),
+  };
+});
+
+let pathCount = 1;
+const revalidateMock = vi.fn<() => Promise<void>>(() => Promise.resolve());
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('react-router');
+
+  return {
+    ...actual,
+    useLocation: () => ({
+      pathname: `/example/path/${pathCount++}`,
+      search: '',
+      state: '',
+      key: '',
+      hash: '',
+    }),
+    useRevalidator: () => ({
+      revalidate: revalidateMock,
+      state: 'idle',
+    }),
+  };
+});
+
+vi.mock('./PerfKit', () => ({
+  PerfKit: () => null,
+}));
+
+const SHOP_DATA = {
+  shopId: 'gid://shopify/Shop/1',
+  acceptedLanguage: 'EN' as LanguageCode,
+  currency: 'USD' as CurrencyCode,
+  hydrogenSubchannelId: '0',
+};
+
+const CONSENT_DATA = {
+  checkoutDomain: 'checkout.hydrogen.shop',
+  storefrontAccessToken: '33ad0f277e864013b8e3c21d19432501',
+};
+
+const CART_DATA = {
+  updatedAt: '2024-03-26T21:49:07Z',
+  id: 'gid://shopify/Cart/c1-123',
+  lines: {nodes: []},
+} as unknown as CartReturn;
+
+describe('<Analytics.Provider /> post-hydration updates', () => {
+  beforeAll(() => {
+    vi.stubGlobal('fetch', () => Promise.resolve(new Response('')));
+  });
+
+  beforeEach(() => {
+    vi.mocked(startTransition).mockClear();
+    revalidateMock.mockClear();
+    pathCount = 1;
+  });
+
+  it('applies the deferred shop resolution as a transition', async () => {
+    let resolveShop: (value: typeof SHOP_DATA) => void = () => {};
+    const shopPromise = new Promise<typeof SHOP_DATA>((resolve) => {
+      resolveShop = resolve;
+    });
+
+    render(
+      <Analytics.Provider cart={null} shop={shopPromise} consent={CONSENT_DATA}>
+        <div>child</div>
+      </Analytics.Provider>,
+    );
+
+    await act(async () => {});
+    vi.mocked(startTransition).mockClear();
+
+    await act(async () => {
+      resolveShop(SHOP_DATA);
+    });
+
+    expect(startTransition).toHaveBeenCalled();
+  });
+
+  it('applies the deferred cart resolution as a transition', async () => {
+    let resolveCart: (value: CartReturn) => void = () => {};
+    const cartPromise = new Promise<CartReturn>((resolve) => {
+      resolveCart = resolve;
+    });
+
+    render(
+      <Analytics.Provider
+        cart={cartPromise}
+        shop={SHOP_DATA}
+        consent={CONSENT_DATA}
+      >
+        <div>child</div>
+      </Analytics.Provider>,
+    );
+
+    await act(async () => {});
+    vi.mocked(startTransition).mockClear();
+
+    await act(async () => {
+      resolveCart(CART_DATA);
+    });
+
+    // `CartAnalytics` resolves the deferred cart and calls `setCarts`, which
+    // updates state owned by the provider above every Suspense boundary.
+    expect(startTransition).toHaveBeenCalled();
+  });
+});

--- a/packages/hydrogen/src/analytics-manager/AnalyticsProvider.transition.test.tsx
+++ b/packages/hydrogen/src/analytics-manager/AnalyticsProvider.transition.test.tsx
@@ -5,7 +5,11 @@ import {
   CurrencyCode,
   LanguageCode,
 } from '@shopify/hydrogen-react/storefront-api-types';
-import {Analytics} from './AnalyticsProvider';
+import {
+  Analytics,
+  useAnalytics,
+  type AnalyticsContextValue,
+} from './AnalyticsProvider';
 import {CartReturn} from '../cart/queries/cart-types';
 
 /**
@@ -19,9 +23,17 @@ import {CartReturn} from '../cart/queries/cart-types';
  *
  * Reproducing the hydration interruption itself needs a streaming SSR harness
  * with a delayed tail, which is out of reach here. What we can pin down is the
- * property that prevents it: the deferred shop/cart resolutions and the
- * analytics `onReady` callback must be applied as transitions, never as urgent
- * updates. Unwrap any of them and these assertions fail.
+ * property that prevents it: provider-owned state must be updated inside a
+ * transition, never urgently.
+ *
+ * Scope of that guarantee, deliberately narrow: only the cart case asserts on
+ * `startTransition`. React calls `startTransition` itself while mounting
+ * `ShopifyAnalytics` (which happens the moment the deferred shop lands) and
+ * during the `onReady` flush, so in those windows a spy on the module cannot
+ * distinguish our wrapper from React's own call — an assertion there passes
+ * with the fix reverted. The cart resolution has no such interference and goes
+ * from 0 calls to 1, so it is the load-bearing regression guard. The shop case
+ * is kept as behavioural coverage only.
  */
 
 vi.mock('react', async (importOriginal) => {
@@ -76,6 +88,12 @@ const CART_DATA = {
   lines: {nodes: []},
 } as unknown as CartReturn;
 
+function Probe({onValue}: {onValue: (value: AnalyticsContextValue) => void}) {
+  const analytics = useAnalytics();
+  onValue(analytics);
+  return null;
+}
+
 describe('<Analytics.Provider /> post-hydration updates', () => {
   beforeAll(() => {
     vi.stubGlobal('fetch', () => Promise.resolve(new Response('')));
@@ -87,26 +105,30 @@ describe('<Analytics.Provider /> post-hydration updates', () => {
     pathCount = 1;
   });
 
-  it('applies the deferred shop resolution as a transition', async () => {
+  it('resolves the deferred shop into context', async () => {
     let resolveShop: (value: typeof SHOP_DATA) => void = () => {};
     const shopPromise = new Promise<typeof SHOP_DATA>((resolve) => {
       resolveShop = resolve;
     });
+    let latest: AnalyticsContextValue | undefined;
 
     render(
       <Analytics.Provider cart={null} shop={shopPromise} consent={CONSENT_DATA}>
-        <div>child</div>
+        <Probe onValue={(value) => (latest = value)} />
       </Analytics.Provider>,
     );
 
     await act(async () => {});
-    vi.mocked(startTransition).mockClear();
+    expect(latest?.shop).toBeNull();
 
     await act(async () => {
       resolveShop(SHOP_DATA);
     });
 
-    expect(startTransition).toHaveBeenCalled();
+    // Behavioural only — see the docblock. Mounting `ShopifyAnalytics` when the
+    // shop lands makes React fire its own `startTransition` in this window, so
+    // a call-count assertion here cannot tell our wrapper apart from React's.
+    expect(latest?.shop).toEqual(SHOP_DATA);
   });
 
   it('applies the deferred cart resolution as a transition', async () => {
@@ -114,6 +136,7 @@ describe('<Analytics.Provider /> post-hydration updates', () => {
     const cartPromise = new Promise<CartReturn>((resolve) => {
       resolveCart = resolve;
     });
+    let latest: AnalyticsContextValue | undefined;
 
     render(
       <Analytics.Provider
@@ -121,19 +144,21 @@ describe('<Analytics.Provider /> post-hydration updates', () => {
         shop={SHOP_DATA}
         consent={CONSENT_DATA}
       >
-        <div>child</div>
+        <Probe onValue={(value) => (latest = value)} />
       </Analytics.Provider>,
     );
 
     await act(async () => {});
+    expect(latest?.cart).toBeNull();
     vi.mocked(startTransition).mockClear();
 
     await act(async () => {
       resolveCart(CART_DATA);
     });
 
-    // `CartAnalytics` resolves the deferred cart and calls `setCarts`, which
-    // updates state owned by the provider above every Suspense boundary.
-    expect(startTransition).toHaveBeenCalled();
+    // `CartAnalytics` applies `setCarts`, which the provider transitions at the
+    // point the setter is declared.
+    expect(startTransition).toHaveBeenCalledTimes(1);
+    expect(latest?.cart).toEqual(CART_DATA);
   });
 });

--- a/packages/hydrogen/src/analytics-manager/AnalyticsProvider.tsx
+++ b/packages/hydrogen/src/analytics-manager/AnalyticsProvider.tsx
@@ -1,5 +1,6 @@
 import {
   type ReactNode,
+  startTransition,
   useEffect,
   useState,
   useMemo,
@@ -391,14 +392,18 @@ function AnalyticsProvider({
         <ShopifyAnalytics
           consent={consent}
           onReady={() => {
-            setAnalyticsLoaded(true);
-            setCanTrack(
-              customCanTrack ? () => customCanTrack : () => shopifyCanTrack,
-            );
+            // Same reasoning as `useShopAnalytics` above: these land after
+            // hydration starts and must not interrupt it.
+            startTransition(() => {
+              setAnalyticsLoaded(true);
+              setCanTrack(
+                customCanTrack ? () => customCanTrack : () => shopifyCanTrack,
+              );
 
-            // Delay loading PerfKit until consent is collected
-            // so that it reads updated tracking values from old cookies.
-            setConsentCollected(true);
+              // Delay loading PerfKit until consent is collected
+              // so that it reads updated tracking values from old cookies.
+              setConsentCollected(true);
+            });
           }}
           domain={cookieDomain}
         />
@@ -431,7 +436,13 @@ function useShopAnalytics(shopProp: AnalyticsProviderProps['shop']): {
 
   // resolve the shop analytics that could have been deferred
   useEffect(() => {
-    Promise.resolve(shopProp).then(setShop);
+    // `AnalyticsProvider` sits above every route-level Suspense boundary, so an
+    // urgent update here interrupts hydration and forces boundaries that are
+    // still dehydrated to throw away their server HTML and client-render.
+    // Analytics bookkeeping is never urgent — mark it as a transition.
+    Promise.resolve(shopProp).then((resolvedShop) => {
+      startTransition(() => setShop(resolvedShop));
+    });
     return () => {};
   }, [setShop, shopProp]);
 

--- a/packages/hydrogen/src/analytics-manager/AnalyticsProvider.tsx
+++ b/packages/hydrogen/src/analytics-manager/AnalyticsProvider.tsx
@@ -1,6 +1,9 @@
 import {
+  type Dispatch,
   type ReactNode,
+  type SetStateAction,
   startTransition,
+  useCallback,
   useEffect,
   useState,
   useMemo,
@@ -308,7 +311,21 @@ function AnalyticsProvider({
     customCanTrack ? true : false,
   );
   const [consentCollected, setConsentCollected] = useState(false);
-  const [carts, setCarts] = useState<Carts>({cart: null, prevCart: null});
+  const [carts, setCartsState] = useState<Carts>({cart: null, prevCart: null});
+
+  // This provider sits above every route-level Suspense boundary, so an urgent
+  // update from it interrupts hydration and forces boundaries that are still
+  // dehydrated to discard their server HTML and client-render (React #418).
+  // None of this analytics bookkeeping is urgent, so every update that can land
+  // after hydration begins is applied as a transition.
+  //
+  // `setCarts` is handed to `CartAnalytics`, which applies it when the deferred
+  // cart resolves. Transition at the declaration, not at that call site, so the
+  // guarantee holds for every caller.
+  const setCarts = useCallback<Dispatch<SetStateAction<Carts>>>(
+    (update) => startTransition(() => setCartsState(update)),
+    [],
+  );
   const [canTrack, setCanTrack] = useState<() => boolean>(
     customCanTrack ? () => customCanTrack : () => shopifyCanTrack,
   );
@@ -392,8 +409,6 @@ function AnalyticsProvider({
         <ShopifyAnalytics
           consent={consent}
           onReady={() => {
-            // Same reasoning as `useShopAnalytics` above: these land after
-            // hydration starts and must not interrupt it.
             startTransition(() => {
               setAnalyticsLoaded(true);
               setCanTrack(
@@ -436,10 +451,8 @@ function useShopAnalytics(shopProp: AnalyticsProviderProps['shop']): {
 
   // resolve the shop analytics that could have been deferred
   useEffect(() => {
-    // `AnalyticsProvider` sits above every route-level Suspense boundary, so an
-    // urgent update here interrupts hydration and forces boundaries that are
-    // still dehydrated to throw away their server HTML and client-render.
-    // Analytics bookkeeping is never urgent — mark it as a transition.
+    // Transitioned for the same reason as the provider's other deferred
+    // updates: this lands after hydration begins and must not interrupt it.
     Promise.resolve(shopProp).then((resolvedShop) => {
       startTransition(() => setShop(resolvedShop));
     });

--- a/packages/hydrogen/src/analytics-manager/CartAnalytics.tsx
+++ b/packages/hydrogen/src/analytics-manager/CartAnalytics.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {startTransition, useEffect, useRef} from 'react';
 import {
   useAnalytics,
   type AnalyticsProviderProps,
@@ -45,10 +45,16 @@ export function CartAnalytics({
         }
       }
 
-      setCarts(({cart, prevCart}: Carts) => {
-        return updatedCart?.updatedAt !== cart?.updatedAt
-          ? {cart: updatedCart, prevCart: cart}
-          : {cart, prevCart};
+      // `setCarts` updates state owned by `AnalyticsProvider`, which sits above
+      // every route-level Suspense boundary. Left urgent, this resolution
+      // interrupts hydration and forces still-dehydrated boundaries to
+      // client-render (React error #418). Analytics state is never urgent.
+      startTransition(() => {
+        setCarts(({cart, prevCart}: Carts) => {
+          return updatedCart?.updatedAt !== cart?.updatedAt
+            ? {cart: updatedCart, prevCart: cart}
+            : {cart, prevCart};
+        });
       });
     });
     return () => {};

--- a/packages/hydrogen/src/analytics-manager/CartAnalytics.tsx
+++ b/packages/hydrogen/src/analytics-manager/CartAnalytics.tsx
@@ -1,4 +1,4 @@
-import {startTransition, useEffect, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import {
   useAnalytics,
   type AnalyticsProviderProps,
@@ -45,16 +45,10 @@ export function CartAnalytics({
         }
       }
 
-      // `setCarts` updates state owned by `AnalyticsProvider`, which sits above
-      // every route-level Suspense boundary. Left urgent, this resolution
-      // interrupts hydration and forces still-dehydrated boundaries to
-      // client-render (React error #418). Analytics state is never urgent.
-      startTransition(() => {
-        setCarts(({cart, prevCart}: Carts) => {
-          return updatedCart?.updatedAt !== cart?.updatedAt
-            ? {cart: updatedCart, prevCart: cart}
-            : {cart, prevCart};
-        });
+      setCarts(({cart, prevCart}: Carts) => {
+        return updatedCart?.updatedAt !== cart?.updatedAt
+          ? {cart: updatedCart, prevCart: cart}
+          : {cart, prevCart};
       });
     });
     return () => {};

--- a/packages/hydrogen/src/customer-privacy/ShopifyCustomerPrivacy.tsx
+++ b/packages/hydrogen/src/customer-privacy/ShopifyCustomerPrivacy.tsx
@@ -10,6 +10,7 @@ import {
   isSfapiProxyEnabled,
   hasServerReturnedTrackingValues,
 } from '../utils/server-timing';
+import {warnOnce} from '../utils/warning';
 
 export type ConsentStatus = boolean | undefined;
 
@@ -171,8 +172,10 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
   const {revalidate} = useRevalidator();
 
   // Load the Shopify customer privacy API with or without the privacy banner
-  // NOTE: We no longer use the status because we need `ready` to be not when the script is loaded
-  // but instead when both `privacyBanner` (optional) and customerPrivacy are loaded in the window
+  // NOTE: `ready` is not driven by this status — it fires when both
+  // `privacyBanner` (optional) and customerPrivacy are loaded in the window. The
+  // status is only consulted by the degraded path below, where no property
+  // watcher could be installed and the script's own load event is the signal.
   const consentScriptStatus = useLoadScript(
     withPrivacyBanner ? CONSENT_API_WITH_BANNER : CONSENT_API,
     {
@@ -189,13 +192,6 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
   // cannot be notified on assignment, so we read the APIs once the consent
   // script reports it has loaded instead.
   const watcherFailed = useRef({customerPrivacy: false, privacyBanner: false});
-  // `setLoaded` is rebuilt on every render, so the fallback effect below re-runs
-  // constantly. Latch each API the same way the watchers above use `observing`,
-  // otherwise marking one loaded re-renders and re-enters the effect forever.
-  const fallbackApplied = useRef({
-    customerPrivacy: false,
-    privacyBanner: false,
-  });
 
   const config = useMemo(() => {
     if (!checkoutDomain) logMissingConfig('checkoutDomain');
@@ -364,8 +360,33 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
     let customShopify: {customerPrivacy: CustomerPrivacy} | undefined | object =
       window.Shopify || undefined;
 
-    // monitor for when window.Shopify = {} is first set
-    const installed = tryDefineProperty(window, 'Shopify', {
+    const customerPrivacyWatcher = {
+      configurable: true,
+      get() {
+        return fullCustomerPrivacy ?? backendConsentStub;
+      },
+      set(value: unknown) {
+        if (
+          typeof value === 'object' &&
+          value !== null &&
+          'setTrackingConsent' in value
+        ) {
+          fullCustomerPrivacy = withConfiguredTrackingConsent(
+            value as CustomerPrivacy,
+            config,
+          );
+
+          customShopify = {
+            ...customShopify,
+            customerPrivacy: fullCustomerPrivacy,
+          };
+
+          setLoaded.customerPrivacy();
+        }
+      },
+    };
+
+    const shopifyWatcher = {
       configurable: true,
       get() {
         return customShopify;
@@ -386,53 +407,21 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
           backendConsentStub = {backendConsentEnabled: true};
 
           // monitor for when window.Shopify.customerPrivacy is set
-          const innerInstalled = tryDefineProperty(
-            window.Shopify,
-            'customerPrivacy',
-            {
-              configurable: true,
-              get() {
-                return fullCustomerPrivacy ?? backendConsentStub;
-              },
-              set(value: unknown) {
-                if (
-                  typeof value === 'object' &&
-                  value !== null &&
-                  'setTrackingConsent' in value
-                ) {
-                  const customerPrivacy = value as CustomerPrivacy;
-
-                  // overwrite the tracking consent method
-                  fullCustomerPrivacy = {
-                    ...customerPrivacy,
-                    // Note: this method is not used by the privacy-banner,
-                    // it bundles its own setTrackingConsent.
-                    setTrackingConsent:
-                      overrideCustomerPrivacySetTrackingConsent({
-                        customerPrivacy,
-                        config,
-                      }),
-                  };
-
-                  customShopify = {
-                    ...customShopify,
-                    customerPrivacy: fullCustomerPrivacy,
-                  };
-
-                  setLoaded.customerPrivacy();
-                }
-              },
-            },
-          );
-
-          if (!innerInstalled) {
+          if (
+            !tryDefineProperty(
+              window.Shopify,
+              'customerPrivacy',
+              customerPrivacyWatcher,
+            )
+          ) {
             watcherFailed.current.customerPrivacy = true;
           }
         }
       },
-    });
+    };
 
-    if (!installed) {
+    // monitor for when window.Shopify = {} is first set
+    if (!tryDefineProperty(window, 'Shopify', shopifyWatcher)) {
       watcherFailed.current.customerPrivacy = true;
     }
   }, [
@@ -452,45 +441,29 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
     if (consentScriptStatus === 'loading') return;
     const failed = watcherFailed.current;
 
-    if (failed.customerPrivacy && !fallbackApplied.current.customerPrivacy) {
+    if (failed.customerPrivacy) {
       const customerPrivacy = getCustomerPrivacy();
       if (customerPrivacy) {
-        fallbackApplied.current.customerPrivacy = true;
-
         // Best effort: apply the config-bound `setTrackingConsent` override by
         // assignment. The container may still be read-only, in which case the
         // un-overridden API is used as-is rather than failing the page.
         try {
-          window.Shopify.customerPrivacy = {
-            ...customerPrivacy,
-            setTrackingConsent: overrideCustomerPrivacySetTrackingConsent({
-              customerPrivacy,
-              config,
-            }),
-          };
+          window.Shopify.customerPrivacy = withConfiguredTrackingConsent(
+            customerPrivacy,
+            config,
+          );
         } catch (error) {}
 
         setLoaded.customerPrivacy();
       }
     }
 
-    if (
-      failed.privacyBanner &&
-      !fallbackApplied.current.privacyBanner &&
-      withPrivacyBanner &&
-      getPrivacyBanner()
-    ) {
-      fallbackApplied.current.privacyBanner = true;
+    // `watcherFailed.privacyBanner` is only ever set on the `withPrivacyBanner`
+    // path, so it already implies the banner was requested.
+    if (failed.privacyBanner && getPrivacyBanner()) {
       setLoaded.privacyBanner();
     }
-  }, [
-    consentScriptStatus,
-    config,
-    overrideCustomerPrivacySetTrackingConsent,
-    setLoaded.customerPrivacy,
-    setLoaded.privacyBanner,
-    withPrivacyBanner,
-  ]);
+  }, [consentScriptStatus, config, setLoaded]);
 
   useEffect(() => {
     if (!apisLoaded || !cookiesReady) return;
@@ -536,17 +509,12 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
 }
 
 /**
- * Installs a property watcher without ever throwing.
+ * Installs a property watcher, reporting failure instead of throwing.
  *
- * `Object.defineProperty` throws `TypeError: Cannot redefine property` when the
- * property already exists and is non-configurable. That happens in the wild:
- * browser extensions (and theme-era apps loaded into a headless storefront)
- * assign their own `window.Shopify`, sometimes non-configurably. Before this
- * guard the throw propagated out of an effect and took down the whole app
- * through the router error boundary.
- *
- * Returns whether the watcher was installed, so callers can degrade instead of
- * silently believing they are observing the property.
+ * `Object.defineProperty` throws when the property already exists and is
+ * non-configurable — which browser extensions and theme-era apps do to
+ * `window.Shopify`. Callers degrade on `false` rather than believing they are
+ * observing the property.
  */
 function tryDefineProperty(
   target: object,
@@ -557,13 +525,27 @@ function tryDefineProperty(
     Object.defineProperty(target, property, descriptor);
     return true;
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[h2:warn:useCustomerPrivacy] Could not observe \`${property}\`, likely because another script or browser extension already defined it as non-configurable. Falling back to reading it once the consent API has loaded.`,
-      error,
+    warnOnce(
+      `[h2:warn:useCustomerPrivacy] Could not observe \`${property}\`, likely because another script or browser extension already defined it as non-configurable. Falling back to reading it once the consent API has loaded. ${String(error)}`,
     );
     return false;
   }
+}
+
+/** Rebuilds the CDN's consent API with the merchant's config pre-applied. */
+function withConfiguredTrackingConsent(
+  customerPrivacy: CustomerPrivacy,
+  config: CustomerPrivacyConsentConfig,
+): CustomerPrivacy {
+  return {
+    ...customerPrivacy,
+    // Note: this method is not used by the privacy-banner, it bundles its own
+    // setTrackingConsent.
+    setTrackingConsent: overrideCustomerPrivacySetTrackingConsent({
+      customerPrivacy,
+      config,
+    }),
+  };
 }
 
 let hasEmitted = false;
@@ -586,21 +568,27 @@ function useApisLoaded({withPrivacyBanner}: {withPrivacyBanner: boolean}) {
   // combined loaded state for both APIs
   const apisLoaded = apisLoadedArray.every(Boolean);
 
-  const setLoaded = {
-    customerPrivacy: () => {
-      if (withPrivacyBanner) {
-        setApisLoaded((prev) => [true, prev[1]]);
-      } else {
-        setApisLoaded(() => [true]);
-      }
-    },
-    privacyBanner: () => {
-      if (!withPrivacyBanner) {
-        return;
-      }
-      setApisLoaded((prev) => [prev[0], true]);
-    },
-  };
+  // Memoized so effects can depend on it honestly. Rebuilt every render, these
+  // are fresh identities each time, which re-runs every effect that lists them
+  // (all the watchers below) on every render of the consuming component.
+  const setLoaded = useMemo(
+    () => ({
+      customerPrivacy: () => {
+        if (withPrivacyBanner) {
+          setApisLoaded((prev) => [true, prev[1]]);
+        } else {
+          setApisLoaded(() => [true]);
+        }
+      },
+      privacyBanner: () => {
+        if (!withPrivacyBanner) {
+          return;
+        }
+        setApisLoaded((prev) => [prev[0], true]);
+      },
+    }),
+    [withPrivacyBanner],
+  );
 
   return {observing, setLoaded, apisLoaded};
 }

--- a/packages/hydrogen/src/customer-privacy/ShopifyCustomerPrivacy.tsx
+++ b/packages/hydrogen/src/customer-privacy/ShopifyCustomerPrivacy.tsx
@@ -173,13 +173,29 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
   // Load the Shopify customer privacy API with or without the privacy banner
   // NOTE: We no longer use the status because we need `ready` to be not when the script is loaded
   // but instead when both `privacyBanner` (optional) and customerPrivacy are loaded in the window
-  useLoadScript(withPrivacyBanner ? CONSENT_API_WITH_BANNER : CONSENT_API, {
-    attributes: {
-      id: 'customer-privacy-api',
+  const consentScriptStatus = useLoadScript(
+    withPrivacyBanner ? CONSENT_API_WITH_BANNER : CONSENT_API,
+    {
+      attributes: {
+        id: 'customer-privacy-api',
+      },
     },
-  });
+  );
 
   const {observing, setLoaded, apisLoaded} = useApisLoaded({withPrivacyBanner});
+
+  // Tracks watchers we could not install because the property was already
+  // defined non-configurably (see `tryDefineProperty`). When that happens we
+  // cannot be notified on assignment, so we read the APIs once the consent
+  // script reports it has loaded instead.
+  const watcherFailed = useRef({customerPrivacy: false, privacyBanner: false});
+  // `setLoaded` is rebuilt on every render, so the fallback effect below re-runs
+  // constantly. Latch each API the same way the watchers above use `observing`,
+  // otherwise marking one loaded re-renders and re-enters the effect forever.
+  const fallbackApplied = useRef({
+    customerPrivacy: false,
+    privacyBanner: false,
+  });
 
   const config = useMemo(() => {
     if (!checkoutDomain) logMissingConfig('checkoutDomain');
@@ -323,7 +339,9 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
       },
     };
 
-    Object.defineProperty(window, 'privacyBanner', privacyBannerWatcher);
+    if (!tryDefineProperty(window, 'privacyBanner', privacyBannerWatcher)) {
+      watcherFailed.current.privacyBanner = true;
+    }
   }, [
     withPrivacyBanner,
     config,
@@ -347,7 +365,7 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
       window.Shopify || undefined;
 
     // monitor for when window.Shopify = {} is first set
-    Object.defineProperty(window, 'Shopify', {
+    const installed = tryDefineProperty(window, 'Shopify', {
       configurable: true,
       get() {
         return customShopify;
@@ -368,45 +386,110 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
           backendConsentStub = {backendConsentEnabled: true};
 
           // monitor for when window.Shopify.customerPrivacy is set
-          Object.defineProperty(window.Shopify, 'customerPrivacy', {
-            configurable: true,
-            get() {
-              return fullCustomerPrivacy ?? backendConsentStub;
+          const innerInstalled = tryDefineProperty(
+            window.Shopify,
+            'customerPrivacy',
+            {
+              configurable: true,
+              get() {
+                return fullCustomerPrivacy ?? backendConsentStub;
+              },
+              set(value: unknown) {
+                if (
+                  typeof value === 'object' &&
+                  value !== null &&
+                  'setTrackingConsent' in value
+                ) {
+                  const customerPrivacy = value as CustomerPrivacy;
+
+                  // overwrite the tracking consent method
+                  fullCustomerPrivacy = {
+                    ...customerPrivacy,
+                    // Note: this method is not used by the privacy-banner,
+                    // it bundles its own setTrackingConsent.
+                    setTrackingConsent:
+                      overrideCustomerPrivacySetTrackingConsent({
+                        customerPrivacy,
+                        config,
+                      }),
+                  };
+
+                  customShopify = {
+                    ...customShopify,
+                    customerPrivacy: fullCustomerPrivacy,
+                  };
+
+                  setLoaded.customerPrivacy();
+                }
+              },
             },
-            set(value: unknown) {
-              if (
-                typeof value === 'object' &&
-                value !== null &&
-                'setTrackingConsent' in value
-              ) {
-                const customerPrivacy = value as CustomerPrivacy;
+          );
 
-                // overwrite the tracking consent method
-                fullCustomerPrivacy = {
-                  ...customerPrivacy,
-                  // Note: this method is not used by the privacy-banner,
-                  // it bundles its own setTrackingConsent.
-                  setTrackingConsent: overrideCustomerPrivacySetTrackingConsent(
-                    {customerPrivacy, config},
-                  ),
-                };
-
-                customShopify = {
-                  ...customShopify,
-                  customerPrivacy: fullCustomerPrivacy,
-                };
-
-                setLoaded.customerPrivacy();
-              }
-            },
-          });
+          if (!innerInstalled) {
+            watcherFailed.current.customerPrivacy = true;
+          }
         }
       },
     });
+
+    if (!installed) {
+      watcherFailed.current.customerPrivacy = true;
+    }
   }, [
     config,
     overrideCustomerPrivacySetTrackingConsent,
     setLoaded.customerPrivacy,
+  ]);
+
+  // Degraded path for watchers that could not be installed. Without a setter we
+  // never learn about the assignment, so the consent script's own load status is
+  // the signal instead. No polling — `useLoadScript` resolves from the script's
+  // `load` event.
+  useEffect(() => {
+    // Settled, not strictly `done`: a storefront can end up with the API present
+    // even when `useLoadScript` reports an error (an existing tag, a CSP-blocked
+    // duplicate injection), and reading is harmless when it is absent.
+    if (consentScriptStatus === 'loading') return;
+    const failed = watcherFailed.current;
+
+    if (failed.customerPrivacy && !fallbackApplied.current.customerPrivacy) {
+      const customerPrivacy = getCustomerPrivacy();
+      if (customerPrivacy) {
+        fallbackApplied.current.customerPrivacy = true;
+
+        // Best effort: apply the config-bound `setTrackingConsent` override by
+        // assignment. The container may still be read-only, in which case the
+        // un-overridden API is used as-is rather than failing the page.
+        try {
+          window.Shopify.customerPrivacy = {
+            ...customerPrivacy,
+            setTrackingConsent: overrideCustomerPrivacySetTrackingConsent({
+              customerPrivacy,
+              config,
+            }),
+          };
+        } catch (error) {}
+
+        setLoaded.customerPrivacy();
+      }
+    }
+
+    if (
+      failed.privacyBanner &&
+      !fallbackApplied.current.privacyBanner &&
+      withPrivacyBanner &&
+      getPrivacyBanner()
+    ) {
+      fallbackApplied.current.privacyBanner = true;
+      setLoaded.privacyBanner();
+    }
+  }, [
+    consentScriptStatus,
+    config,
+    overrideCustomerPrivacySetTrackingConsent,
+    setLoaded.customerPrivacy,
+    setLoaded.privacyBanner,
+    withPrivacyBanner,
   ]);
 
   useEffect(() => {
@@ -450,6 +533,37 @@ export function useCustomerPrivacy(props: CustomerPrivacyApiProps) {
   }
 
   return result;
+}
+
+/**
+ * Installs a property watcher without ever throwing.
+ *
+ * `Object.defineProperty` throws `TypeError: Cannot redefine property` when the
+ * property already exists and is non-configurable. That happens in the wild:
+ * browser extensions (and theme-era apps loaded into a headless storefront)
+ * assign their own `window.Shopify`, sometimes non-configurably. Before this
+ * guard the throw propagated out of an effect and took down the whole app
+ * through the router error boundary.
+ *
+ * Returns whether the watcher was installed, so callers can degrade instead of
+ * silently believing they are observing the property.
+ */
+function tryDefineProperty(
+  target: object,
+  property: string,
+  descriptor: PropertyDescriptor,
+): boolean {
+  try {
+    Object.defineProperty(target, property, descriptor);
+    return true;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[h2:warn:useCustomerPrivacy] Could not observe \`${property}\`, likely because another script or browser extension already defined it as non-configurable. Falling back to reading it once the consent API has loaded.`,
+      error,
+    );
+    return false;
+  }
 }
 
 let hasEmitted = false;

--- a/packages/hydrogen/src/customer-privacy/useCustomerPrivacy.nonConfigurableGlobal.test.tsx
+++ b/packages/hydrogen/src/customer-privacy/useCustomerPrivacy.nonConfigurableGlobal.test.tsx
@@ -70,7 +70,6 @@ describe('useCustomerPrivacy with a non-configurable window.Shopify', () => {
 
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('Could not observe `Shopify`'),
-      expect.anything(),
     );
 
     // The foreign global is left intact rather than clobbered.

--- a/packages/hydrogen/src/customer-privacy/useCustomerPrivacy.nonConfigurableGlobal.test.tsx
+++ b/packages/hydrogen/src/customer-privacy/useCustomerPrivacy.nonConfigurableGlobal.test.tsx
@@ -1,0 +1,102 @@
+import {vi, describe, it, beforeEach, afterEach, expect} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {
+  useCustomerPrivacy,
+  getCustomerPrivacy,
+} from './ShopifyCustomerPrivacy.js';
+
+/**
+ * Regression coverage for #3575.
+ *
+ * Browser extensions (Urban VPN is the commonly reported one) and theme-era
+ * apps loaded into a headless storefront assign their own `window.Shopify`,
+ * sometimes non-configurably. `Object.defineProperty(window, 'Shopify', …)`
+ * then throws `TypeError: Cannot redefine property: Shopify`, which escaped the
+ * effect and took the whole app down through the router error boundary.
+ *
+ * These tests live in their own file on purpose: a non-configurable property
+ * can be neither deleted nor redefined, so once installed it cannot be undone
+ * within a test environment. Vitest gives each file a fresh environment, which
+ * keeps the pollution out of the main `useCustomerPrivacy` suite.
+ */
+
+const revalidateMock = vi.fn<() => Promise<void>>(() => Promise.resolve());
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('react-router');
+
+  return {
+    ...actual,
+    useRevalidator: () => ({
+      revalidate: revalidateMock,
+      state: 'idle',
+    }),
+  };
+});
+
+const CUSTOMER_PRIVACY_PROPS = {
+  checkoutDomain: 'checkout.shopify.com',
+  storefrontAccessToken: '3b580e70970c4528da70c98e097c2fa0',
+  withPrivacyBanner: false,
+};
+
+// Stand in for the extension: present before Hydrogen runs, and locked down.
+// `writable: true` still allows assignment, which is what the Shopify CDN does.
+Object.defineProperty(window, 'Shopify', {
+  configurable: false,
+  writable: true,
+  value: {},
+});
+
+describe('useCustomerPrivacy with a non-configurable window.Shopify', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    window.Shopify = {} as any;
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.querySelectorAll('script').forEach((node) => node.remove());
+  });
+
+  it('does not throw when the watcher cannot be installed', () => {
+    window.Shopify = {theme: 'from-an-extension'} as any;
+
+    expect(() =>
+      renderHook(() => useCustomerPrivacy(CUSTOMER_PRIVACY_PROPS)),
+    ).not.toThrow();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not observe `Shopify`'),
+      expect.anything(),
+    );
+
+    // The foreign global is left intact rather than clobbered.
+    expect((window.Shopify as any).theme).toBe('from-an-extension');
+  });
+
+  it('still resolves customerPrivacy through the fallback path', async () => {
+    const onReady = vi.fn();
+    const initialProps = {...CUSTOMER_PRIVACY_PROPS, onReady};
+
+    const {rerender} = renderHook((props) => useCustomerPrivacy(props), {
+      initialProps,
+    });
+
+    // The CDN assigns the real API onto the extension's object. There is no
+    // setter to observe it, so the fallback has to read it directly once the
+    // consent script has settled.
+    window.Shopify.customerPrivacy = {
+      setTrackingConsent: () => {},
+    } as any;
+
+    await act(async () => {});
+    rerender(initialProps);
+    await act(async () => {});
+
+    expect(getCustomerPrivacy()).not.toBeNull();
+    expect(onReady).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #3838
Fixes #3575

TL;DR: Two client-side bugs in the analytics and consent bootstrap. Both come from the same place — work that lands at an unpredictable point relative to React hydration. One throws away server HTML on every warm-cart page load; the other crashes the whole page when a browser extension has claimed `window.Shopify`.

They are grouped because they live in two adjacent modules (`analytics-manager/` and `customer-privacy/`), share a root cause, and each is a few lines. Reviewing them together is cheaper than twice separately.

## #3838 — `Analytics.Provider` interrupts hydration

`Analytics.Provider` wraps the whole app, so its state sits above every route-level Suspense boundary. It applied three updates urgently right after hydration begins:

1. `useShopAnalytics` resolving the (possibly deferred) shop promise into state
2. `CartAnalytics` calling `setCarts` inside the cart promise's `.then`
3. The `ShopifyAnalytics` `onReady` callback firing `setAnalyticsLoaded` / `setCanTrack` / `setConsentCollected`

When one of those lands while a streamed boundary below is still dehydrated, React abandons hydration for that boundary, discards its server-rendered HTML, and client-renders it:

```
Uncaught Error: This Suspense boundary received an update before it finished hydrating.
This caused the boundary to switch to client rendering.
```

Two conditions are needed and both are ordinary in production: a non-empty cart, and a streamed boundary whose chunk has not arrived by the time the shell finishes hydrating. The skeleton template ships both. The reporter measured ~40 mismatches per page load, with the header cart badge and deferred sections flashing empty and repainting.

### Before

```ts
Promise.resolve(shopProp).then(setShop);
```

### After

```ts
Promise.resolve(shopProp).then((resolvedShop) => {
  startTransition(() => setShop(resolvedShop));
});
```

Transitions do not interrupt in-progress hydration, so dehydrated boundaries keep their server HTML. None of these updates is urgent — they are analytics bookkeeping. No other behavior changes; the state still lands through the same effects.

Credit to @Sean-R-Wilson's report, which diagnosed this down to the exact three call sites and named the fix.

## #3575 — a browser extension can crash the page

`useCustomerPrivacy` installs watchers so it can override `setTrackingConsent` with the merchant's config once the CDN assigns the consent API:

```ts
Object.defineProperty(window, 'Shopify', {configurable: true, get() {…}, set(value) {…}});
```

`Object.defineProperty` throws `TypeError: Cannot redefine property: Shopify` when the property already exists and is non-configurable. Browser extensions do exactly that — Urban VPN is the one users keep naming, and four people confirmed it on the issue. The throw escaped the effect and took the entire app down through the router error boundary. Merchants have been shipping copy telling shoppers to disable their VPN extension.

Both watcher installs now go through a helper that never throws:

```ts
const installed = tryDefineProperty(window, 'Shopify', {…});
if (!installed) watcherFailed.current.customerPrivacy = true;
```

When a watcher cannot be installed there is no setter to notify us, so a fallback reads the consent APIs directly once the consent script has settled, applies the `setTrackingConsent` override by assignment where the container allows it, and marks the API loaded. Consent still works; it just loses the interception point. The foreign `window.Shopify` is left intact rather than clobbered.

The happy path is untouched — when the property is configurable, the watchers install and behave exactly as before.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. No public API changes, no new exports, no signature changes. Both fixes are internal to `Analytics.Provider` and `useCustomerPrivacy`.

## UX impact

- Streamed sections (header cart badge, deferred homepage content) no longer flash empty and repaint on page loads with a warm cart on a slow connection.
- Shoppers running an extension that claims `window.Shopify` get a working storefront instead of an error boundary.

## Out of scope

**#3752 (customer privacy utilities returning false positives).** This was the third issue in the group and I pulled it back out. It is the same bootstrap layer, but the fix is not mechanical and I could not verify it without a real store:

- Making `canTrack()` fail closed until the consent APIs load opens a render window where `ShopifyAnalytics.tsx:93-98` sees `privacyReady === true` while the provider still reports `canTrack() === false`. That computes `hasUserConsent: false` and can clear cookies early — the code comment there explicitly warns against it.
- Gating `shopifyCanTrack()` on `customerPrivacy.cachedConsent` instead would permanently report `false` for any visitor with no consent cookie, because `ShopifyCustomerPrivacy.tsx:500-507` only seeds that field when `trackingValues.consent` is already truthy. That would silently kill analytics for merchants who do not show a banner.

Shipping either without confirmation seemed worse than the bug. I have asked on the issue what the intended contract is and will follow up separately.

## Risk

- The `#3575` fallback path relies on the consent script's load status rather than a setter. It fires when the script settles, which is when the CDN has already assigned the API synchronously during execution. If a storefront somehow assigns `window.Shopify.customerPrivacy` well after that, the degraded path would miss it — but that path is only reached when the page would previously have crashed outright, so it is strictly an improvement.
- In the degraded path the config-bound `setTrackingConsent` override is best-effort. If the container is read-only the un-overridden CDN API is used as-is.
- `startTransition` requires React 18+, which the package already requires (`^18.3.1 || ~19.0.3 || ~19.1.4 || ^19.2.3`).

## How to Test

Both fixes have regression tests, verified by stashing the source change and re-running. One caveat worth stating: for #3838 only the **cart** case is a true guard (0 `startTransition` calls without the fix, 1 with). React fires its own `startTransition` while mounting `ShopifyAnalytics`, which happens exactly when the deferred shop lands, so a spy cannot separate our wrapper from React's in the shop and `onReady` windows — an assertion there passes with the fix reverted. The shop case is therefore behavioural coverage only, and the test docblock says so.

For manual verification:

**#3575** — this one is easy to see by hand.

1. Run `pnpm install && pnpm run build:pkg`.
2. Run `pnpm run dev:app` to start the skeleton template.
3. Open the storefront and run this in the console **before** the page scripts finish, or add it to the top of `entry.client.jsx`:
   ```js
   Object.defineProperty(window, 'Shopify', {configurable: false, writable: true, value: {}});
   ```
4. On `main` the page dies with `TypeError: Cannot redefine property: Shopify` and the error boundary renders. On this branch the page renders normally and logs a single `[h2:warn:useCustomerPrivacy] Could not observe \`Shopify\`` warning.
5. Confirm the cookie banner still appears and accepting consent still works.

**#3838** — needs a delayed streaming tail.

1. Add a product to the cart so `CartAnalytics` has a resolution to apply.
2. Make the streamed tail of the HTML arrive late — DevTools "Slow 4G" works if a deferred loader is slow enough; a small TCP proxy that forwards the first chunk and holds the rest for ~3s makes it deterministic.
3. Reload with the console open.
4. On `main` you get `This Suspense boundary received an update before it finished hydrating`, once per dehydrated boundary, and the cart badge flashes empty. On this branch the console is clean and the badge keeps its server-rendered value.

