### PR TITLE
Fix Vue ShopifyScripts prop forwarding

### DIFF
--- a/.changeset/vue-shopify-scripts-props.md
+++ b/.changeset/vue-shopify-scripts-props.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Fix the Vue `ShopifyScripts` component to declare and forward all core script options, including `shopifyAnalytics`, and align Inbox runtime prop validation with its boolean API.

--- a/packages/hydrogen/src/vue/shopify-scripts.test.ts
+++ b/packages/hydrogen/src/vue/shopify-scripts.test.ts
@@ -48,6 +48,7 @@ describe("ShopifyScripts", () => {
         routes: routeTemplates,
         shop: TEST_SHOP,
         inbox: true,
+        shopifyAnalytics: false,
       }),
     );
 
@@ -66,6 +67,7 @@ describe("ShopifyScripts", () => {
     expect(html).toContain(
       `<script id="shopify-inbox" type="module" async crossorigin="anonymous" nonce="test-nonce" src="${SHOPIFY_INBOX_SCRIPT}"></script>`,
     );
+    expect(html).not.toContain(`id="shopify-storefront-analytics"`);
     expect(html).not.toContain("<shopify-chat");
     expect(html).toContain(`id="shopify-perfkit"`);
     expect(html).toContain(`async`);

--- a/packages/hydrogen/src/vue/shopify-scripts.ts
+++ b/packages/hydrogen/src/vue/shopify-scripts.ts
@@ -15,6 +15,10 @@ export type ShopifyScriptsProps = ShopifyScriptTagsOptions & {
   webMcp?: boolean;
 };
 
+type CompletePropOptions<T> = {
+  [K in keyof T]-?: unknown;
+};
+
 const i18nProp: PropType<ShopifyScriptsI18n> = Object;
 const navigateProp: PropType<NonNullable<ShopifyRoutesOptions["navigate"]>> | null = null;
 const routesProp: PropType<NonNullable<ShopifyRoutesOptions["routes"]>> | null = null;
@@ -22,7 +26,7 @@ const shopProp: PropType<ShopifyScriptsShop> = Object;
 const consentProp: PropType<ShopifyScriptTagsOptions["consent"]> = Object;
 const analyticsProp: PropType<ShopifyScriptTagsOptions["analytics"]> = Object;
 const debugProp: PropType<ShopifyScriptTagsOptions["debug"]> = Object;
-const inboxProp: PropType<ShopifyScriptTagsOptions["inbox"]> = [Boolean, Object];
+const inboxProp: PropType<ShopifyScriptTagsOptions["inbox"]> = Boolean;
 
 export const ShopifyScripts = defineComponent({
   name: "ShopifyScripts",
@@ -63,11 +67,15 @@ export const ShopifyScripts = defineComponent({
       type: inboxProp,
       default: undefined,
     },
+    shopifyAnalytics: {
+      type: Boolean,
+      default: undefined,
+    },
     shop: {
       type: shopProp,
-      required: true,
+      required: true as const,
     },
-  },
+  } satisfies CompletePropOptions<ShopifyScriptsProps>,
   setup(props) {
     onMounted(() => {
       void initializeShopifyScripts({
@@ -78,15 +86,7 @@ export const ShopifyScripts = defineComponent({
     });
 
     return () =>
-      getShopifyScriptTags({
-        analytics: props.analytics,
-        consent: props.consent,
-        debug: props.debug,
-        i18n: props.i18n,
-        nonce: props.nonce,
-        shop: props.shop,
-        inbox: props.inbox ?? undefined,
-      }).tags.map(({ tagName, attributes, innerHTML }) =>
+      getShopifyScriptTags(props).tags.map(({ tagName, attributes, innerHTML }) =>
         h(tagName, {
           ...attributes,
           ...(innerHTML ? { innerHTML } : {}),


### PR DESCRIPTION
TL;DR: Fix the Vue `ShopifyScripts` binding so its runtime props stay aligned with the shared script options and `shopifyAnalytics` can be disabled.

## Before

The public Vue props type included `shopifyAnalytics`, but the component did not declare or forward it at runtime. The Inbox prop also accepted objects even though the shared API is boolean-only.

## After

Vue declares and forwards `shopifyAnalytics`, validates Inbox as a boolean, and verifies at compile time that every public component prop has a runtime declaration.

## What this changes

- Pass all declared Vue props to the shared script-tag generator.
- Add SSR regression coverage for disabling Shopify analytics.
- Add a compile-time completeness check for the Vue runtime props declaration.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. This fixes existing Vue component behavior without adding exports or changing the public contract.

## Risk

- Low. The shared generator destructures its supported script options, so Vue-only initialization props are ignored.
