### PR TITLE
Add automatic labels for preview pull requests

### DIFF
--- a/.github/workflows/label-preview-pr.yml
+++ b/.github/workflows/label-preview-pr.yml
@@ -1,0 +1,32 @@
+name: Label Preview Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches: [preview]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add preview labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const authorAssociation = context.payload.pull_request.author_association;
+            const labels = ['preview'];
+
+            if (['MEMBER', 'OWNER'].includes(authorAssociation)) {
+              labels.push('gsd:50917');
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels,
+            });


### PR DESCRIPTION
## Summary

- add the `preview` label to newly opened pull requests targeting `preview`
- also add `gsd:50917` when the author is a Shopify organization member
- use an API-only `pull_request_target` workflow with limited permissions

## Testing

- parsed the workflow successfully as YAML
- ran `git diff --cached --check` before committing