### PR TITLE
Fix customer logout when token refresh fails with transient errors

### DIFF
--- a/.changeset/tough-hoops-refuse.md
+++ b/.changeset/tough-hoops-refuse.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Keep customers logged in when a Customer Account API token refresh fails due to a transient error. The session is now only cleared when the refresh token is missing or the token endpoint returns `invalid_grant`, so other OAuth errors, HTTP failures, and network failures can be retried on a subsequent request.

--- a/packages/hydrogen/src/customer/auth.helpers.test.ts
+++ b/packages/hydrogen/src/customer/auth.helpers.test.ts
@@ -14,6 +14,7 @@ vi.mock('./BadRequest', () => {
   return {
     BadRequest: class BadRequest {
       message: string;
+      status = 400;
       constructor(message?: string, helpMessage?: string) {
         this.message = `${message} ${helpMessage}`;
       }
@@ -25,19 +26,25 @@ vi.stubGlobal(
   'Response',
   class Response {
     message;
+    status;
     constructor(body: any, options: any) {
       this.message = body;
+      this.status = options?.status;
     }
   },
 );
 
 const fetch = (globalThis.fetch = vi.fn() as any);
 
-function createFetchResponse<T>(data: T, options: {ok: boolean}) {
+function createFetchResponse<T>(
+  data: T,
+  options: {ok: boolean; status?: number},
+) {
   return {
     json: () => new Promise((resolve) => resolve(data)),
     text: async () => JSON.stringify(data),
     ok: options.ok,
+    status: options.status,
   };
 }
 
@@ -97,6 +104,7 @@ describe('auth.helpers', () => {
       await expect(run).rejects.toThrowError(
         'Unauthorized No refreshToken found in the session. Make sure your session is configured correctly and passed to `createCustomerAccountClient`.',
       );
+      expect(session.unset).toHaveBeenCalledWith(CUSTOMER_ACCOUNT_SESSION_KEY);
     });
 
     it('Throws Unauthorized when refresh token fails', async () => {
@@ -144,6 +152,34 @@ describe('auth.helpers', () => {
       await expect(run).rejects.toThrowError(
         'Unauthorized Invalid access token received.',
       );
+      expect(session.unset).not.toHaveBeenCalled();
+    });
+
+    it('Clears the session when a success response carries invalid_grant', async () => {
+      (session.get as any).mockReturnValueOnce({
+        refreshToken: 'refreshToken',
+      });
+
+      fetch.mockResolvedValue(
+        createFetchResponse(
+          {access_token: '', error: 'invalid_grant'},
+          {ok: true},
+        ),
+      );
+
+      async function run() {
+        await refreshToken({
+          session,
+          customerAccountId: 'customerAccountId',
+          customerAccountTokenExchangeUrl: 'customerAccountTokenExchangeUrl',
+          httpsOrigin: 'https://localhost',
+        });
+      }
+
+      await expect(run).rejects.toThrowError(
+        'Unauthorized Invalid access token received.',
+      );
+      expect(session.unset).toHaveBeenCalledWith(CUSTOMER_ACCOUNT_SESSION_KEY);
     });
 
     it('Refreshes the token', async () => {
@@ -216,6 +252,17 @@ describe('auth.helpers', () => {
     afterEach(() => {
       vi.clearAllMocks();
     });
+
+    function checkExpiredSession() {
+      return checkExpires({
+        locks: {},
+        expiresAt: '100',
+        session,
+        customerAccountId: 'customerAccountId',
+        customerAccountTokenExchangeUrl: 'customerAccountTokenExchangeUrl',
+        httpsOrigin: 'https://localhost',
+      });
+    }
 
     it("no-ops if the session isn't expired", async () => {
       async function run() {
@@ -303,6 +350,90 @@ describe('auth.helpers', () => {
         expiresAt: expect.any(String),
         refreshToken: 'refresh_token',
       });
+    });
+
+    it('clears the session when the refresh token is invalid', async () => {
+      (session.get as any).mockReturnValueOnce({
+        refreshToken: 'old_refresh_token',
+      });
+      fetch.mockResolvedValue(
+        createFetchResponse(
+          {error: 'invalid_grant', error_description: 'Invalid refresh token.'},
+          {ok: false, status: 400},
+        ),
+      );
+
+      await expect(checkExpiredSession()).rejects.toThrowError();
+      expect(session.unset).toHaveBeenCalledWith(CUSTOMER_ACCOUNT_SESSION_KEY);
+    });
+
+    it.each([
+      ['another 4xx', 401, {error: 'temporarily_unavailable'}],
+      ['rate limiting', 429, {error: 'temporarily_unavailable'}],
+    ])('does not clear the session for %s', async (_, status, body) => {
+      (session.get as any).mockReturnValueOnce({
+        refreshToken: 'old_refresh_token',
+      });
+      fetch.mockResolvedValue(createFetchResponse(body, {ok: false, status}));
+
+      await expect(checkExpiredSession()).rejects.toThrowError();
+      expect(session.unset).not.toHaveBeenCalled();
+    });
+
+    it('does not clear the session for a non-JSON error body', async () => {
+      (session.get as any).mockReturnValueOnce({
+        refreshToken: 'old_refresh_token',
+      });
+      fetch.mockResolvedValue({
+        text: async () => '<html>502 Bad Gateway</html>',
+        ok: false,
+        status: 502,
+      });
+
+      await expect(checkExpiredSession()).rejects.toThrowError();
+      expect(session.unset).not.toHaveBeenCalled();
+    });
+
+    it('retries after a transient failure without clearing the session', async () => {
+      (session.get as any).mockReturnValue({
+        refreshToken: 'old_refresh_token',
+      });
+      fetch
+        .mockResolvedValueOnce(
+          createFetchResponse('Internal Server Error', {
+            ok: false,
+            status: 500,
+          }),
+        )
+        .mockResolvedValueOnce(
+          createFetchResponse(
+            {
+              access_token: 'access_token',
+              expires_in: 3600,
+              refresh_token: 'refresh_token',
+            },
+            {ok: true},
+          ),
+        );
+
+      await expect(checkExpiredSession()).rejects.toThrowError();
+      await expect(checkExpiredSession()).resolves.toBeUndefined();
+
+      expect(session.unset).not.toHaveBeenCalled();
+      expect(session.set).toHaveBeenCalledWith(
+        CUSTOMER_ACCOUNT_SESSION_KEY,
+        expect.objectContaining({accessToken: 'access_token'}),
+      );
+    });
+
+    it('does not clear the session for a network error', async () => {
+      (session.get as any).mockReturnValueOnce({
+        refreshToken: 'old_refresh_token',
+      });
+      fetch.mockRejectedValue(new TypeError('fetch failed'));
+
+      await expect(checkExpiredSession()).rejects.toThrowError('fetch failed');
+      expect(session.unset).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/hydrogen/src/customer/auth.helpers.test.ts
+++ b/packages/hydrogen/src/customer/auth.helpers.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import type {HydrogenSession} from '../types';
-import {CUSTOMER_ACCOUNT_SESSION_KEY} from './constants';
+import {BUYER_SESSION_KEY, CUSTOMER_ACCOUNT_SESSION_KEY} from './constants';
 import {
   checkExpires,
   clearSession,
@@ -105,6 +105,7 @@ describe('auth.helpers', () => {
         'Unauthorized No refreshToken found in the session. Make sure your session is configured correctly and passed to `createCustomerAccountClient`.',
       );
       expect(session.unset).toHaveBeenCalledWith(CUSTOMER_ACCOUNT_SESSION_KEY);
+      expect(session.unset).toHaveBeenCalledWith(BUYER_SESSION_KEY);
     });
 
     it('Throws Unauthorized when refresh token fails', async () => {
@@ -180,6 +181,7 @@ describe('auth.helpers', () => {
         'Unauthorized Invalid access token received.',
       );
       expect(session.unset).toHaveBeenCalledWith(CUSTOMER_ACCOUNT_SESSION_KEY);
+      expect(session.unset).toHaveBeenCalledWith(BUYER_SESSION_KEY);
     });
 
     it('Refreshes the token', async () => {
@@ -236,6 +238,7 @@ describe('auth.helpers', () => {
     it('Clears the session', async () => {
       clearSession(session);
       expect(session.unset).toHaveBeenCalledWith(CUSTOMER_ACCOUNT_SESSION_KEY);
+      expect(session.unset).toHaveBeenCalledWith(BUYER_SESSION_KEY);
     });
   });
 
@@ -365,6 +368,7 @@ describe('auth.helpers', () => {
 
       await expect(checkExpiredSession()).rejects.toThrowError();
       expect(session.unset).toHaveBeenCalledWith(CUSTOMER_ACCOUNT_SESSION_KEY);
+      expect(session.unset).toHaveBeenCalledWith(BUYER_SESSION_KEY);
     });
 
     it.each([

--- a/packages/hydrogen/src/customer/auth.helpers.ts
+++ b/packages/hydrogen/src/customer/auth.helpers.ts
@@ -86,11 +86,13 @@ export async function refreshToken({
   const refreshToken = customerAccount?.refreshToken;
   const idToken = customerAccount?.idToken;
 
-  if (!refreshToken)
+  if (!refreshToken) {
+    clearSession(session);
     throw new BadRequest(
       'Unauthorized',
       'No refreshToken found in the session. Make sure your session is configured correctly and passed to `createCustomerAccountClient`.',
     );
+  }
 
   newBody.append('grant_type', 'refresh_token');
   newBody.append('refresh_token', refreshToken);
@@ -120,6 +122,14 @@ export async function refreshToken({
 
   if (!response.ok) {
     const text = await response.text();
+
+    // `invalid_grant` means the refresh token is expired, revoked, or invalid
+    // and cannot recover. Other OAuth and HTTP errors can be transient, so keep
+    // the session intact and retry the refresh on a subsequent request.
+    if (getOAuthError(text) === 'invalid_grant') {
+      clearSession(session);
+    }
+
     throw new Response(text, {
       status: response.status,
       headers: {
@@ -132,9 +142,16 @@ export async function refreshToken({
     access_token,
     expires_in,
     refresh_token,
+    error,
   }: Omit<AccessTokenResponse, 'id_token'> = await response.json();
 
   if (!access_token || access_token.length === 0) {
+    // Defensive: a success status that still carries `invalid_grant` means the
+    // refresh token is dead, so treat it like the error response above.
+    if (error === 'invalid_grant') {
+      clearSession(session);
+    }
+
     throw new BadRequest('Unauthorized', 'Invalid access token received.');
   }
 
@@ -185,8 +202,6 @@ export async function checkExpires({
       await locks.refresh;
       delete locks.refresh;
     } catch (error) {
-      clearSession(session);
-
       if (error && (error as Response).status !== 401) {
         throw error;
       } else {
@@ -196,6 +211,15 @@ export async function checkExpires({
         );
       }
     }
+  }
+}
+
+function getOAuthError(body: string): string | undefined {
+  try {
+    const data = JSON.parse(body);
+    return typeof data?.error === 'string' ? data.error : undefined;
+  } catch {
+    return undefined;
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3892

A failed Customer Account access-token refresh currently clears the entire customer session. This logs customers out whenever the token endpoint has a transient failure, even though their refresh token is still valid.

### WHAT is this pull request doing?

`checkExpires` no longer clears the session for every refresh error. The session is cleared only when the refresh token is genuinely dead:

- The refresh token is missing from the session.
- The token endpoint returns `invalid_grant`, including the defensive case of a `2xx` body carrying `invalid_grant` with no access token.

Network failures, 5xx, 429, and other OAuth/4xx errors keep the stored tokens so the refresh is retried on a later request. Error propagation is otherwise unchanged.

#### Why classify on `invalid_grant` rather than HTTP status

Every dead-refresh-token path on the token endpoint (unknown token, previously revoked, expired, client mismatch, inactive provider) returns `400` with `{"error": "invalid_grant"}`. Transient upstream failures return `401` with an empty error code and `"Access token request error."`, and `invalid_client` / `unauthorized_client` indicate app misconfiguration rather than a dead customer token. Clearing on status alone would therefore still log customers out during instability, and `429` would be treated as permanent.

Error bodies are RFC 6749 §5.2 JSON regardless of request headers, so parsing `error` is reliable.

This matches how other Shopify OAuth clients classify refresh failures: `invalid_grant` means discard and re-authenticate, everything else including a `401` from a misconfigured client is transient and retried.

#### Deliberately unchanged

`locks.refresh` is still only deleted on success, so a second `isLoggedIn()` in the same request awaits the already-rejected promise rather than issuing another token request. That caps refresh attempts at one per request, which matters most during an outage. This is existing behaviour and this PR does not alter it.

### HOW to test your changes?

Follow the reproduction in #3892. With the refresh endpoint forced to return 500, the request still reports the customer as not authenticated, but the tokens stay in the session and the next request refreshes successfully once the endpoint recovers.

Validated locally:

- `pnpm exec vitest run src` in `packages/hydrogen` (538 passed)
- `SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK=false pnpm run typecheck` (17 tasks passed)
- ESLint and Prettier on changed files

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets)
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation (not applicable; no public API change)
