### PR TITLE
Fix createStorefrontClient editor autocomplete

### DIFF
--- a/.changeset/breezy-pandas-repeat.md
+++ b/.changeset/breezy-pandas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix editor autocomplete on `createStorefrontClient`: the `type` discriminant now suggests all client types and `config` completions narrow to the selected type, instead of resolving against the first overload only.

--- a/packages/hydrogen/src/client/client.autocomplete.test.ts
+++ b/packages/hydrogen/src/client/client.autocomplete.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+// Editor autocomplete regression tests for createStorefrontClient.
+//
+// `expectTypeOf` cannot catch these regressions: valid calls still typecheck.
+// What breaks is contextual typing of *partial* input — while the user is
+// still typing, TS resolves the object literal against the first overload
+// instead of the full discriminated union, so completions degrade (e.g. only
+// "public" is suggested for `type`, and private config suggests
+// `publicStorefrontToken`). We assert on real language-service completions,
+// the same API the editor uses.
+
+const CURSOR = "/*cursor*/";
+const packageRoot = path.resolve(__dirname, "../..");
+const scratchPath = path.join(packageRoot, "src/client/__autocomplete-scratch__.ts");
+
+function getCompletionsAt(sourceWithCursor: string): string[] {
+  const cursorOffset = sourceWithCursor.indexOf(CURSOR);
+  if (cursorOffset === -1) {
+    throw new Error(`source must contain a ${CURSOR} marker`);
+  }
+  const scratchText = sourceWithCursor.replace(CURSOR, "");
+
+  const configFile = ts.readConfigFile(path.join(packageRoot, "tsconfig.json"), ts.sys.readFile);
+  const parsedConfig = ts.parseJsonConfigFileContent(configFile.config, ts.sys, packageRoot);
+
+  const host: ts.LanguageServiceHost = {
+    getScriptFileNames: () => [scratchPath],
+    getScriptVersion: () => "1",
+    getScriptSnapshot: (fileName) => {
+      if (fileName === scratchPath) return ts.ScriptSnapshot.fromString(scratchText);
+      if (!fs.existsSync(fileName)) return undefined;
+      return ts.ScriptSnapshot.fromString(fs.readFileSync(fileName, "utf8"));
+    },
+    getCurrentDirectory: () => packageRoot,
+    getCompilationSettings: () => parsedConfig.options,
+    getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+    readDirectory: ts.sys.readDirectory,
+    directoryExists: ts.sys.directoryExists,
+    getDirectories: ts.sys.getDirectories,
+  };
+
+  const service = ts.createLanguageService(host, ts.createDocumentRegistry());
+  try {
+    const completions = service.getCompletionsAtPosition(scratchPath, cursorOffset, {});
+    return completions?.entries.map((entry) => entry.name) ?? [];
+  } finally {
+    service.dispose();
+  }
+}
+
+const SCRATCH_PRELUDE = `import { createStorefrontClient, createShopifyRequestContext } from "../core";
+
+const requestContext = createShopifyRequestContext({
+  request: { headers: new Headers() },
+  i18n: { country: "US", language: "EN", pathPrefix: "" },
+});
+`;
+
+describe("createStorefrontClient editor autocomplete", () => {
+  it("suggests every client type for the `type` discriminant", () => {
+    const completions = getCompletionsAt(`${SCRATCH_PRELUDE}
+const storefrontClient = createStorefrontClient({
+  type: "${CURSOR}",
+});
+`);
+
+    expect(completions).toContain("public");
+    expect(completions).toContain("private");
+    expect(completions).toContain("private_no_buyer_context");
+  });
+
+  it("suggests private config keys once `type` is narrowed to private", () => {
+    const completions = getCompletionsAt(`${SCRATCH_PRELUDE}
+const storefrontClient = createStorefrontClient({
+  type: "private",
+  requestContext,
+  config: { ${CURSOR} },
+});
+`);
+
+    expect(completions).toContain("privateStorefrontToken");
+    expect(completions).toContain("buyerIp");
+    expect(completions).not.toContain("publicStorefrontToken");
+  });
+});

--- a/packages/hydrogen/src/client/client.autocomplete.test.ts
+++ b/packages/hydrogen/src/client/client.autocomplete.test.ts
@@ -76,6 +76,20 @@ const storefrontClient = createStorefrontClient({
     expect(completions).toContain("private_no_buyer_context");
   });
 
