### PR TITLE
feat: storefrontClient gets buyerIp from request context instead of a param

### DIFF
--- a/.changeset/calm-cats-context.md
+++ b/.changeset/calm-cats-context.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Source private Storefront API buyer IP exclusively from `requestContext`. Remove `buyerIp` from private client config and require a buyer-bearing context created with `createShopifyRequestContext({buyerIp})`.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Below is the kind of code the skills produce.
 
 **A typed Storefront API client** — works anywhere you can `fetch`:
 
+Implement `getBuyerIp` using trusted request data exposed by your deployment platform.
+
 ```ts
 import {
   createShopifyRequestContext,
@@ -106,11 +108,14 @@ import {
   gql,
 } from "@shopify/hydrogen";
 
+const buyerIp = getBuyerIp(request.headers);
+
 const storefront = createStorefrontClient({
   type: "private",
   requestContext: createShopifyRequestContext({
     request,
     i18n: { country: "US", language: "EN" },
+    buyerIp,
   }),
   config: {
     storeDomain: process.env.NEXT_PUBLIC_STORE_DOMAIN,

--- a/examples/hydrogen/app/lib/context.ts
+++ b/examples/hydrogen/app/lib/context.ts
@@ -1,4 +1,4 @@
-import type { ShopifyBuyerRequestContext, ShopifyRequestContext } from "@shopify/hydrogen";
+import type { ShopifyRequestContext, ShopifyRequestContextWithBuyerIp } from "@shopify/hydrogen";
 import { RouterContextProvider } from "react-router";
 
 import { AppSession } from "~/lib/session";
@@ -27,7 +27,7 @@ export async function createHydrogenRouterContext(
   request: Request,
   env: Env,
   executionContext: ExecutionContext,
-  shopifyRequestContext: ShopifyBuyerRequestContext,
+  shopifyRequestContext: ShopifyRequestContextWithBuyerIp,
   customerAccount: CustomerAccountContext,
 ) {
   const waitUntil = executionContext.waitUntil.bind(executionContext);

--- a/examples/hydrogen/app/lib/context.ts
+++ b/examples/hydrogen/app/lib/context.ts
@@ -1,7 +1,6 @@
-import type { ShopifyRequestContext } from "@shopify/hydrogen";
+import type { ShopifyBuyerRequestContext, ShopifyRequestContext } from "@shopify/hydrogen";
 import { RouterContextProvider } from "react-router";
 
-import { getLocaleFromRequest } from "~/lib/i18n";
 import { AppSession } from "~/lib/session";
 import { createStorefrontClientForRequest, type StorefrontClient } from "~/lib/storefront-client";
 
@@ -28,7 +27,7 @@ export async function createHydrogenRouterContext(
   request: Request,
   env: Env,
   executionContext: ExecutionContext,
-  shopifyRequestContext: ShopifyRequestContext,
+  shopifyRequestContext: ShopifyBuyerRequestContext,
   customerAccount: CustomerAccountContext,
 ) {
   const waitUntil = executionContext.waitUntil.bind(executionContext);
@@ -36,13 +35,10 @@ export async function createHydrogenRouterContext(
     caches.open("hydrogen"),
     AppSession.init(request, [env.SESSION_SECRET]),
   ]);
-  const i18n = getLocaleFromRequest(request);
   const storefront = createStorefrontClientForRequest({
-    request,
     env,
     cache,
     waitUntil,
-    i18n,
     shopifyRequestContext,
   });
   const contextValues: HydrogenRouterContext = {

--- a/examples/hydrogen/app/lib/storefront-client.ts
+++ b/examples/hydrogen/app/lib/storefront-client.ts
@@ -1,4 +1,3 @@
-import { getBuyerIp } from "@shared/buyer-ip";
 import { getPrivateStorefrontToken } from "@shared/private-env";
 import {
   Cache as HydrogenCache,
@@ -6,18 +5,16 @@ import {
   type GraphQLFormattedError,
   type RequestScopedPrivateStorefrontClient,
   type CachingStrategy,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 
 import type { I18nLocale } from "~/lib/i18n";
 
 type CreateStorefrontClientOptions = {
-  request: Request;
   env: Env;
   cache: Cache;
   waitUntil: ExecutionContext["waitUntil"];
-  i18n: I18nLocale;
-  shopifyRequestContext: ShopifyRequestContext;
+  shopifyRequestContext: ShopifyBuyerRequestContext;
 };
 
 type StorefrontQueryOptions = {
@@ -67,21 +64,17 @@ function CacheDefault(): CachingStrategy {
 }
 
 export function createStorefrontClientForRequest({
-  request,
   env,
   cache,
   waitUntil,
-  i18n,
   shopifyRequestContext,
 }: CreateStorefrontClientOptions): StorefrontClient {
-  const buyerIp = shopifyRequestContext.buyerIp ?? getBuyerIp(request.headers);
   const client = createStorefrontClient({
     type: "private",
     requestContext: shopifyRequestContext,
     config: {
       storeDomain: env.PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: getPrivateStorefrontToken(env),
-      buyerIp,
       cache,
       waitUntil,
     },

--- a/examples/hydrogen/app/lib/storefront-client.ts
+++ b/examples/hydrogen/app/lib/storefront-client.ts
@@ -5,7 +5,7 @@ import {
   type GraphQLFormattedError,
   type RequestScopedPrivateStorefrontClient,
   type CachingStrategy,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 
 import type { I18nLocale } from "~/lib/i18n";
@@ -14,7 +14,7 @@ type CreateStorefrontClientOptions = {
   env: Env;
   cache: Cache;
   waitUntil: ExecutionContext["waitUntil"];
-  shopifyRequestContext: ShopifyBuyerRequestContext;
+  shopifyRequestContext: ShopifyRequestContextWithBuyerIp;
 };
 
 type StorefrontQueryOptions = {

--- a/examples/hydrogen/server.ts
+++ b/examples/hydrogen/server.ts
@@ -44,7 +44,6 @@ export default {
         config: {
           storeDomain: env.PUBLIC_STORE_DOMAIN,
           privateStorefrontToken: getPrivateStorefrontToken(env),
-          buyerIp,
         },
       });
       const customerSessionManager = await createCustomerSessionManager(

--- a/examples/nextjs/lib/storefront.ts
+++ b/examples/nextjs/lib/storefront.ts
@@ -40,7 +40,6 @@ export const getStorefrontClient = cache(
       config: {
         storeDomain,
         privateStorefrontToken,
-        buyerIp,
       },
     });
   },

--- a/examples/nextjs/proxy.ts
+++ b/examples/nextjs/proxy.ts
@@ -47,7 +47,6 @@ export async function proxy(request: NextRequest) {
     config: {
       storeDomain,
       privateStorefrontToken,
-      buyerIp,
     },
   });
 

--- a/examples/poc/astro/src/middleware.ts
+++ b/examples/poc/astro/src/middleware.ts
@@ -11,6 +11,7 @@ import {
   createShopifyRequestContext,
   handleShopifyRedirects,
   handleShopifyRoutes,
+  type ShopifyBuyerRequestContext,
   type ShopifyRequestContext,
 } from "@shopify/hydrogen";
 import { defineMiddleware } from "astro:middleware";
@@ -31,7 +32,7 @@ export const onRequest = defineMiddleware(async ({ locals, request }, next) => {
     i18n: defaultI18n,
     buyerIp,
   });
-  const storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  const storefrontClient = createPrivateStorefrontClient(requestContext);
   const sessionManager = await createCustomerSessionManager(request);
 
   const kitRoute = await handleShopifyRoutes({
@@ -77,14 +78,13 @@ function applyStorefrontResponseHeaders(
   }
 }
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: storefrontConfig.storeDomain,
       privateStorefrontToken: getPrivateStorefrontToken(),
-      buyerIp,
       cache: storefrontCache,
     },
   });

--- a/examples/poc/astro/src/middleware.ts
+++ b/examples/poc/astro/src/middleware.ts
@@ -11,7 +11,7 @@ import {
   createShopifyRequestContext,
   handleShopifyRedirects,
   handleShopifyRoutes,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
   type ShopifyRequestContext,
 } from "@shopify/hydrogen";
 import { defineMiddleware } from "astro:middleware";
@@ -78,7 +78,7 @@ function applyStorefrontResponseHeaders(
   }
 }
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/examples/poc/nuxt-binding/server/middleware/shopify.ts
+++ b/examples/poc/nuxt-binding/server/middleware/shopify.ts
@@ -5,7 +5,7 @@ import { handleShopifyRoutes } from "@shopify/hydrogen";
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 
 import { cartHandlers } from "../../storefront/cart-handlers";
@@ -24,7 +24,7 @@ export default defineEventHandler(async (event) => {
     i18n: defaultI18n,
     buyerIp,
   });
-  const storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  const storefrontClient = createPrivateStorefrontClient(requestContext);
   const sessionManager = await createCustomerSessionManager(request);
   const customerAccountClient = createRequestCustomerAccountClient(requestContext);
 
@@ -45,14 +45,13 @@ export default defineEventHandler(async (event) => {
   event.context.customerAccountClient = customerAccountClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: storefrontConfig.storeDomain,
       privateStorefrontToken: getPrivateStorefrontToken(),
-      buyerIp,
     },
   });
 }

--- a/examples/poc/nuxt-binding/server/middleware/shopify.ts
+++ b/examples/poc/nuxt-binding/server/middleware/shopify.ts
@@ -5,7 +5,7 @@ import { handleShopifyRoutes } from "@shopify/hydrogen";
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 
 import { cartHandlers } from "../../storefront/cart-handlers";
@@ -45,7 +45,7 @@ export default defineEventHandler(async (event) => {
   event.context.customerAccountClient = customerAccountClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/examples/poc/nuxt/server/middleware/shopify.ts
+++ b/examples/poc/nuxt/server/middleware/shopify.ts
@@ -9,7 +9,7 @@ import { handleShopifyRoutes } from "@shopify/hydrogen";
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 import { LRUCache } from "lru-cache";
 
@@ -54,7 +54,7 @@ export default defineEventHandler(async (event) => {
   event.context.customerAccountClient = customerAccountClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/examples/poc/nuxt/server/middleware/shopify.ts
+++ b/examples/poc/nuxt/server/middleware/shopify.ts
@@ -9,7 +9,7 @@ import { handleShopifyRoutes } from "@shopify/hydrogen";
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 import { LRUCache } from "lru-cache";
 
@@ -33,7 +33,7 @@ export default defineEventHandler(async (event) => {
     i18n: defaultI18n,
     buyerIp,
   });
-  const storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  const storefrontClient = createPrivateStorefrontClient(requestContext);
   const sessionManager = await createCustomerSessionManager(request);
   const customerAccountClient = createRequestCustomerAccountClient(requestContext);
 
@@ -54,14 +54,13 @@ export default defineEventHandler(async (event) => {
   event.context.customerAccountClient = customerAccountClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: storefrontConfig.storeDomain,
       privateStorefrontToken: getPrivateStorefrontToken(),
-      buyerIp,
       cache: storefrontCache,
     },
   });

--- a/examples/poc/solid-start/src/middleware.ts
+++ b/examples/poc/solid-start/src/middleware.ts
@@ -10,7 +10,7 @@ import {
   createCartServerHandlers,
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 import { createMiddleware } from "@solidjs/start/middleware";
 import { LRUCache } from "lru-cache";
@@ -73,7 +73,7 @@ export default createMiddleware({
   ],
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/examples/poc/solid-start/src/middleware.ts
+++ b/examples/poc/solid-start/src/middleware.ts
@@ -10,7 +10,7 @@ import {
   createCartServerHandlers,
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 import { createMiddleware } from "@solidjs/start/middleware";
 import { LRUCache } from "lru-cache";
@@ -43,7 +43,7 @@ export default createMiddleware({
         i18n: defaultI18n,
         buyerIp,
       });
-      const storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+      const storefrontClient = createPrivateStorefrontClient(requestContext);
       const sessionManager = await createCustomerSessionManager(event.request);
       const customerAccountClient = createRequestCustomerAccountClient(requestContext);
 
@@ -73,14 +73,13 @@ export default createMiddleware({
   ],
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: storefrontConfig.storeDomain,
       privateStorefrontToken: getPrivateStorefrontToken(),
-      buyerIp,
       cache: storefrontCache,
     },
   });

--- a/examples/poc/sveltekit/src/hooks.server.ts
+++ b/examples/poc/sveltekit/src/hooks.server.ts
@@ -13,6 +13,7 @@ import {
   createCartServerHandlers,
   createStorefrontClient,
   createShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
   type ShopifyRequestContext,
 } from "@shopify/hydrogen";
 import type { Handle } from "@sveltejs/kit";
@@ -30,7 +31,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     i18n: defaultI18n,
     buyerIp,
   });
-  const storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  const storefrontClient = createPrivateStorefrontClient(requestContext);
   const sessionManager = await createCustomerSessionManager(event.request);
 
   const kitRoute = await handleShopifyRoutes({
@@ -76,14 +77,13 @@ function applyStorefrontResponseHeaders(
   }
 }
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: storefrontConfig.storeDomain,
       privateStorefrontToken: getPrivateStorefrontToken(env),
-      buyerIp,
       cache: storefrontCache,
     },
   });

--- a/examples/poc/sveltekit/src/hooks.server.ts
+++ b/examples/poc/sveltekit/src/hooks.server.ts
@@ -13,7 +13,7 @@ import {
   createCartServerHandlers,
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
   type ShopifyRequestContext,
 } from "@shopify/hydrogen";
 import type { Handle } from "@sveltejs/kit";
@@ -77,7 +77,7 @@ function applyStorefrontResponseHeaders(
   }
 }
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/examples/react-router/app/lib/storefront-middleware.ts
+++ b/examples/react-router/app/lib/storefront-middleware.ts
@@ -107,7 +107,6 @@ export const storefrontMiddleware: MiddlewareFunction<Response> = async (
     config: {
       storeDomain,
       privateStorefrontToken: resolvedPrivateStorefrontToken,
-      buyerIp,
       cache: storefrontCache,
     },
   });

--- a/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
@@ -47,7 +47,7 @@ const redirect = await handleShopifyRedirects({
 
 - Default to one request-scoped private Storefront client per request when buyer context exists.
 - Route handlers and cart server handlers accept any provided Storefront client when public or no-buyer-context access is intentional.
-- Resolve trusted `buyerIp` before creating a private client; pass it to both `createShopifyRequestContext` and private client config. Use the `hydrogen-storefront-client` buyer-IP guidance for the app's deployment.
+- Resolve trusted `buyerIp` before creating a private client and pass it to `createShopifyRequestContext`. Use the `hydrogen-storefront-client` buyer-IP guidance for the app's deployment.
 - Create `requestContext` with `createShopifyRequestContext({ request, i18n, buyerIp })` where buyer context exists and the framework exposes a real `Request`; use `request: { headers }` only when no `Request` exists.
 - Pass the same request-scoped `requestContext`, `storefrontClient`, and `sessionManager` into `handleShopifyRoutes` and registered handler groups.
 - Call `handleShopifyRoutes` without awaiting it immediately. It returns `null` synchronously when no route matches; only return or await the promise after checking that it is truthy.

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
@@ -59,7 +59,6 @@ export async function handleRequest(request: Request, next: () => Promise<Respon
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 
@@ -123,7 +122,6 @@ export const middleware: Route.MiddlewareFunction[] = [
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
         privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-        buyerIp,
       },
     });
 

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
@@ -36,7 +36,6 @@ export async function proxy(request: NextRequest) {
     config: {
       storeDomain: process.env.NEXT_PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
   const sessionManager = await createSessionManager(request);

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
@@ -29,7 +29,7 @@ import {
   createStorefrontClient,
   createShopifyRequestContext,
   handleShopifyRoutes,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 
 const cartHandlers = createCartServerHandlers();
@@ -43,7 +43,7 @@ export default defineEventHandler(async (event) => {
     buyerIp,
   });
   const sessionManager = await createSessionManager(request);
-  const storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  const storefrontClient = createPrivateStorefrontClient(requestContext);
 
   const shopifyRoute = handleShopifyRoutes({
     request,
@@ -58,14 +58,13 @@ export default defineEventHandler(async (event) => {
   event.context.storefrontClient = storefrontClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 }

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
@@ -29,7 +29,7 @@ import {
   createStorefrontClient,
   createShopifyRequestContext,
   handleShopifyRoutes,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 
 const cartHandlers = createCartServerHandlers();
@@ -58,7 +58,7 @@ export default defineEventHandler(async (event) => {
   event.context.storefrontClient = storefrontClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/packages/hydrogen/skills/hydrogen-storefront-client/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/SKILL.md
@@ -91,7 +91,6 @@ const client = createStorefrontClient({
   config: {
     storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
     privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-    buyerIp,
   },
 });
 ```
