### PR TITLE
An fix currency empty before cart

### DIFF
--- a/.changeset/currency-before-cart.md
+++ b/.changeset/currency-before-cart.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Update analytics skills to require `i18n.currency` during initial `ShopifyScripts` rendering so `window.Shopify.currency.active` exists before consent replays buffered events.

--- a/.changeset/shiny-coins-count.md
+++ b/.changeset/shiny-coins-count.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Require `i18n.currency` in `ShopifyScripts` / `getShopifyScriptTags()` whenever Shopify analytics is enabled (the default). Product events carry prices, and product pages can be viewed before the cart initializes currency, so `window.Shopify.currency.active` must be set from initial script rendering. `i18n` and `currency` remain optional with `shopifyAnalytics: false`. JS consumers and the Vue binding get a runtime warning instead of a compile-time error. Adds the `ShopifyScriptsI18nWithCurrency` type.

--- a/.changeset/shiny-coins-count.md
+++ b/.changeset/shiny-coins-count.md
@@ -1,5 +1,5 @@
 ---
-"@shopify/hydrogen": patch
+"@shopify/hydrogen": minor
 ---
 
 Require `i18n.currency` in `ShopifyScripts` / `getShopifyScriptTags()` whenever Shopify analytics is enabled (the default). Product events carry prices, and product pages can be viewed before the cart initializes currency, so `window.Shopify.currency.active` must be set from initial script rendering. `i18n` and `currency` remain optional with `shopifyAnalytics: false`. JS consumers and the Vue binding get a runtime warning instead of a compile-time error. Adds the `ShopifyScriptsI18nWithCurrency` type.

--- a/examples/hydrogen/app/root.tsx
+++ b/examples/hydrogen/app/root.tsx
@@ -29,6 +29,9 @@ import appStyles from "~/styles/app.css?url";
 import resetStyles from "~/styles/reset.css?url";
 
 const FALLBACK_STOREFRONT_ID = "0";
+// Shopify analytics requires a currency for product events; used until the
+// Storefront API localization currency is available.
+const FALLBACK_ANALYTICS_CURRENCY = "USD";
 
 export type RootLoader = typeof loader;
 
