### PR TITLE
Simplify JSON-LD escaping in framework examples

### DIFF
--- a/examples/nextjs/lib/site.ts
+++ b/examples/nextjs/lib/site.ts
@@ -17,11 +17,8 @@ export function canonicalUrl(path: string): string {
 /**
  * Serialize JSON-LD and escape it for safe embedding in a `<script type="application/ld+json">`
  * tag (engineering.md F6). This is an app-owned helper — it is NOT a Hydrogen
- * export. It escapes `<` and `</script>` so the payload cannot break out of the
- * script element.
+ * export. It escapes `<` so the payload cannot break out of the script element.
  */
 export function jsonLdScript(data: object): string {
-  const json = JSON.stringify(data);
-  const escaped = json.replace(/</g, "\\u003c").replace(/<\/script>/gi, "\\u003c/script\\u003e");
-  return escaped;
+  return JSON.stringify(data).replace(/</g, "\\u003c");
 }

--- a/examples/react-router/app/lib/site.ts
+++ b/examples/react-router/app/lib/site.ts
@@ -17,11 +17,8 @@ export function canonicalUrl(path: string): string {
 /**
  * Serialize JSON-LD and escape it for safe embedding in a `<script type="application/ld+json">`
  * tag (engineering.md F6). This is an app-owned helper — it is NOT a Hydrogen
- * export. It escapes `<` and `</script>` so the payload cannot break out of the
- * script element.
+ * export. It escapes `<` so the payload cannot break out of the script element.
  */
 export function jsonLdScript(data: object): string {
-  const json = JSON.stringify(data);
-  const escaped = json.replace(/</g, "\\u003c").replace(/<\/script>/gi, "\\u003c/script\\u003e");
-  return escaped;
+  return JSON.stringify(data).replace(/</g, "\\u003c");
 }


### PR DESCRIPTION
## Why

JSON-LD embedded in a script element must not contain a literal closing script token. Escaping every `<` during serialization prevents script breakout while preserving the original data when the JSON is parsed.

## What changed

- Simplified `jsonLdScript` in the Next.js and React Router examples
- Updated the helper documentation to describe the single required escape

## Testing

- Verified a script-breakout payload contains no literal `<` in both helpers
- Verified both serialized payloads round-trip through `JSON.parse`
- Ran scoped formatting and lint checks