@@ -105,7 +104,7 @@ Hydrogen does not infer buyer IP headers. Apps decide how to build `buyerIp` bas
 
 Use the same request-scoped Storefront client for Hydrogen route handlers, cart server handlers, and server data loaders when they share the same request data. Route and cart handlers accept any provided Storefront client. Redirect handlers still require a private server-side client.
 
-When using `handleShopifyRoutes`, pass the same trusted `buyerIp` into `createShopifyRequestContext`. The SFAPI proxy sources buyer IP from request context so proxy requests and direct `client.graphql()` calls use the same buyer identity.
+When using `handleShopifyRoutes`, pass the trusted `buyerIp` into `createShopifyRequestContext`. Both the SFAPI proxy and direct `client.graphql()` calls source buyer identity from that request context.
 
 ### Private client without buyer context
 

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/astro.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/astro.md
@@ -27,7 +27,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
     config: {
       storeDomain: import.meta.env.PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: import.meta.env.PRIVATE_STOREFRONT_API_TOKEN,
-      buyerIp,
     },
   });
 

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/nextjs.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/nextjs.md
@@ -32,7 +32,6 @@ export const getStorefrontClient = cache(async () => {
     config: {
       storeDomain: process.env.NEXT_PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 });

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/nuxt.md
@@ -15,7 +15,7 @@ Create the private client in server middleware where Nuxt exposes the incoming r
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 
 export default defineEventHandler((event) => {
@@ -27,18 +27,17 @@ export default defineEventHandler((event) => {
     buyerIp,
   });
 
-  event.context.storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  event.context.storefrontClient = createPrivateStorefrontClient(requestContext);
   event.context.shopifyRequestContext = requestContext;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 }

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/nuxt.md
@@ -15,7 +15,7 @@ Create the private client in server middleware where Nuxt exposes the incoming r
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 
 export default defineEventHandler((event) => {
@@ -31,7 +31,7 @@ export default defineEventHandler((event) => {
   event.context.shopifyRequestContext = requestContext;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/react-router.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/react-router.md
@@ -39,7 +39,6 @@ export const storefrontMiddleware: Route.MiddlewareFunction = async (
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/solidstart.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/solidstart.md
@@ -30,7 +30,6 @@ export default createMiddleware({
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
         privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-        buyerIp,
       },
     });
 
@@ -119,7 +118,6 @@ export default createMiddleware({
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
         privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-        buyerIp,
       },
     });
 

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/sveltekit.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/sveltekit.md
@@ -34,7 +34,6 @@ export const handle: Handle = async ({ event, resolve }) => {
     config: {
       storeDomain: PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: PRIVATE_STOREFRONT_API_TOKEN,
-      buyerIp,
     },
   });
 
@@ -105,7 +104,6 @@ export const handle: Handle = async ({ event, resolve }) => {
     config: {
       storeDomain: PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: PRIVATE_STOREFRONT_API_TOKEN,
-      buyerIp,
     },
   });
 

--- a/packages/hydrogen/src/client/client.autocomplete.test.ts
+++ b/packages/hydrogen/src/client/client.autocomplete.test.ts
@@ -61,6 +61,11 @@ const requestContext = createShopifyRequestContext({
   request: { headers: new Headers() },
   i18n: { country: "US", language: "EN", pathPrefix: "" },
 });
+const buyerRequestContext = createShopifyRequestContext({
+  request: { headers: new Headers() },
+  i18n: { country: "US", language: "EN", pathPrefix: "" },
+  buyerIp: "1.2.3.4",
+});
 `;
 
 describe("createStorefrontClient editor autocomplete", () => {
@@ -94,13 +99,13 @@ const storefrontClient = createStorefrontClient({
     const completions = getCompletionsAt(`${SCRATCH_PRELUDE}
 const storefrontClient = createStorefrontClient({
   type: "private",
-  requestContext,
+  requestContext: buyerRequestContext,
   config: { ${CURSOR} },
 });
 `);
 
     expect(completions).toContain("privateStorefrontToken");
-    expect(completions).toContain("buyerIp");
+    expect(completions).not.toContain("buyerIp");
     expect(completions).not.toContain("publicStorefrontToken");
   });
 });

--- a/packages/hydrogen/src/client/client.test.ts
+++ b/packages/hydrogen/src/client/client.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import type { CacheInstance } from "../core";
 import { Cache } from "../core/cache";
-import { createShopifyRequestContext, type ShopifyRequestContext } from "../core/request-context";
+import {
+  createShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContext,
+} from "../core/request-context";
 import { assert } from "../core/test-utils";
 import { gql } from "../graphql";
 import { createStorefrontClient } from "./client";

--- a/packages/hydrogen/src/client/client.test.ts
+++ b/packages/hydrogen/src/client/client.test.ts
@@ -4,8 +4,8 @@ import type { CacheInstance } from "../core";
 import { Cache } from "../core/cache";
 import {
   createShopifyRequestContext,
-  type ShopifyBuyerRequestContext,
   type ShopifyRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "../core/request-context";
 import { assert } from "../core/test-utils";
 import { gql } from "../graphql";
@@ -257,14 +257,15 @@ describe("createStorefrontClient", () => {
     });
 
     it("sends buyer meta headers for private client", async () => {
-      const requestContext = createTestRequestContext(
-        new Request("https://example.com", {
+      const requestContext = createShopifyRequestContext({
+        request: new Request("https://example.com", {
           headers: { "request-id": "request-context-group" },
         }),
-      );
+        i18n: DEFAULT_I18N,
+        buyerIp: "10.0.0.1",
+      });
       const client = createPrivateClient({
         fetch: mockFetch,
-        buyerIp: "10.0.0.1",
         requestContext,
       });
       await client.graphql(SHOP_QUERY);
@@ -275,19 +276,21 @@ describe("createStorefrontClient", () => {
       expect(headers.get("Custom-Storefront-Request-Group-ID")).toBe("request-context-group");
     });
 
-    it("rejects mismatched request context and private client buyer IP", () => {
-      const requestContext = createShopifyRequestContext({
-        request: new Request("https://example.com"),
-        i18n: DEFAULT_I18N,
-        buyerIp: "10.0.0.1",
-      });
+    it("requires buyer IP on the private client request context at runtime", () => {
+      const createInvalidClient = () =>
+        createStorefrontClient({
+          type: "private",
+          requestContext: createTestRequestContext() as ShopifyRequestContextWithBuyerIp,
+          config: {
+            storeDomain: "test.myshopify.com",
+            privateStorefrontToken: "test-priv-token",
+          },
+        });
 
-      expect(() =>
-        createPrivateClient({
-          buyerIp: "10.0.0.2",
-          requestContext,
-        }),
-      ).toThrow("requestContext.buyerIp must match private Storefront API client buyerIp");
+      expect(createInvalidClient).toThrow(TypeError);
+      expect(createInvalidClient).toThrow(
+        "requestContext.buyerIp is required for private Storefront API clients",
+      );
     });
 
     it("omits buyer meta headers for private client without buyer context", async () => {
@@ -801,7 +804,7 @@ describe("createStorefrontClient", () => {
 
     it("forwards requestContext signal to fetch", async () => {
       const controller = new AbortController();
-      const requestContext = createTestRequestContext(
+      const requestContext = createBuyerTestRequestContext(
         new Request("http://localhost", {
           signal: controller.signal,
         }),
@@ -855,7 +858,7 @@ describe("createStorefrontClient", () => {
     it("throws AbortError when requestContext signal is already aborted", async () => {
       const controller = new AbortController();
       controller.abort();
-      const requestContext = createTestRequestContext(
+      const requestContext = createBuyerTestRequestContext(
         new Request("http://localhost", {
           signal: controller.signal,
         }),
@@ -885,7 +888,7 @@ describe("createStorefrontClient", () => {
       const client = createPrivateClient({
         fetch: mockFetch,
         defaultTimeoutInMs: 0,
-        requestContext: createTestRequestContext(
+        requestContext: createBuyerTestRequestContext(
           new Request("http://localhost", {
             signal: controller.signal,
           }),
@@ -916,6 +919,17 @@ function createTestRequestContext(
   i18n: I18nConfig = DEFAULT_I18N,
 ): ShopifyRequestContext {
   return createShopifyRequestContext({ request: input, i18n });
+}
+
+function createBuyerTestRequestContext(
+  input: StorefrontRequestInput = { headers: new Headers() },
+  i18n: I18nConfig = DEFAULT_I18N,
+): ShopifyRequestContextWithBuyerIp {
+  return createShopifyRequestContext({
+    request: input,
+    i18n,
+    buyerIp: "127.0.0.1",
+  });
 }
 
 function createPublicClient(
@@ -950,19 +964,23 @@ function createPrivateClient(
     privateStorefrontToken?: string;
     fetch?: typeof globalThis.fetch;
     cache?: CacheInstance;
-    buyerIp?: string;
-    requestContext?: ShopifyRequestContext;
+    requestContext?: ShopifyRequestContextWithBuyerIp;
     defaultTimeoutInMs?: number;
   } = {},
 ): StorefrontClient {
   return createStorefrontClient({
     type: "private",
-    requestContext: overrides.requestContext ?? createTestRequestContext(),
+    requestContext:
+      overrides.requestContext ??
+      createShopifyRequestContext({
+        request: { headers: new Headers() },
+        i18n: DEFAULT_I18N,
+        buyerIp: "127.0.0.1",
+      }),
     config: {
       storeDomain: overrides.storeDomain ?? "test.myshopify.com",
       apiVersion: overrides.apiVersion,
       privateStorefrontToken: overrides.privateStorefrontToken ?? "test-priv-token",
-      buyerIp: overrides.buyerIp ?? "127.0.0.1",
       fetch: overrides.fetch,
       cache: overrides.cache,
       defaultTimeoutInMs: overrides.defaultTimeoutInMs,

--- a/packages/hydrogen/src/client/client.ts
+++ b/packages/hydrogen/src/client/client.ts
@@ -171,16 +171,12 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
   requestContext.applyStorefrontRequestHeaders(requestHeaders);
 
   if (clientType === "private") {
-    const { buyerIp } = config;
+    const { buyerIp } = requestContext;
     if (!buyerIp) {
-      throw new Error("buyerIp is required for private Storefront API clients");
+      throw new Error("requestContext.buyerIp is required for private Storefront API clients");
     }
-    if (requestContext.buyerIp && requestContext.buyerIp !== buyerIp) {
-      throw new Error("requestContext.buyerIp must match private Storefront API client buyerIp");
-    }
-    const trustedBuyerIp = requestContext.buyerIp ?? buyerIp;
-    requestHeaders.set(STOREFRONT_BUYER_IP_HEADER, trustedBuyerIp);
-    requestHeaders.set(SHOPIFY_CLIENT_IP_HEADER, trustedBuyerIp);
+    requestHeaders.set(STOREFRONT_BUYER_IP_HEADER, buyerIp);
+    requestHeaders.set(SHOPIFY_CLIENT_IP_HEADER, buyerIp);
   }
 
   async function graphql(

--- a/packages/hydrogen/src/client/client.ts
+++ b/packages/hydrogen/src/client/client.ts
@@ -173,7 +173,7 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
   if (clientType === "private") {
     const { buyerIp } = requestContext;
     if (!buyerIp) {
-      throw new Error("requestContext.buyerIp is required for private Storefront API clients");
+      throw new TypeError("requestContext.buyerIp is required for private Storefront API clients");
     }
     requestHeaders.set(STOREFRONT_BUYER_IP_HEADER, buyerIp);
     requestHeaders.set(SHOPIFY_CLIENT_IP_HEADER, buyerIp);

--- a/packages/hydrogen/src/client/client.type-test.ts
+++ b/packages/hydrogen/src/client/client.type-test.ts
@@ -343,6 +343,9 @@ describe('type tests', () => {
 
       expectTypeOf(requestContext.buyerIp).toEqualTypeOf<string>();
       expectTypeOf<PrivateStorefrontClient['requestContext']['buyerIp']>().toEqualTypeOf<string>();
+
+      // @ts-expect-error — buyerIp is immutable after context creation
+      requestContext.buyerIp = '4.3.2.1';
     });
 
     it('rejects requestGroupId next to buyerIp', () => {

--- a/packages/hydrogen/src/client/client.type-test.ts
+++ b/packages/hydrogen/src/client/client.type-test.ts
@@ -10,6 +10,7 @@ import type {
   StorefrontGraphqlResult,
   GraphQLFormattedError,
   I18nConfig,
+  PrivateStorefrontClient,
   StorefrontQueryString,
 } from './index';
 import type {CachingStrategy} from '../core';
@@ -23,6 +24,14 @@ vi.stubGlobal('fetch', fetchMock);
 
 function createTestRequestContext(i18n: I18nConfig = DEFAULT_I18N) {
   return createShopifyRequestContext({request: {headers: new Headers()}, i18n});
+}
+
+function createBuyerRequestContext(i18n: I18nConfig = DEFAULT_I18N) {
+  return createShopifyRequestContext({
+    request: {headers: new Headers()},
+    i18n,
+    buyerIp: '1.2.3.4',
+  });
 }
 
 const SHOP_QUERY = gql(`query { shop { name } }`);
@@ -173,11 +182,10 @@ describe('type tests', () => {
     it('private client accepts all optional fields from PrivateClientOptions', () => {
       createStorefrontClient({
         type: 'private',
-        requestContext: createTestRequestContext(),
+        requestContext: createBuyerRequestContext(),
         config: {
           storeDomain: 'test.myshopify.com',
           privateStorefrontToken: 'priv-token',
-          buyerIp: '1.2.3.4',
           fetch: globalThis.fetch,
           defaultTimeoutInMs: 5000,
         },
@@ -199,9 +207,9 @@ describe('type tests', () => {
   });
 
   describe('discriminated union enforcement', () => {
-    it('rejects private token without buyerIp', () => {
+    it('rejects private clients without buyerIp on requestContext', () => {
       () =>
-        // @ts-expect-error — buyerIp required with private token
+        // @ts-expect-error — private clients require a buyer request context
         createStorefrontClient({
           type: 'private',
           requestContext: createTestRequestContext(),
@@ -318,11 +326,10 @@ describe('type tests', () => {
     it('rejects both public and private tokens', () => {
       createStorefrontClient({
         type: 'private',
-        requestContext: createTestRequestContext(),
+        requestContext: createBuyerRequestContext(),
         config: {
           storeDomain: 'test.myshopify.com',
           privateStorefrontToken: 'priv-token',
-          buyerIp: '1.2.3.4',
           // @ts-expect-error — choose either public or private token path
           publicStorefrontToken: 'pub-token',
         },
@@ -331,26 +338,20 @@ describe('type tests', () => {
   });
 
   describe('buyerIp', () => {
-    it('accepts a static buyer IP string', () => {
-      createStorefrontClient({
-        type: 'private',
-        requestContext: createTestRequestContext(),
-        config: {
-          storeDomain: 'test.myshopify.com',
-          privateStorefrontToken: 'priv-token',
-          buyerIp: '1.2.3.4',
-        },
-      });
+    it('preserves a static buyer IP on the request context type', () => {
+      const requestContext = createBuyerRequestContext();
+
+      expectTypeOf(requestContext.buyerIp).toEqualTypeOf<string>();
+      expectTypeOf<PrivateStorefrontClient['requestContext']['buyerIp']>().toEqualTypeOf<string>();
     });
 
     it('rejects requestGroupId next to buyerIp', () => {
       createStorefrontClient({
         type: 'private',
-        requestContext: createTestRequestContext(),
+        requestContext: createBuyerRequestContext(),
         config: {
           storeDomain: 'test.myshopify.com',
           privateStorefrontToken: 'priv-token',
-          buyerIp: '1.2.3.4',
           // @ts-expect-error — requestGroupId belongs to requestContext
           requestGroupId: 'g',
         },
@@ -358,14 +359,23 @@ describe('type tests', () => {
     });
 
     it('rejects buyerIp callbacks', () => {
+      // @ts-expect-error — resolve request-derived buyerIp before creating the context
+      createShopifyRequestContext({
+        request: {headers: new Headers()},
+        i18n: DEFAULT_I18N,
+        buyerIp: (_request: Request) => '1.2.3.4',
+      });
+    });
+
+    it('rejects buyerIp in private client config', () => {
       createStorefrontClient({
         type: 'private',
-        requestContext: createTestRequestContext(),
+        requestContext: createBuyerRequestContext(),
         config: {
           storeDomain: 'test.myshopify.com',
           privateStorefrontToken: 'priv-token',
-          // @ts-expect-error — resolve request-derived buyerIp before creating the client
-          buyerIp: (_request: Request) => '1.2.3.4',
+          // @ts-expect-error — buyerIp belongs to requestContext
+          buyerIp: '1.2.3.4',
         },
       });
     });
@@ -379,7 +389,6 @@ describe('type tests', () => {
         config: {
           storeDomain: 'test.myshopify.com',
           privateStorefrontToken: 'priv-token',
-          buyerIp: '1.2.3.4',
         },
       });
     });
@@ -387,11 +396,10 @@ describe('type tests', () => {
     it('private client accepts requestContext at client creation', () => {
       const client = createStorefrontClient({
         type: 'private',
-        requestContext: createTestRequestContext(),
+        requestContext: createBuyerRequestContext(),
         config: {
           storeDomain: 'test.myshopify.com',
           privateStorefrontToken: 'priv-token',
-          buyerIp: '1.2.3.4',
         },
       });
       () => client.graphql(SHOP_QUERY);
@@ -400,13 +408,12 @@ describe('type tests', () => {
     it('rejects raw request at client creation', () => {
       createStorefrontClient({
         type: 'private',
-        requestContext: createTestRequestContext(),
+        requestContext: createBuyerRequestContext(),
         config: {
           storeDomain: 'test.myshopify.com',
           privateStorefrontToken: 'priv-token',
           // @ts-expect-error — pass createShopifyRequestContext({request, i18n}) instead
           request: new Request('http://localhost'),
-          buyerIp: '1.2.3.4',
         },
       });
     });
@@ -565,11 +572,10 @@ describe('type tests', () => {
   describe('private client graphql signature', () => {
     const privateClient = createStorefrontClient({
       type: 'private',
-      requestContext: createTestRequestContext(),
+      requestContext: createBuyerRequestContext(),
       config: {
         storeDomain: 'test.myshopify.com',
         privateStorefrontToken: 'priv-token',
-        buyerIp: '1.2.3.4',
       },
     });
 

--- a/packages/hydrogen/src/client/index.ts
+++ b/packages/hydrogen/src/client/index.ts
@@ -2,7 +2,11 @@ export { createStorefrontClient } from "./client";
 export { createShopifyRequestContext } from "../core/request-context";
 export { gql } from "../graphql";
 export { StorefrontApiError, StorefrontTimeoutError } from "./errors";
-export type { I18nConfig, ShopifyRequestContext } from "../core/request-context";
+export type {
+  I18nConfig,
+  ShopifyBuyerRequestContext,
+  ShopifyRequestContext,
+} from "../core/request-context";
 export type { AnyStorefrontQueryString, StorefrontQueryString } from "../graphql";
 export type { InferResult, InferVariables } from "../graphql";
 export type {

--- a/packages/hydrogen/src/client/index.ts
+++ b/packages/hydrogen/src/client/index.ts
@@ -4,8 +4,8 @@ export { gql } from "../graphql";
 export { StorefrontApiError, StorefrontTimeoutError } from "./errors";
 export type {
   I18nConfig,
-  ShopifyBuyerRequestContext,
   ShopifyRequestContext,
+  ShopifyRequestContextWithBuyerIp,
 } from "../core/request-context";
 export type { AnyStorefrontQueryString, StorefrontQueryString } from "../graphql";
 export type { InferResult, InferVariables } from "../graphql";

--- a/packages/hydrogen/src/client/types.ts
+++ b/packages/hydrogen/src/client/types.ts
@@ -5,7 +5,10 @@ import type {
 } from "gql.tada";
 
 import type { CacheInstance, WaitUntil } from "../core/cache/run-with-cache";
-import type { ShopifyBuyerRequestContext, ShopifyRequestContext } from "../core/request-context";
+import type {
+  ShopifyRequestContext,
+  ShopifyRequestContextWithBuyerIp,
+} from "../core/request-context";
 import type { AnyStorefrontQueryString, SourceOf, StorefrontQueryString } from "../graphql";
 import type { InferResult, InferVariables } from "../graphql";
 import type { InferOperationKind } from "../graphql/type-resolver";
@@ -88,7 +91,7 @@ export interface PublicClientOptions<
 /**
  * Private client — uses a private Storefront Access Token.
  *
- * `buyerIp` must be resolved before creating the client.
+ * `buyerIp` must be resolved on the request context before creating the client.
  *
  * Best for: SSR/server-side requests where you control the fetch
  * layer and can forward trusted buyer context.
@@ -100,7 +103,6 @@ export interface PrivateClientOptions<
 > extends CommonOptions {
   fetch?: Fetch;
   privateStorefrontToken: string;
-  buyerIp: string;
 }
 
 /**
@@ -140,7 +142,7 @@ export type CreateStorefrontClientArgs<
     }
   | {
       type: "private" & Type;
-      requestContext: RequestContext;
+      requestContext: RequestContext & ShopifyRequestContextWithBuyerIp;
       config: PrivateClientOptions<AnyFetch | undefined> & { cache?: CacheConfig };
     }
   | {
@@ -218,11 +220,11 @@ export type PublicStorefrontClient<
 
 export type PrivateStorefrontClient<
   Extra extends Record<string, unknown> = {},
-  RequestContext extends ShopifyRequestContext = ShopifyRequestContext,
+  RequestContext extends ShopifyRequestContextWithBuyerIp = ShopifyRequestContextWithBuyerIp,
 > = StorefrontClient<Extra, "private", RequestContext>;
 
 export type RequestScopedPrivateStorefrontClient<Extra extends Record<string, unknown> = {}> =
-  PrivateStorefrontClient<Extra, ShopifyRequestContext>;
+  PrivateStorefrontClient<Extra, ShopifyRequestContextWithBuyerIp>;
 
 export type PrivateNoBuyerContextStorefrontClient<
   Extra extends Record<string, unknown> = {},

--- a/packages/hydrogen/src/client/types.ts
+++ b/packages/hydrogen/src/client/types.ts
@@ -5,7 +5,7 @@ import type {
 } from "gql.tada";
 
 import type { CacheInstance, WaitUntil } from "../core/cache/run-with-cache";
-import type { ShopifyRequestContext } from "../core/request-context";
+import type { ShopifyBuyerRequestContext, ShopifyRequestContext } from "../core/request-context";
 import type { AnyStorefrontQueryString, SourceOf, StorefrontQueryString } from "../graphql";
 import type { InferResult, InferVariables } from "../graphql";
 import type { InferOperationKind } from "../graphql/type-resolver";

--- a/packages/hydrogen/src/core/cart/get-cart.test.ts
+++ b/packages/hydrogen/src/core/cart/get-cart.test.ts
@@ -45,6 +45,8 @@ type MockStorefrontClientOptions = {
   rejectWith?: Error;
 };
 
+const DEFAULT_BUYER_IP = "127.0.0.1";
+
 function mockStorefrontClient(
   data: unknown,
   options: MockStorefrontClientOptions = {},
@@ -62,6 +64,7 @@ function mockStorefrontClient(
     requestContext: createShopifyRequestContext({
       request: options.request ?? new Request("https://shop.example.com/"),
       i18n: { country: "US", language: "EN" },
+      buyerIp: DEFAULT_BUYER_IP,
     }),
     graphql: options.rejectWith
       ? vi.fn().mockRejectedValue(options.rejectWith)

--- a/packages/hydrogen/src/core/cart/get-cart.type-test.ts
+++ b/packages/hydrogen/src/core/cart/get-cart.type-test.ts
@@ -9,6 +9,7 @@ const i18n = { country: "US", language: "EN" } as const;
 const requestContext = createShopifyRequestContext({
   request: new Request("https://shop.example.com"),
   i18n,
+  buyerIp: "203.0.113.10",
 });
 const sessionManager = {
   getSessionOrigin: () => "https://shop.example.com",
@@ -26,7 +27,6 @@ describe("createCartServerHandlers type tests", () => {
       config: {
         storeDomain: "shop.example.com",
         privateStorefrontToken: "private-token",
-        buyerIp: "203.0.113.10",
       },
     });
 

--- a/packages/hydrogen/src/core/cart/route.test.ts
+++ b/packages/hydrogen/src/core/cart/route.test.ts
@@ -120,11 +120,11 @@ function createPrivateStorefrontClient(
     requestContext: createShopifyRequestContext({
       request,
       i18n: fixture.i18n ?? DEFAULT_I18N,
+      buyerIp: "127.0.0.1",
     }),
     config: {
       storeDomain: fixture.storeDomain,
       privateStorefrontToken: "test-private-token",
-      buyerIp: "127.0.0.1",
     },
   });
 }

--- a/packages/hydrogen/src/core/index.ts
+++ b/packages/hydrogen/src/core/index.ts
@@ -21,7 +21,7 @@ export { Cache, createFetchWithCache, createRunWithCache } from "./cache";
 export type { CacheInstance, CacheOptions, CachingStrategy } from "./cache";
 export { StorefrontApiError, StorefrontTimeoutError } from "../client/errors";
 export { gql } from "../graphql";
-export type { I18nConfig, ShopifyRequestContext } from "./request-context";
+export type { I18nConfig, ShopifyBuyerRequestContext, ShopifyRequestContext } from "./request-context";
 export type { AnyStorefrontQueryString, StorefrontQueryString } from "../graphql";
 export type { InferResult, InferVariables } from "../graphql";
 export type {

--- a/packages/hydrogen/src/core/index.ts
+++ b/packages/hydrogen/src/core/index.ts
@@ -21,7 +21,11 @@ export { Cache, createFetchWithCache, createRunWithCache } from "./cache";
 export type { CacheInstance, CacheOptions, CachingStrategy } from "./cache";
 export { StorefrontApiError, StorefrontTimeoutError } from "../client/errors";
 export { gql } from "../graphql";
-export type { I18nConfig, ShopifyBuyerRequestContext, ShopifyRequestContext } from "./request-context";
+export type {
+  I18nConfig,
+  ShopifyRequestContext,
+  ShopifyRequestContextWithBuyerIp,
+} from "./request-context";
 export type { AnyStorefrontQueryString, StorefrontQueryString } from "../graphql";
 export type { InferResult, InferVariables } from "../graphql";
 export type {

--- a/packages/hydrogen/src/core/predictive-search/server-handlers.test.ts
+++ b/packages/hydrogen/src/core/predictive-search/server-handlers.test.ts
@@ -49,11 +49,14 @@ function createPredictiveSearchRequest(search = "?q=snow"): Request {
 function createPrivateStorefrontClient(request: Request) {
   return createStorefrontClient({
     type: "private",
-    requestContext: createShopifyRequestContext({ request, i18n: DEFAULT_I18N }),
+    requestContext: createShopifyRequestContext({
+      request,
+      i18n: DEFAULT_I18N,
+      buyerIp: "127.0.0.1",
+    }),
     config: {
       storeDomain: "https://test-store.myshopify.com",
       privateStorefrontToken: "test-private-token",
-      buyerIp: "127.0.0.1",
     },
   });
 }

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -108,6 +108,16 @@ describe("createShopifyRequestContext", () => {
     ).toThrow("buyerIp must be non-empty when provided");
   });
 
+  it("treats an undefined buyer IP as absent", () => {
+    const result = createShopifyRequestContext({
+      request: new Request("https://example.com"),
+      i18n: DEFAULT_I18N,
+      buyerIp: undefined,
+    });
+
+    expect(result).not.toHaveProperty("buyerIp");
+  });
+
   it("defaults pathPrefix to an empty string", () => {
     const result = createTestRequestContext({ headers: new Headers() });
 

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -98,6 +98,16 @@ describe("createShopifyRequestContext", () => {
     expect(result.buyerIp).toBe(buyerIp);
   });
 
+  it("rejects an empty buyer IP", () => {
+    expect(() =>
+      createShopifyRequestContext({
+        request: new Request("https://example.com"),
+        i18n: DEFAULT_I18N,
+        buyerIp: "",
+      }),
+    ).toThrow("buyerIp must be non-empty when provided");
+  });
+
   it("defaults pathPrefix to an empty string", () => {
     const result = createTestRequestContext({ headers: new Headers() });
 

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -43,11 +43,16 @@ type NormalizedI18nConfig<I18n extends I18nConfig = I18nConfig> = Omit<I18n, "pa
   pathPrefix: string;
 };
 
-type ShopifyRequestContextInput<I18n extends I18nConfig = I18nConfig> = {
+type ShopifyRequestContextInputBase<I18n extends I18nConfig = I18nConfig> = {
   request: StorefrontRequest;
   i18n: I18n;
-  buyerIp?: string;
 };
+
+type ShopifyRequestContextInput<I18n extends I18nConfig = I18nConfig> =
+  ShopifyRequestContextInputBase<I18n> & { buyerIp?: never };
+
+type ShopifyBuyerRequestContextInput<I18n extends I18nConfig = I18nConfig> =
+  ShopifyRequestContextInputBase<I18n> & { buyerIp: string };
 
 type ShopifyRequestContextBase = {
   // -- Private fields --
@@ -103,6 +108,9 @@ export type ShopifyRequestContext<I18n extends I18nConfig = I18nConfig> =
     i18n: NormalizedI18nConfig<I18n>;
   };
 
+export type ShopifyBuyerRequestContext<I18n extends I18nConfig = I18nConfig> =
+  ShopifyRequestContext<I18n> & { buyerIp: string };
+
 type Context<I18n extends I18nConfig = I18nConfig> = {
   cookie?: string;
   uniqueToken?: string;
@@ -118,15 +126,22 @@ type Context<I18n extends I18nConfig = I18nConfig> = {
 };
 
 export function createShopifyRequestContext<const I18n extends I18nConfig>(
+  input: ShopifyBuyerRequestContextInput<I18n>,
+): ShopifyBuyerRequestContext<I18n>;
+export function createShopifyRequestContext<const I18n extends I18nConfig>(
   input: ShopifyRequestContextInput<I18n>,
 ): ShopifyRequestContext<I18n>;
 export function createShopifyRequestContext<const I18n extends I18nConfig>(
-  input: ShopifyRequestContextInput<I18n>,
+  input: ShopifyRequestContextInputBase<I18n> & { buyerIp?: string },
 ): ShopifyRequestContext<I18n> {
   const { request } = input;
 
   if (!input.i18n?.country || !input.i18n?.language) {
     throw new Error("i18n with country and language is required for Shopify request contexts.");
+  }
+
+  if ("buyerIp" in input && !input.buyerIp) {
+    throw new Error("buyerIp must be non-empty when provided");
   }
 
   const i18n = normalizeI18n(input.i18n);

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -51,7 +51,7 @@ type ShopifyRequestContextInputBase<I18n extends I18nConfig = I18nConfig> = {
 type ShopifyRequestContextInput<I18n extends I18nConfig = I18nConfig> =
   ShopifyRequestContextInputBase<I18n> & { buyerIp?: never };
 
-type ShopifyBuyerRequestContextInput<I18n extends I18nConfig = I18nConfig> =
+type ShopifyRequestContextWithBuyerIpInput<I18n extends I18nConfig = I18nConfig> =
   ShopifyRequestContextInputBase<I18n> & { buyerIp: string };
 
 type ShopifyRequestContextBase = {
@@ -70,7 +70,7 @@ type ShopifyRequestContextBase = {
   /** @internal */
   legacyTokens?: boolean;
   /** @internal */
-  buyerIp?: string;
+  readonly buyerIp?: string;
   /** @internal */
   requestGroupId: string;
   /** @internal */
@@ -108,8 +108,8 @@ export type ShopifyRequestContext<I18n extends I18nConfig = I18nConfig> =
     i18n: NormalizedI18nConfig<I18n>;
   };
 
-export type ShopifyBuyerRequestContext<I18n extends I18nConfig = I18nConfig> =
-  ShopifyRequestContext<I18n> & { buyerIp: string };
+export type ShopifyRequestContextWithBuyerIp<I18n extends I18nConfig = I18nConfig> =
+  ShopifyRequestContext<I18n> & { readonly buyerIp: string };
 
 type Context<I18n extends I18nConfig = I18nConfig> = {
   cookie?: string;
@@ -126,8 +126,8 @@ type Context<I18n extends I18nConfig = I18nConfig> = {
 };
 
 export function createShopifyRequestContext<const I18n extends I18nConfig>(
-  input: ShopifyBuyerRequestContextInput<I18n>,
-): ShopifyBuyerRequestContext<I18n>;
+  input: ShopifyRequestContextWithBuyerIpInput<I18n>,
+): ShopifyRequestContextWithBuyerIp<I18n>;
 export function createShopifyRequestContext<const I18n extends I18nConfig>(
   input: ShopifyRequestContextInput<I18n>,
 ): ShopifyRequestContext<I18n>;
@@ -140,7 +140,7 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
     throw new Error("i18n with country and language is required for Shopify request contexts.");
   }
 
-  if ("buyerIp" in input && !input.buyerIp) {
+  if (input.buyerIp !== undefined && !input.buyerIp) {
     throw new Error("buyerIp must be non-empty when provided");
   }
 

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-redirects.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-redirects.test.ts
@@ -18,11 +18,10 @@ const DEFAULT_ROUTE_TEMPLATES = createShopifyRouteTemplates({});
 function createPrivateStorefrontClient(request: Request, i18n: I18nConfig = DEFAULT_I18N) {
   return createStorefrontClient({
     type: "private",
-    requestContext: createShopifyRequestContext({ request, i18n }),
+    requestContext: createShopifyRequestContext({ request, i18n, buyerIp: "127.0.0.1" }),
     config: {
       storeDomain: defaultConfig.storeDomain,
       privateStorefrontToken: "test-private-token",
-      buyerIp: "127.0.0.1",
     },
   });
 }

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.development.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.development.test.ts
@@ -20,6 +20,7 @@ function handleShopifyRoutesDev(
   const requestContext = createShopifyRequestContext({
     request: options.request,
     i18n: DEFAULT_I18N,
+    buyerIp: "127.0.0.1",
   });
   return handleShopifyRoutesDevImpl({
     ...options,
@@ -31,7 +32,6 @@ function handleShopifyRoutesDev(
       config: {
         storeDomain: defaultConfig.storeDomain,
         privateStorefrontToken: "test-private-token",
-        buyerIp: "127.0.0.1",
       },
     }),
   });

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -41,7 +41,6 @@ function createPrivateStorefrontClient(
     config: {
       storeDomain: fixture.storeDomain,
       privateStorefrontToken: "test-private-token",
-      buyerIp: DEFAULT_BUYER_IP,
     },
   });
 }
@@ -151,14 +150,17 @@ describe("handleShopifyRoutes", () => {
     const request = new Request("https://my-app.com/api/cart?cartId=123", {
       headers: { "oxygen-buyer-ip": "10.0.0.2" },
     });
-    const requestContext = createShopifyRequestContext({ request, i18n: DEFAULT_I18N });
+    const requestContext = createShopifyRequestContext({
+      request,
+      i18n: DEFAULT_I18N,
+      buyerIp: "10.0.0.2",
+    });
     const storefrontClient = createStorefrontClient({
       type: "private",
       requestContext,
       config: {
         storeDomain: defaultConfig.storeDomain,
         privateStorefrontToken: "test-private-token",
-        buyerIp: "10.0.0.2",
       },
     });
 
@@ -300,14 +302,17 @@ describe("handleShopifyRoutes", () => {
         "oxygen-buyer-ip": "10.0.0.2",
       },
     });
-    const requestContext = createShopifyRequestContext({ request, i18n: DEFAULT_I18N });
+    const requestContext = createShopifyRequestContext({
+      request,
+      i18n: DEFAULT_I18N,
+      buyerIp: "10.0.0.2",
+    });
     const storefrontClient = createStorefrontClient({
       type: "private",
       requestContext,
       config: {
         storeDomain: defaultConfig.storeDomain,
         privateStorefrontToken: "test-private-token",
-        buyerIp: "10.0.0.2",
       },
     });
 

--- a/packages/hydrogen/src/core/request-routing/interceptors/admin-redirect.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/admin-redirect.test.ts
@@ -8,6 +8,7 @@ import type { RedirectOptions } from "../handle-shopify-redirects";
 import { handleAdminRedirect } from "./admin-redirect";
 
 const DEFAULT_I18N = { country: "US", language: "EN", pathPrefix: "" } as const;
+const DEFAULT_BUYER_IP = "127.0.0.1";
 const DEFAULT_ROUTE_TEMPLATES = createShopifyRouteTemplates({});
 
 function mockStorefrontClient(
@@ -22,6 +23,7 @@ function mockStorefrontClient(
     requestContext: createShopifyRequestContext({
       request: { headers: new Headers() },
       i18n: DEFAULT_I18N,
+      buyerIp: DEFAULT_BUYER_IP,
     }),
   } satisfies PrivateStorefrontClient;
 }

--- a/packages/hydrogen/src/core/request-routing/interceptors/checkout.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/checkout.test.ts
@@ -39,11 +39,14 @@ function createPrivateStorefrontClient(
 ) {
   return createStorefrontClient({
     type: "private",
-    requestContext: createShopifyRequestContext({ request, i18n: DEFAULT_I18N }),
+    requestContext: createShopifyRequestContext({
+      request,
+      i18n: DEFAULT_I18N,
+      buyerIp: "127.0.0.1",
+    }),
     config: {
       storeDomain: fixture.storeDomain,
       privateStorefrontToken: "test-private-token",
-      buyerIp: "127.0.0.1",
     },
   });
 }

--- a/packages/hydrogen/src/core/request-routing/interceptors/graphiql.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/graphiql.test.ts
@@ -7,6 +7,7 @@ import type { GraphiQLOptions } from "../../types";
 import { handleGraphiql as handleGraphiqlImpl } from "./graphiql";
 
 const DEFAULT_I18N = { country: "US", language: "EN", pathPrefix: "" } as const;
+const DEFAULT_BUYER_IP = "127.0.0.1";
 
 const storefrontClient = {
   type: "private",
@@ -17,6 +18,7 @@ const storefrontClient = {
   requestContext: createShopifyRequestContext({
     request: { headers: new Headers() },
     i18n: DEFAULT_I18N,
+    buyerIp: DEFAULT_BUYER_IP,
   }),
 } satisfies PrivateStorefrontClient;
 

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
@@ -51,11 +51,16 @@ function handleSfapiProxyWithClientType(
   storeUrl = defaultStoreUrl,
   buyerIp?: string,
 ) {
-  const requestContext = createShopifyRequestContext({
-    request,
-    i18n: { country: "US", language: "EN" },
-    buyerIp,
-  });
+  const requestContext = buyerIp
+    ? createShopifyRequestContext({
+        request,
+        i18n: { country: "US", language: "EN" },
+        buyerIp,
+      })
+    : createShopifyRequestContext({
+        request,
+        i18n: { country: "US", language: "EN" },
+      });
   const clientBase = {
     i18n: { country: "US", language: "EN", pathPrefix: "" } as const,
     storeUrl,

--- a/packages/hydrogen/src/core/request-routing/interceptors/url-redirects.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/url-redirects.test.ts
@@ -24,11 +24,14 @@ function createPrivateStorefrontClient(
 ) {
   return createStorefrontClient({
     type: "private",
-    requestContext: createShopifyRequestContext({ request, i18n: DEFAULT_I18N }),
+    requestContext: createShopifyRequestContext({
+      request,
+      i18n: DEFAULT_I18N,
+      buyerIp: "127.0.0.1",
+    }),
     config: {
       storeDomain: fixture.storeDomain,
       privateStorefrontToken: "test-private-token",
-      buyerIp: "127.0.0.1",
     },
   });
 }

--- a/packages/hydrogen/src/customer-account/session.test.ts
+++ b/packages/hydrogen/src/customer-account/session.test.ts
@@ -185,14 +185,17 @@ function createRequestContext(request = new Request(ORIGIN)) {
 }
 
 function createPrivateStorefrontClient(request: Request) {
-  const requestContext = createRequestContext(request);
+  const requestContext = createShopifyRequestContext({
+    request,
+    i18n: { country: "US", language: "EN" },
+    buyerIp: "127.0.0.1",
+  });
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: "test-store.myshopify.com",
       privateStorefrontToken: "test-private-token",
-      buyerIp: "127.0.0.1",
     },
   });
 }

--- a/templates/nextjs/.agents/skills/hydrogen-request-handlers/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-request-handlers/SKILL.md
@@ -47,9 +47,11 @@ const redirect = await handleShopifyRedirects({
 
 - Default to one request-scoped private Storefront client per request when buyer context exists.
 - Route handlers and cart server handlers accept any provided Storefront client when public or no-buyer-context access is intentional.
-- Resolve trusted `buyerIp` before creating a private client; pass it to both `createShopifyRequestContext` and private client config. Use the `hydrogen-storefront-client` buyer-IP guidance for the app's deployment.
+- Resolve trusted `buyerIp` before creating a private client and pass it to `createShopifyRequestContext`. Use the `hydrogen-storefront-client` buyer-IP guidance for the app's deployment.
 - Create `requestContext` with `createShopifyRequestContext({ request, i18n, buyerIp })` where buyer context exists and the framework exposes a real `Request`; use `request: { headers }` only when no `Request` exists.
 - Pass the same request-scoped `requestContext`, `storefrontClient`, and `sessionManager` into `handleShopifyRoutes` and registered handler groups.
+- Call `handleShopifyRoutes` without awaiting it immediately. It returns `null` synchronously when no route matches; only return or await the promise after checking that it is truthy.
+- If the app has a request-level `try/catch` that converts errors into a `Response`, use `return await shopifyRoute` inside that boundary so rejected route promises reach the same error handling as synchronous setup failures. If the framework owns request error handling, return `shopifyRoute` directly. Do not add an inline `.catch()` unless the matched route intentionally needs different error handling.
 - Pass `request` and `storefrontClient` into `handleShopifyRedirects`; it does not receive a session manager.
 - Pass registered handler groups explicitly, for example `handlers: [cartHandlers, customerAccountHandlers]`.
 - `handleShopifyRoutes` applies request-context response headers before returning matched Hydrogen route responses.

--- a/templates/nextjs/.agents/skills/hydrogen-request-handlers/references/frameworks.md
+++ b/templates/nextjs/.agents/skills/hydrogen-request-handlers/references/frameworks.md
@@ -14,6 +14,22 @@ This reference covers React Router, SvelteKit, Astro, SolidStart, and unknown se
 
 Use this when one server hook can both return a `Response` before routing and inspect the resolved response status after routing. SvelteKit and Astro fit this shape.
 
+The example lets the framework handle rejected route promises, so it returns a matched promise directly. If the app instead wraps the request lifecycle in a `try/catch` that creates an error `Response`, await only after the truthy check so that boundary also catches a matched route rejection:
+
+```ts
+try {
+  const shopifyRoute = handleShopifyRoutes(options);
+  if (shopifyRoute) return await shopifyRoute;
+
+  // Continue framework routing.
+} catch (error) {
+  logger.error(error);
+  return new Response("Unexpected error", { status: 500 });
+}
+```
+
+Prefer this over adding `.catch()` only to the returned promise: the request-level boundary also handles synchronous setup and validation errors.
+
 Resolve `buyerIp` with the app's trusted deployment header before creating the private client. Use the buyer-IP guidance from `hydrogen-storefront-client`.
 
 ```ts
@@ -43,11 +59,10 @@ export async function handleRequest(request: Request, next: () => Promise<Respon
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 
-  const shopifyRoute = await handleShopifyRoutes({
+  const shopifyRoute = handleShopifyRoutes({
     request,
     requestContext,
     sessionManager,
@@ -107,11 +122,10 @@ export const middleware: Route.MiddlewareFunction[] = [
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
         privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-        buyerIp,
       },
     });
 
-    const shopifyRoute = await handleShopifyRoutes({
+    const shopifyRoute = handleShopifyRoutes({
       request,
       requestContext,
       sessionManager,
@@ -143,7 +157,7 @@ SolidStart middleware can short-circuit before routing, but cannot reliably obse
 In middleware, create an app-owned request-scoped `sessionManager` before calling `handleShopifyRoutes`:
 
 ```ts
-const shopifyRoute = await handleShopifyRoutes({
+const shopifyRoute = handleShopifyRoutes({
   request: event.request,
   requestContext,
   sessionManager,

--- a/templates/nextjs/.agents/skills/hydrogen-request-handlers/references/nextjs.md
+++ b/templates/nextjs/.agents/skills/hydrogen-request-handlers/references/nextjs.md
@@ -36,12 +36,11 @@ export async function proxy(request: NextRequest) {
     config: {
       storeDomain: process.env.NEXT_PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
   const sessionManager = await createSessionManager(request);
 
-  const shopifyRoute = await handleShopifyRoutes({
+  const shopifyRoute = handleShopifyRoutes({
     request,
     requestContext,
     sessionManager,
@@ -60,6 +59,8 @@ export const config = {
   matcher: ["/((?!_next/static|_next/image|_next/data|favicon.ico).*)"],
 };
 ```
+
+The proxy returns a matched promise directly so Next owns any rejection. If the app adds a request-level `try/catch` that returns a custom error response, use `return await shopifyRoute` inside that boundary after the truthy check.
 
 Use `proxy.ts` for Next 16+. Older Next projects may still use `middleware.ts`, but keep the file name and exported function name matched to the installed Next version.
 

--- a/templates/nextjs/.agents/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/templates/nextjs/.agents/skills/hydrogen-request-handlers/references/nuxt.md
@@ -29,7 +29,7 @@ import {
   createStorefrontClient,
   createShopifyRequestContext,
   handleShopifyRoutes,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 
 const cartHandlers = createCartServerHandlers();
@@ -43,33 +43,34 @@ export default defineEventHandler(async (event) => {
     buyerIp,
   });
   const sessionManager = await createSessionManager(request);
-  const storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  const storefrontClient = createPrivateStorefrontClient(requestContext);
 
-  const shopifyRoute = await handleShopifyRoutes({
+  const shopifyRoute = handleShopifyRoutes({
     request,
     requestContext,
     sessionManager,
     storefrontClient,
     handlers: [cartHandlers],
   });
-  if (shopifyRoute) return sendWebResponse(event, shopifyRoute);
+  if (shopifyRoute) return sendWebResponse(event, await shopifyRoute);
 
   event.context.shopifyRequestContext = requestContext;
   event.context.storefrontClient = storefrontClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 }
 ```
+
+This middleware awaits a matched promise because `sendWebResponse` needs the resolved `Response`; rejected promises continue through Nitro's request error handling. Do not attach an inline `.catch()` unless this route intentionally needs handling that differs from the app's normal error boundary.
 
 Use project-owned helpers for env access. Do not expose the private token to client plugins.
 
@@ -163,8 +164,10 @@ if (import.meta.server && props.error.statusCode === 404) {
     const storefrontClient = event.context.storefrontClient;
     if (!storefrontClient) throw new Error("Storefront client was not created.");
     const redirect = await handleShopifyRedirects({ request, routeTemplates, storefrontClient });
-    const location = redirect?.headers.get("location");
-    if (location) await navigateTo(location, { redirectCode: redirect!.status as 301 | 302 });
+    if (redirect) {
+      const location = redirect.headers.get("location");
+      if (location) await navigateTo(location, { redirectCode: redirect.status as 301 | 302 });
+    }
   }
 }
 </script>

--- a/templates/nextjs/.agents/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/templates/nextjs/.agents/skills/hydrogen-request-handlers/references/nuxt.md
@@ -29,7 +29,7 @@ import {
   createStorefrontClient,
   createShopifyRequestContext,
   handleShopifyRoutes,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 
 const cartHandlers = createCartServerHandlers();
@@ -58,7 +58,7 @@ export default defineEventHandler(async (event) => {
   event.context.storefrontClient = storefrontClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/templates/nextjs/.agents/skills/hydrogen-storefront-client/SKILL.md
+++ b/templates/nextjs/.agents/skills/hydrogen-storefront-client/SKILL.md
@@ -91,7 +91,6 @@ const client = createStorefrontClient({
   config: {
     storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
     privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-    buyerIp,
   },
 });
 ```
@@ -105,7 +104,7 @@ Hydrogen does not infer buyer IP headers. Apps decide how to build `buyerIp` bas
 
 Use the same request-scoped Storefront client for Hydrogen route handlers, cart server handlers, and server data loaders when they share the same request data. Route and cart handlers accept any provided Storefront client. Redirect handlers still require a private server-side client.
 
-When using `handleShopifyRoutes`, pass the same trusted `buyerIp` into `createShopifyRequestContext`. The SFAPI proxy sources buyer IP from request context so proxy requests and direct `client.graphql()` calls use the same buyer identity.
+When using `handleShopifyRoutes`, pass the trusted `buyerIp` into `createShopifyRequestContext`. Both the SFAPI proxy and direct `client.graphql()` calls source buyer identity from that request context.
 
 ### Private client without buyer context
 

--- a/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/astro.md
+++ b/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/astro.md
@@ -27,7 +27,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
     config: {
       storeDomain: import.meta.env.PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: import.meta.env.PRIVATE_STOREFRONT_API_TOKEN,
-      buyerIp,
     },
   });
 

--- a/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/nextjs.md
+++ b/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/nextjs.md
@@ -32,7 +32,6 @@ export const getStorefrontClient = cache(async () => {
     config: {
       storeDomain: process.env.NEXT_PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 });

--- a/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/nuxt.md
+++ b/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/nuxt.md
@@ -15,7 +15,7 @@ Create the private client in server middleware where Nuxt exposes the incoming r
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 
 export default defineEventHandler((event) => {
@@ -27,18 +27,17 @@ export default defineEventHandler((event) => {
     buyerIp,
   });
 
-  event.context.storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  event.context.storefrontClient = createPrivateStorefrontClient(requestContext);
   event.context.shopifyRequestContext = requestContext;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 }

--- a/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/nuxt.md
+++ b/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/nuxt.md
@@ -15,7 +15,7 @@ Create the private client in server middleware where Nuxt exposes the incoming r
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 
 export default defineEventHandler((event) => {
@@ -31,7 +31,7 @@ export default defineEventHandler((event) => {
   event.context.shopifyRequestContext = requestContext;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/react-router.md
+++ b/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/react-router.md
@@ -39,7 +39,6 @@ export const storefrontMiddleware: Route.MiddlewareFunction = async (
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 

--- a/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/solidstart.md
+++ b/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/solidstart.md
@@ -30,7 +30,6 @@ export default createMiddleware({
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
         privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-        buyerIp,
       },
     });
 
@@ -119,7 +118,6 @@ export default createMiddleware({
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
         privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-        buyerIp,
       },
     });
 

--- a/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/sveltekit.md
+++ b/templates/nextjs/.agents/skills/hydrogen-storefront-client/references/sveltekit.md
@@ -34,7 +34,6 @@ export const handle: Handle = async ({ event, resolve }) => {
     config: {
       storeDomain: PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: PRIVATE_STOREFRONT_API_TOKEN,
-      buyerIp,
     },
   });
 
@@ -105,7 +104,6 @@ export const handle: Handle = async ({ event, resolve }) => {
     config: {
       storeDomain: PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: PRIVATE_STOREFRONT_API_TOKEN,
-      buyerIp,
     },
   });
 

--- a/templates/nextjs/lib/storefront.ts
+++ b/templates/nextjs/lib/storefront.ts
@@ -40,7 +40,6 @@ export const getStorefrontClient = cache(
       config: {
         storeDomain,
         privateStorefrontToken,
-        buyerIp,
       },
     });
   },

--- a/templates/nextjs/proxy.ts
+++ b/templates/nextjs/proxy.ts
@@ -48,7 +48,6 @@ export async function proxy(request: NextRequest) {
     config: {
       storeDomain,
       privateStorefrontToken,
-      buyerIp,
     },
   });
 

--- a/templates/react-router/.agents/skills/hydrogen-request-handlers/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-request-handlers/SKILL.md
@@ -47,9 +47,11 @@ const redirect = await handleShopifyRedirects({
 
 - Default to one request-scoped private Storefront client per request when buyer context exists.
 - Route handlers and cart server handlers accept any provided Storefront client when public or no-buyer-context access is intentional.
-- Resolve trusted `buyerIp` before creating a private client; pass it to both `createShopifyRequestContext` and private client config. Use the `hydrogen-storefront-client` buyer-IP guidance for the app's deployment.
+- Resolve trusted `buyerIp` before creating a private client and pass it to `createShopifyRequestContext`. Use the `hydrogen-storefront-client` buyer-IP guidance for the app's deployment.
 - Create `requestContext` with `createShopifyRequestContext({ request, i18n, buyerIp })` where buyer context exists and the framework exposes a real `Request`; use `request: { headers }` only when no `Request` exists.
 - Pass the same request-scoped `requestContext`, `storefrontClient`, and `sessionManager` into `handleShopifyRoutes` and registered handler groups.
+- Call `handleShopifyRoutes` without awaiting it immediately. It returns `null` synchronously when no route matches; only return or await the promise after checking that it is truthy.
+- If the app has a request-level `try/catch` that converts errors into a `Response`, use `return await shopifyRoute` inside that boundary so rejected route promises reach the same error handling as synchronous setup failures. If the framework owns request error handling, return `shopifyRoute` directly. Do not add an inline `.catch()` unless the matched route intentionally needs different error handling.
 - Pass `request` and `storefrontClient` into `handleShopifyRedirects`; it does not receive a session manager.
 - Pass registered handler groups explicitly, for example `handlers: [cartHandlers, customerAccountHandlers]`.
 - `handleShopifyRoutes` applies request-context response headers before returning matched Hydrogen route responses.

--- a/templates/react-router/.agents/skills/hydrogen-request-handlers/references/frameworks.md
+++ b/templates/react-router/.agents/skills/hydrogen-request-handlers/references/frameworks.md
@@ -14,6 +14,22 @@ This reference covers React Router, SvelteKit, Astro, SolidStart, and unknown se
 
 Use this when one server hook can both return a `Response` before routing and inspect the resolved response status after routing. SvelteKit and Astro fit this shape.
 
+The example lets the framework handle rejected route promises, so it returns a matched promise directly. If the app instead wraps the request lifecycle in a `try/catch` that creates an error `Response`, await only after the truthy check so that boundary also catches a matched route rejection:
+
+```ts
+try {
+  const shopifyRoute = handleShopifyRoutes(options);
+  if (shopifyRoute) return await shopifyRoute;
+
+  // Continue framework routing.
+} catch (error) {
+  logger.error(error);
+  return new Response("Unexpected error", { status: 500 });
+}
+```
+
+Prefer this over adding `.catch()` only to the returned promise: the request-level boundary also handles synchronous setup and validation errors.
+
 Resolve `buyerIp` with the app's trusted deployment header before creating the private client. Use the buyer-IP guidance from `hydrogen-storefront-client`.
 
 ```ts
@@ -43,11 +59,10 @@ export async function handleRequest(request: Request, next: () => Promise<Respon
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 
-  const shopifyRoute = await handleShopifyRoutes({
+  const shopifyRoute = handleShopifyRoutes({
     request,
     requestContext,
     sessionManager,
@@ -107,11 +122,10 @@ export const middleware: Route.MiddlewareFunction[] = [
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
         privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-        buyerIp,
       },
     });
 
-    const shopifyRoute = await handleShopifyRoutes({
+    const shopifyRoute = handleShopifyRoutes({
       request,
       requestContext,
       sessionManager,
@@ -143,7 +157,7 @@ SolidStart middleware can short-circuit before routing, but cannot reliably obse
 In middleware, create an app-owned request-scoped `sessionManager` before calling `handleShopifyRoutes`:
 
 ```ts
-const shopifyRoute = await handleShopifyRoutes({
+const shopifyRoute = handleShopifyRoutes({
   request: event.request,
   requestContext,
   sessionManager,

--- a/templates/react-router/.agents/skills/hydrogen-request-handlers/references/nextjs.md
+++ b/templates/react-router/.agents/skills/hydrogen-request-handlers/references/nextjs.md
@@ -36,12 +36,11 @@ export async function proxy(request: NextRequest) {
     config: {
       storeDomain: process.env.NEXT_PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
   const sessionManager = await createSessionManager(request);
 
-  const shopifyRoute = await handleShopifyRoutes({
+  const shopifyRoute = handleShopifyRoutes({
     request,
     requestContext,
     sessionManager,
@@ -60,6 +59,8 @@ export const config = {
   matcher: ["/((?!_next/static|_next/image|_next/data|favicon.ico).*)"],
 };
 ```
+
+The proxy returns a matched promise directly so Next owns any rejection. If the app adds a request-level `try/catch` that returns a custom error response, use `return await shopifyRoute` inside that boundary after the truthy check.
 
 Use `proxy.ts` for Next 16+. Older Next projects may still use `middleware.ts`, but keep the file name and exported function name matched to the installed Next version.
 

--- a/templates/react-router/.agents/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/templates/react-router/.agents/skills/hydrogen-request-handlers/references/nuxt.md
@@ -29,7 +29,7 @@ import {
   createStorefrontClient,
   createShopifyRequestContext,
   handleShopifyRoutes,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 
 const cartHandlers = createCartServerHandlers();
@@ -43,33 +43,34 @@ export default defineEventHandler(async (event) => {
     buyerIp,
   });
   const sessionManager = await createSessionManager(request);
-  const storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  const storefrontClient = createPrivateStorefrontClient(requestContext);
 
-  const shopifyRoute = await handleShopifyRoutes({
+  const shopifyRoute = handleShopifyRoutes({
     request,
     requestContext,
     sessionManager,
     storefrontClient,
     handlers: [cartHandlers],
   });
-  if (shopifyRoute) return sendWebResponse(event, shopifyRoute);
+  if (shopifyRoute) return sendWebResponse(event, await shopifyRoute);
 
   event.context.shopifyRequestContext = requestContext;
   event.context.storefrontClient = storefrontClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 }
 ```
+
+This middleware awaits a matched promise because `sendWebResponse` needs the resolved `Response`; rejected promises continue through Nitro's request error handling. Do not attach an inline `.catch()` unless this route intentionally needs handling that differs from the app's normal error boundary.
 
 Use project-owned helpers for env access. Do not expose the private token to client plugins.
 
@@ -163,8 +164,10 @@ if (import.meta.server && props.error.statusCode === 404) {
     const storefrontClient = event.context.storefrontClient;
     if (!storefrontClient) throw new Error("Storefront client was not created.");
     const redirect = await handleShopifyRedirects({ request, routeTemplates, storefrontClient });
-    const location = redirect?.headers.get("location");
-    if (location) await navigateTo(location, { redirectCode: redirect!.status as 301 | 302 });
+    if (redirect) {
+      const location = redirect.headers.get("location");
+      if (location) await navigateTo(location, { redirectCode: redirect.status as 301 | 302 });
+    }
   }
 }
 </script>

--- a/templates/react-router/.agents/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/templates/react-router/.agents/skills/hydrogen-request-handlers/references/nuxt.md
@@ -29,7 +29,7 @@ import {
   createStorefrontClient,
   createShopifyRequestContext,
   handleShopifyRoutes,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 
 const cartHandlers = createCartServerHandlers();
@@ -58,7 +58,7 @@ export default defineEventHandler(async (event) => {
   event.context.storefrontClient = storefrontClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/templates/react-router/.agents/skills/hydrogen-storefront-client/SKILL.md
+++ b/templates/react-router/.agents/skills/hydrogen-storefront-client/SKILL.md
@@ -91,7 +91,6 @@ const client = createStorefrontClient({
   config: {
     storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
     privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-    buyerIp,
   },
 });
 ```
@@ -105,7 +104,7 @@ Hydrogen does not infer buyer IP headers. Apps decide how to build `buyerIp` bas
 
 Use the same request-scoped Storefront client for Hydrogen route handlers, cart server handlers, and server data loaders when they share the same request data. Route and cart handlers accept any provided Storefront client. Redirect handlers still require a private server-side client.
 
-When using `handleShopifyRoutes`, pass the same trusted `buyerIp` into `createShopifyRequestContext`. The SFAPI proxy sources buyer IP from request context so proxy requests and direct `client.graphql()` calls use the same buyer identity.
+When using `handleShopifyRoutes`, pass the trusted `buyerIp` into `createShopifyRequestContext`. Both the SFAPI proxy and direct `client.graphql()` calls source buyer identity from that request context.
 
 ### Private client without buyer context
 

--- a/templates/react-router/.agents/skills/hydrogen-storefront-client/references/astro.md
+++ b/templates/react-router/.agents/skills/hydrogen-storefront-client/references/astro.md
@@ -27,7 +27,6 @@ export const onRequest = defineMiddleware(async (context, next) => {
     config: {
       storeDomain: import.meta.env.PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: import.meta.env.PRIVATE_STOREFRONT_API_TOKEN,
-      buyerIp,
     },
   });
 

--- a/templates/react-router/.agents/skills/hydrogen-storefront-client/references/nextjs.md
+++ b/templates/react-router/.agents/skills/hydrogen-storefront-client/references/nextjs.md
@@ -32,7 +32,6 @@ export const getStorefrontClient = cache(async () => {
     config: {
       storeDomain: process.env.NEXT_PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 });

--- a/templates/react-router/.agents/skills/hydrogen-storefront-client/references/nuxt.md
+++ b/templates/react-router/.agents/skills/hydrogen-storefront-client/references/nuxt.md
@@ -15,7 +15,7 @@ Create the private client in server middleware where Nuxt exposes the incoming r
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyRequestContext,
+  type ShopifyBuyerRequestContext,
 } from "@shopify/hydrogen";
 
 export default defineEventHandler((event) => {
@@ -27,18 +27,17 @@ export default defineEventHandler((event) => {
     buyerIp,
   });
 
-  event.context.storefrontClient = createPrivateStorefrontClient(requestContext, buyerIp);
+  event.context.storefrontClient = createPrivateStorefrontClient(requestContext);
   event.context.shopifyRequestContext = requestContext;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContext, buyerIp: string) {
+function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
   return createStorefrontClient({
     type: "private",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 }

--- a/templates/react-router/.agents/skills/hydrogen-storefront-client/references/nuxt.md
+++ b/templates/react-router/.agents/skills/hydrogen-storefront-client/references/nuxt.md
@@ -15,7 +15,7 @@ Create the private client in server middleware where Nuxt exposes the incoming r
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyBuyerRequestContext,
+  type ShopifyRequestContextWithBuyerIp,
 } from "@shopify/hydrogen";
 
 export default defineEventHandler((event) => {
@@ -31,7 +31,7 @@ export default defineEventHandler((event) => {
   event.context.shopifyRequestContext = requestContext;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyBuyerRequestContext) {
+function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
   return createStorefrontClient({
     type: "private",
     requestContext,

--- a/templates/react-router/.agents/skills/hydrogen-storefront-client/references/react-router.md
+++ b/templates/react-router/.agents/skills/hydrogen-storefront-client/references/react-router.md
@@ -39,7 +39,6 @@ export const storefrontMiddleware: Route.MiddlewareFunction = async (
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
       privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-      buyerIp,
     },
   });
 

--- a/templates/react-router/.agents/skills/hydrogen-storefront-client/references/solidstart.md
+++ b/templates/react-router/.agents/skills/hydrogen-storefront-client/references/solidstart.md
@@ -30,7 +30,6 @@ export default createMiddleware({
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
         privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-        buyerIp,
       },
     });
 
@@ -119,7 +118,6 @@ export default createMiddleware({
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
         privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
-        buyerIp,
       },
     });
 

--- a/templates/react-router/.agents/skills/hydrogen-storefront-client/references/sveltekit.md
+++ b/templates/react-router/.agents/skills/hydrogen-storefront-client/references/sveltekit.md
@@ -34,7 +34,6 @@ export const handle: Handle = async ({ event, resolve }) => {
     config: {
       storeDomain: PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: PRIVATE_STOREFRONT_API_TOKEN,
-      buyerIp,
     },
   });
 
@@ -105,7 +104,6 @@ export const handle: Handle = async ({ event, resolve }) => {
     config: {
       storeDomain: PUBLIC_STORE_DOMAIN,
       privateStorefrontToken: PRIVATE_STOREFRONT_API_TOKEN,
-      buyerIp,
     },
   });
 

--- a/templates/react-router/app/lib/storefront.ts
+++ b/templates/react-router/app/lib/storefront.ts
@@ -47,7 +47,6 @@ export function createRequestStorefrontClient(
     config: {
       storeDomain,
       privateStorefrontToken,
-      buyerIp,
     },
   });
 }


### PR DESCRIPTION
TL;DR: Make `requestContext` the single source of truth for private Storefront API buyer IP.

This follows up on [the developer preview docs review](https://github.com/shop/world/pull/976512/changes#r3717727496), where the current API required the same `buyerIp` in two places. Those values could disagree, and every integration had to repeat request-scoped configuration in static client config.

## Before

```ts
const requestContext = createShopifyRequestContext({request, i18n, buyerIp});

createStorefrontClient({
  type: "private",
  requestContext,
  config: {storeDomain, privateStorefrontToken, buyerIp},
});
```

## After

```ts
const requestContext = createShopifyRequestContext({request, i18n, buyerIp});

createStorefrontClient({
  type: "private",
  requestContext,
  config: {storeDomain, privateStorefrontToken},
});
```

## What this changes

- Reads private-client buyer IP exclusively from `requestContext`.
- Adds `ShopifyBuyerRequestContext` so private clients require buyer IP at compile time.
- Rejects empty buyer IP values at the request-context boundary and keeps a runtime guard for JavaScript and asserted callers.
- Updates the README, framework examples, scaffold templates, packaged skills, and generated skill copies to teach the same contract.

## Developer impact

Preview consumers must move `buyerIp` from private client config to `createShopifyRequestContext`. `PrivateStorefrontClient` and `RequestScopedPrivateStorefrontClient` now expose a buyer-bearing request context.

Includes a **patch** changeset for `@shopify/hydrogen`. This corrects the prerelease API before its stable release while preserving the existing private-client requirement that a trusted buyer IP is present.

## Out of scope

- Deriving buyer IP from request headers. Applications remain responsible for using trusted request data provided by their deployment platform.

## Risk

- This is a compile-time breaking change for consumers of the current preview API that still pass `buyerIp` in private client config.
- Forged or JavaScript calls without a buyer-bearing request context fail with an explicit runtime error.