+  it("suggests public config keys once `type` is narrowed to public", () => {
+    const completions = getCompletionsAt(`${SCRATCH_PRELUDE}
+const storefrontClient = createStorefrontClient({
+  type: "public",
+  requestContext,
+  config: { ${CURSOR} },
+});
+`);
+
+    expect(completions).toContain("publicStorefrontToken");
+    expect(completions).not.toContain("privateStorefrontToken");
+    expect(completions).not.toContain("buyerIp");
+  });
+
   it("suggests private config keys once `type` is narrowed to private", () => {
     const completions = getCompletionsAt(`${SCRATCH_PRELUDE}
 const storefrontClient = createStorefrontClient({

--- a/packages/hydrogen/src/client/client.ts
+++ b/packages/hydrogen/src/client/client.ts
@@ -97,7 +97,13 @@ export function createStorefrontClient<
 >(
   args: CreateStorefrontClientArgs<RequestContext, Type, CacheConfig>,
 ): StorefrontClient<
-  CacheConfig extends CacheInstance ? { cache?: CachingStrategy } : {},
+  // Tuple-wrapped to stay non-distributive so an explicit
+  // `CacheInstance | undefined` type argument yields one client type, not a
+  // union. Note a *value* of that type still unlocks cache options: optional
+  // property inference strips `undefined` before it reaches CacheConfig, so
+  // definiteness is undecidable here — the runtime guard rejects cache
+  // options when no cache instance was actually configured.
+  [CacheConfig] extends [CacheInstance] ? { cache?: CachingStrategy } : {},
   Type,
   RequestContext
 >;

--- a/packages/hydrogen/src/client/client.ts
+++ b/packages/hydrogen/src/client/client.ts
@@ -23,14 +23,9 @@ import { normalizeStoreDomain } from "../core/url";
 import type { AnyStorefrontQueryString } from "../graphql";
 import { StorefrontApiError, StorefrontTimeoutError } from "./errors";
 import type {
+  ClientType,
   CreateStorefrontClientArgs,
   GraphQLFormattedError,
-  PrivateClientOptions,
-  PrivateStorefrontClient,
-  PublicClientOptions,
-  PublicStorefrontClient,
-  PrivateNoBuyerContextClientOptions,
-  PrivateNoBuyerContextStorefrontClient,
   StorefrontClient,
   StorefrontGraphqlResult,
 } from "./types";
@@ -38,7 +33,6 @@ import type {
 type DocLike = TadaDocumentNode<unknown, unknown> | AnyStorefrontQueryString;
 type FetchInput = Parameters<typeof globalThis.fetch>[0];
 type FetchInit = Parameters<typeof globalThis.fetch>[1];
-type StorefrontClientFetch = typeof globalThis.fetch | ((...args: never[]) => Promise<Response>);
 type ResolvedStorefrontFetch = (
   input: FetchInput,
   init: FetchInit,
@@ -97,54 +91,16 @@ class StorefrontCacheConfigError extends Error {}
  * @see {@link https://shopify.dev/docs/api/storefront#authentication | Storefront API authentication}
  */
 export function createStorefrontClient<
+  const Type extends ClientType,
   const RequestContext extends ShopifyRequestContext,
-  const Fetch extends StorefrontClientFetch | undefined = undefined,
->(args: {
-  type: "public";
-  requestContext: RequestContext;
-  config: PublicClientOptions<Fetch> & { cache: CacheInstance };
-}): PublicStorefrontClient<{ cache?: CachingStrategy }, RequestContext>;
-export function createStorefrontClient<
-  const RequestContext extends ShopifyRequestContext,
-  const Fetch extends StorefrontClientFetch | undefined = undefined,
->(args: {
-  type: "public";
-  requestContext: RequestContext;
-  config: PublicClientOptions<Fetch> & { cache?: undefined };
-}): PublicStorefrontClient<{}, RequestContext>;
-export function createStorefrontClient<
-  const RequestContext extends ShopifyRequestContext,
-  const Fetch extends StorefrontClientFetch | undefined = undefined,
->(args: {
-  type: "private";
-  requestContext: RequestContext;
-  config: PrivateClientOptions<Fetch> & { cache: CacheInstance };
-}): PrivateStorefrontClient<{ cache?: CachingStrategy }, RequestContext>;
-export function createStorefrontClient<
-  const RequestContext extends ShopifyRequestContext,
-  const Fetch extends StorefrontClientFetch | undefined = undefined,
->(args: {
-  type: "private";
-  requestContext: RequestContext;
-  config: PrivateClientOptions<Fetch> & { cache?: undefined };
-}): PrivateStorefrontClient<{}, RequestContext>;
-export function createStorefrontClient<
-  const RequestContext extends ShopifyRequestContext,
-  const Fetch extends StorefrontClientFetch | undefined = undefined,
->(args: {
-  type: "private_no_buyer_context";
-  requestContext: RequestContext;
-  config: PrivateNoBuyerContextClientOptions<Fetch> & { cache: CacheInstance };
-}): PrivateNoBuyerContextStorefrontClient<{ cache?: CachingStrategy }, RequestContext>;
-export function createStorefrontClient<
-  const RequestContext extends ShopifyRequestContext,
-  const Fetch extends StorefrontClientFetch | undefined = undefined,
->(args: {
-  type: "private_no_buyer_context";
-  requestContext: RequestContext;
-  config: PrivateNoBuyerContextClientOptions<Fetch> & { cache?: undefined };
-}): PrivateNoBuyerContextStorefrontClient<{}, RequestContext>;
-export function createStorefrontClient(args: CreateStorefrontClientArgs): StorefrontClient;
+  const CacheConfig extends CacheInstance | undefined = undefined,
+>(
+  args: CreateStorefrontClientArgs<RequestContext, Type, CacheConfig>,
+): StorefrontClient<
+  CacheConfig extends CacheInstance ? { cache?: CachingStrategy } : {},
+  Type,
+  RequestContext
+>;
 export function createStorefrontClient(args: CreateStorefrontClientArgs): StorefrontClient {
   const { config, requestContext, type: clientType } = args;
 

--- a/packages/hydrogen/src/client/client.type-test.ts
+++ b/packages/hydrogen/src/client/client.type-test.ts
@@ -479,6 +479,26 @@ describe('type tests', () => {
         publicClient.graphql(SHOP_QUERY, {cache: Cache.long()});
     });
 
+    it('accepts cache options when the configured cache is possibly undefined', () => {
+      const maybeCache = Math.random() > 0.5 ? keyValueCache : undefined;
+      const maybeCacheClient = createStorefrontClient({
+        type: 'public',
+        requestContext: createTestRequestContext(),
+        config: {
+          storeDomain: 'test.myshopify.com',
+          publicStorefrontToken: 'pub-token',
+          cache: maybeCache,
+        },
+      });
+
+      // Deliberate: optional property inference strips `undefined`, so cache
+      // definiteness is undecidable at the type level (and consumer tsconfigs
+      // control inference anyway). A maybe-undefined cache unlocks cache
+      // options; the runtime StorefrontCacheConfigError guard rejects them
+      // when the cache turned out to be absent.
+      () => maybeCacheClient.graphql(SHOP_QUERY, {cache: Cache.long()});
+    });
+
     it('accepts cache options when cache is configured with a custom origin fetch', () => {
       const customOriginClient = createStorefrontClient({
         type: 'public',

--- a/packages/hydrogen/src/client/types.ts
+++ b/packages/hydrogen/src/client/types.ts
@@ -5,7 +5,6 @@ import type {
 } from "gql.tada";
 
 import type { CacheInstance, WaitUntil } from "../core/cache/run-with-cache";
-import type { CachingStrategy } from "../core/cache/strategies";
 import type { ShopifyRequestContext } from "../core/headers";
 import type { AnyStorefrontQueryString, SourceOf, StorefrontQueryString } from "../graphql";
 import type { InferResult, InferVariables } from "../graphql";

--- a/packages/hydrogen/src/client/types.ts
+++ b/packages/hydrogen/src/client/types.ts
@@ -62,6 +62,8 @@ type CommonOptions = {
    */
   apiVersion?: string;
   defaultTimeoutInMs?: number;
+  // Mirrored by the `cache?: CacheConfig` inference hole in
+  // CreateStorefrontClientArgs — keep the key and type in sync.
   cache?: CacheInstance;
   waitUntil?: WaitUntil;
 };

--- a/packages/hydrogen/src/client/types.ts
+++ b/packages/hydrogen/src/client/types.ts
@@ -5,6 +5,7 @@ import type {
 } from "gql.tada";
 
 import type { CacheInstance, WaitUntil } from "../core/cache/run-with-cache";
+import type { CachingStrategy } from "../core/cache/strategies";
 import type { ShopifyRequestContext } from "../core/headers";
 import type { AnyStorefrontQueryString, SourceOf, StorefrontQueryString } from "../graphql";
 import type { InferResult, InferVariables } from "../graphql";
@@ -120,23 +121,31 @@ export type StorefrontClientOptions =
   | PrivateClientOptions
   | PrivateNoBuyerContextClientOptions;
 
+// `Type` and `CacheConfig` are inference holes for `createStorefrontClient`:
+// each member's discriminant is intersected with `Type` (resolving to the plain
+// literal when `Type` is the full `ClientType` default) and `cache` narrows
+// `CacheConfig`, so the call signature can recover both without wrapping this
+// union in an intersection — which would defeat discriminant narrowing and
+// excess-property checks while the user is still typing.
 export type CreateStorefrontClientArgs<
   RequestContext extends ShopifyRequestContext = ShopifyRequestContext,
+  Type extends ClientType = ClientType,
+  CacheConfig extends CacheInstance | undefined = CacheInstance | undefined,
 > =
   | {
-      type: "public";
+      type: "public" & Type;
       requestContext: RequestContext;
-      config: PublicClientOptions<AnyFetch | undefined>;
+      config: PublicClientOptions<AnyFetch | undefined> & { cache?: CacheConfig };
     }
   | {
-      type: "private";
+      type: "private" & Type;
       requestContext: RequestContext;
-      config: PrivateClientOptions<AnyFetch | undefined>;
+      config: PrivateClientOptions<AnyFetch | undefined> & { cache?: CacheConfig };
     }
   | {
-      type: "private_no_buyer_context";
+      type: "private_no_buyer_context" & Type;
       requestContext: RequestContext;
-      config: PrivateNoBuyerContextClientOptions<AnyFetch | undefined>;
+      config: PrivateNoBuyerContextClientOptions<AnyFetch | undefined> & { cache?: CacheConfig };
     };
 type AutoAddedVariableNames = "country" | "language";
 type UserVariables<Doc> = Omit<VariablesOfDoc<Doc>, AutoAddedVariableNames>;


### PR DESCRIPTION
TL;DR: Editor autocomplete on `createStorefrontClient` was broken — typing `type:` only suggested `"public"`, and a `type: "private"` config suggested `publicStorefrontToken` while hiding `privateStorefrontToken` and `buyerIp`. The 7-overload matrix was the cause: TS contextually types partial input against the first overload only. This replaces the matrix with a single generic signature over the discriminated union, guarded by language-service regression tests.

## Before

```ts
const storefrontClient = createStorefrontClient({
  type: "|   // suggests only "public"; "No overload matches this call" while typing
});
```

Completions for a `type: "private"` config offered `publicStorefrontToken` and omitted the private-only keys.

## After

```ts
const storefrontClient = createStorefrontClient({
  type: "|   // suggests "public" | "private" | "private_no_buyer_context"
});
```

Config completions narrow to the selected `type`. Valid calls, return types, and all 60 existing type tests (including excess-property guards) are unchanged.

## What this changes

- Replaces the 7 `createStorefrontClient` overloads (3 client types × with/without cache, plus a catch-all) with one generic signature over `CreateStorefrontClientArgs`.
- Adds `Type` and `CacheConfig` inference holes to `CreateStorefrontClientArgs`. The union stays the top-level contextual type, so discriminant narrowing and excess-property checks keep working while the user is mid-keystroke. Defaults reduce to the previous exported shape, so existing consumers of the type see no change.
- Recovers what the overload return types encoded: `client.type` narrows via the `"public" & Type` discriminant hole, and per-request `cache` options on `graphql()` are gated by the `CacheConfig` hole (tuple-wrapped to stay non-distributive).
- Removes the vestigial `Fetch` generic and `StorefrontClientFetch` alias — no return type referenced them since cache gating moved off custom fetch arity.
- Adds `client.autocomplete.test.ts`: completions are queried from a real `ts.LanguageService` (the same API editors use), because `expectTypeOf` cannot catch contextual typing of partial input — valid calls always typechecked. This regression previously crept in unnoticed across four PRs in the storefront-kit repo.
- Pins the maybe-undefined cache edge case as deliberate: `cache: CacheInstance | undefined` unlocks per-request cache options at the type level (optional-property inference strips `undefined` before it is observable, and consumer tsconfigs control inference regardless); the runtime `StorefrontCacheConfigError` guard rejects cache options when the cache turns out to be absent.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. No new exports and no runtime behavior changes.

One signature nuance: the generic parameter order changed from `<RequestContext, Fetch>` to `<Type, RequestContext, CacheConfig>`. Anyone passing explicit type arguments would break; no in-repo callers do, and types are inferred in normal usage.

## Risk

- The `"public" & Type` and `cache?: CacheConfig` inference holes rely on TS intersection-reduction and inference behavior. If a future TS version changes this, the new language-service tests fail in CI rather than autocomplete silently regressing again.
- Hover display of the return type now renders as `StorefrontClient<..., "public", ...>` instead of the `PublicStorefrontClient` alias. The aliases are still exported.

## How to Test

1. Run `pnpm install` from the repo root.
2. Open `packages/hydrogen/src/client/client.type-test.ts` in your editor and, in any test body, start a new call: `createStorefrontClient({ type: "` — all three client types should be suggested with no premature "No overload matches this call" noise.
3. Complete it with `type: 'private'` and open completions inside `config: { }` — `privateStorefrontToken` and `buyerIp` should be suggested; `publicStorefrontToken` should not.
4. Switch to `type: 'public'` and confirm config completions flip accordingly.