@@ -81,7 +84,7 @@ export async function loader(args: Route.LoaderArgs) {
     country: storefront.i18n.country,
     language: storefront.i18n.language,
     pathPrefix: storefront.i18n.pathPrefix,
-    ...(analyticsCurrency ? { currency: analyticsCurrency } : {}),
+    currency: analyticsCurrency ?? FALLBACK_ANALYTICS_CURRENCY,
   };
 
   return {

--- a/packages/hydrogen/skills/hydrogen-analytics/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-analytics/SKILL.md
@@ -43,7 +43,12 @@ export function getAnalytics(): StorefrontAnalytics | null {
 export { trackCartAnalytics };
 ```
 
-Read `shop` and `i18n` values on the server and pass them to `ShopifyScripts`. Do not read env APIs in browser modules.
+Read `shop` and `i18n` values on the server and pass them to `ShopifyScripts`. For analytics-enabled storefronts,
+provide `i18n.currency` during initial script rendering so `window.Shopify.currency.active` exists before consent can
+replay buffered events. Prefer the configured market currency when it is authoritative; otherwise query
+`localization.country.currency.isoCode` under the same Storefront API `@inContext(country:, language:)` values used by
+the request. Keep an explicit failure/mock fallback. Do not use `shop.paymentSettings.currencyCode`, which is the shop
+currency rather than necessarily the active market's presentment currency. Do not read env APIs in browser modules.
 
 In the ShopifyScripts `analytics` config, `channel` is optional and defaults to `"hydrogen"`. The `"hydrogen"` channel is the one that requires `storefrontId` — it is pulled from the ShopifyScripts `shop` config into analytics payloads. Headless storefronts pass `channel: "headless"` in the ShopifyScripts `analytics` config; the analytics payload then omits `storefrontId`, but `shop.storefrontId` itself is still required (pass `"0"` when the app has no storefront ID).
 
@@ -58,7 +63,7 @@ Publish these from route/page boundaries:
 - `CART_VIEWED` when the full cart page or cart drawer is viewed.
 - Wire cart tracking once per cart store lifecycle with `trackCartAnalytics(cartStore)` — React apps use the `useCartAnalytics()` hook from `@shopify/hydrogen/react` and Vue apps use the `useCartAnalytics()` composable from `@shopify/hydrogen/vue`; both call it with the provider's cart store and clean up on unmount. The tracker subscribes to the cart store itself, skips pending/revalidating/note updates, publishes cart delta events on confirmed cart changes, and returns an unsubscribe function. Call it from a client-only effect (`useEffect` / `onMounted`), never at cart-store creation time — it throws when `window.Shopify.analytics` is missing (SSR). Do not manually publish cart delta events.
 
-The bus defaults `shop` from the top-level `shop` config passed to ShopifyScripts; pass `shop` in an event payload only when intentionally overriding that configured value. Shopify analytics reads language and currency from `window.Shopify.locale` and `window.Shopify.currency.active`.
+The bus defaults `shop` from the top-level `shop` config passed to ShopifyScripts; pass `shop` in an event payload only when intentionally overriding that configured value. Shopify analytics reads language and currency from `window.Shopify.locale` and `window.Shopify.currency.active`. Cart tracking may synchronize the currency after cart data arrives, but it is not initial currency setup.
 
 Required product analytics fields include Shopify Product GID, ProductVariant GID when available, title, price, vendor, quantity, and variant title.
 
@@ -78,3 +83,4 @@ Required product analytics fields include Shopify Product GID, ProductVariant GI
 - Confirmed cart data changes flow through `trackCartAnalytics(cartStore)` (React/Vue bindings: `useCartAnalytics()`), and the cart query includes `updatedAt`.
 - Consent-denied visitors do not deliver destination events.
 - No browser module reads private or server-only env variables.
+- Before and after consent, `window.Shopify.currency.active` matches the resolved market without requiring a cart mutation.

--- a/packages/hydrogen/skills/hydrogen-analytics/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-analytics/SKILL.md
@@ -19,7 +19,7 @@ Prerequisite: analytics depends on the same-origin SFAPI proxy (see `hydrogen-re
 
 ## Core Pattern
 
-Render Shopify runtime scripts once from the app root/document head with the same resolved market used by Storefront API requests. Use `ShopifyScripts` from your framework binding if it exports one, or `getShopifyScriptTags()` / `renderShopifyScriptTags()` from core in other framework heads. Pass the `shop` object matching the `ShopifyScriptsShop` type, and `i18n` matching the `ShopifyScriptsI18n` type and serialize them into ShopifyScripts. — declare them as constants with type annotations to keep errors located close to the source of writing. The analytics bus is created by default; pass `analytics` only for optional bus configuration such as `customData`. Do not pass market `country` or `language` through analytics consent config.
+Render Shopify runtime scripts once from the app root/document head with the same resolved market used by Storefront API requests. Use `ShopifyScripts` from your framework binding if it exports one, or `getShopifyScriptTags()` / `renderShopifyScriptTags()` from core in other framework heads. Pass the `shop` object matching the `ShopifyScriptsShop` type, and `i18n` matching the `ShopifyScriptsI18nWithCurrency` type and serialize them into ShopifyScripts. — declare them as constants with type annotations to keep errors located close to the source of writing. The analytics bus is created by default; pass `analytics` only for optional bus configuration such as `customData`. Do not pass market `country` or `language` through analytics consent config.
 
 Read one browser-lazy singleton from the Shopify global created by `ShopifyScripts`:
 

--- a/packages/hydrogen/skills/hydrogen-setup/references/analytics.md
+++ b/packages/hydrogen/skills/hydrogen-setup/references/analytics.md
@@ -23,7 +23,7 @@
 **Prerequisites:**
 
 - A storefront built on `@shopify/hydrogen` with the request interceptors already wired (`handleShopifyRoutes` and `handleShopifyRedirects`). The analytics bus depends on the SFAPI proxy so the browser can observe same-origin Storefront API responses for session cookies. Without the proxy, analytics falls back to deprecated JavaScript-visible cookies and should be treated as incomplete. If you have not installed the interceptors yet, install them first with the local `hydrogen-request-handlers` skill.
-- Shopify runtime scripts rendered from the root/document head. Use `ShopifyScripts` from your framework binding if it exports one, or `getShopifyScriptTags()` / `renderShopifyScriptTags()` from core in other framework heads. Pass `{country, language, currency?}` as `i18n`; pass `{shopId: env.SHOP_ID, storefrontId: env.PUBLIC_STOREFRONT_ID ?? "0", myshopifyDomain: env.PUBLIC_STORE_DOMAIN}` as `shop`. Resolve both on the server, declare them as consts annotated with the `ShopifyScriptsShop` / `ShopifyScriptsI18n` types from `@shopify/hydrogen` (so wrong or missing fields fail typecheck where they are built), and serialize them into ShopifyScripts. ShopifyScripts creates `window.Shopify.analytics` by default and exposes the permanent domain as `window.Shopify.shop`. Analytics consent config does not accept `country` or `language`.
+- Shopify runtime scripts rendered from the root/document head. Use `ShopifyScripts` from your framework binding if it exports one, or `getShopifyScriptTags()` / `renderShopifyScriptTags()` from core in other framework heads. Pass `{country, language, currency}` as `i18n`; pass `{shopId: env.SHOP_ID, storefrontId: env.PUBLIC_STOREFRONT_ID ?? "0", myshopifyDomain: env.PUBLIC_STORE_DOMAIN}` as `shop`. Resolve both on the server, declare them as consts annotated with the `ShopifyScriptsShop` / `ShopifyScriptsI18n` types from `@shopify/hydrogen` (so wrong or missing fields fail typecheck where they are built), and serialize them into ShopifyScripts. ShopifyScripts creates `window.Shopify.analytics` by default and exposes the permanent domain as `window.Shopify.shop`. Analytics consent config does not accept `country` or `language`.
 - A client-side lifecycle hook in your framework (route-change effect, navigation event, `<script>` tag, etc.) so view events can fire on the right URL transitions.
 
 `ShopifyScripts` creates the zero-dependency analytics bus, sets it on `window.Shopify.analytics`, and owns Shopify consent setup, analytics CDN loading, and deprecated-cookie compatibility. Framework adapters stay thin: they translate framework lifecycle events into bus calls and wire cart delta tracking with `trackCartAnalytics()`.
@@ -85,7 +85,7 @@ const shop: ShopifyScriptsShop = {
 const i18n: ShopifyScriptsI18n = {
   country: "US",
   language: "EN",              // sent as Monorail content language
-  currency: "USD",             // optional; sets window.Shopify.currency.active
+  currency: "USD",             // required for analytics initialization
 };
 
 const consent: ConsentConfig = {
@@ -111,11 +111,31 @@ Resolve shop metadata on the server and pass it to ShopifyScripts. Shopify analy
 
 ### `i18n`
 
-Pass the app's resolved `country` and `language` market values. Optional `currency` sets `window.Shopify.currency.active` for Shopify runtime scripts and Shopify analytics. Shopify analytics reads its content language from `window.Shopify.locale`.
+Pass the app's resolved market values. Although `currency` is optional in the general ShopifyScripts type, treat it as
+required when Shopify analytics is enabled: it initializes `window.Shopify.currency.active` before consent-gated
+events can replay. Use an authoritative configured market currency or select the active presentment currency from the
+Storefront API under the same market context as the request:
+
+```graphql
+query AnalyticsCurrency($country: CountryCode, $language: LanguageCode)
+@inContext(country: $country, language: $language) {
+  localization {
+    country {
+      currency {
+        isoCode
+      }
+    }
+  }
+}
+```
+
+Keep an explicit configured fallback for API failures or mock mode. Do not use
+`shop.paymentSettings.currencyCode`: that is the shop currency and may differ from the active market's presentment
+currency. Shopify analytics reads its content language from `window.Shopify.locale`.
 
 ### `analytics`
 
-The analytics bus is enabled by default. Pass `analytics` only when you need optional bus configuration such as `customData`, which is attached to bus-generated payloads. Shopify analytics reads currency from `window.Shopify.currency.active`, which is seeded by `i18n.currency` and updated from cart currency when available.
+The analytics bus is enabled by default. Pass `analytics` only when you need optional bus configuration such as `customData`, which is attached to bus-generated payloads. Shopify analytics reads currency from `window.Shopify.currency.active`, which must be seeded by `i18n.currency`; cart currency is only later synchronization or fallback, not initial setup.
 
 ### `consent`
 
@@ -591,6 +611,8 @@ After wiring, smoke-test each event in the browser dev tools:
 3. **Per-route navigation fires page_viewed** — click around. Each navigation should produce a fresh `page_viewed` event. If only the initial page load fires, the route-change hook is wired wrong (e.g. effect dependency missing in React, reactive read missing in Solid).
 4. **Cart events fire** — add an item to the cart. You should see `cart_updated` followed by `product_added_to_cart`. If you see `cart_updated` repeating with the same payload, the dedupe key (`updatedAt`) is stale — confirm your cart query selects `updatedAt`.
 5. **Privacy banner renders for EU/UK visitors** — if `mode: "default-banner"`, simulate a GDPR-protected region with browser dev-tools location override or VPN. The banner should render. If it does not, check that `cdn.shopify.com` is not blocked by your CSP.
+6. **Currency exists across consent** — before and after granting consent, verify `window.Shopify.currency.active`
+   matches the resolved market currency without first adding an item to the cart.
 
 For production, re-verify against the production bundle. Several gotchas only appear once the SSR/CSR boundary stabilizes.
 
@@ -601,6 +623,9 @@ For production, re-verify against the production bundle. Several gotchas only ap
 - **Replay is destination-only.** Raw `analytics.subscribe()` listeners only receive live events. `analytics.addDestination()` callbacks receive consent-gated live events plus buffered replay after analytics consent is granted. If the visitor explicitly denies analytics consent, the buffer is cleared and those pre-denial events are never replayed.
 - **The singleton must be lazy.** Reading the global bus at module top-level can run on the server during SSR and crash on `window` access. Always wrap in a `typeof window === 'undefined'` guard.
 - **Use the right shop shape for each API.** `ShopifyScripts` accepts a numeric Shop ID or Shopify Shop GID plus `storefrontId` and the permanent `myshopifyDomain`; the analytics bus normalizes `shop.shopId` to a Shopify Shop GID before dispatch, while the bootstrap exposes the domain as `window.Shopify.shop`.
+- **Currency only appears after a cart mutation.** The cart tracker can synchronize currency, which may hide missing
+  bootstrap data. Resolve the active market currency on the server and pass it as `i18n.currency` during initial
+  ShopifyScripts rendering.
 - **Customer Privacy script blocked by CSP.** If your CSP does not allow `cdn.shopify.com`, the consent script never loads, `analyticsProcessingAllowed()` stays `false`, and destination events never deliver. Check Network tab for blocked requests; add `cdn.shopify.com` to `script-src`.
 - **`mode: "no-banner"` is wrong for any storefront with EU/UK/CA visitors unless consent is handled elsewhere.** Without a hosted or custom banner, those visitors have no UI to grant consent — destination events never deliver. Default to `mode: "default-banner"` unless you have a custom consent UI that calls `setTrackingConsent()`.
 - **Multiple bus instances on the same page conflict.** `window.Shopify.customerPrivacy.config` is global; the latest initialized config wins. Multi-store-per-page is not supported. Use one bus per active storefront shell.
@@ -622,3 +647,5 @@ For production, re-verify against the production bundle. Several gotchas only ap
 - **Don't put per-route view events in a global subscriber.** A single subscriber that watches `page_viewed` and synthesizes `product_viewed` from URL parsing is brittle and loses payload context. Publish each view event from the route that has the data.
 - **Don't construct multiple buses for "different consent contexts" on the same page.** Customer Privacy config is global; the latest initialized config takes effect. If you need conditional behavior, branch inside subscribers, not at construction.
 - **Don't skip the request-handler prerequisite.** Without the SFAPI proxy, modern same-origin Shopify cookies cannot be set. Analytics may appear to work via deprecated JS-visible cookies, but session continuity into checkout breaks. Treat analytics as incomplete until the proxy is live in production.
+- **Don't use `shop.paymentSettings.currencyCode` for market analytics.** It is the shop currency, not necessarily the
+  active market's presentment currency; use `localization.country.currency.isoCode` in the active market context.

--- a/packages/hydrogen/skills/hydrogen-setup/references/analytics.md
+++ b/packages/hydrogen/skills/hydrogen-setup/references/analytics.md
@@ -23,7 +23,7 @@
 **Prerequisites:**
 
 - A storefront built on `@shopify/hydrogen` with the request interceptors already wired (`handleShopifyRoutes` and `handleShopifyRedirects`). The analytics bus depends on the SFAPI proxy so the browser can observe same-origin Storefront API responses for session cookies. Without the proxy, analytics falls back to deprecated JavaScript-visible cookies and should be treated as incomplete. If you have not installed the interceptors yet, install them first with the local `hydrogen-request-handlers` skill.
-- Shopify runtime scripts rendered from the root/document head. Use `ShopifyScripts` from your framework binding if it exports one, or `getShopifyScriptTags()` / `renderShopifyScriptTags()` from core in other framework heads. Pass `{country, language, currency}` as `i18n`; pass `{shopId: env.SHOP_ID, storefrontId: env.PUBLIC_STOREFRONT_ID ?? "0", myshopifyDomain: env.PUBLIC_STORE_DOMAIN}` as `shop`. Resolve both on the server, declare them as consts annotated with the `ShopifyScriptsShop` / `ShopifyScriptsI18n` types from `@shopify/hydrogen` (so wrong or missing fields fail typecheck where they are built), and serialize them into ShopifyScripts. ShopifyScripts creates `window.Shopify.analytics` by default and exposes the permanent domain as `window.Shopify.shop`. Analytics consent config does not accept `country` or `language`.
+- Shopify runtime scripts rendered from the root/document head. Use `ShopifyScripts` from your framework binding if it exports one, or `getShopifyScriptTags()` / `renderShopifyScriptTags()` from core in other framework heads. Pass `{country, language, currency}` as `i18n`; pass `{shopId: env.SHOP_ID, storefrontId: env.PUBLIC_STOREFRONT_ID ?? "0", myshopifyDomain: env.PUBLIC_STORE_DOMAIN}` as `shop`. Resolve both on the server, declare them as consts annotated with the `ShopifyScriptsShop` / `ShopifyScriptsI18nWithCurrency` types from `@shopify/hydrogen` (so wrong or missing fields fail typecheck where they are built), and serialize them into ShopifyScripts. ShopifyScripts creates `window.Shopify.analytics` by default and exposes the permanent domain as `window.Shopify.shop`. Analytics consent config does not accept `country` or `language`.
 - A client-side lifecycle hook in your framework (route-change effect, navigation event, `<script>` tag, etc.) so view events can fire on the right URL transitions.
 
 `ShopifyScripts` creates the zero-dependency analytics bus, sets it on `window.Shopify.analytics`, and owns Shopify consent setup, analytics CDN loading, and deprecated-cookie compatibility. Framework adapters stay thin: they translate framework lifecycle events into bus calls and wire cart delta tracking with `trackCartAnalytics()`.
@@ -73,7 +73,7 @@ import {
   type ConsentConfig,
   type ShopifyScriptTagsOptions,
   type ShopifyScriptsShop,
-  type ShopifyScriptsI18n,
+  type ShopifyScriptsI18nWithCurrency,
 } from "@shopify/hydrogen";
 
 const shop: ShopifyScriptsShop = {
@@ -82,10 +82,10 @@ const shop: ShopifyScriptsShop = {
   myshopifyDomain: "example.myshopify.com", // permanent MyShopify domain
 };
 
-const i18n: ShopifyScriptsI18n = {
+const i18n: ShopifyScriptsI18nWithCurrency = {
   country: "US",
   language: "EN",              // sent as Monorail content language
-  currency: "USD",             // required for analytics initialization
+  currency: "USD",             // required while Shopify analytics is enabled
 };
 
 const consent: ConsentConfig = {
@@ -111,9 +111,9 @@ Resolve shop metadata on the server and pass it to ShopifyScripts. Shopify analy
 
 ### `i18n`
 
-Pass the app's resolved market values. Although `currency` is optional in the general ShopifyScripts type, treat it as
-required when Shopify analytics is enabled: it initializes `window.Shopify.currency.active` before consent-gated
-events can replay. Use an authoritative configured market currency or select the active presentment currency from the
+Pass the app's resolved market values. `currency` is required by the ShopifyScripts types whenever Shopify analytics
+is enabled (the default); it is only optional with `shopifyAnalytics: false`. It initializes
+`window.Shopify.currency.active` before consent-gated events can replay. Use an authoritative configured market currency or select the active presentment currency from the
 Storefront API under the same market context as the request:
 
 ```graphql

--- a/packages/hydrogen/skills/hydrogen-setup/steps/7-shopify-runtime-scripts.md
+++ b/packages/hydrogen/skills/hydrogen-setup/steps/7-shopify-runtime-scripts.md
@@ -12,7 +12,7 @@ Render Shopify runtime scripts once in the root document.
 Build both in a server-only module, annotated with the types exported from `@shopify/hydrogen`, so TypeScript rejects wrong or missing fields at the declaration — not at the distant `ShopifyScripts` call site:
 
 ```ts
-import type { ShopifyScriptsI18n, ShopifyScriptsShop } from "@shopify/hydrogen";
+import type { ShopifyScriptsI18nWithCurrency, ShopifyScriptsShop } from "@shopify/hydrogen";
 
 const shop: ShopifyScriptsShop = {
   shopId: env.SHOP_ID,
@@ -20,9 +20,10 @@ const shop: ShopifyScriptsShop = {
   myshopifyDomain: env.PUBLIC_STORE_DOMAIN,
 };
 
-const i18n: ShopifyScriptsI18n = {
+const i18n: ShopifyScriptsI18nWithCurrency = {
   country, // resolved market country, e.g. "US"
   language, // resolved market language, e.g. "EN"
+  currency, // resolved market currency, e.g. "USD" — required while Shopify analytics is enabled
 };
 ```
 
@@ -32,7 +33,7 @@ All three `shop` fields are required and identify different things:
 - `storefrontId` — the specific **headless/Hydrogen storefront instance** attached to the shop. A shop can have several storefronts; analytics and PerfKit use this ID to attribute traffic to this one. Use `"0"` when the app has no provisioned storefront ID.
 - `myshopifyDomain` — the shop's permanent `*.myshopify.com` domain, exposed as `window.Shopify.shop`.
 
-`i18n` is the same resolved market used by Storefront API requests (`country` + `language`, optional `currency`) — not a locale string, and not the analytics consent config.
+`i18n` is the same resolved market used by Storefront API requests (`country` + `language` + `currency`) — not a locale string, and not the analytics consent config. `currency` is required whenever Shopify analytics is enabled (the default); it is only optional when `shopifyAnalytics: false`.
 
 For vanilla browser code that does not use SSR or a framework head API, render the HTML from core and include it in the document shell. If your app renders tags through core helpers instead of a framework binding, call `initializeShopifyScripts()` from bundled client code:
 

--- a/packages/hydrogen/src/core/index.ts
+++ b/packages/hydrogen/src/core/index.ts
@@ -136,6 +136,7 @@ export type {
   ShopifyScriptsShop,
   ShopifyScriptTagsOptions,
   ShopifyScriptsI18n,
+  ShopifyScriptsI18nWithCurrency,
 } from "./shopify-scripts/index";
 
 export { createCollectionReconciler, createCollectionStore } from "./collection";

--- a/packages/hydrogen/src/core/shopify-scripts.test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 
+import { configureLogging, resetLoggingForTests } from "./logging";
 import { SHOPIFY_STOREFRONT_STANDARD_EVENTS_INSPECTOR_SCRIPT } from "./shopify-scripts/constants";
 import {
   getShopifyScriptTags,
@@ -20,7 +21,7 @@ import {
   SHOPIFY_STOREFRONT_WEBMCP_SCRIPT,
 } from "./shopify-scripts/index";
 import { createShopifyRouteTemplates } from "./standard-routes/index";
-import { assert } from "./test-utils";
+import { assert, createTestLogger } from "./test-utils";
 import { loadScript } from "./utils/load-script";
 
 vi.mock("./utils/load-script", () => ({
@@ -41,9 +42,14 @@ const TEST_SHOP = {
   storefrontId: TEST_STOREFRONT_ID,
   myshopifyDomain: TEST_MYSHOPIFY_DOMAIN,
 };
+const TEST_I18N = { country: "US", language: "EN", currency: "USD" } as const;
 
 describe("shopify scripts", () => {
   const emptyRouteTemplates = createShopifyRouteTemplates({});
+
+  afterEach(() => {
+    resetLoggingForTests();
+  });
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -331,7 +337,7 @@ describe("shopify scripts", () => {
   it("builds script tag descriptors for the Shopify runtime", () => {
     const descriptors = getShopifyScriptTags({
       debug: { standardEventsInspector: true },
-      i18n: { country: "US", language: "EN" },
+      i18n: TEST_I18N,
       nonce: "test-nonce",
       shop: TEST_SHOP,
     });
@@ -543,6 +549,7 @@ describe("shopify scripts", () => {
 
   it("preserves an explicitly empty nonce on nonce-capable scripts", () => {
     const descriptors = getShopifyScriptTags({
+      i18n: TEST_I18N,
       debug: { standardEventsInspector: true },
       nonce: "",
       shop: TEST_SHOP,
@@ -554,7 +561,7 @@ describe("shopify scripts", () => {
   });
 
   it("does not include WebMCP in SSR descriptors", () => {
-    const descriptors = getShopifyScriptTags({ shop: TEST_SHOP });
+    const descriptors = getShopifyScriptTags({ i18n: TEST_I18N, shop: TEST_SHOP });
 
     expect(descriptors.scripts).toHaveLength(8);
     expect(descriptors.scripts).not.toContainEqual(
@@ -573,6 +580,7 @@ describe("shopify scripts", () => {
 
   it("includes the async Inbox module when enabled", () => {
     const descriptors = getShopifyScriptTags({
+      i18n: TEST_I18N,
       nonce: "test-nonce",
       shop: TEST_SHOP,
       inbox: true,
@@ -610,8 +618,34 @@ describe("shopify scripts", () => {
     );
   });
 
+  it("warns when Shopify analytics is enabled without a currency", () => {
+    const logger = createTestLogger();
+    configureLogging({ logger });
+
+    // @ts-expect-error Intentionally omits currency to validate the JS-consumer warning.
+    getShopifyScriptTags({
+      i18n: { country: "US", language: "EN" },
+      shop: TEST_SHOP,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "shopify analytics is enabled without i18n.currency; analytics events fail until window.Shopify.currency.active is set",
+      { scope: "shopify-scripts" },
+    );
+  });
+
+  it("does not warn about currency when Shopify analytics is disabled", () => {
+    const logger = createTestLogger();
+    configureLogging({ logger });
+
+    getShopifyScriptTags({ shop: TEST_SHOP, shopifyAnalytics: false });
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it("includes PerfKit when configured", () => {
     const descriptors = getShopifyScriptTags({
+      i18n: TEST_I18N,
       shop: {
         shopId: TEST_SHOP_GID,
         storefrontId: TEST_STOREFRONT_ID,
@@ -635,6 +669,7 @@ describe("shopify scripts", () => {
     });
     expect(getPerfKitBridgeScript(descriptors.scripts)?.innerHTML).toContain("perfkit-spa-bridge");
     const renderedTags = renderShopifyScriptTags({
+      i18n: TEST_I18N,
       shop: {
         shopId: TEST_SHOP_ID,
         storefrontId: TEST_STOREFRONT_ID,
@@ -647,6 +682,7 @@ describe("shopify scripts", () => {
 
   it("accepts numeric PerfKit shop IDs", () => {
     const descriptors = getShopifyScriptTags({
+      i18n: TEST_I18N,
       shop: {
         shopId: TEST_SHOP_ID,
         storefrontId: TEST_STOREFRONT_ID,
@@ -684,6 +720,7 @@ describe("shopify scripts", () => {
 
   it("skips PerfKit when the shop ID has no numeric segment", () => {
     const descriptors = getShopifyScriptTags({
+      i18n: TEST_I18N,
       shop: {
         shopId: "gid://shopify/Shop/not-a-number",
         storefrontId: TEST_STOREFRONT_ID,
@@ -704,6 +741,7 @@ describe("shopify scripts", () => {
     setDocumentReadyState("loading");
     const addDestination = vi.fn();
     const descriptors = getShopifyScriptTags({
+      i18n: TEST_I18N,
       shop: {
         shopId: TEST_SHOP_ID,
         storefrontId: TEST_STOREFRONT_ID,
@@ -732,6 +770,7 @@ describe("shopify scripts", () => {
       setPageType: vi.fn(),
     };
     const descriptors = getShopifyScriptTags({
+      i18n: TEST_I18N,
       shop: {
         shopId: TEST_SHOP_ID,
         storefrontId: TEST_STOREFRONT_ID,
@@ -765,7 +804,7 @@ describe("shopify scripts", () => {
   });
 
   it("returns a new ordered tag array each time", () => {
-    const descriptors = getShopifyScriptTags({ shop: TEST_SHOP });
+    const descriptors = getShopifyScriptTags({ i18n: TEST_I18N, shop: TEST_SHOP });
     const firstTags = descriptors.tags;
     const secondTags = descriptors.tags;
 
@@ -804,7 +843,7 @@ describe("shopify scripts", () => {
   it("renders all Shopify script tags to an HTML array", () => {
     const htmlTags = renderShopifyScriptTags({
       debug: { standardEventsInspector: true },
-      i18n: { country: "US", language: "EN" },
+      i18n: TEST_I18N,
       nonce: "test-nonce",
       shop: TEST_SHOP,
     });

--- a/packages/hydrogen/src/core/shopify-scripts.test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts.test.ts
@@ -634,6 +634,21 @@ describe("shopify scripts", () => {
     );
   });
 
+  it.each(["", "   "])("warns when the currency is blank (%j)", (currency) => {
+    const logger = createTestLogger();
+    configureLogging({ logger });
+
+    getShopifyScriptTags({
+      i18n: { country: "US", language: "EN", currency },
+      shop: TEST_SHOP,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "shopify analytics is enabled without i18n.currency; analytics events fail until window.Shopify.currency.active is set",
+      { scope: "shopify-scripts" },
+    );
+  });
+
   it("does not warn about currency when Shopify analytics is disabled", () => {
     const logger = createTestLogger();
     configureLogging({ logger });

--- a/packages/hydrogen/src/core/shopify-scripts.type-test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts.type-test.ts
@@ -73,4 +73,21 @@ export function shopifyScriptCurrencyTypes() {
     i18n: { country: "US", language: "EN" },
   };
   void analyticsDisabledWithoutCurrency;
+
+  const runtimeFlag = Math.random() > 0.5;
+
+  const runtimeFlagWithCurrency: ShopifyScriptTagsOptions = {
+    shop,
+    shopifyAnalytics: runtimeFlag,
+    i18n: { country: "US", language: "EN", currency: "USD" },
+  };
+  void runtimeFlagWithCurrency;
+
+  // @ts-expect-error a runtime boolean cannot prove analytics is disabled, so currency is required
+  const runtimeFlagWithoutCurrency: ShopifyScriptTagsOptions = {
+    shop,
+    shopifyAnalytics: runtimeFlag,
+    i18n: { country: "US", language: "EN" },
+  };
+  void runtimeFlagWithoutCurrency;
 }

--- a/packages/hydrogen/src/core/shopify-scripts.type-test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts.type-test.ts
@@ -4,6 +4,7 @@ import type { ShopifyScriptTagsOptions } from "./shopify-scripts";
 
 describe("Shopify script option types", () => {
   it("requires complete shop identity", () => {});
+  it("requires i18n currency when Shopify analytics is enabled", () => {});
 });
 
 export function shopifyScriptOptionTypes() {
@@ -23,6 +24,53 @@ export function shopifyScriptOptionTypes() {
       storefrontId: "sub-1",
       myshopifyDomain: "test-shop.myshopify.com",
     },
+    shopifyAnalytics: false,
   };
   void missingShopId;
+}
+
+export function shopifyScriptCurrencyTypes() {
+  const shop = {
+    shopId: "gid://shopify/Shop/1",
+    storefrontId: "sub-1",
+    myshopifyDomain: "test-shop.myshopify.com",
+  };
+
+  // @ts-expect-error i18n with currency is required when Shopify analytics is enabled by default
+  const missingI18n: ShopifyScriptTagsOptions = { shop };
+  void missingI18n;
+
+  // @ts-expect-error currency is required when Shopify analytics is enabled by default
+  const missingCurrency: ShopifyScriptTagsOptions = {
+    shop,
+    i18n: { country: "US", language: "EN" },
+  };
+  void missingCurrency;
+
+  // @ts-expect-error currency is required when Shopify analytics is enabled
+  const missingCurrencyExplicitAnalytics: ShopifyScriptTagsOptions = {
+    shop,
+    shopifyAnalytics: true,
+    i18n: { country: "US", language: "EN" },
+  };
+  void missingCurrencyExplicitAnalytics;
+
+  const withCurrency: ShopifyScriptTagsOptions = {
+    shop,
+    i18n: { country: "US", language: "EN", currency: "USD" },
+  };
+  void withCurrency;
+
+  const analyticsDisabledWithoutI18n: ShopifyScriptTagsOptions = {
+    shop,
+    shopifyAnalytics: false,
+  };
+  void analyticsDisabledWithoutI18n;
+
+  const analyticsDisabledWithoutCurrency: ShopifyScriptTagsOptions = {
+    shop,
+    shopifyAnalytics: false,
+    i18n: { country: "US", language: "EN" },
+  };
+  void analyticsDisabledWithoutCurrency;
 }

--- a/packages/hydrogen/src/core/shopify-scripts/consent-tracking.test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/consent-tracking.test.ts
@@ -16,10 +16,11 @@ const SHOP = {
   storefrontId: "sub-1",
   myshopifyDomain: "test-shop.myshopify.com",
 };
+const I18N = { country: "US", language: "EN", currency: "USD" } as const;
 
 describe("consent script tags", () => {
   it("renders the standalone consent API as an async script when consent is omitted", () => {
-    const { scripts } = getShopifyScriptTags({ shop: SHOP });
+    const { scripts } = getShopifyScriptTags({ i18n: I18N, shop: SHOP });
 
     expect(scripts[0].innerHTML).toContain('"consentStatus":"pending"');
     expect(scripts[0].innerHTML).toContain('"config":{"isHeadless":true}');
@@ -38,7 +39,7 @@ describe("consent script tags", () => {
   });
 
   it("renders the standalone consent API as an async script by default", () => {
-    const { scripts } = getShopifyScriptTags({ consent: CONSENT, shop: SHOP });
+    const { scripts } = getShopifyScriptTags({ consent: CONSENT, i18n: I18N, shop: SHOP });
 
     expect(scripts).toContainEqual(
       expect.objectContaining({
@@ -59,6 +60,7 @@ describe("consent script tags", () => {
         ...CONSENT,
         mode: "default-banner",
       },
+      i18n: I18N,
       nonce: "test-nonce",
       shop: SHOP,
     });
@@ -78,7 +80,7 @@ describe("consent script tags", () => {
   });
 
   it("bootstraps customer privacy config before consent scripts", () => {
-    const { scripts } = getShopifyScriptTags({ consent: CONSENT, shop: SHOP });
+    const { scripts } = getShopifyScriptTags({ consent: CONSENT, i18n: I18N, shop: SHOP });
     const consentApiIndex = scripts.findIndex(
       (script) => script.attributes?.id === SHOPIFY_CONSENT_SCRIPT_ID,
     );
@@ -108,7 +110,7 @@ describe("consent script tags", () => {
   });
 
   it("renders consent tags to HTML", () => {
-    const html = renderShopifyScriptTags({ shop: SHOP }).join("");
+    const html = renderShopifyScriptTags({ i18n: I18N, shop: SHOP }).join("");
 
     expect(html).toContain(`id="shopify-consent"`);
     expect(html).toContain(`src="${SHOPIFY_CONSENT_API_SCRIPT}"`);

--- a/packages/hydrogen/src/core/shopify-scripts/index.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/index.ts
@@ -59,7 +59,9 @@ function warnWhenAnalyticsCurrencyMissing(
   shopifyAnalytics: boolean,
   i18n: ShopifyScriptTagsOptions["i18n"],
 ): void {
-  if (shopifyAnalytics && i18n?.currency === undefined) {
+  // `!currency?.trim()` treats undefined, null, empty, and whitespace-only values as missing:
+  // untyped consumers can pass any of these, and all leave window.Shopify.currency.active unusable.
+  if (shopifyAnalytics && !i18n?.currency?.trim()) {
     log.warn(
       "shopify analytics is enabled without i18n.currency; analytics events fail until window.Shopify.currency.active is set",
     );

--- a/packages/hydrogen/src/core/shopify-scripts/index.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/index.ts
@@ -1,3 +1,4 @@
+import { getLogger } from "../logging";
 import { getShopifyAnalyticsBusScript, getShopifyAnalyticsConfig } from "./analytics";
 import { getShopifyConsentTrackingScript } from "./consent";
 import {
@@ -46,8 +47,24 @@ export type {
   ShopifyScriptTagsOptions,
   ShopifyScriptsOptions,
   ShopifyScriptsI18n,
+  ShopifyScriptsI18nWithCurrency,
   ShopifyScriptsShop,
 } from "./types";
+
+const log = getLogger("shopify-scripts");
+
+// Compile-time enforcement lives in ShopifyScriptTagsOptions; this guard covers JS consumers and
+// bindings (such as Vue) whose runtime props cannot express that union.
+function warnWhenAnalyticsCurrencyMissing(
+  shopifyAnalytics: boolean,
+  i18n: ShopifyScriptTagsOptions["i18n"],
+): void {
+  if (shopifyAnalytics && i18n?.currency === undefined) {
+    log.warn(
+      "shopify analytics is enabled without i18n.currency; analytics events fail until window.Shopify.currency.active is set",
+    );
+  }
+}
 
 /**
  * Returns grouped Shopify storefront script/link descriptors for SSR frameworks and bindings.
@@ -66,6 +83,8 @@ export function getShopifyScriptTags({
   shopifyAnalytics = true,
   inbox = false,
 }: ShopifyScriptTagsOptions): ShopifyScriptTagDescriptors {
+  warnWhenAnalyticsCurrencyMissing(shopifyAnalytics, i18n);
+
   const nonceAttributes = nonce !== undefined ? { nonce } : undefined;
   const analyticsConfig = getShopifyAnalyticsConfig({ analytics, consent, shop });
 

--- a/packages/hydrogen/src/core/shopify-scripts/types.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/types.ts
@@ -102,8 +102,11 @@ type ShopifyScriptTagsBaseOptions = {
 export type ShopifyScriptTagsOptions =
   | (ShopifyScriptTagsBaseOptions & {
       i18n: ShopifyScriptsI18nWithCurrency;
-      /** Shopify analytics is enabled by default and requires `i18n.currency`. */
-      shopifyAnalytics?: true;
+      /**
+       * Shopify analytics is enabled by default and requires `i18n.currency`. Accepts any
+       * boolean so runtime-computed flags type-check; currency is present either way.
+       */
+      shopifyAnalytics?: boolean;
     })
   | (ShopifyScriptTagsBaseOptions & {
       i18n?: ShopifyScriptsI18n;

--- a/packages/hydrogen/src/core/shopify-scripts/types.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/types.ts
@@ -17,6 +17,16 @@ export type ShopifyScriptsI18n = Pick<I18nConfig, "country" | "language"> &
     currency?: string;
   };
 
+export type ShopifyScriptsI18nWithCurrency = ShopifyScriptsI18n & {
+  /**
+   * Active currency code, exposed as `window.Shopify.currency.active`. Required when Shopify
+   * analytics is enabled: product events carry prices, and a price without a currency is
+   * meaningless. Product pages can be viewed before the cart initializes, so the currency cannot
+   * be sourced from the cart.
+   */
+  currency: string;
+};
+
 // DOM types expose element properties such as `crossOrigin`, but these descriptors represent
 // serialized HTML attributes such as `crossorigin` so they work outside React. Attribute values are
 // kept narrow where JSX runtimes define stricter unions for serialized HTML attributes.
@@ -74,20 +84,31 @@ export type ShopifyScriptsShop = {
   myshopifyDomain: string;
 };
 
-export type ShopifyScriptTagsOptions = {
+type ShopifyScriptTagsBaseOptions = {
   analytics?: ShopifyScriptsAnalyticsConfig;
   consent?: ConsentConfig;
   debug?: {
     /** Loads Shopify's standard events inspector in development builds. */
     standardEventsInspector?: boolean;
   };
-  i18n?: ShopifyScriptsI18n;
   /** Loads Inbox. Render `<shopify-chat>` where you want the chat UI to appear. */
   inbox?: boolean;
   nonce?: string;
   shop: ShopifyScriptsShop;
-  shopifyAnalytics?: boolean;
 };
+
+// Discriminated on `shopifyAnalytics` so enabling Shopify analytics (the default) requires
+// `i18n.currency` at compile time instead of failing at runtime in the analytics script.
+export type ShopifyScriptTagsOptions =
+  | (ShopifyScriptTagsBaseOptions & {
+      i18n: ShopifyScriptsI18nWithCurrency;
+      /** Shopify analytics is enabled by default and requires `i18n.currency`. */
+      shopifyAnalytics?: true;
+    })
+  | (ShopifyScriptTagsBaseOptions & {
+      i18n?: ShopifyScriptsI18n;
+      shopifyAnalytics: false;
+    });
 
 export type ShopifyRoutesOptions = {
   navigate?: ShopifyGlobal["routes"]["navigate"];

--- a/packages/hydrogen/src/react/shopify-scripts.test.tsx
+++ b/packages/hydrogen/src/react/shopify-scripts.test.tsx
@@ -36,6 +36,7 @@ const TEST_SHOP = {
   storefrontId: TEST_STOREFRONT_ID,
   myshopifyDomain: TEST_MYSHOPIFY_DOMAIN,
 };
+const TEST_I18N = { country: "US", language: "EN", currency: "USD" } as const;
 const CONSENT = {
   mode: "default-banner" as const,
 };
@@ -72,7 +73,10 @@ async function hydrateShopifyScripts(serverHtml: string, nonce: string) {
 
   let root: Root | undefined;
   await act(async () => {
-    root = hydrateRoot(container, createElement(ShopifyScripts, { nonce, shop: TEST_SHOP }));
+    root = hydrateRoot(
+      container,
+      createElement(ShopifyScripts, { i18n: TEST_I18N, nonce, shop: TEST_SHOP }),
+    );
   });
   assert(root, "Expected ShopifyScripts hydration to create a React root");
 
@@ -93,7 +97,7 @@ describe("ShopifyScripts", () => {
     const html = renderToStaticMarkup(
       createElement(ShopifyScripts, {
         debug: { standardEventsInspector: true },
-        i18n: { country: "US", language: "EN" },
+        i18n: TEST_I18N,
         nonce: "test-nonce",
         routes: routeTemplates,
         shop: TEST_SHOP,
@@ -137,7 +141,7 @@ describe("ShopifyScripts", () => {
 
   it("suppresses hydration warnings caused by concealed script nonces", async () => {
     const html = renderToString(
-      createElement(ShopifyScripts, { nonce: "test-nonce", shop: TEST_SHOP }),
+      createElement(ShopifyScripts, { i18n: TEST_I18N, nonce: "test-nonce", shop: TEST_SHOP }),
     );
     concealScriptNonceAttributes();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -159,7 +163,7 @@ describe("ShopifyScripts", () => {
       tags: [script],
     });
     const html = renderToString(
-      createElement(ShopifyScripts, { nonce: "test-nonce", shop: TEST_SHOP }),
+      createElement(ShopifyScripts, { i18n: TEST_I18N, nonce: "test-nonce", shop: TEST_SHOP }),
     ).replace('data-test="expected"', 'data-test="unexpected"');
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -171,7 +175,7 @@ describe("ShopifyScripts", () => {
 
   it("hydrates an explicitly empty nonce against a concealed server nonce", async () => {
     const html = renderToString(
-      createElement(ShopifyScripts, { nonce: "test-nonce", shop: TEST_SHOP }),
+      createElement(ShopifyScripts, { i18n: TEST_I18N, nonce: "test-nonce", shop: TEST_SHOP }),
     );
     concealScriptNonceAttributes();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -185,6 +189,7 @@ describe("ShopifyScripts", () => {
   it("always renders standard scripts", () => {
     const html = renderToStaticMarkup(
       createElement(ShopifyScripts, {
+        i18n: TEST_I18N,
         routes: emptyRouteTemplates,
         shop: TEST_SHOP,
       }),
@@ -207,7 +212,7 @@ describe("ShopifyScripts", () => {
   it("preserves Shopify script ordering during React SSR", () => {
     const html = renderToStaticMarkup(
       createElement(ShopifyScripts, {
-        i18n: { country: "US", language: "EN", currency: "USD" },
+        i18n: TEST_I18N,
         shop: TEST_SHOP,
       }),
     );
@@ -233,7 +238,7 @@ describe("ShopifyScripts", () => {
 
   it("renders consent scripts during SSR when consent is provided", () => {
     const html = renderToStaticMarkup(
-      createElement(ShopifyScripts, { consent: CONSENT, shop: TEST_SHOP }),
+      createElement(ShopifyScripts, { consent: CONSENT, i18n: TEST_I18N, shop: TEST_SHOP }),
     );
 
     expect(html).toContain(`id="shopify-consent"`);
@@ -246,6 +251,7 @@ describe("ShopifyScripts", () => {
   it("accepts disabled WebMCP without rendering SSR scripts", () => {
     const html = renderToStaticMarkup(
       createElement(ShopifyScripts, {
+        i18n: TEST_I18N,
         routes: emptyRouteTemplates,
         shop: TEST_SHOP,
         webMcp: false,
@@ -270,6 +276,7 @@ describe("ShopifyScripts", () => {
     const { rerender } = render(
       createElement(ShopifyScripts, {
         consent: CONSENT,
+        i18n: TEST_I18N,
         navigate,
         routes: routeTemplates,
         shop: TEST_SHOP,
@@ -299,6 +306,7 @@ describe("ShopifyScripts", () => {
     rerender(
       createElement(ShopifyScripts, {
         consent: { ...CONSENT, mode: "no-banner" },
+        i18n: TEST_I18N,
         navigate: vi.fn(),
         routes: routeTemplates,
         shop: TEST_SHOP,

--- a/packages/hydrogen/src/vue/shopify-scripts.ts
+++ b/packages/hydrogen/src/vue/shopify-scripts.ts
@@ -86,11 +86,13 @@ export const ShopifyScripts = defineComponent({
     });
 
     return () =>
-      getShopifyScriptTags(props).tags.map(({ tagName, attributes, innerHTML }) =>
-        h(tagName, {
-          ...attributes,
-          ...(innerHTML ? { innerHTML } : {}),
-        }),
+      // oxlint-disable-next-line @typescript-eslint/consistent-type-assertions -- Vue runtime props are flat and cannot express the union tying shopifyAnalytics to a required i18n.currency; getShopifyScriptTags warns at runtime when currency is missing
+      getShopifyScriptTags(props as ShopifyScriptTagsOptions).tags.map(
+        ({ tagName, attributes, innerHTML }) =>
+          h(tagName, {
+            ...attributes,
+            ...(innerHTML ? { innerHTML } : {}),
+          }),
       );
   },
 });

--- a/skills/create-oxygen-template/SKILL.md
+++ b/skills/create-oxygen-template/SKILL.md
@@ -58,6 +58,24 @@ Keep `lib/route-templates.ts` unchanged. It defines `routeTemplates` via `create
 8. Update README and env files for a real starter project.
 9. Run install/typecheck/build/dev/preview validation (see "Prerequisites" and "Validation").
 
+When analytics is enabled, resolve the active-market currency in the root loader from Storefront API localization and
+pass the loader-derived value to `ShopifyScripts` as `i18n.currency` before consent can replay events:
+
+```graphql
+localization {
+  country {
+    currency {
+      isoCode
+    }
+  }
+}
+```
+
+Run this field under the same `@inContext(country:, language:)` values as the storefront request. Keep an explicit
+configured fallback for API failures and mock mode, but do not use `shop.paymentSettings.currencyCode`: it is the shop
+currency, not necessarily the active market's presentment currency. Cart data may synchronize currency later, but it
+must not be the initial source because analytics can replay immediately after consent.
+
 Implementation details (exact per-file shape) live in [reference/react-router-pattern.md](reference/react-router-pattern.md) — read it when writing the template files.
 
 ## Prerequisites (do these before validating)
@@ -192,6 +210,8 @@ Before finishing:
 6. **Actually drive both runtimes, don't just check that a server starts** (static assets can serve even when the Worker isn't exercised):
    - `npm run dev`: request `/`, a product, a collection, `/search`, `/account`, `/cart` — expect HTTP 200 and live data.
    - `npm run preview` (= `react-router build && vite preview`, requires MiniOxygen `>= 4.2.0`): same requests through the built Worker. Confirm `.env` is loaded (root routes need real env, or they 500).
+   - Before and after accepting consent, confirm `window.Shopify.currency.active` exists and matches the resolved
+     market currency without requiring a cart mutation.
 7. For distribution validation, copy the template to a temporary directory, replace `workspace:*` with the version
    selected by the `preview` dist-tag, generate `package-lock.json`, and verify Hydrogen resolves to a registry tarball
    with integrity. Leave the source template lockfile-free.

--- a/skills/create-oxygen-template/reference/react-router-pattern.md
+++ b/skills/create-oxygen-template/reference/react-router-pattern.md
@@ -308,10 +308,18 @@ Additionally, keep `lib/route-templates.ts` unchanged — `routeTemplates` is re
 
 - Public identity -> bundled `app/lib/config.ts` (store domain, public Storefront token, shop/storefront IDs,
   Customer Account client ID, `defaultI18n`, `analyticsShop`, `analyticsConsent`). These are non-secret and safe in the
-  client bundle; default them to the demo store so the template runs out of the box.
+  client bundle; default them to the demo store so the template runs out of the box. Treat `defaultI18n.currency` as a
+  startup fallback only.
 - Real secrets -> Worker `env`, read on the server only: `SESSION_SECRET`, `PRIVATE_STOREFRONT_API_TOKEN`, plus an
   optional `PUBLIC_STORE_DOMAIN` override. Read them in root middleware, not at module scope.
 
 This avoids a fragile loader->client refactor and keeps every feature working. Note this applies beyond root middleware: route modules also import public identity (e.g. `analyticsShop`) on the client, so keeping it as a bundled `config.ts` constant — rather than something read from `env` — is what makes those client imports work.
+
+The active-market currency is request data, not bundled identity. Select
+`localization.country.currency.isoCode` in a root-loader Storefront query using the same `@inContext(country:,
+language:)` values as the rest of the request, fall back to `defaultI18n.currency` on failure, and return the resolved
+`i18n` through loader data. The root `Layout` must pass that loader-derived `i18n` to `ShopifyScripts` so
+`window.Shopify.currency.active` exists before consent replay. Do not use `shop.paymentSettings.currencyCode`, and do
+not wait for cart data to initialize it.
 
 Keep Customer Account, cart, search, analytics, and other example features unless the user explicitly asks to remove them.

--- a/skills/create-vercel-template/SKILL.md
+++ b/skills/create-vercel-template/SKILL.md
@@ -38,6 +38,25 @@ Next.js on Vercel runs on the Node/serverless runtime, so `process.env` works an
 7. Update README and env files for a Vercel starter.
 8. Run install/typecheck/build/dev validation (see "Prerequisites" and "Validation").
 
+When analytics is enabled, resolve the active-market currency in a server-side root/shop lookup from Storefront API
+localization, assemble the complete `i18n` object in the server layout, and pass it to `ShopifyScripts` as `i18n`
+before consent can replay events:
+
+```graphql
+localization {
+  country {
+    currency {
+      isoCode
+    }
+  }
+}
+```
+
+Run this field under the same `@inContext(country:, language:)` values as storefront requests. Reuse the template's
+cached shop lookup when practical and keep an explicit fallback for API failures and mock mode. Do not add a required
+currency environment variable, do not use `shop.paymentSettings.currencyCode` (shop currency is not necessarily the
+active market's presentment currency), and do not wait for cart data to initialize currency.
+
 ## Prerequisites (do these before validating)
 
 - **Use `CI=true` for installs** in this repo (installs abort without a TTY), and `--no-frozen-lockfile` on the first
@@ -291,6 +310,8 @@ Before finishing:
    the demo store, scrape `href="/products/..."` / `href="/collections/..."` from `/` or a collection page (guessing
    handles 404s); e.g. `v2-snowboard` and the `freestyle` collection are live. `/account` legitimately 307-redirects to
    `/account/refresh?...` when logged out — that is the Customer Account flow, not a failure.
+   Before and after accepting consent, confirm `window.Shopify.currency.active` exists and matches the resolved market
+   currency without requiring a cart mutation.
 7. **Check the output isn't gitignored:** run `git check-ignore templates/<name>` — if the whole `templates/` dir is
    ignored (a bare `templates` line in the repo root `.gitignore`), the template can't be committed. Surface this to the
    user rather than shipping an untrackable template.

--- a/templates/nextjs/app/layout.tsx
+++ b/templates/nextjs/app/layout.tsx
@@ -48,11 +48,13 @@ export async function generateMetadata(): Promise<Metadata> {
 // middleware/parent server component instead.
 const htmlLang = defaultI18n.language.toLowerCase();
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const { currency } = await getAnalyticsShop();
+
   return (
     <html lang={htmlLang}>
       <head>
-        <ShopifyScriptsWithNavigation shop={shop} />
+        <ShopifyScriptsWithNavigation shop={shop} currency={currency} />
       </head>
       <body className="bg-surface text-on-surface font-body flex min-h-svh flex-col antialiased">
         <div

--- a/templates/nextjs/app/layout.tsx
+++ b/templates/nextjs/app/layout.tsx
@@ -50,11 +50,12 @@ const htmlLang = defaultI18n.language.toLowerCase();
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const { currency } = await getAnalyticsShop();
+  const i18n = { ...defaultI18n, currency };
 
   return (
     <html lang={htmlLang}>
       <head>
-        <ShopifyScriptsWithNavigation shop={shop} currency={currency} />
+        <ShopifyScriptsWithNavigation shop={shop} i18n={i18n} />
       </head>
       <body className="bg-surface text-on-surface font-body flex min-h-svh flex-col antialiased">
         <div

--- a/templates/nextjs/components/ShopifyScriptsWithNavigation.tsx
+++ b/templates/nextjs/components/ShopifyScriptsWithNavigation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ShopifyScriptsI18nWithCurrency } from "@shopify/hydrogen";
 import { ShopifyScripts, type ShopifyScriptsProps } from "@shopify/hydrogen/react";
 import { useRouter } from "next/navigation";
 
@@ -13,7 +14,7 @@ import { routeTemplates } from "@/lib/route-templates";
  * `i18n` (with server-fetched currency) and passes it here as a complete object.
  */
 type ShopConfig = NonNullable<ShopifyScriptsProps["shop"]>;
-type I18nConfig = NonNullable<ShopifyScriptsProps["i18n"]>;
+type I18nConfig = ShopifyScriptsI18nWithCurrency;
 
 export function ShopifyScriptsWithNavigation({
   shop,

--- a/templates/nextjs/components/ShopifyScriptsWithNavigation.tsx
+++ b/templates/nextjs/components/ShopifyScriptsWithNavigation.tsx
@@ -3,30 +3,29 @@
 import { ShopifyScripts, type ShopifyScriptsProps } from "@shopify/hydrogen/react";
 import { useRouter } from "next/navigation";
 
-import { analyticsConsent, defaultI18n } from "@/lib/config";
+import { analyticsConsent } from "@/lib/config";
 import { routeTemplates } from "@/lib/route-templates";
 
 /**
- * `ShopifyScripts` navigation wrapper (`hydrogen-analytics` / `references/react.md`
- * + `hydrogen-setup` / `references/analytics.md`). The root layout is a server
- * component and cannot call `useRouter`, so `ShopifyScripts` (which needs a
- * `navigate` callback) must live in a client component. Rendered once in the
- * root layout with the resolved market `i18n` (single-market example →
- * `defaultI18n`) and server-resolved shop metadata.
+ * `ShopifyScripts` navigation wrapper. The root layout is a server component
+ * and cannot call `useRouter`, so `ShopifyScripts` (which needs a `navigate`
+ * callback) must live in a client component. The layout assembles the resolved
+ * `i18n` (with server-fetched currency) and passes it here as a complete object.
  */
 type ShopConfig = NonNullable<ShopifyScriptsProps["shop"]>;
+type I18nConfig = NonNullable<ShopifyScriptsProps["i18n"]>;
 
 export function ShopifyScriptsWithNavigation({
   shop,
-  currency,
+  i18n,
 }: {
   shop: ShopConfig;
-  currency: string;
+  i18n: I18nConfig;
 }) {
   const router = useRouter();
   return (
     <ShopifyScripts
-      i18n={{ ...defaultI18n, currency }}
+      i18n={i18n}
       shop={shop}
       consent={analyticsConsent}
       navigate={(url: string) => router.push(url)}

--- a/templates/nextjs/components/ShopifyScriptsWithNavigation.tsx
+++ b/templates/nextjs/components/ShopifyScriptsWithNavigation.tsx
@@ -16,11 +16,17 @@ import { routeTemplates } from "@/lib/route-templates";
  */
 type ShopConfig = NonNullable<ShopifyScriptsProps["shop"]>;
 
-export function ShopifyScriptsWithNavigation({ shop }: { shop: ShopConfig }) {
+export function ShopifyScriptsWithNavigation({
+  shop,
+  currency,
+}: {
+  shop: ShopConfig;
+  currency: string;
+}) {
   const router = useRouter();
   return (
     <ShopifyScripts
-      i18n={defaultI18n}
+      i18n={{ ...defaultI18n, currency }}
       shop={shop}
       consent={analyticsConsent}
       navigate={(url: string) => router.push(url)}

--- a/templates/nextjs/lib/analytics-shop.ts
+++ b/templates/nextjs/lib/analytics-shop.ts
@@ -2,7 +2,7 @@ import "server-only";
 import type { ShopAnalytics } from "@shopify/hydrogen";
 import { cacheLife, cacheTag } from "next/cache";
 
-import { shop as shopConfig } from "@/lib/config";
+import { defaultI18n, shop as shopConfig } from "@/lib/config";
 import { SHOP_ANALYTICS_QUERY } from "@/lib/queries";
 import { staticStorefrontClient } from "@/lib/storefront-static";
 
@@ -16,6 +16,15 @@ type ShopIdentity = {
   shopId: string;
   shopName: string;
   shopDescription: string | null;
+  currency: string;
+};
+
+type LocalizationData = {
+  localization?: {
+    country?: {
+      currency?: { isoCode?: string } | null;
+    } | null;
+  } | null;
 };
 
 export type AnalyticsShop = ShopAnalytics & ShopIdentity;
@@ -26,6 +35,7 @@ const SHOP_FALLBACK: ShopIdentity = {
   shopId: shopConfig.shopId ? `gid://shopify/Shop/${shopConfig.shopId}` : "",
   shopName: "CORE",
   shopDescription: null,
+  currency: defaultI18n.currency,
 };
 
 /** Cache the shop query result for hours (it almost never changes). */
@@ -42,7 +52,12 @@ async function fetchShopAnalytics(): Promise<ShopIdentity> {
     shopId: data?.shop?.id ?? SHOP_FALLBACK.shopId,
     shopName: data?.shop?.name ?? SHOP_FALLBACK.shopName,
     shopDescription: data?.shop?.description ?? null,
+    currency: getLocalizationCurrency(data),
   };
+}
+
+function getLocalizationCurrency(data: LocalizationData | null | undefined): string {
+  return data?.localization?.country?.currency?.isoCode ?? SHOP_FALLBACK.currency;
 }
 
 /**
@@ -67,6 +82,7 @@ export async function getAnalyticsShop(): Promise<AnalyticsShop> {
     storefrontId: shopConfig.storefrontId,
     shopName: resolved.shopName,
     shopDescription: resolved.shopDescription,
+    currency: resolved.currency,
   };
 }
 

--- a/templates/nextjs/lib/config.ts
+++ b/templates/nextjs/lib/config.ts
@@ -3,7 +3,7 @@ type StorefrontConfigShape = {
   publicStorefrontToken: string;
 };
 
-type I18nShape = { country: "US"; language: "EN"; currency: "USD" };
+type I18nShape = { country: "US"; language: "EN"; currency: string };
 
 type ShopifyScriptsShopShape = {
   shopId: string;
@@ -33,6 +33,7 @@ export const customerAccountConfig = {
 export const defaultI18n = {
   country: "US",
   language: "EN",
+  // Used only if Storefront API localization cannot resolve the active market.
   currency: "USD",
 } satisfies I18nShape;
 

--- a/templates/nextjs/lib/queries.ts
+++ b/templates/nextjs/lib/queries.ts
@@ -162,11 +162,19 @@ export type SearchAvailableFilter = NonNullable<SearchQuery["search"]>["productF
 
 /** Shop analytics GID query (root layout, best-effort + non-blocking, F1). */
 export const SHOP_ANALYTICS_QUERY = gql(`
-  query RootShopAnalytics {
+  query RootShopAnalytics($country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
     shop {
       id
       name
       description
+    }
+    localization {
+      country {
+        currency {
+          isoCode
+        }
+      }
     }
   }
 `);

--- a/templates/react-router/app/lib/shop.ts
+++ b/templates/react-router/app/lib/shop.ts
@@ -15,7 +15,9 @@
 
 export const storefrontConfig = {
   storeDomain: "hydrogen-preview.myshopify.com", // ← default; or set PUBLIC_STORE_DOMAIN
-  i18n: { country: "US", language: "EN" },
+  // Currency is a startup fallback. The root loader replaces it with the
+  // active market currency returned by Storefront API localization.
+  i18n: { country: "US", language: "EN", currency: "USD" },
 } as const;
 
 // Real store iff a private Storefront API token is available; otherwise the

--- a/templates/react-router/app/root.tsx
+++ b/templates/react-router/app/root.tsx
@@ -14,6 +14,7 @@ import {
   Scripts,
   ScrollRestoration,
   useNavigate,
+  useRouteLoaderData,
 } from "react-router";
 
 import { AnalyticsTracker, CartAnalyticsTracker } from "~/components/AnalyticsTrackers";
@@ -38,7 +39,15 @@ import type { Route } from "./+types/root";
 import "./app.css";
 
 const NAV_COLLECTIONS_QUERY = gql(`
-  query NavCollections {
+  query NavCollections($country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    localization {
+      country {
+        currency {
+          isoCode
+        }
+      }
+    }
     collections(first: 5) {
       nodes {
         handle
@@ -108,6 +117,11 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   return {
     cartData: cartResult.data,
     navCollections: navResult.data?.collections.nodes ?? [],
+    i18n: {
+      ...storefrontConfig.i18n,
+      currency:
+        navResult.data?.localization?.country?.currency?.isoCode ?? storefrontConfig.i18n.currency,
+    },
     analyticsShop,
     consent: analyticsConsent,
     forceConsentBanner: env.MOCK_SHOP === "1",
@@ -116,6 +130,7 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
 export function Layout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
+  const rootData = useRouteLoaderData<typeof loader>("root");
 
   return (
     <html lang="en">
@@ -123,7 +138,7 @@ export function Layout({ children }: { children: ReactNode }) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <ShopifyScripts
-          i18n={storefrontConfig.i18n}
+          i18n={rootData?.i18n ?? storefrontConfig.i18n}
           shop={shop}
           consent={analyticsConsent}
           navigate={navigate}


### PR DESCRIPTION
TL;DR: Initialize Shopify analytics with the active market currency before consent can replay buffered events. This prevents analytics from failing on a fresh session until the shopper adds an item to the cart.

## Before

`ShopifyScripts` rendered before `window.Shopify.currency.active` was initialized. Accepting consent could therefore produce a missing-currency analytics error. Adding an item to the cart appeared to fix the issue because cart tracking synchronized the currency later.

## After

Both storefront templates resolve `localization.country.currency.isoCode` under the active Storefront API market context and pass it to `ShopifyScripts` as `i18n.currency` during initial rendering. A configured `USD` fallback covers API failures and mock mode.

## What this changes

- Resolves the active market currency in the React Router root loader and passes the loader-derived `i18n` to `ShopifyScripts`.
- Extends the Next.js cached shop lookup with localization currency and passes the resolved `i18n` through its client wrapper.
- Avoids introducing a required Next.js currency environment variable.
- Documents that `shop.paymentSettings.currencyCode` is the shop currency, not necessarily the active market presentment currency.
- Treats cart currency updates as later synchronization rather than initial analytics setup.
- Updates and synchronizes the template-generation and packaged analytics skills with the same guidance.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. This hardens the packaged analytics guidance and starter templates without adding exports or changing a public runtime contract.

## UX impact

Analytics can send consent-replayed events on a fresh storefront session without requiring the shopper to modify their cart first.

## Risk

- If the localization lookup fails or exceeds the Next.js lookup timeout, analytics uses the configured fallback currency.
- Market-aware storefronts should keep the localization query under the same country and language context as their catalog requests.

## How to Test

1. Start either storefront template and open it in a fresh browser session with an empty cart.
2. Before accepting consent, confirm `window.Shopify.currency.active` matches the active market currency.
3. Accept analytics consent without adding an item to the cart.
4. Confirm `window.Shopify.currency.active` is unchanged and no missing-currency analytics error appears in the console.
5. Confirm the buffered analytics event produces a Monorail request.
