### PR TITLE
Proxy Shopify runtime API requests

### DIFF
--- a/.changeset/calm-routes-proxy.md
+++ b/.changeset/calm-routes-proxy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Enable Shopify runtime modules initialized by `ShopifyScripts` to send same-origin API requests through `handleShopifyRoutes`, forwarding them to the Shopify's backend while filtering hop-by-hop request headers.

--- a/packages/hydrogen/src/client/client.test.ts
+++ b/packages/hydrogen/src/client/client.test.ts
@@ -238,6 +238,7 @@ describe("createStorefrontClient", () => {
       expect(headers.get("X-Shopify-UniqueToken")).toBe("unique-token");
       expect(headers.get("X-Shopify-VisitToken")).toBe("visit-token");
       expect(headers.get("Custom-Storefront-Request-Group-ID")).toBeTruthy();
+      expect(headers.get("Sec-Shopify-Storefront-Origin")).toBe("https://example.com");
     });
 
     it("sends private access token header", async () => {

--- a/packages/hydrogen/src/client/client.ts
+++ b/packages/hydrogen/src/client/client.ts
@@ -7,7 +7,11 @@ import type { CacheInstance } from "../core/cache/run-with-cache";
 import type { CachingStrategy } from "../core/cache/strategies";
 import { DEFAULT_TIMEOUT_IN_MS, STOREFRONT_API_VERSION } from "../core/constants";
 import {
+  HYDROGEN_VERSION_HEADER,
   REQUEST_GROUP_ID_HEADER,
+  SDK_VARIANT_HEADER,
+  SDK_VARIANT_SOURCE_HEADER,
+  SDK_VERSION_HEADER,
   SHOPIFY_CLIENT_IP_HEADER,
   SHOPIFY_STOREFRONT_S_HEADER,
   SHOPIFY_STOREFRONT_Y_HEADER,
@@ -38,10 +42,6 @@ type ResolvedStorefrontFetch = (
   cacheOptions: FetchCacheOptions | undefined,
 ) => Promise<Response>;
 
-const SDK_VARIANT_HEADER = "X-SDK-Variant";
-const SDK_VARIANT_SOURCE_HEADER = "X-SDK-Variant-Source";
-const SDK_VERSION_HEADER = "X-SDK-Version";
-const HYDROGEN_VERSION_HEADER = "X-Hydrogen-Version";
 const COUNTRY_VAR_RE = /\$country\s*:/;
 const LANGUAGE_VAR_RE = /\$language\s*:/;
 const REQUEST_CACHE_KEY_HEADERS = new Set([
@@ -138,10 +138,6 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
 
   const staticHeaders: Record<string, string> = {
     "content-type": "application/json",
-    [SDK_VARIANT_HEADER]: "hydrogen",
-    [SDK_VARIANT_SOURCE_HEADER]: "kit",
-    [SDK_VERSION_HEADER]: STOREFRONT_API_VERSION,
-    [HYDROGEN_VERSION_HEADER]: __HYDROGEN_VERSION__,
   };
 
   switch (clientType) {
@@ -171,10 +167,8 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
   }
 
   const i18n = requestContext.i18n;
-  const requestHeaders = requestContext.getSubrequestHeaders();
-  for (const [name, value] of Object.entries(staticHeaders)) {
-    requestHeaders.set(name, value);
-  }
+  const requestHeaders = new Headers(staticHeaders);
+  requestContext.applyStorefrontRequestHeaders(requestHeaders);
 
   if (clientType === "private") {
     const { buyerIp } = config;

--- a/packages/hydrogen/src/client/client.type-test.ts
+++ b/packages/hydrogen/src/client/client.type-test.ts
@@ -233,9 +233,7 @@ describe('type tests', () => {
           getForwardedRequestHeaders() {
             return new Headers();
           },
-          getSubrequestHeaders() {
-            return new Headers();
-          },
+          applyStorefrontRequestHeaders() {},
           captureSubrequestHeaders() {},
           applyResponseHeaders() {},
         },

--- a/packages/hydrogen/src/core/headers.ts
+++ b/packages/hydrogen/src/core/headers.ts
@@ -20,13 +20,22 @@ export type StandardHeaderName =
   | "access-control-request-headers"
   | "access-control-request-method"
   | typeof CACHE_CONTROL_HEADER
+  | "connection"
   | "content-length"
   | "content-type"
   | "cookie"
+  | "host"
+  | "keep-alive"
   | "origin"
+  | "proxy-authenticate"
+  | "proxy-authorization"
   | "referer"
   | typeof SERVER_TIMING_HEADER
   | typeof SURROGATE_CONTROL_HEADER
+  | "te"
+  | "trailer"
+  | "transfer-encoding"
+  | "upgrade"
   | "user-agent"
   | "x-requested-with";
 
@@ -104,4 +113,17 @@ export const AJAX_API_REQUEST_HEADER_ALLOWLIST = defineHeaderList(
   ...COMMON_PROXY_HEADER_ALLOWLIST,
   "content-length",
   "x-requested-with",
+);
+
+export const SHOPIFY_API_PROXY_REQUEST_HEADER_DENYLIST = defineHeaderList(
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
 );

--- a/packages/hydrogen/src/core/headers.ts
+++ b/packages/hydrogen/src/core/headers.ts
@@ -1,9 +1,14 @@
 export const CACHE_CONTROL_HEADER = "Cache-Control";
+export const HYDROGEN_VERSION_HEADER = "X-Hydrogen-Version";
 export const SERVER_TIMING_HEADER = "Server-Timing";
 export const SURROGATE_CONTROL_HEADER = "Surrogate-Control";
 export const REQUEST_GROUP_ID_HEADER = "Custom-Storefront-Request-Group-ID";
+export const SDK_VARIANT_HEADER = "X-SDK-Variant";
+export const SDK_VARIANT_SOURCE_HEADER = "X-SDK-Variant-Source";
+export const SDK_VERSION_HEADER = "X-SDK-Version";
 export const SHOPIFY_CHAT_FRAME_ORIGIN_HEADER = "Sec-Shopify-Chat-Frame-Origin";
 export const SHOPIFY_CLIENT_IP_HEADER = "X-Shopify-Client-IP";
+export const SHOPIFY_STOREFRONT_ORIGIN_HEADER = "Sec-Shopify-Storefront-Origin";
 export const SHOPIFY_STOREFRONT_S_HEADER = "Shopify-Storefront-S";
 export const SHOPIFY_STOREFRONT_Y_HEADER = "Shopify-Storefront-Y";
 export const SHOPIFY_UNIQUE_TOKEN_HEADER = "X-Shopify-UniqueToken";
@@ -40,9 +45,14 @@ export type StandardHeaderName =
   | "x-requested-with";
 
 export type ShopifyHeaderName =
+  | typeof HYDROGEN_VERSION_HEADER
   | typeof REQUEST_GROUP_ID_HEADER
+  | typeof SDK_VARIANT_HEADER
+  | typeof SDK_VARIANT_SOURCE_HEADER
+  | typeof SDK_VERSION_HEADER
   | typeof SHOPIFY_CHAT_FRAME_ORIGIN_HEADER
   | typeof SHOPIFY_CLIENT_IP_HEADER
+  | typeof SHOPIFY_STOREFRONT_ORIGIN_HEADER
   | typeof SHOPIFY_STOREFRONT_S_HEADER
   | typeof SHOPIFY_STOREFRONT_Y_HEADER
   | typeof SHOPIFY_UNIQUE_TOKEN_HEADER

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  HYDROGEN_VERSION_HEADER,
   REQUEST_GROUP_ID_HEADER,
+  SDK_VARIANT_HEADER,
+  SDK_VARIANT_SOURCE_HEADER,
+  SDK_VERSION_HEADER,
+  SHOPIFY_STOREFRONT_ORIGIN_HEADER,
   SHOPIFY_STOREFRONT_S_HEADER,
   SHOPIFY_STOREFRONT_Y_HEADER,
   SHOPIFY_UNIQUE_TOKEN_HEADER,
@@ -33,6 +38,7 @@ describe("createShopifyRequestContext", () => {
     const result = createTestRequestContext(request);
 
     expect(result.url).toBe("https://example.com/products/snowboard");
+    expect(result.storefrontOrigin).toBe("https://example.com");
     expect(result.requestGroupId).toBeTruthy();
     expect(result.uniqueToken).toBeTruthy();
     expect(result.visitToken).toBeTruthy();
@@ -57,6 +63,10 @@ describe("createShopifyRequestContext", () => {
     });
 
     expect(result.url).toBe("https://example.com/products/snowboard");
+    expect(result.storefrontOrigin).toBe("https://example.com");
+    const headers = new Headers();
+    result.applyStorefrontRequestHeaders(headers);
+    expect(headers.get(SHOPIFY_STOREFRONT_ORIGIN_HEADER)).toBe("https://example.com");
   });
 
   it("stores request-scoped i18n metadata", () => {
@@ -198,6 +208,7 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("cookie")).toBe("_shopify_y=unique-token; _shopify_s=visit-token");
     expect(headers.get("x-storefront-url")).toBe("https://example.com/products/snowboard");
     expect(headers.get(REQUEST_GROUP_ID_HEADER)).toBe("incoming-request-id");
+    expect(headers.get(SHOPIFY_STOREFRONT_ORIGIN_HEADER)).toBe("https://example.com");
     expect(headers.get(SHOPIFY_UNIQUE_TOKEN_HEADER)).toBe("unique-token");
     expect(headers.get(SHOPIFY_VISIT_TOKEN_HEADER)).toBe("visit-token");
     expect(headers.get(SHOPIFY_STOREFRONT_Y_HEADER)).toBe("unique-token");
@@ -217,7 +228,7 @@ describe("createShopifyRequestContext", () => {
     expect(originalHeaders.get(REQUEST_GROUP_ID_HEADER)).toBeNull();
   });
 
-  it("gets subrequest headers from only storefront context", () => {
+  it("applies storefront request headers from only storefront context", () => {
     const context = createTestRequestContext(
       new Request("https://example.com/products/snowboard", {
         headers: {
@@ -229,29 +240,29 @@ describe("createShopifyRequestContext", () => {
       }),
     );
 
-    const headers = context.getSubrequestHeaders();
+    const headers = new Headers({
+      [SHOPIFY_STOREFRONT_ORIGIN_HEADER]: "https://untrusted.example",
+      "x-custom": "preserved",
+    });
+    context.applyStorefrontRequestHeaders(headers);
 
     expect(headers.get("accept")).toBeNull();
     expect(headers.get("x-random")).toBeNull();
     expect(headers.get("x-storefront-url")).toBeNull();
-    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("content-type")).toBeNull();
     expect(headers.get("x-shopify-storefront-access-token")).toBeNull();
+    expect(headers.get("x-custom")).toBe("preserved");
+    expect(headers.get(SDK_VARIANT_HEADER)).toBe("hydrogen");
+    expect(headers.get(SDK_VARIANT_SOURCE_HEADER)).toBe("kit");
+    expect(headers.get(SDK_VERSION_HEADER)).toBe("2026-04");
+    expect(headers.get(HYDROGEN_VERSION_HEADER)).toBeTruthy();
     expect(headers.get("cookie")).toBe("_shopify_y=unique-token; _shopify_s=visit-token");
     expect(headers.get(REQUEST_GROUP_ID_HEADER)).toBe("incoming-request-id");
+    expect(headers.get(SHOPIFY_STOREFRONT_ORIGIN_HEADER)).toBe("https://example.com");
     expect(headers.get(SHOPIFY_UNIQUE_TOKEN_HEADER)).toBe("unique-token");
     expect(headers.get(SHOPIFY_VISIT_TOKEN_HEADER)).toBe("visit-token");
     expect(headers.get(SHOPIFY_STOREFRONT_Y_HEADER)).toBe("unique-token");
     expect(headers.get(SHOPIFY_STOREFRONT_S_HEADER)).toBe("visit-token");
-  });
-
-  it("gets mutable subrequest headers", () => {
-    const context = createTestRequestContext(new Request("https://example.com"));
-
-    const headers = context.getSubrequestHeaders();
-    headers.set("content-type", "application/json");
-
-    expect(headers.get(REQUEST_GROUP_ID_HEADER)).toBeTruthy();
-    expect(headers.get("content-type")).toBe("application/json");
   });
 
   it("applies tracking tokens as server-timing", () => {

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -50,29 +50,52 @@ type ShopifyRequestContextInput<I18n extends I18nConfig = I18nConfig> = {
 };
 
 type ShopifyRequestContextBase = {
-  /** Compile-time brand so callers use createShopifyRequestContext(). */
+  // -- Private fields --
+  /**
+   * Compile-time brand so callers use createShopifyRequestContext().
+   * @internal
+   */
   readonly __hydrogenShopifyRequestContextBrand: never;
+  /** @internal */
   cookie?: string;
+  /** @internal */
   uniqueToken?: string;
+  /** @internal */
   visitToken?: string;
+  /** @internal */
   legacyTokens?: boolean;
+  /** @internal */
   buyerIp?: string;
+  /** @internal */
   requestGroupId: string;
+  /** @internal */
   signal?: AbortSignal;
+  /** @internal */
   url?: string;
-  /** Origin of the storefront request URL. */
+  /** @internal */
   storefrontOrigin?: string;
+  /**
+   * Apply request-scoped headers required by every Shopify storefront subrequest.
+   * @internal
+   */
+  applyStorefrontRequestHeaders(headers: Headers): void;
+  /**
+   * Capture the first fresh SFAPI response headers for replay onto the final app response.
+   * @internal
+   */
+  captureSubrequestHeaders(headers: Headers): void;
+  /**
+   * Mark the final app response as influenced by private customer state.
+   * @internal
+   */
+  markResponseAsPersonalized(reason: string): void;
+
+  // -- Public fields --
+  i18n: NormalizedI18nConfig;
   /** Return incoming request headers plus request lifecycle headers for proxy/origin handoff. */
   getForwardedRequestHeaders(): Headers;
-  /** Apply request-scoped headers required by every Shopify storefront subrequest. */
-  applyStorefrontRequestHeaders(headers: Headers): void;
-  /** Capture the first fresh SFAPI response headers for replay onto the final app response. */
-  captureSubrequestHeaders(headers: Headers): void;
-  /** Mark the final app response as influenced by private customer state. */
-  markResponseAsPersonalized(reason: string): void;
   /** Apply captured SFAPI headers and document tracking fallback headers to an app response. */
   applyResponseHeaders(headers: Headers): void;
-  i18n: NormalizedI18nConfig;
 };
 
 export type ShopifyRequestContext<I18n extends I18nConfig = I18nConfig> =

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -6,10 +6,16 @@ import type {
   CountryCode as StorefrontCountryCode,
   LanguageCode as StorefrontLanguageCode,
 } from "../graphql/generated/storefront-api-types";
+import { STOREFRONT_API_VERSION } from "./constants";
 import {
   applyPrivateResponseCacheHeaders,
+  HYDROGEN_VERSION_HEADER,
   REQUEST_GROUP_ID_HEADER,
+  SDK_VARIANT_HEADER,
+  SDK_VARIANT_SOURCE_HEADER,
+  SDK_VERSION_HEADER,
   SERVER_TIMING_HEADER,
+  SHOPIFY_STOREFRONT_ORIGIN_HEADER,
   SHOPIFY_STOREFRONT_S_HEADER,
   SHOPIFY_STOREFRONT_Y_HEADER,
   SHOPIFY_UNIQUE_TOKEN_HEADER,
@@ -54,10 +60,12 @@ type ShopifyRequestContextBase = {
   requestGroupId: string;
   signal?: AbortSignal;
   url?: string;
+  /** Origin of the storefront request URL. */
+  storefrontOrigin?: string;
   /** Return incoming request headers plus request lifecycle headers for proxy/origin handoff. */
   getForwardedRequestHeaders(): Headers;
-  /** Return mutable Storefront API subrequest headers from this request context. */
-  getSubrequestHeaders(): Headers;
+  /** Apply request-scoped headers required by every Shopify storefront subrequest. */
+  applyStorefrontRequestHeaders(headers: Headers): void;
   /** Capture the first fresh SFAPI response headers for replay onto the final app response. */
   captureSubrequestHeaders(headers: Headers): void;
   /** Mark the final app response as influenced by private customer state. */
@@ -81,6 +89,7 @@ type Context<I18n extends I18nConfig = I18nConfig> = {
   requestGroupId: string;
   signal?: AbortSignal;
   url?: string;
+  storefrontOrigin?: string;
   i18n: NormalizedI18nConfig<I18n>;
   documentRequest?: boolean;
 };
@@ -100,10 +109,12 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
   const i18n = normalizeI18n(input.i18n);
   const cookie = request.headers.get("cookie") || undefined;
   const url = request.url ?? request.headers.get(STOREFRONT_URL_HEADER) ?? undefined;
+  const storefrontOrigin = getUrlOrigin(url);
   const context = {
     ...(cookie && { cookie }),
     i18n,
     ...(url && { url }),
+    ...(storefrontOrigin && { storefrontOrigin }),
     ...(input.buyerIp && { buyerIp: input.buyerIp }),
     requestGroupId:
       request.headers.get(REQUEST_GROUP_ID_HEADER) ??
@@ -138,16 +149,12 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
     ...context,
     getForwardedRequestHeaders() {
       const headers = new Headers(request.headers);
-      applyShopifyRequestContextHeaders(context, headers);
+      applyStorefrontRequestHeaders(context, headers);
       if (context.url) headers.set(STOREFRONT_URL_HEADER, context.url);
       return headers;
     },
-    getSubrequestHeaders() {
-      const headers = new Headers();
-      headers.set("content-type", "application/json");
-      if (context.cookie) headers.set("cookie", context.cookie);
-      applyShopifyRequestContextHeaders(context, headers);
-      return headers;
+    applyStorefrontRequestHeaders(headers) {
+      applyStorefrontRequestHeaders(context, headers);
     },
     captureSubrequestHeaders(headers) {
       // Capture this the first time we get a fresh response to increase the
@@ -209,8 +216,19 @@ function normalizePathPrefix(pathPrefix: string | undefined): string {
   return normalized ? `/${normalized}` : "";
 }
 
-function applyShopifyRequestContextHeaders(context: Context, headers: Headers): void {
+function applyStorefrontRequestHeaders(context: Context, headers: Headers): void {
+  headers.set(SDK_VARIANT_HEADER, "hydrogen");
+  headers.set(SDK_VARIANT_SOURCE_HEADER, "kit");
+  headers.set(SDK_VERSION_HEADER, STOREFRONT_API_VERSION);
+  headers.set(HYDROGEN_VERSION_HEADER, __HYDROGEN_VERSION__);
   headers.set(REQUEST_GROUP_ID_HEADER, context.requestGroupId);
+
+  if (context.cookie) headers.set("cookie", context.cookie);
+  else headers.delete("cookie");
+  if (context.storefrontOrigin) {
+    headers.set(SHOPIFY_STOREFRONT_ORIGIN_HEADER, context.storefrontOrigin);
+  } else headers.delete(SHOPIFY_STOREFRONT_ORIGIN_HEADER);
+
   if (context.uniqueToken) headers.set(SHOPIFY_UNIQUE_TOKEN_HEADER, context.uniqueToken);
   if (context.visitToken) headers.set(SHOPIFY_VISIT_TOKEN_HEADER, context.visitToken);
   if (context.legacyTokens && context.uniqueToken) {
@@ -218,6 +236,15 @@ function applyShopifyRequestContextHeaders(context: Context, headers: Headers): 
   }
   if (context.legacyTokens && context.visitToken) {
     headers.set(SHOPIFY_STOREFRONT_S_HEADER, context.visitToken);
+  }
+}
+
+function getUrlOrigin(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
   }
 }
 

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createStorefrontClient } from "../../client/client";
 import { createCartServerHandlers } from "../cart/server-handlers";
 import { createShopifyRequestContext } from "../request-context";
+import { assert } from "../test-utils";
 import { handleShopifyRoutes as handleShopifyRoutesImpl } from "./handle-shopify-routes";
 import { createShopifyRouteHandler } from "./registered-routes";
 
@@ -90,6 +91,25 @@ describe("handleShopifyRoutes", () => {
 
     expect(result).not.toBeNull();
     expect(result).toBeInstanceOf(Response);
+  });
+
+  it("returns Response for Shopify API proxy requests", async () => {
+    const result = await handleShopifyRoutes({
+      request: new Request("https://my-app.com/__shopify/apps/inbox/config.json"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toBeInstanceOf(Response);
+  });
+
+  it("rewrites cart.js AJAX requests to cart.json", async () => {
+    await handleShopifyRoutes({
+      request: new Request("https://my-app.com/en/cart.js?locale=en"),
+    });
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    expect(call[0].href).toBe("https://test-store.myshopify.com/en/cart.json?locale=en");
   });
 
   it("returns Response for MCP proxy requests", async () => {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
@@ -1,5 +1,6 @@
 import { handleAgentProxy } from "./interceptors/agent-proxy";
 import { handleAjaxApi } from "./interceptors/ajax-api";
+import { handleShopifyApiProxy } from "./interceptors/api-proxy";
 import { handleCheckoutRedirect } from "./interceptors/checkout";
 import { handleMcpProxy } from "./interceptors/mcp-proxy";
 import { handleSfapiProxy } from "./interceptors/sfapi-proxy";
@@ -13,6 +14,7 @@ export type {
 } from "./route-types";
 
 const SHOPIFY_ROUTE_INTERCEPTORS = [
+  handleShopifyApiProxy,
   handleSfapiProxy,
   handleShopifyRouteHandlers,
   handleCheckoutRedirect,

--- a/packages/hydrogen/src/core/request-routing/interceptors/ajax-api.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/ajax-api.ts
@@ -2,10 +2,13 @@ import { AJAX_API_REQUEST_HEADER_ALLOWLIST } from "../../headers";
 import { AJAX_CART_RE } from "../../url";
 import { createProxyInterceptor } from "./proxy";
 
+// Known workaround for Shopify server redirects on `.js` endpoints.
+export const rewriteShopifyJsPathname = (pathname: string): string =>
+  pathname.replace(/\.js$/i, ".json");
+
 export const handleAjaxApi = createProxyInterceptor({
   match: AJAX_CART_RE,
   headers: { allow: AJAX_API_REQUEST_HEADER_ALLOWLIST },
-  // Known workaround for buggy Shopify server redirects on the `.js` cart endpoint.
-  rewritePathname: (pathname) => pathname.replace(/\/cart\.js$/i, "/cart.json"),
+  rewritePathname: rewriteShopifyJsPathname,
   scope: "ajax-api",
 });

--- a/packages/hydrogen/src/core/request-routing/interceptors/ajax-api.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/ajax-api.ts
@@ -5,5 +5,7 @@ import { createProxyInterceptor } from "./proxy";
 export const handleAjaxApi = createProxyInterceptor({
   match: AJAX_CART_RE,
   headers: { allow: AJAX_API_REQUEST_HEADER_ALLOWLIST },
+  // Known workaround for buggy Shopify server redirects on the `.js` cart endpoint.
+  rewritePathname: (pathname) => pathname.replace(/\/cart\.js$/i, "/cart.json"),
   scope: "ajax-api",
 });

--- a/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { SHOPIFY_STOREFRONT_ORIGIN_HEADER } from "../../headers";
 import { createShopifyRequestContext } from "../../request-context";
 import { assert } from "../../test-utils";
 import { handleShopifyApiProxy as handleShopifyApiProxyImpl } from "./api-proxy";
@@ -93,6 +94,7 @@ describe("handleShopifyApiProxy", () => {
           authorization: "Bearer browser-token",
           cookie: "_shopify_y=abc",
           "content-type": "application/json",
+          [SHOPIFY_STOREFRONT_ORIGIN_HEADER]: "https://untrusted.example",
           "sec-fetch-site": "same-origin",
           "x-custom-header": "custom-value",
         },
@@ -108,6 +110,7 @@ describe("handleShopifyApiProxy", () => {
     expect(headers.get("authorization")).toBe("Bearer browser-token");
     expect(headers.get("cookie")).toBe("_shopify_y=abc");
     expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get(SHOPIFY_STOREFRONT_ORIGIN_HEADER)).toBe("https://my-app.com");
     expect(headers.get("sec-fetch-site")).toBe("same-origin");
     expect(headers.get("x-custom-header")).toBe("custom-value");
   });

--- a/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SHOPIFY_STOREFRONT_ORIGIN_HEADER } from "../../headers";
+import { configureLogging, resetLoggingForTests } from "../../logging";
 import { createShopifyRequestContext } from "../../request-context";
-import { assert } from "../../test-utils";
+import { assert, createTestLogger } from "../../test-utils";
 import { handleShopifyApiProxy as handleShopifyApiProxyImpl } from "./api-proxy";
 
 const STORE_URL = "https://test-store.myshopify.com";
@@ -36,6 +37,10 @@ function handleShopifyApiProxy(request: Request) {
 describe("handleShopifyApiProxy", () => {
   let mockFetch: ReturnType<typeof vi.fn>;
 
+  afterEach(() => {
+    resetLoggingForTests();
+  });
+
   beforeEach(() => {
     mockFetch = vi.fn().mockResolvedValue(new Response("ok"));
     vi.stubGlobal("fetch", mockFetch);
@@ -66,12 +71,38 @@ describe("handleShopifyApiProxy", () => {
     expect(call[0].href).toBe("https://test-store.myshopify.com/");
   });
 
-  it("rewrites the cart.js endpoint to cart.json", async () => {
-    await handleShopifyApiProxy(new Request("https://my-app.com/__shopify/cart.js?locale=en"));
+  it.each([
+    ["cart.js", "cart.json"],
+    ["products/snowboard.js", "products/snowboard.json"],
+    ["variants/123.js", "variants/123.json"],
+  ])("rewrites the %s endpoint to %s", async (requestPath, upstreamPath) => {
+    await handleShopifyApiProxy(
+      new Request(`https://my-app.com/__shopify/${requestPath}?locale=en`),
+    );
 
     const call = mockFetch.mock.calls[0];
     assert(call, "expected fetch to be called");
-    expect(call[0].href).toBe("https://test-store.myshopify.com/cart.json?locale=en");
+    expect(call[0].href).toBe(`https://test-store.myshopify.com/${upstreamPath}?locale=en`);
+  });
+
+  it("returns 500 for unsupported CDN proxy requests", async () => {
+    const logger = createTestLogger();
+    configureLogging({ logger });
+
+    const responsePromise = handleShopifyApiProxy(
+      new Request("https://my-app.com/__shopify/cdn/assets/theme.js?version=1"),
+    );
+
+    expect(responsePromise).toBeInstanceOf(Promise);
+    const response = await responsePromise;
+    assert(response, "expected proxy to return an error response");
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "CDN proxy is not supported." });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith("request failed", {
+      scope: "shopify-api-proxy",
+      error: expect.objectContaining({ message: "CDN proxy is not supported." }),
+    });
   });
 
   it("keeps repeated slashes in the path from changing the upstream origin", async () => {

--- a/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createShopifyRequestContext } from "../../request-context";
+import { assert } from "../../test-utils";
+import { handleShopifyApiProxy as handleShopifyApiProxyImpl } from "./api-proxy";
+
+const STORE_URL = "https://test-store.myshopify.com";
+
+function handleShopifyApiProxy(request: Request) {
+  const requestContext = createShopifyRequestContext({
+    request,
+    i18n: { country: "US", language: "EN" },
+  });
+
+  return handleShopifyApiProxyImpl(new URL(request.url), {
+    request,
+    requestContext,
+    sessionManager: {
+      getSessionOrigin: () => new URL(request.url).origin,
+      getSessionItem: () => undefined,
+      setSessionItem: () => undefined,
+      removeSessionItem: () => undefined,
+    },
+    storefrontClient: {
+      type: "public",
+      i18n: { country: "US", language: "EN", pathPrefix: "" },
+      storeUrl: STORE_URL,
+      apiUrl: `${STORE_URL}/api/2026-04/graphql.json`,
+      requestContext,
+      graphql: vi.fn(),
+    },
+  });
+}
+
+describe("handleShopifyApiProxy", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("returns null synchronously outside the reserved prefix", () => {
+    expect(
+      handleShopifyApiProxy(new Request("https://my-app.com/__shopify-other/path")),
+    ).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("removes the prefix and forwards the path and search params to SFR", async () => {
+    await handleShopifyApiProxy(
+      new Request("https://my-app.com/__shopify/apps/inbox/config.json?locale=en"),
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    expect(call[0].href).toBe("https://test-store.myshopify.com/apps/inbox/config.json?locale=en");
+  });
+
+  it("forwards the prefix root to the SFR root", async () => {
+    await handleShopifyApiProxy(new Request("https://my-app.com/__shopify"));
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    expect(call[0].href).toBe("https://test-store.myshopify.com/");
+  });
+
+  it("rewrites the cart.js endpoint to cart.json", async () => {
+    await handleShopifyApiProxy(new Request("https://my-app.com/__shopify/cart.js?locale=en"));
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    expect(call[0].href).toBe("https://test-store.myshopify.com/cart.json?locale=en");
+  });
+
+  it("keeps repeated slashes in the path from changing the upstream origin", async () => {
+    await handleShopifyApiProxy(
+      new Request("https://my-app.com/__shopify//untrusted.example/path"),
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    expect(call[0].href).toBe("https://test-store.myshopify.com/untrusted.example/path");
+  });
+
+  it("forwards the method, body, and browser headers", async () => {
+    const body = JSON.stringify({ event: "test" });
+    await handleShopifyApiProxy(
+      new Request("https://my-app.com/__shopify/events", {
+        method: "POST",
+        body,
+        headers: {
+          authorization: "Bearer browser-token",
+          cookie: "_shopify_y=abc",
+          "content-type": "application/json",
+          "sec-fetch-site": "same-origin",
+          "x-custom-header": "custom-value",
+        },
+      }),
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const [, init] = call;
+    const headers = new Headers(init.headers);
+    expect(init.method).toBe("POST");
+    expect(init.body).not.toBeNull();
+    expect(headers.get("authorization")).toBe("Bearer browser-token");
+    expect(headers.get("cookie")).toBe("_shopify_y=abc");
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("sec-fetch-site")).toBe("same-origin");
+    expect(headers.get("x-custom-header")).toBe("custom-value");
+  });
+
+  it.each([
+    "connection",
+    "content-length",
+    "host",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+  ])("does not forward the problematic %s header", async (header) => {
+    await handleShopifyApiProxy(
+      new Request("https://my-app.com/__shopify/events", {
+        headers: { [header]: "untrusted-value" },
+      }),
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    expect(new Headers(call[1].headers).get(header)).toBeNull();
+  });
+});

--- a/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.ts
@@ -1,0 +1,17 @@
+import { SHOPIFY_API_PROXY_REQUEST_HEADER_DENYLIST } from "../../headers";
+import { SHOPIFY_API_PROXY_PREFIX, SHOPIFY_API_PROXY_RE } from "../../url";
+import { createProxyInterceptor } from "./proxy";
+
+export const handleShopifyApiProxy = createProxyInterceptor({
+  match: SHOPIFY_API_PROXY_RE,
+  headers: { deny: SHOPIFY_API_PROXY_REQUEST_HEADER_DENYLIST },
+  rewritePathname: (pathname) => {
+    const upstreamPathname = `/${pathname
+      .slice(SHOPIFY_API_PROXY_PREFIX.length)
+      .replace(/^\/+/, "")}`;
+
+    // Known workaround for buggy Shopify server redirects on the `.js` cart endpoint.
+    return upstreamPathname.replace(/\/cart\.js$/i, "/cart.json");
+  },
+  scope: "shopify-api-proxy",
+});

--- a/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.ts
@@ -1,17 +1,20 @@
 import { SHOPIFY_API_PROXY_REQUEST_HEADER_DENYLIST } from "../../headers";
 import { SHOPIFY_API_PROXY_PREFIX, SHOPIFY_API_PROXY_RE } from "../../url";
+import { rewriteShopifyJsPathname } from "./ajax-api";
 import { createProxyInterceptor } from "./proxy";
 
 export const handleShopifyApiProxy = createProxyInterceptor({
   match: SHOPIFY_API_PROXY_RE,
   headers: { deny: SHOPIFY_API_PROXY_REQUEST_HEADER_DENYLIST },
   rewritePathname: (pathname) => {
-    const upstreamPathname = `/${pathname
-      .slice(SHOPIFY_API_PROXY_PREFIX.length)
-      .replace(/^\/+/, "")}`;
+    const upstreamPathname =
+      "/" + pathname.slice(SHOPIFY_API_PROXY_PREFIX.length).replace(/^\/+/, "");
 
-    // Known workaround for buggy Shopify server redirects on the `.js` cart endpoint.
-    return upstreamPathname.replace(/\/cart\.js$/i, "/cart.json");
+    if (upstreamPathname.startsWith("/cdn/")) {
+      throw new Error("CDN proxy is not supported.");
+    }
+
+    return rewriteShopifyJsPathname(upstreamPathname);
   },
   scope: "shopify-api-proxy",
 });

--- a/packages/hydrogen/src/core/request-routing/interceptors/mcp-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/mcp-proxy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 
+import { SHOPIFY_STOREFRONT_ORIGIN_HEADER } from "../../headers";
 import { configureLogging, resetLoggingForTests } from "../../logging";
 import { createShopifyRequestContext } from "../../request-context";
 import { assert, createTestLogger } from "../../test-utils";
@@ -128,18 +129,17 @@ describe("handleMcpProxy", () => {
     const [, init] = call;
     const headers = new Headers(init.headers);
     expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get(SHOPIFY_STOREFRONT_ORIGIN_HEADER)).toBe("https://my-app.com");
     expect(headers.get("user-agent")).toBe("test-agent");
   });
 
-  it("does NOT forward CORS or browser tracking headers", async () => {
+  it("filters CORS headers", async () => {
     const request = createRequest("/api/mcp", {
       headers: {
         "content-type": "application/json",
         "access-control-request-headers": "x-test",
         "access-control-request-method": "POST",
         "content-length": "100",
-        "X-Shopify-UniqueToken": "unique-token",
-        "X-Shopify-VisitToken": "visit-token",
       },
     });
 
@@ -152,8 +152,6 @@ describe("handleMcpProxy", () => {
     expect(headers.get("access-control-request-headers")).toBeNull();
     expect(headers.get("access-control-request-method")).toBeNull();
     expect(headers.get("content-length")).toBeNull();
-    expect(headers.get("X-Shopify-UniqueToken")).toBeNull();
-    expect(headers.get("X-Shopify-VisitToken")).toBeNull();
   });
 
   it("does not add server-side headers", async () => {

--- a/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
@@ -4,8 +4,10 @@ import type { HydrogenRouteInterceptor, HydrogenRoutesOptions } from "../route-t
 
 const PROXY_TIMEOUT_MS = 30_000;
 
-type ProxyHeaderOptions = {
-  allow: readonly string[];
+type ProxyHeaderOptions = (
+  | { allow: readonly string[]; deny?: never }
+  | { allow?: never; deny: readonly string[] }
+) & {
   prepare?: (headers: Headers, options: HydrogenRoutesOptions, url: URL) => void;
 };
 
@@ -15,6 +17,7 @@ type ProxyDescriptor = {
   formatError?: (message: string) => unknown;
   scope: string;
   timeoutMs?: number;
+  rewritePathname?: (pathname: string) => string;
 };
 
 export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRouteInterceptor {
@@ -24,18 +27,10 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
     const { request, storefrontClient } = options;
     if (!descriptor.match.test(url.pathname)) return null;
 
-    const upstreamUrl = new URL(url.pathname + url.search, storefrontClient.storeUrl);
+    const upstreamPathname = descriptor.rewritePathname?.(url.pathname) ?? url.pathname;
+    const upstreamUrl = new URL(upstreamPathname + url.search, storefrontClient.storeUrl);
 
-    const forwardedHeaders = new Headers(
-      extractHeaders((key) => request.headers.get(key), descriptor.headers.allow),
-    );
-    forwardedHeaders.set(
-      REQUEST_GROUP_ID_HEADER,
-      request.headers.get(REQUEST_GROUP_ID_HEADER) ??
-        request.headers.get("x-request-id") ??
-        request.headers.get("request-id") ??
-        crypto.randomUUID(),
-    );
+    const forwardedHeaders = createProxyRequestHeaders(descriptor, request);
     descriptor.headers.prepare?.(forwardedHeaders, options, url);
 
     const init: RequestInit & { duplex?: "half" } = {
@@ -72,6 +67,22 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
 
 function defaultFormatError(message: string): { error: string } {
   return { error: message };
+}
+
+function createProxyRequestHeaders(descriptor: ProxyDescriptor, request: Request): Headers {
+  const { allow, deny } = descriptor.headers;
+  const headers = allow
+    ? new Headers(extractHeaders((key) => request.headers.get(key), allow))
+    : new Headers(request.headers);
+  for (const header of deny ?? []) headers.delete(header);
+  headers.set(
+    REQUEST_GROUP_ID_HEADER,
+    request.headers.get(REQUEST_GROUP_ID_HEADER) ??
+      request.headers.get("x-request-id") ??
+      request.headers.get("request-id") ??
+      crypto.randomUUID(),
+  );
+  return headers;
 }
 
 export function createProxyResponseHeaders(upstreamHeaders: Headers): Headers {

--- a/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
@@ -1,4 +1,4 @@
-import { extractHeaders, REQUEST_GROUP_ID_HEADER } from "../../headers";
+import { extractHeaders } from "../../headers";
 import { getLogger } from "../../logging";
 import type { HydrogenRouteInterceptor, HydrogenRoutesOptions } from "../route-types";
 
@@ -23,6 +23,7 @@ type ProxyDescriptor = {
 export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRouteInterceptor {
   const log = getLogger(descriptor.scope);
   const formatError = descriptor.formatError ?? defaultFormatError;
+
   return (url, options) => {
     const { request, storefrontClient } = options;
     if (!descriptor.match.test(url.pathname)) return null;
@@ -31,6 +32,7 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
     const upstreamUrl = new URL(upstreamPathname + url.search, storefrontClient.storeUrl);
 
     const forwardedHeaders = createProxyRequestHeaders(descriptor, request);
+    options.requestContext.applyStorefrontRequestHeaders(forwardedHeaders);
     descriptor.headers.prepare?.(forwardedHeaders, options, url);
 
     const init: RequestInit & { duplex?: "half" } = {
@@ -75,13 +77,6 @@ function createProxyRequestHeaders(descriptor: ProxyDescriptor, request: Request
     ? new Headers(extractHeaders((key) => request.headers.get(key), allow))
     : new Headers(request.headers);
   for (const header of deny ?? []) headers.delete(header);
-  headers.set(
-    REQUEST_GROUP_ID_HEADER,
-    request.headers.get(REQUEST_GROUP_ID_HEADER) ??
-      request.headers.get("x-request-id") ??
-      request.headers.get("request-id") ??
-      crypto.randomUUID(),
-  );
   return headers;
 }
 

--- a/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
@@ -28,23 +28,29 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
     const { request, storefrontClient } = options;
     if (!descriptor.match.test(url.pathname)) return null;
 
-    const upstreamPathname = descriptor.rewritePathname?.(url.pathname) ?? url.pathname;
-    const upstreamUrl = new URL(upstreamPathname + url.search, storefrontClient.storeUrl);
+    let upstreamUrl: URL;
+    let init: RequestInit & { duplex?: "half" };
+    try {
+      const upstreamPathname = descriptor.rewritePathname?.(url.pathname) ?? url.pathname;
+      upstreamUrl = new URL(upstreamPathname + url.search, storefrontClient.storeUrl);
+      const forwardedHeaders = createProxyRequestHeaders(descriptor, request);
+      options.requestContext.applyStorefrontRequestHeaders(forwardedHeaders);
+      descriptor.headers.prepare?.(forwardedHeaders, options, url);
 
-    const forwardedHeaders = createProxyRequestHeaders(descriptor, request);
-    options.requestContext.applyStorefrontRequestHeaders(forwardedHeaders);
-    descriptor.headers.prepare?.(forwardedHeaders, options, url);
+      init = {
+        method: request.method,
+        body: request.body,
+        headers: forwardedHeaders,
+        signal: AbortSignal.timeout(descriptor.timeoutMs ?? PROXY_TIMEOUT_MS),
+        redirect: "manual",
+      };
 
-    const init: RequestInit & { duplex?: "half" } = {
-      method: request.method,
-      body: request.body,
-      headers: forwardedHeaders,
-      signal: AbortSignal.timeout(descriptor.timeoutMs ?? PROXY_TIMEOUT_MS),
-      redirect: "manual",
-    };
-
-    // Node's fetch requires this when forwarding a streaming request body.
-    if (request.body) init.duplex = "half";
+      // Node's fetch requires this when forwarding a streaming request body.
+      if (request.body) init.duplex = "half";
+    } catch (error) {
+      log.error("request failed", { error });
+      return Promise.resolve(createProxyErrorResponse(error, 500, formatError));
+    }
 
     return fetch(upstreamUrl, init)
       .then(
@@ -57,18 +63,25 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
       )
       .catch((error) => {
         log.error("request failed", { error });
-        const message = error instanceof Error ? error.message : "Internal proxy error";
-
-        return new Response(JSON.stringify(formatError(message)), {
-          status: 502,
-          headers: { "content-type": "application/json" },
-        });
+        return createProxyErrorResponse(error, 502, formatError);
       });
   };
 }
 
 function defaultFormatError(message: string): { error: string } {
   return { error: message };
+}
+
+function createProxyErrorResponse(
+  error: unknown,
+  status: number,
+  formatError: (message: string) => unknown,
+): Response {
+  const message = error instanceof Error ? error.message : "Internal proxy error";
+  return new Response(JSON.stringify(formatError(message)), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
 }
 
 function createProxyRequestHeaders(descriptor: ProxyDescriptor, request: Request): Headers {

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
@@ -332,11 +332,28 @@ describe("handleSfapiProxy", () => {
     expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBeNull();
   });
 
-  it("requires request context buyer IP for private client proxy requests", () => {
-    expect(() =>
-      handlePrivateSfapiProxyWithoutBuyerContext(createRequest("/api/2025-01/graphql.json")),
-    ).toThrow("requestContext.buyerIp is required for private Storefront API proxy requests");
+  it("returns 500 when request header preparation fails", async () => {
+    const logger = createTestLogger();
+    configureLogging({ logger });
+
+    const responsePromise = handlePrivateSfapiProxyWithoutBuyerContext(
+      createRequest("/api/2025-01/graphql.json"),
+    );
+
+    expect(responsePromise).toBeInstanceOf(Promise);
+    const response = await responsePromise;
+    assert(response, "expected proxy to return an error response");
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: "requestContext.buyerIp is required for private Storefront API proxy requests",
+    });
     expect(mockFetch).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith("request failed", {
+      scope: "sfapi-proxy",
+      error: expect.objectContaining({
+        message: "requestContext.buyerIp is required for private Storefront API proxy requests",
+      }),
+    });
   });
 
   it("sets Custom-Storefront-Request-Group-ID as a UUID", async () => {

--- a/packages/hydrogen/src/core/shopify-scripts.test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts.test.ts
@@ -249,6 +249,7 @@ describe("shopify scripts", () => {
       country: "CA",
       language: "fr",
     });
+    expect(window.Shopify?.routes.apiProxyPrefix).toBe("/__shopify");
     expect(getShopifyRoutesRoot()).toBe("/fr-ca/");
   });
 
@@ -793,7 +794,7 @@ describe("shopify scripts", () => {
     expect(html).toContain('<script id="shopify-global-bootstrap" nonce="test-nonce">');
     expect(html).toContain('"country":"US"');
     expect(html).toContain('"locale":"en"');
-    expect(html).toContain('"routes":{"root":"/"}');
+    expect(html).toContain('"routes":{"root":"/","apiProxyPrefix":"/__shopify"}');
     expect(html).not.toContain('"templates"');
     expect(html).toContain(`<link rel="preconnect" href="${SHOPIFY_CDN_ORIGIN}">`);
     expect(html).toContain(`<link rel="preconnect" href="${SHOPIFY_SHOP_APP_ORIGIN}">`);

--- a/packages/hydrogen/src/core/shopify-scripts/global.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/global.ts
@@ -5,6 +5,7 @@ import {
   resolveStandardRouteUrl,
   type ShopifyRouteTemplates,
 } from "../standard-routes/index";
+import { SHOPIFY_API_PROXY_PREFIX } from "../url";
 import initializeShopifyGlobal from "./global-script" with { type: "script" };
 import type { ShopifyScriptsI18n } from "./types";
 import type { ShopifyScriptsShop } from "./types";
@@ -20,6 +21,7 @@ export type ShopifyGlobalConfig = {
   };
   routes: {
     root: string;
+    apiProxyPrefix: string;
   };
   shop: string;
 };
@@ -116,6 +118,7 @@ export function getShopifyGlobalBootstrapScript({
     >,
     routes: {
       root: getShopifyRoutesRoot(i18n?.pathPrefix),
+      apiProxyPrefix: SHOPIFY_API_PROXY_PREFIX,
     },
     shop: normalizeMyshopifyDomain(shop.myshopifyDomain),
     customerPrivacy: {

--- a/packages/hydrogen/src/core/url.ts
+++ b/packages/hydrogen/src/core/url.ts
@@ -1,4 +1,6 @@
 export const SFAPI_RE = /^\/api\/(unstable|2\d{3}-\d{2})\/graphql\.json$/;
+export const SHOPIFY_API_PROXY_PREFIX = "/__shopify";
+export const SHOPIFY_API_PROXY_RE = /^\/__shopify(?:\/|$)/;
 export const MCP_RE = /^\/api\/mcp$/;
 export const CART_RE = /^\/api\/cart$/;
 export const CHECKOUT_RE = /^\/checkout$/;

--- a/packages/hydrogen/src/globals.ts
+++ b/packages/hydrogen/src/globals.ts
@@ -42,6 +42,8 @@ export type ShopifyGlobal = {
   routes: {
     root: string;
     /** @internal */
+    apiProxyPrefix?: string;
+    /** @internal */
     match?: (url: string) => ShopifyStandardRouteMatch | null;
     /** @internal */
     resolve?: (url: string) => string;

--- a/packages/hydrogen/src/package.test.ts
+++ b/packages/hydrogen/src/package.test.ts
@@ -97,6 +97,7 @@ if (typeof plugin !== "function" || typeof plugin({typescript}).create !== "func
     expect(declaration).toContain("customerPrivacy: {");
     expect(declaration).toContain("routes: {");
     expect(declaration).toContain("root: string;");
+    expect(declaration).toMatch(/\/\*\* @internal \*\/\s+apiProxyPrefix\?:/);
     expect(declaration).toMatch(/\/\*\* @internal \*\/\s+match\?:/);
     expect(declaration).toMatch(/\/\*\* @internal \*\/\s+resolve\?:/);
     expect(declaration).toMatch(/\/\*\* @internal \*\/\s+navigate\?:/);

--- a/packages/hydrogen/src/react/shopify-scripts.test.tsx
+++ b/packages/hydrogen/src/react/shopify-scripts.test.tsx
@@ -104,7 +104,7 @@ describe("ShopifyScripts", () => {
     expect(html).toContain('nonce="test-nonce"');
     expect(html).toContain('"country":"US"');
     expect(html).toContain('"locale":"en"');
-    expect(html).toContain('"routes":{"root":"/"}');
+    expect(html).toContain('"routes":{"root":"/","apiProxyPrefix":"/__shopify"}');
     expect(html).toContain(`"shop":"${TEST_MYSHOPIFY_DOMAIN}"`);
     expect(html).toContain('"customerPrivacy":{"config":{"isHeadless":true}');
     expect(html).toContain("consentDomain=window.location.host");
@@ -197,7 +197,7 @@ describe("ShopifyScripts", () => {
     expect(html).not.toContain(SHOPIFY_STOREFRONT_WEBMCP_SCRIPT);
     expect(html).toContain('"country":"US"');
     expect(html).toContain('"locale":"en"');
-    expect(html).toContain('"routes":{"root":"/"}');
+    expect(html).toContain('"routes":{"root":"/","apiProxyPrefix":"/__shopify"}');
     expect(html).toContain('"customerPrivacy":{"config":{"isHeadless":true}');
     expect(html).toContain("consentDomain=window.location.host");
     expect(html).toContain(`id="shopify-consent"`);

--- a/packages/hydrogen/src/vue/shopify-scripts.test.ts
+++ b/packages/hydrogen/src/vue/shopify-scripts.test.ts
@@ -54,7 +54,7 @@ describe("ShopifyScripts", () => {
     expect(html).toContain('nonce="test-nonce"');
     expect(html).toContain('"country":"US"');
     expect(html).toContain('"locale":"en"');
-    expect(html).toContain('"routes":{"root":"/"}');
+    expect(html).toContain('"routes":{"root":"/","apiProxyPrefix":"/__shopify"}');
     expect(html).toContain(`"shop":"${TEST_MYSHOPIFY_DOMAIN}"`);
     expect(html).not.toContain('"templates"');
     expect(html).toContain(`<link rel="preconnect" href="${SHOPIFY_CDN_ORIGIN}">`);
@@ -96,7 +96,7 @@ describe("ShopifyScripts", () => {
     expect(html).not.toContain(SHOPIFY_STOREFRONT_WEBMCP_SCRIPT);
     expect(html).toContain('"country":"US"');
     expect(html).toContain('"locale":"en"');
-    expect(html).toContain('"routes":{"root":"/"}');
+    expect(html).toContain('"routes":{"root":"/","apiProxyPrefix":"/__shopify"}');
     expect(html).not.toContain('"templates"');
   });
 


### PR DESCRIPTION
Stacked on #3925.

TL;DR: Shopify runtime modules need a same-origin route to Shopify's storefront backend. This extends `handleShopifyRoutes` with that proxy while preserving safe browser and storefront request-context headers.

## What this changes

- Adds internal routing metadata to `ShopifyScripts` and intercepts matching runtime API requests in `handleShopifyRoutes`.
- Forwards browser headers except problematic transport and CORS headers, then applies cookies, request grouping, tracking, and SDK metadata.
- Always forwards the storefront origin to Shopify's backend in a new dedicated request header for both Storefront API calls and proxied requests.
- Rewrites cart `.js` requests to `.json` as a workaround for known incorrect Shopify server redirects.
- Marks request-context implementation fields and lifecycle methods internal while keeping `i18n` and the supported forwarding and response methods public.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. Apps using `ShopifyScripts` with `handleShopifyRoutes` gain the runtime proxy without new public configuration.

## Risk

- Header filtering and path rewriting affect requests forwarded to Shopify's storefront backend and deserve extra review.
- The runtime route metadata is intentionally internal so its path is not treated as a consumer-facing contract.
