### PR TITLE
Forward required IP headers for Oxygen

### DIFF
--- a/.changeset/bright-dogs-forward.md
+++ b/.changeset/bright-dogs-forward.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Forward required IP headers for Oxygen.

--- a/packages/hydrogen/src/client/client.test.ts
+++ b/packages/hydrogen/src/client/client.test.ts
@@ -251,7 +251,7 @@ describe("createStorefrontClient", () => {
       expect(headers.get("Shopify-Storefront-Private-Token")).toBe("priv-token-456");
     });
 
-    it("sends buyer meta headers for private client", async () => {
+    it("keeps private-client buyer IP separate from Oxygen client IP", async () => {
       const requestContext = createTestRequestContext(
         new Request("https://example.com", {
           headers: { "request-id": "request-context-group" },
@@ -266,8 +266,28 @@ describe("createStorefrontClient", () => {
 
       const headers = getHeaders(mockFetch);
       expect(headers.get("Shopify-Storefront-Buyer-IP")).toBe("10.0.0.1");
-      expect(headers.get("X-Shopify-Client-IP")).toBe("10.0.0.1");
+      expect(headers.get("X-Shopify-Client-IP")).toBeNull();
+      expect(headers.get("X-Shopify-Client-IP-Sig")).toBeNull();
       expect(headers.get("Custom-Storefront-Request-Group-ID")).toBe("request-context-group");
+    });
+
+    it("sends Oxygen-provided client IP headers", async () => {
+      const requestContext = createTestRequestContext(
+        new Request("https://example.com", {
+          headers: {
+            "oxygen-buyer-ip": "10.0.0.2",
+            "X-Shopify-Client-IP-Sig": "signed-client-ip",
+          },
+        }),
+      );
+      const client = createPublicClient({ fetch: mockFetch, requestContext });
+
+      await client.graphql(SHOP_QUERY);
+
+      const headers = getHeaders(mockFetch);
+      expect(headers.get("X-Shopify-Client-IP")).toBe("10.0.0.2");
+      expect(headers.get("X-Shopify-Client-IP-Sig")).toBe("signed-client-ip");
+      expect(headers.get("Shopify-Storefront-Buyer-IP")).toBeNull();
     });
 
     it("rejects mismatched request context and private client buyer IP", () => {

--- a/packages/hydrogen/src/client/client.ts
+++ b/packages/hydrogen/src/client/client.ts
@@ -9,6 +9,7 @@ import { DEFAULT_TIMEOUT_IN_MS, STOREFRONT_API_VERSION } from "../core/constants
 import {
   REQUEST_GROUP_ID_HEADER,
   SHOPIFY_CLIENT_IP_HEADER,
+  SHOPIFY_CLIENT_IP_SIG_HEADER,
   SHOPIFY_STOREFRONT_S_HEADER,
   SHOPIFY_STOREFRONT_Y_HEADER,
   STOREFRONT_ACCESS_TOKEN_HEADER,
@@ -66,6 +67,7 @@ const REQUEST_IDENTITY_HEADERS = new Set([
   REQUEST_GROUP_ID_HEADER.toLowerCase(),
   STOREFRONT_BUYER_IP_HEADER.toLowerCase(),
   SHOPIFY_CLIENT_IP_HEADER.toLowerCase(),
+  SHOPIFY_CLIENT_IP_SIG_HEADER.toLowerCase(),
   SHOPIFY_UNIQUE_TOKEN_HEADER.toLowerCase(),
   SHOPIFY_VISIT_TOKEN_HEADER.toLowerCase(),
   SHOPIFY_STOREFRONT_Y_HEADER.toLowerCase(),
@@ -215,6 +217,11 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
     requestHeaders.set(name, value);
   }
 
+  if (requestContext.clientIp && requestContext.clientIpSig) {
+    requestHeaders.set(SHOPIFY_CLIENT_IP_HEADER, requestContext.clientIp);
+    requestHeaders.set(SHOPIFY_CLIENT_IP_SIG_HEADER, requestContext.clientIpSig);
+  }
+
   if (clientType === "private") {
     const { buyerIp } = config;
     if (!buyerIp) {
@@ -225,7 +232,6 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
     }
     const trustedBuyerIp = requestContext.buyerIp ?? buyerIp;
     requestHeaders.set(STOREFRONT_BUYER_IP_HEADER, trustedBuyerIp);
-    requestHeaders.set(SHOPIFY_CLIENT_IP_HEADER, trustedBuyerIp);
   }
 
   async function graphql(

--- a/packages/hydrogen/src/core/handle-shopify-redirects.test.ts
+++ b/packages/hydrogen/src/core/handle-shopify-redirects.test.ts
@@ -88,6 +88,22 @@ describe("handleShopifyRedirects", () => {
     expect(result.headers.get("location")).toBe("/new-page");
   });
 
+  it("forwards Oxygen-provided client IP headers to redirect queries", async () => {
+    const request = new Request("https://my-app.com/old-page", {
+      headers: {
+        "oxygen-buyer-ip": "1.2.3.4",
+        "X-Shopify-Client-IP-Sig": "signed-client-ip",
+      },
+    });
+
+    await handleShopifyRedirects(redirectOptions(request));
+
+    const [, init] = mockFetch.mock.calls[0];
+    const headers = new Headers(init.headers);
+    expect(headers.get("X-Shopify-Client-IP")).toBe("1.2.3.4");
+    expect(headers.get("X-Shopify-Client-IP-Sig")).toBe("signed-client-ip");
+  });
+
   it("falls through to query param redirect", async () => {
     const request = new Request("https://my-app.com/some-page?return_to=/dashboard");
     const result = await handleShopifyRedirects(redirectOptions(request));

--- a/packages/hydrogen/src/core/headers.test.ts
+++ b/packages/hydrogen/src/core/headers.test.ts
@@ -8,6 +8,7 @@ import {
   SHOPIFY_STOREFRONT_Y_HEADER,
   SHOPIFY_UNIQUE_TOKEN_HEADER,
   SHOPIFY_VISIT_TOKEN_HEADER,
+  SHOPIFY_CLIENT_IP_SIG_HEADER,
   REQUEST_GROUP_ID_HEADER,
 } from "./headers";
 
@@ -118,6 +119,42 @@ describe("createShopifyRequestContext", () => {
     });
 
     expect(result.buyerIp).toBe(buyerIp);
+  });
+
+  it("stores Oxygen-provided client IP metadata", () => {
+    const result = createTestRequestContext(
+      new Request("https://example.com", {
+        headers: {
+          "oxygen-buyer-ip": "1.2.3.4",
+          [SHOPIFY_CLIENT_IP_SIG_HEADER]: "signed-client-ip",
+        },
+      }),
+    );
+
+    expect(result.clientIp).toBe("1.2.3.4");
+    expect(result.clientIpSig).toBe("signed-client-ip");
+  });
+
+  it("ignores a client IP signature outside Oxygen", () => {
+    const result = createTestRequestContext(
+      new Request("https://example.com", {
+        headers: { [SHOPIFY_CLIENT_IP_SIG_HEADER]: "untrusted-signature" },
+      }),
+    );
+
+    expect(result.clientIp).toBeUndefined();
+    expect(result.clientIpSig).toBeUndefined();
+  });
+
+  it("ignores an unsigned Oxygen client IP", () => {
+    const result = createTestRequestContext(
+      new Request("https://example.com", {
+        headers: { "oxygen-buyer-ip": "1.2.3.4" },
+      }),
+    );
+
+    expect(result.clientIp).toBeUndefined();
+    expect(result.clientIpSig).toBeUndefined();
   });
 
   it("defaults pathPrefix to an empty string", () => {

--- a/packages/hydrogen/src/core/headers.ts
+++ b/packages/hydrogen/src/core/headers.ts
@@ -12,6 +12,7 @@ export const STOREFRONT_PRIVATE_TOKEN_HEADER = "Shopify-Storefront-Private-Token
 export const REQUEST_GROUP_ID_HEADER = "Custom-Storefront-Request-Group-ID";
 export const STOREFRONT_BUYER_IP_HEADER = "Shopify-Storefront-Buyer-IP";
 export const SHOPIFY_CLIENT_IP_HEADER = "X-Shopify-Client-IP";
+export const SHOPIFY_CLIENT_IP_SIG_HEADER = "X-Shopify-Client-IP-Sig";
 export const SHOPIFY_UNIQUE_TOKEN_HEADER = "X-Shopify-UniqueToken";
 export const SHOPIFY_VISIT_TOKEN_HEADER = "X-Shopify-VisitToken";
 export const SHOPIFY_STOREFRONT_Y_HEADER = "Shopify-Storefront-Y";
@@ -69,6 +70,8 @@ type ShopifyRequestContextBase = {
   visitToken?: string;
   legacyTokens?: boolean;
   buyerIp?: string;
+  clientIp?: string;
+  clientIpSig?: string;
   requestGroupId: string;
   signal?: AbortSignal;
   url?: string;
@@ -96,6 +99,8 @@ type Context<I18n extends I18nConfig = I18nConfig> = {
   visitToken?: string;
   legacyTokens?: boolean;
   buyerIp?: string;
+  clientIp?: string;
+  clientIpSig?: string;
   requestGroupId: string;
   signal?: AbortSignal;
   url?: string;
@@ -118,11 +123,19 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
   const i18n = normalizeI18n(input.i18n);
   const cookie = request.headers.get("cookie") || undefined;
   const url = request.url ?? request.headers.get(STOREFRONT_URL_HEADER) ?? undefined;
+
+  // Temporary workaround of Oxygen
+  const clientIp = request.headers.get("oxygen-buyer-ip") || undefined;
+  const clientIpSig = clientIp
+    ? request.headers.get(SHOPIFY_CLIENT_IP_SIG_HEADER) || undefined
+    : undefined;
+
   const context = {
     ...(cookie && { cookie }),
     i18n,
     ...(url && { url }),
     ...(input.buyerIp && { buyerIp: input.buyerIp }),
+    ...(clientIp && clientIpSig && { clientIp, clientIpSig }),
     requestGroupId:
       request.headers.get(REQUEST_GROUP_ID_HEADER) ??
       request.headers.get("x-request-id") ??

--- a/packages/hydrogen/src/core/interceptors/mcp-proxy.test.ts
+++ b/packages/hydrogen/src/core/interceptors/mcp-proxy.test.ts
@@ -152,23 +152,6 @@ describe("handleMcpProxy", () => {
     expect(headers.get("X-Shopify-VisitToken")).toBeNull();
   });
 
-  it("does not add server-side headers", async () => {
-    await handleMcpProxy(
-      createRequest("/api/mcp", {
-        headers: { "oxygen-buyer-ip": "1.2.3.4" },
-      }),
-      defaultStoreUrl,
-    );
-
-    const call = mockFetch.mock.calls[0];
-    assert(call, "expected fetch to be called");
-    const [, init] = call;
-    const headers = new Headers(init.headers);
-    expect(headers.get("X-Shopify-Storefront-Access-Token")).toBeNull();
-    expect(headers.get("X-Shopify-Client-IP")).toBeNull();
-    expect(headers.get("x-forwarded-for")).toBeNull();
-  });
-
   it("sets Custom-Storefront-Request-Group-ID as a UUID", async () => {
     await handleMcpProxy(createRequest("/api/mcp"), defaultStoreUrl);
 

--- a/packages/hydrogen/src/core/interceptors/proxy.test.ts
+++ b/packages/hydrogen/src/core/interceptors/proxy.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createStorefrontClient } from "../../client/client";
+import {
+  createShopifyRequestContext,
+  REQUEST_GROUP_ID_HEADER,
+  SHOPIFY_CLIENT_IP_HEADER,
+  SHOPIFY_CLIENT_IP_SIG_HEADER,
+} from "../headers";
+import { assert } from "../test-utils";
+import { createProxyInterceptor } from "./proxy";
+
+type ProxyDescriptor = Parameters<typeof createProxyInterceptor>[0];
+
+const DEFAULT_DESCRIPTOR: ProxyDescriptor = {
+  match: /^\/proxy$/,
+  allowlist: ["accept", SHOPIFY_CLIENT_IP_HEADER, SHOPIFY_CLIENT_IP_SIG_HEADER],
+  formatError: (message) => ({ error: message }),
+  logPrefix: "Test proxy",
+};
+
+function proxyRequest(request: Request, descriptor: Partial<ProxyDescriptor> = {}) {
+  const requestContext = createShopifyRequestContext({
+    request,
+    i18n: { country: "US", language: "EN" },
+  });
+  const storefrontClient = createStorefrontClient({
+    type: "public",
+    requestContext,
+    config: { storeDomain: "test-store.myshopify.com" },
+  });
+  const data = new Map<string, unknown>();
+  const handleProxy = createProxyInterceptor({ ...DEFAULT_DESCRIPTOR, ...descriptor });
+
+  return handleProxy({
+    request,
+    requestContext,
+    storefrontClient,
+    sessionManager: {
+      getSessionOrigin: () => new URL(request.url).origin,
+      getSessionItem: (key) => data.get(key),
+      setSessionItem: (key, value) => data.set(key, value),
+      removeSessionItem: (key) => data.delete(key),
+    },
+  });
+}
+
+describe("createProxyInterceptor", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    mockFetch.mockReset().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("returns null without fetching when the pathname does not match", async () => {
+    const response = await proxyRequest(new Request("https://example.com/not-proxied"));
+
+    expect(response).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards the path, query, method, body, and allowlisted headers", async () => {
+    const request = new Request("https://example.com/proxy?cursor=next", {
+      method: "POST",
+      body: "request-body",
+      headers: {
+        accept: "application/json",
+        "x-not-allowed": "private",
+      },
+    });
+
+    await proxyRequest(request);
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const [url, init] = call;
+    expect(url.href).toBe("https://test-store.myshopify.com/proxy?cursor=next");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(request.body);
+    expect(init.duplex).toBe("half");
+    expect(init.redirect).toBe("manual");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    const headers = new Headers(init.headers);
+    expect(headers.get("accept")).toBe("application/json");
+    expect(headers.get("x-not-allowed")).toBeNull();
+  });
+
+  it("reuses the incoming request ID and applies descriptor headers", async () => {
+    const prepareHeaders = vi.fn((headers: Headers) => headers.set("x-prepared", "true"));
+
+    await proxyRequest(
+      new Request("https://example.com/proxy", {
+        headers: { "x-request-id": "incoming-request-id" },
+      }),
+      { prepareHeaders },
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const headers = new Headers(call[1].headers);
+    expect(prepareHeaders).toHaveBeenCalledOnce();
+    expect(headers.get(REQUEST_GROUP_ID_HEADER)).toBe("incoming-request-id");
+    expect(headers.get("x-prepared")).toBe("true");
+  });
+
+  it("generates a request group ID when the request has none", async () => {
+    await proxyRequest(new Request("https://example.com/proxy"));
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const headers = new Headers(call[1].headers);
+    expect(headers.get(REQUEST_GROUP_ID_HEADER)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("uses the descriptor timeout", async () => {
+    const timeoutSignal = new AbortController().signal;
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+
+    await proxyRequest(new Request("https://example.com/proxy"), { timeoutMs: 1_234 });
+
+    expect(timeout).toHaveBeenCalledWith(1_234);
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    expect(call[1].signal).toBe(timeoutSignal);
+  });
+
+  it("replaces incoming client IP headers with Oxygen-provided values", async () => {
+    await proxyRequest(
+      new Request("https://example.com/proxy", {
+        headers: {
+          "oxygen-buyer-ip": "1.2.3.4",
+          [SHOPIFY_CLIENT_IP_HEADER]: "5.6.7.8",
+          [SHOPIFY_CLIENT_IP_SIG_HEADER]: "signed-client-ip",
+        },
+      }),
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const headers = new Headers(call[1].headers);
+    expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBe("1.2.3.4");
+    expect(headers.get(SHOPIFY_CLIENT_IP_SIG_HEADER)).toBe("signed-client-ip");
+  });
+
+  it("removes client IP headers without Oxygen-provided values", async () => {
+    await proxyRequest(
+      new Request("https://example.com/proxy", {
+        headers: {
+          [SHOPIFY_CLIENT_IP_HEADER]: "5.6.7.8",
+          [SHOPIFY_CLIENT_IP_SIG_HEADER]: "untrusted-signature",
+        },
+      }),
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const headers = new Headers(call[1].headers);
+    expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBeNull();
+    expect(headers.get(SHOPIFY_CLIENT_IP_SIG_HEADER)).toBeNull();
+  });
+
+  it("preserves the upstream response while removing stale body metadata", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("response-body", {
+        status: 202,
+        statusText: "Accepted",
+        headers: {
+          "content-encoding": "gzip",
+          "content-length": "999",
+          "x-upstream": "preserved",
+        },
+      }),
+    );
+
+    const response = await proxyRequest(new Request("https://example.com/proxy"));
+
+    assert(response, "expected a proxy response");
+    expect(response.status).toBe(202);
+    expect(response.statusText).toBe("Accepted");
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("x-upstream")).toBe("preserved");
+    expect(await response.text()).toBe("response-body");
+  });
+
+  it("formats fetch errors as 502 responses and logs the failure", async () => {
+    const error = new Error("Connection refused");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValueOnce(error);
+
+    const response = await proxyRequest(new Request("https://example.com/proxy"));
+
+    assert(response, "expected an error response");
+    expect(response.status).toBe(502);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(await response.json()).toEqual({ error: "Connection refused" });
+    expect(consoleError).toHaveBeenCalledWith("Test proxy request failed:", error);
+  });
+
+  it("uses a generic message for non-Error fetch failures", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockFetch.mockRejectedValueOnce("offline");
+
+    const response = await proxyRequest(new Request("https://example.com/proxy"));
+
+    assert(response, "expected an error response");
+    expect(await response.json()).toEqual({ error: "Internal proxy error" });
+  });
+});

--- a/packages/hydrogen/src/core/interceptors/proxy.test.ts
+++ b/packages/hydrogen/src/core/interceptors/proxy.test.ts
@@ -39,8 +39,12 @@ function proxyRequest(request: Request, descriptor: Partial<ProxyDescriptor> = {
     sessionManager: {
       getSessionOrigin: () => new URL(request.url).origin,
       getSessionItem: (key) => data.get(key),
-      setSessionItem: (key, value) => data.set(key, value),
-      removeSessionItem: (key) => data.delete(key),
+      setSessionItem: (key, value) => {
+        data.set(key, value);
+      },
+      removeSessionItem: (key) => {
+        data.delete(key);
+      },
     },
   });
 }

--- a/packages/hydrogen/src/core/interceptors/proxy.ts
+++ b/packages/hydrogen/src/core/interceptors/proxy.ts
@@ -1,5 +1,10 @@
 import type { HydrogenRoutesOptions } from "../handle-shopify-routes";
-import { extractHeaders, REQUEST_GROUP_ID_HEADER } from "../headers";
+import {
+  extractHeaders,
+  REQUEST_GROUP_ID_HEADER,
+  SHOPIFY_CLIENT_IP_HEADER,
+  SHOPIFY_CLIENT_IP_SIG_HEADER,
+} from "../headers";
 
 const PROXY_TIMEOUT_MS = 30_000;
 
@@ -31,6 +36,15 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor) {
         crypto.randomUUID(),
     );
     descriptor.prepareHeaders?.(forwardedHeaders, options);
+
+    forwardedHeaders.delete(SHOPIFY_CLIENT_IP_HEADER);
+    forwardedHeaders.delete(SHOPIFY_CLIENT_IP_SIG_HEADER);
+    if (options.requestContext.clientIp) {
+      forwardedHeaders.set(SHOPIFY_CLIENT_IP_HEADER, options.requestContext.clientIp);
+    }
+    if (options.requestContext.clientIpSig) {
+      forwardedHeaders.set(SHOPIFY_CLIENT_IP_SIG_HEADER, options.requestContext.clientIpSig);
+    }
 
     try {
       const init: RequestInit & { duplex?: "half" } = {

--- a/packages/hydrogen/src/core/interceptors/sfapi-proxy.test.ts
+++ b/packages/hydrogen/src/core/interceptors/sfapi-proxy.test.ts
@@ -282,12 +282,11 @@ describe("handleSfapiProxy", () => {
     const [, init] = call;
     const headers = new Headers(init.headers);
     expect(headers.get(STOREFRONT_BUYER_IP_HEADER)).toBe(trustedBuyerIp);
-    expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBe(trustedBuyerIp);
     expect(headers.get("x-forwarded-for")).toBeNull();
   });
 
   it.each(["public", "private_no_buyer_context"] as const)(
-    "adds request context buyer IP headers for %s clients",
+    "adds the request context buyer IP header for %s clients",
     async (clientType) => {
       const trustedBuyerIp = "1.2.3.4";
       const browserBuyerIp = "5.6.7.8";
@@ -306,11 +305,11 @@ describe("handleSfapiProxy", () => {
       const [, init] = call;
       const headers = new Headers(init.headers);
       expect(headers.get(STOREFRONT_BUYER_IP_HEADER)).toBe(trustedBuyerIp);
-      expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBe(trustedBuyerIp);
+      expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBeNull();
     },
   );
 
-  it("does not add buyer IP headers without request context buyer IP", async () => {
+  it("does not trust a browser-supplied buyer IP header", async () => {
     const browserBuyerIp = "5.6.7.8";
 
     await handleSfapiProxyWithClientType(
@@ -325,7 +324,6 @@ describe("handleSfapiProxy", () => {
     const [, init] = call;
     const headers = new Headers(init.headers);
     expect(headers.get(STOREFRONT_BUYER_IP_HEADER)).toBeNull();
-    expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBeNull();
   });
 
   it("requires request context buyer IP for private client proxy requests", async () => {

--- a/packages/hydrogen/src/core/interceptors/sfapi-proxy.ts
+++ b/packages/hydrogen/src/core/interceptors/sfapi-proxy.ts
@@ -1,8 +1,4 @@
-import {
-  SFAPI_REQUEST_HEADER_ALLOWLIST,
-  SHOPIFY_CLIENT_IP_HEADER,
-  STOREFRONT_BUYER_IP_HEADER,
-} from "../headers";
+import { SFAPI_REQUEST_HEADER_ALLOWLIST, STOREFRONT_BUYER_IP_HEADER } from "../headers";
 import { SFAPI_RE } from "../url";
 import { createProxyInterceptor } from "./proxy";
 
@@ -11,14 +7,10 @@ export const handleSfapiProxy = createProxyInterceptor({
   allowlist: SFAPI_REQUEST_HEADER_ALLOWLIST,
   prepareHeaders: (headers, { requestContext, storefrontClient }) => {
     headers.delete(STOREFRONT_BUYER_IP_HEADER);
-    headers.delete(SHOPIFY_CLIENT_IP_HEADER);
     const { buyerIp } = requestContext;
     if (buyerIp) {
       headers.set(STOREFRONT_BUYER_IP_HEADER, buyerIp);
-      headers.set(SHOPIFY_CLIENT_IP_HEADER, buyerIp);
-      return;
-    }
-    if (storefrontClient.type === "private") {
+    } else if (storefrontClient.type === "private") {
       throw new Error(
         "requestContext.buyerIp is required for private Storefront API proxy requests",
       );


### PR DESCRIPTION
TL;DR: Forward Oxygen's signed client IP headers through Hydrogen Storefront requests and Shopify proxy interceptors. This is needed temporarily for backward compatibility in Oxygen deployments.

## Before

Hydrogen reused the configured buyer IP for `X-Shopify-Client-IP` and did not forward Oxygen's client IP signature. Proxy interceptors also handled client identity inconsistently.

## After

`createShopifyRequestContext` captures Oxygen's client IP and signature as a required pair. The Storefront client and shared proxy interceptor forward that trusted pair while removing incoming client IP headers first.
