### PR TITLE
chore: remove dead code from the Hydrogen preview package

### DIFF
--- a/.changeset/tidy-donuts-clean.md
+++ b/.changeset/tidy-donuts-clean.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Remove dead code and tighten internal module boundaries. Delete unused files and helpers, stop exporting internal symbols that nothing consumes, prune unused barrel re-exports, and consolidate duplicated path-prefix normalization (which also fixes whitespace-padded locale prefixes producing malformed paths). No public API changes.

--- a/.changeset/tidy-donuts-clean.md
+++ b/.changeset/tidy-donuts-clean.md
@@ -2,4 +2,9 @@
 "@shopify/hydrogen": patch
 ---
 
-Fix malformed URLs when a locale path prefix has surrounding whitespace: a prefix like `" /fr-ca/ "` now normalizes to `/fr-ca` instead of leaking spaces and slashes into resolved paths. Also removes internal dead code; no public API changes.
+Fix malformed URLs when a locale path prefix has surrounding whitespace.
+
+Before: a prefix like `" /fr-ca/ "` leaked into resolved paths, producing `/ /fr-ca/ /products`.
+After: the prefix normalizes to `/fr-ca`, producing `/fr-ca/products`.
+
+Also removes internal dead code; no public API changes.

--- a/.changeset/tidy-donuts-clean.md
+++ b/.changeset/tidy-donuts-clean.md
@@ -2,4 +2,4 @@
 "@shopify/hydrogen": patch
 ---
 
-Remove dead code and tighten internal module boundaries. Delete unused files and helpers, stop exporting internal symbols that nothing consumes, prune unused barrel re-exports, and consolidate duplicated path-prefix normalization (which also fixes whitespace-padded locale prefixes producing malformed paths). No public API changes.
+Fix malformed URLs when a locale path prefix has surrounding whitespace: a prefix like `" /fr-ca/ "` now normalizes to `/fr-ca` instead of leaking spaces and slashes into resolved paths. Also removes internal dead code; no public API changes.

--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -92,7 +92,6 @@
     "gql.tada": "1.9.2"
   },
   "devDependencies": {
-    "@0no-co/graphqlsp": "^1.15.4",
     "@graphql-codegen/cli": "^7.0.0",
     "@graphql-codegen/introspection": "^6.0.0",
     "@graphql-codegen/typescript": "^6.0.0",

--- a/packages/hydrogen/plugins/minify-graphql-literals.ts
+++ b/packages/hydrogen/plugins/minify-graphql-literals.ts
@@ -3,7 +3,7 @@ import MagicString, { type SourceMap } from "magic-string";
 import { parseSync, type Comment, type Node } from "oxc-parser";
 import { walk } from "oxc-walker";
 
-export type MinifyGraphQLLiteralsOptions = {
+type MinifyGraphQLLiteralsOptions = {
   /**
    * Function calls whose first string/template argument is GraphQL. Member
    * calls are matched by their final property name, e.g. `client.gql(...)`.

--- a/packages/hydrogen/src/cli/gql.ts
+++ b/packages/hydrogen/src/cli/gql.ts
@@ -20,7 +20,7 @@ interface RunCommandOptions {
 
 type RunCommand = (command: string, args: string[], options: RunCommandOptions) => Promise<void>;
 
-export interface CheckGraphQLOptions {
+interface CheckGraphQLOptions {
   args?: string[];
   cwd?: string;
   gqlTadaCliPath?: string;

--- a/packages/hydrogen/src/cli/setup.ts
+++ b/packages/hydrogen/src/cli/setup.ts
@@ -53,7 +53,7 @@ export type RunCommand = (
   options: { cwd: string },
 ) => Promise<void>;
 
-export interface SetupHydrogenOptions {
+interface SetupHydrogenOptions {
   cwd?: string;
   packageRoot?: string;
   env?: Record<string, string | undefined>;

--- a/packages/hydrogen/src/client/development.ts
+++ b/packages/hydrogen/src/client/development.ts
@@ -1,1 +1,0 @@
-export * from "./index";

--- a/packages/hydrogen/src/client/errors.ts
+++ b/packages/hydrogen/src/client/errors.ts
@@ -1,4 +1,4 @@
-export interface StorefrontApiErrorOptions {
+interface StorefrontApiErrorOptions {
   requestId?: string;
   status?: number;
   cause?: unknown;

--- a/packages/hydrogen/src/client/index.ts
+++ b/packages/hydrogen/src/client/index.ts
@@ -1,30 +1,12 @@
 export { createStorefrontClient } from "./client";
-export { createShopifyRequestContext } from "../core/request-context";
-export { gql } from "../graphql";
-export { StorefrontApiError, StorefrontTimeoutError } from "./errors";
+export type { I18nConfig } from "../core/request-context";
+export type { StorefrontQueryString } from "../graphql";
 export type {
-  I18nConfig,
-  ShopifyRequestContext,
-  ShopifyRequestContextWithBuyerIp,
-} from "../core/request-context";
-export type { AnyStorefrontQueryString, StorefrontQueryString } from "../graphql";
-export type { InferResult, InferVariables } from "../graphql";
-export type {
-  ClientType,
-  CreateStorefrontClientArgs,
   StorefrontClient,
   PublicStorefrontClient,
   PrivateStorefrontClient,
   RequestScopedPrivateStorefrontClient,
-  PrivateNoBuyerContextStorefrontClient,
-  StorefrontClientOptions,
-  PublicClientOptions,
-  PrivateClientOptions,
-  PrivateNoBuyerContextClientOptions,
-  StorefrontGraphql,
-  StorefrontGraphqlOptions,
   StorefrontGraphqlResult,
-  GqlRestParam,
   GraphQLFormattedError,
 } from "./types";
 export type { StorefrontApi } from "./types";

--- a/packages/hydrogen/src/core/analytics/types.ts
+++ b/packages/hydrogen/src/core/analytics/types.ts
@@ -119,7 +119,6 @@ export type CartViewPayload = CartPayload & UrlPayload & BasePayload;
 export type SearchViewPayload = SearchPayload & UrlPayload & BasePayload;
 export type CartUpdatePayload = CartChangePayload & BasePayload & OtherData;
 export type CartLineUpdatePayload = CartLinePayload & CartChangePayload & BasePayload & OtherData;
-export type CustomEventPayload = BasePayload & OtherData;
 
 export type EventPayloads =
   | PageViewPayload

--- a/packages/hydrogen/src/core/analytics/utils/shop.ts
+++ b/packages/hydrogen/src/core/analytics/utils/shop.ts
@@ -2,7 +2,7 @@ import type { ShopAnalytics, StorefrontAnalyticsConfig } from "../types";
 
 const SHOPIFY_SHOP_GID_PREFIX = "gid://shopify/Shop/";
 
-export function normalizeShopifyShopId(shopId: ShopAnalytics["shopId"]): string {
+function toShopAnalyticsGid(shopId: ShopAnalytics["shopId"]): string {
   return shopId.startsWith(SHOPIFY_SHOP_GID_PREFIX)
     ? shopId
     : `${SHOPIFY_SHOP_GID_PREFIX}${shopId}`;
@@ -15,6 +15,6 @@ export function normalizeShopAnalytics(
 
   return {
     ...shop,
-    shopId: normalizeShopifyShopId(shop.shopId),
+    shopId: toShopAnalyticsGid(shop.shopId),
   };
 }

--- a/packages/hydrogen/src/core/cache/cache-status.ts
+++ b/packages/hydrogen/src/core/cache/cache-status.ts
@@ -1,6 +1,6 @@
 export const HYDROGEN_CACHE_STATUS_PRODUCT = "Hydrogen";
 
-export type HydrogenCacheStatus = "hit" | "miss" | "bypass";
+type HydrogenCacheStatus = "hit" | "miss" | "bypass";
 
 export function getHydrogenCacheStatus(headers: Headers): HydrogenCacheStatus | undefined {
   const cacheStatus = headers.get("cache-status");

--- a/packages/hydrogen/src/core/cache/fetch-with-cache.ts
+++ b/packages/hydrogen/src/core/cache/fetch-with-cache.ts
@@ -44,12 +44,12 @@ export type FetchCacheOptions = {
   shouldCacheResponse?: (context: FetchCacheResponseContext) => MaybePromise<boolean>;
 };
 
-export type FetchWithCache = {
+type FetchWithCache = {
   (input: FetchInput, init?: FetchInit): Promise<Response>;
   (input: FetchInput, init: FetchInit | undefined, options: FetchCacheOptions): Promise<Response>;
 };
 
-export type CreateFetchWithCacheOptions = (
+type CreateFetchWithCacheOptions = (
   | CreateRunWithCacheOptions
   | {
       runWithCache: RunWithCache;

--- a/packages/hydrogen/src/core/cache/store.ts
+++ b/packages/hydrogen/src/core/cache/store.ts
@@ -30,7 +30,7 @@ export type KeyValueCacheLike = {
   delete?(key: string): unknown | Promise<unknown>;
 };
 
-export type NormalizedCacheStore = {
+type NormalizedCacheStore = {
   get<T extends SerializableCacheValue>(key: string): Promise<CacheEnvelope<T> | undefined>;
   set<T extends SerializableCacheValue>(
     key: string,

--- a/packages/hydrogen/src/core/cache/strategies.ts
+++ b/packages/hydrogen/src/core/cache/strategies.ts
@@ -29,7 +29,7 @@ export type CacheOptions = {
   staleIfError?: CacheDuration;
 };
 
-export type NoStoreStrategy = CachingStrategy & {
+type NoStoreStrategy = CachingStrategy & {
   mode: typeof NO_STORE;
 };
 
@@ -46,21 +46,6 @@ export function getCacheRetentionTtl(strategy: CachingStrategy): number {
     0,
     (strategy.maxAge ?? 0) + (strategy.staleWhileRevalidate ?? 0) + (strategy.staleIfError ?? 0),
   );
-}
-
-export function getCacheControlHeader(strategy: CachingStrategy): string {
-  const cacheControl: string[] = [];
-
-  if (strategy.mode) cacheControl.push(strategy.mode);
-  if (strategy.maxAge != null) cacheControl.push(`max-age=${strategy.maxAge}`);
-  if (strategy.staleWhileRevalidate != null) {
-    cacheControl.push(`stale-while-revalidate=${strategy.staleWhileRevalidate}`);
-  }
-  if (strategy.staleIfError != null) {
-    cacheControl.push(`stale-if-error=${strategy.staleIfError}`);
-  }
-
-  return cacheControl.join(", ");
 }
 
 export function getPlatformCacheControlHeader(strategy: CachingStrategy): string {

--- a/packages/hydrogen/src/core/cart/cookie.ts
+++ b/packages/hydrogen/src/core/cart/cookie.ts
@@ -2,7 +2,7 @@ const COOKIE_NAME = "cart";
 const MAX_AGE_IN_SECONDS = 1209600; // 14 days
 const CART_GID_PREFIX = "gid://shopify/Cart/";
 
-export type CartCookieSource = Request | { cookie?: string };
+type CartCookieSource = Request | { cookie?: string };
 
 export function normalizeCartId(cartId: string | null | undefined): string | null {
   if (!cartId) return null;

--- a/packages/hydrogen/src/core/cart/index.ts
+++ b/packages/hydrogen/src/core/cart/index.ts
@@ -27,23 +27,16 @@ export type {
   CartLineMerchandise,
   CartCost,
   DiscountCode,
-  Attribute,
 } from "./state";
 export {
   EMPTY_CART_DATA,
   EMPTY_CART_STATE,
-  createEmptyPending,
   createEmptyCartErrors,
   createEmptyErrorGroup,
 } from "./state";
 export { getCartId, getCart } from "./get-cart";
 export type { CartDataFromQuery, CartResult } from "./get-cart";
-export {
-  CART_API_PATH,
-  CART_GET_METHOD,
-  CART_POST_METHOD,
-  createCartServerHandlers,
-} from "./server-handlers";
+export { createCartServerHandlers } from "./server-handlers";
 export type {
   CartError,
   CartErrorCode,

--- a/packages/hydrogen/src/core/cart/queries.ts
+++ b/packages/hydrogen/src/core/cart/queries.ts
@@ -426,17 +426,16 @@ type CartQueriesForSources<
   readonly cartNoteUpdate: QueryFor<CartNoteUpdateMutationSource, Fragments>;
 };
 
-export type CartQueriesForFragment<TCartFragment extends CartFragmentDocument> =
-  CartQueriesForSources<
-    readonly [typeof HYDROGEN_CART_FRAGMENT, TCartFragment],
-    typeof CUSTOM_CART_QUERY_SOURCE,
-    typeof CUSTOM_CART_CREATE_MUTATION_SOURCE,
-    typeof CUSTOM_CART_LINES_ADD_MUTATION_SOURCE,
-    typeof CUSTOM_CART_LINES_UPDATE_MUTATION_SOURCE,
-    typeof CUSTOM_CART_LINES_REMOVE_MUTATION_SOURCE,
-    typeof CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE,
-    typeof CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE
-  >;
+type CartQueriesForFragment<TCartFragment extends CartFragmentDocument> = CartQueriesForSources<
+  readonly [typeof HYDROGEN_CART_FRAGMENT, TCartFragment],
+  typeof CUSTOM_CART_QUERY_SOURCE,
+  typeof CUSTOM_CART_CREATE_MUTATION_SOURCE,
+  typeof CUSTOM_CART_LINES_ADD_MUTATION_SOURCE,
+  typeof CUSTOM_CART_LINES_UPDATE_MUTATION_SOURCE,
+  typeof CUSTOM_CART_LINES_REMOVE_MUTATION_SOURCE,
+  typeof CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE,
+  typeof CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE
+>;
 
 type DefaultCartQueries = CartQueriesForSources<
   readonly [typeof HYDROGEN_CART_FRAGMENT],
@@ -448,17 +447,6 @@ type DefaultCartQueries = CartQueriesForSources<
   typeof CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE,
   typeof CART_NOTE_UPDATE_MUTATION_SOURCE
 >;
-
-export type CartFragmentForOptions<TOptions> = TOptions extends {
-  readonly fragment: infer TCartFragment extends AnyStorefrontQueryString;
-}
-  ? TCartFragment
-  : typeof HYDROGEN_CART_FRAGMENT;
-
-export type CartFragmentResult<TFragment extends AnyStorefrontQueryString> =
-  TFragment extends StorefrontQueryString<infer TResult, infer _Variables, infer _Source>
-    ? TResult
-    : unknown;
 
 type CartDataFromCartQuery<TQuery extends AnyStorefrontQueryString> =
   TQuery extends StorefrontQueryString<infer Result, infer _Variables, string>
@@ -588,4 +576,3 @@ export function makeCartQueries(options?: CreateCartQueriesOptions) {
 }
 
 export const cartQueries = makeCartQueries();
-export type CartQueries = ReturnType<typeof makeCartQueries>;

--- a/packages/hydrogen/src/core/cart/server-handlers.ts
+++ b/packages/hydrogen/src/core/cart/server-handlers.ts
@@ -24,10 +24,10 @@ import {
 import type { CartData } from "./state";
 const log = getLogger("cart-api");
 
-export const CART_API_PATH = "/api/cart" as const;
-export const CART_GET_METHOD = "GET" as const;
-export const CART_POST_METHOD = "POST" as const;
-export const cartServerHandlersCartQuery: unique symbol = Symbol("hydrogen.cartQuery");
+const CART_API_PATH = "/api/cart" as const;
+const CART_GET_METHOD = "GET" as const;
+const CART_POST_METHOD = "POST" as const;
+const cartServerHandlersCartQuery: unique symbol = Symbol("hydrogen.cartQuery");
 
 export type CartGetData<TCart = CartData> = {
   cart: TCart | null;
@@ -99,7 +99,7 @@ export type CartDataFromHandlers<THandlers> = CartDataFromHandlerResult<
   CartGetHandlerResult<THandlers>
 >;
 
-export type CreateCartServerHandlersOptions<
+type CreateCartServerHandlersOptions<
   TCartFragment extends AnyStorefrontQueryString = AnyStorefrontQueryString,
 > = CreateCartQueriesOptions<TCartFragment>;
 

--- a/packages/hydrogen/src/core/collection/index.ts
+++ b/packages/hydrogen/src/core/collection/index.ts
@@ -16,7 +16,6 @@ export { createCollectionReconciler } from "./reconciler";
 export type { CollectionReconciler, ReconcilerCallbacks } from "./reconciler";
 
 export {
-  collectionSearchEqual,
   filterEquals,
   isFilterInputActive,
   getFilterRemovalUrl,

--- a/packages/hydrogen/src/core/headers.ts
+++ b/packages/hydrogen/src/core/headers.ts
@@ -62,7 +62,7 @@ export type ShopifyHeaderName =
   | typeof STOREFRONT_PRIVATE_TOKEN_HEADER
   | typeof STOREFRONT_URL_HEADER;
 
-export type KnownHeaderName = StandardHeaderName | ShopifyHeaderName;
+type KnownHeaderName = StandardHeaderName | ShopifyHeaderName;
 
 export function defineHeaderList<const HeaderNames extends readonly KnownHeaderName[]>(
   ...headerNames: HeaderNames

--- a/packages/hydrogen/src/core/logging/index.ts
+++ b/packages/hydrogen/src/core/logging/index.ts
@@ -1,17 +1,8 @@
 export {
   configureLogging,
   consoleLogger,
-  formatLogPrefix,
   getLogger,
   resetLoggingForTests,
   type ConfigureLoggingOptions,
-  type ScopedLogger,
 } from "./logging";
-export {
-  DEFAULT_LOG_LEVEL,
-  isLevelEnabled,
-  type HydrogenLogger,
-  type LogContext,
-  type LogLevel,
-  type LogSeverity,
-} from "./types";
+export type { HydrogenLogger, LogContext, LogLevel, LogSeverity } from "./types";

--- a/packages/hydrogen/src/core/logging/logging.ts
+++ b/packages/hydrogen/src/core/logging/logging.ts
@@ -95,10 +95,7 @@ export function resetLoggingForTests(): void {
  */
 type ScopedLogContext = Omit<LogContext, "scope"> & { scope?: never };
 
-export type ScopedLogger = Record<
-  LogSeverity,
-  (message: string, context?: ScopedLogContext) => void
->;
+type ScopedLogger = Record<LogSeverity, (message: string, context?: ScopedLogContext) => void>;
 
 function emit(scope: string, level: LogSeverity, message: string, context?: LogContext): void {
   if (!isLevelEnabled(level, state.level)) return;

--- a/packages/hydrogen/src/core/observable.ts
+++ b/packages/hydrogen/src/core/observable.ts
@@ -1,4 +1,4 @@
-export interface Observable<T> {
+interface Observable<T> {
   readonly state: T;
   subscribe(fn: (state: T) => void): () => void;
   subscribe<S>(

--- a/packages/hydrogen/src/core/predictive-search/index.ts
+++ b/packages/hydrogen/src/core/predictive-search/index.ts
@@ -1,9 +1,4 @@
 export {
-  PREDICTIVE_SEARCH_API_PATH,
-  PREDICTIVE_SEARCH_GET_METHOD,
-  PREDICTIVE_SEARCH_QUERY_PARAM,
-} from "./constants";
-export {
   createPredictiveSearchFormRegister,
   getPredictiveSearchFormAttributes,
   readPredictiveSearchFormTerm,
@@ -14,45 +9,22 @@ export type {
   PredictiveSearchQueryInputAttributes,
 } from "./form";
 export { makePredictiveSearchQueries, predictiveSearchQueries } from "./queries";
-export type {
-  CreatePredictiveSearchQueriesOptions,
-  PredictiveSearchFragments,
-  PredictiveSearchQueriesForOptions,
-} from "./queries";
+export type { CreatePredictiveSearchQueriesOptions, PredictiveSearchFragments } from "./queries";
 export {
   DEFAULT_PREDICTIVE_SEARCH_LIMIT,
-  DEFAULT_PREDICTIVE_SEARCH_LIMIT_SCOPE,
-  DEFAULT_PREDICTIVE_SEARCH_UNAVAILABLE_PRODUCTS,
   MAX_PREDICTIVE_SEARCH_LIMIT,
   MIN_PREDICTIVE_SEARCH_LIMIT,
   fetchPredictiveSearch,
   queryPredictiveSearch,
 } from "./search";
 export type {
-  FetchPredictiveSearchResult,
   PredictiveSearchData,
   PredictiveSearchDataForOptions,
-  PredictiveSearchDataForQuery,
   QueryPredictiveSearchOptions,
 } from "./search";
-export {
-  createPredictiveSearchServerHandlers,
-  predictiveSearchServerHandlersQuery,
-} from "./server-handlers";
-export type {
-  CreatePredictiveSearchServerHandlersOptions,
-  PredictiveSearchError,
-  PredictiveSearchErrorCode,
-  PredictiveSearchGetData,
-  PredictiveSearchGetHandler,
-  PredictiveSearchGetResult,
-  PredictiveSearchServerHandlers,
-} from "./server-handlers";
-export {
-  DEFAULT_PREDICTIVE_SEARCH_DEBOUNCE_IN_MS,
-  DEFAULT_PREDICTIVE_SEARCH_MIN_TERM_LENGTH,
-  createPredictiveSearchStore,
-} from "./store";
+export { createPredictiveSearchServerHandlers } from "./server-handlers";
+export type { CreatePredictiveSearchServerHandlersOptions } from "./server-handlers";
+export { DEFAULT_PREDICTIVE_SEARCH_DEBOUNCE_IN_MS, createPredictiveSearchStore } from "./store";
 export type {
   CreatePredictiveSearchStoreOptions,
   PredictiveSearchState,

--- a/packages/hydrogen/src/core/predictive-search/search.ts
+++ b/packages/hydrogen/src/core/predictive-search/search.ts
@@ -56,7 +56,7 @@ export type QueryPredictiveSearchOptions<
   signal?: AbortSignal;
 };
 
-export type FetchPredictiveSearchResult<TQuery extends AnyStorefrontQueryString> = {
+type FetchPredictiveSearchResult<TQuery extends AnyStorefrontQueryString> = {
   data: PredictiveSearchDataForQuery<TQuery>;
   headers: Headers;
 };

--- a/packages/hydrogen/src/core/predictive-search/server-handlers.ts
+++ b/packages/hydrogen/src/core/predictive-search/server-handlers.ts
@@ -28,9 +28,7 @@ import {
   type QueryPredictiveSearchOptions,
 } from "./search";
 
-export const predictiveSearchServerHandlersQuery: unique symbol = Symbol(
-  "hydrogen.predictiveSearchQuery",
-);
+const predictiveSearchServerHandlersQuery: unique symbol = Symbol("hydrogen.predictiveSearchQuery");
 
 const VALID_LIMIT_SCOPES: readonly PredictiveSearchLimitScope[] = ["ALL", "EACH"];
 const VALID_PREDICTIVE_SEARCH_TYPES: readonly PredictiveSearchType[] = [
@@ -62,25 +60,24 @@ type PredictiveSearchHandlerContext = {
   storefrontClient: QueryPredictiveSearchOptions["storefrontClient"];
 };
 
-export type PredictiveSearchGetData<TData = PredictiveSearchDataForOptions<{}>> = TData;
-export type PredictiveSearchGetResult<TData = PredictiveSearchDataForOptions<{}>> =
+type PredictiveSearchGetData<TData = PredictiveSearchDataForOptions<{}>> = TData;
+type PredictiveSearchGetResult<TData = PredictiveSearchDataForOptions<{}>> =
   | ShopifyRouteJsonResult<PredictiveSearchGetData<TData>>
   | ShopifyRouteErrorResult<PredictiveSearchError>;
 
-export type PredictiveSearchErrorCode = "invalid_predictive_search_request";
-export type PredictiveSearchError = ShopifyRouteError & {
+type PredictiveSearchErrorCode = "invalid_predictive_search_request";
+type PredictiveSearchError = ShopifyRouteError & {
   code: PredictiveSearchErrorCode;
 };
 
-export type PredictiveSearchGetHandler<TData = PredictiveSearchDataForOptions<{}>> =
-  CallableRouteHandler<
-    PredictiveSearchHandlerContext,
-    PredictiveSearchGetResult<TData>,
-    string,
-    typeof PREDICTIVE_SEARCH_GET_METHOD
-  >;
+type PredictiveSearchGetHandler<TData = PredictiveSearchDataForOptions<{}>> = CallableRouteHandler<
+  PredictiveSearchHandlerContext,
+  PredictiveSearchGetResult<TData>,
+  string,
+  typeof PREDICTIVE_SEARCH_GET_METHOD
+>;
 
-export type PredictiveSearchServerHandlers<
+type PredictiveSearchServerHandlers<
   TOptions extends CreatePredictiveSearchServerHandlersOptions = {},
   TData = PredictiveSearchDataForOptions<TOptions>,
 > = {

--- a/packages/hydrogen/src/core/predictive-search/store.ts
+++ b/packages/hydrogen/src/core/predictive-search/store.ts
@@ -12,7 +12,7 @@ import { getEmptyPredictiveSearchResult, type PredictiveSearchData } from "./sea
 export const DEFAULT_PREDICTIVE_SEARCH_DEBOUNCE_IN_MS = 150;
 
 /** Default minimum trimmed term length required before predictive search sends a request. */
-export const DEFAULT_PREDICTIVE_SEARCH_MIN_TERM_LENGTH = 1;
+const DEFAULT_PREDICTIVE_SEARCH_MIN_TERM_LENGTH = 1;
 
 /** Lifecycle state for the predictive search client store. */
 export type PredictiveSearchStatus = "idle" | "loading" | "success" | "error";

--- a/packages/hydrogen/src/core/product/options.ts
+++ b/packages/hydrogen/src/core/product/options.ts
@@ -65,7 +65,7 @@ export function getSelectedProductOptions({
   return selectedOptions;
 }
 
-export function getAdjacentAndFirstSelectableVariants<TProduct extends ProductInput>(
+function getAdjacentAndFirstSelectableVariants<TProduct extends ProductInput>(
   product: TProduct,
 ): ProductVariantFrom<TProduct>[] {
   // Shopify returns a bounded set, not the whole matrix. Treat it as a concrete-variant cache.
@@ -442,7 +442,7 @@ function combinationMatchesConstraints(
   );
 }
 
-export function decodeEncodedVariant(encodedVariantField: string | null | undefined): number[][] {
+function decodeEncodedVariant(encodedVariantField: string | null | undefined): number[][] {
   if (!encodedVariantField) return [];
   if (!encodedVariantField.startsWith("v1_")) {
     log.warn(`unsupported variant encoding: "${encodedVariantField}"`);

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -137,6 +137,19 @@ describe("createShopifyRequestContext", () => {
     expect(result.i18n.pathPrefix).toBe("/es-es");
   });
 
+  it("normalizes pathPrefix with surrounding whitespace", () => {
+    const result = createTestRequestContext(
+      { headers: new Headers() },
+      {
+        country: "FR",
+        language: "FR",
+        pathPrefix: " /fr-ca/ ",
+      },
+    );
+
+    expect(result.i18n.pathPrefix).toBe("/fr-ca");
+  });
+
   it("does not create fallback tokens when modern Shopify analytics cookies are present", () => {
     const result = createTestRequestContext(
       new Request("https://example.com", {

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -22,6 +22,7 @@ import {
   SHOPIFY_VISIT_TOKEN_HEADER,
   STOREFRONT_URL_HEADER,
 } from "./headers";
+import { normalizePathPrefix } from "./standard-routes/path";
 
 const UNIQUE_TOKEN_MARKER = "_y";
 const VISIT_TOKEN_MARKER = "_s";
@@ -247,11 +248,6 @@ function normalizeI18n<I18n extends I18nConfig>(i18n: I18n): NormalizedI18nConfi
     ...i18n,
     pathPrefix: normalizePathPrefix(i18n.pathPrefix),
   } as NormalizedI18nConfig<I18n>;
-}
-
-function normalizePathPrefix(pathPrefix: string | undefined): string {
-  const normalized = pathPrefix?.trim().replace(/^\/+/, "").replace(/\/+$/, "") ?? "";
-  return normalized ? `/${normalized}` : "";
 }
 
 function applyStorefrontRequestHeaders(context: Context, headers: Headers): void {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.development.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.development.ts
@@ -1,13 +1,11 @@
 import type { GraphiQLOptions } from "../types";
 import { handleShopifyRoutes } from "./handle-shopify-routes";
 import { handleGraphiql } from "./interceptors/graphiql";
-import type { HydrogenRouteHandler, HydrogenRoutesOptions } from "./route-types";
+import type { HydrogenRouteHandler } from "./route-types";
 
 type HydrogenRoutesDevOptions = {
   graphiql?: GraphiQLOptions;
 };
-
-export type HydrogenRoutesOptionsWithDev = HydrogenRoutesOptions & HydrogenRoutesDevOptions;
 
 export const handleShopifyRoutesDev: HydrogenRouteHandler<HydrogenRoutesDevOptions> = (options) => {
   const productionResult = handleShopifyRoutes(options);

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
@@ -7,12 +7,6 @@ import { handleSfapiProxy } from "./interceptors/sfapi-proxy";
 import { handleShopifyRouteHandlers } from "./registered-routes";
 import type { HydrogenRouteHandler, HydrogenRouteInterceptor } from "./route-types";
 
-export type {
-  HydrogenRouteHandler,
-  HydrogenRouteInterceptor,
-  HydrogenRoutesOptions,
-} from "./route-types";
-
 const SHOPIFY_ROUTE_INTERCEPTORS = [
   handleShopifyApiProxy,
   handleSfapiProxy,

--- a/packages/hydrogen/src/core/request-routing/registered-routes.ts
+++ b/packages/hydrogen/src/core/request-routing/registered-routes.ts
@@ -69,10 +69,7 @@ export const handleShopifyRouteHandlers: HydrogenRouteInterceptor = (
   );
 };
 
-export function createShopifyRouteResponse(
-  result: ShopifyRouteHandlerResult,
-  request: Request,
-): Response {
+function createShopifyRouteResponse(result: ShopifyRouteHandlerResult, request: Request): Response {
   if (result.type === "redirect") {
     const headers = new Headers(result.headers);
     headers.set("location", resolveRedirectLocation(result.location, request));

--- a/packages/hydrogen/src/core/shopify-scripts/perfkit.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/perfkit.ts
@@ -15,7 +15,7 @@ export function getPerfKitScript(
 ): ShopifyScriptDescriptor | undefined {
   if (!shop.storefrontId) return;
 
-  const shopId = normalizeShopifyShopId(shop.shopId);
+  const shopId = parseNumericShopId(shop.shopId);
   if (!shopId) return;
 
   return {
@@ -48,7 +48,7 @@ export function getPerfKitSpaBridgeScript(
   };
 }
 
-function normalizeShopifyShopId(shopId: ShopifyScriptsShop["shopId"]): string | undefined {
+function parseNumericShopId(shopId: ShopifyScriptsShop["shopId"]): string | undefined {
   const parsedShopId = shopId.split("/").pop();
   if (!parsedShopId) return;
 

--- a/packages/hydrogen/src/core/shopify-scripts/utils/inline-script.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/utils/inline-script.ts
@@ -1,6 +1,6 @@
 type InlineScriptSource = (...args: never[]) => unknown;
 
-export type InlineScriptFactory<T extends InlineScriptSource> = (...args: Parameters<T>) => string;
+type InlineScriptFactory<T extends InlineScriptSource> = (...args: Parameters<T>) => string;
 
 export function asInlineScript<T extends InlineScriptSource>(script: T): InlineScriptFactory<T>;
 export function asInlineScript(script: InlineScriptSource) {

--- a/packages/hydrogen/src/core/shopify-scripts/utils/serialize-script-data.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/utils/serialize-script-data.ts
@@ -1,6 +1,0 @@
-export function serializeScriptData<T>(value: T): string {
-  return JSON.stringify(value)
-    .replace(/</g, "\\u003c")
-    .replace(/\u2028/g, "\\u2028")
-    .replace(/\u2029/g, "\\u2029");
-}

--- a/packages/hydrogen/src/core/shopify-scripts/utils/tracking-values.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/utils/tracking-values.ts
@@ -4,7 +4,7 @@
  * and the Performance API.
  */
 
-export type TrackingValues = {
+type TrackingValues = {
   uniqueToken: string;
   visitToken: string;
   consent: string;

--- a/packages/hydrogen/src/core/standard-routes.test.ts
+++ b/packages/hydrogen/src/core/standard-routes.test.ts
@@ -6,6 +6,7 @@ import {
   matchStandardRouteUrl,
   resolveStandardRouteUrl,
 } from "./standard-routes/index";
+import { normalizePathPrefix, prependPathPrefix } from "./standard-routes/path";
 
 describe("standard routes", () => {
   it("builds default Shopify standard routes", () => {
@@ -270,6 +271,13 @@ describe("standard routes", () => {
         url: "https://cdn.example/products/snowboard",
       }),
     ).toBe("https://cdn.example/products/snowboard");
+  });
+
+  it("normalizes path prefixes with surrounding whitespace", () => {
+    expect(normalizePathPrefix(" /fr-ca/ ")).toBe("/fr-ca");
+    expect(normalizePathPrefix("  ")).toBe("");
+    expect(normalizePathPrefix(undefined)).toBe("");
+    expect(prependPathPrefix("/products", " /fr-ca/ ")).toBe("/fr-ca/products");
   });
 
   it("does not match external or unknown URLs", () => {

--- a/packages/hydrogen/src/core/standard-routes/defaults.ts
+++ b/packages/hydrogen/src/core/standard-routes/defaults.ts
@@ -7,7 +7,7 @@ type DefaultStandardRoutes = {
   ];
 };
 
-export const STANDARD_ROUTE_PARAM_NAMES = [
+const STANDARD_ROUTE_PARAM_NAMES = [
   "articleHandle",
   "blogHandle",
   "collectionHandle",

--- a/packages/hydrogen/src/core/standard-routes/index.ts
+++ b/packages/hydrogen/src/core/standard-routes/index.ts
@@ -5,9 +5,4 @@ export {
   resolveStandardRouteUrl,
 } from "./redirects";
 export { matchStandardRouteUrl } from "./match";
-export type {
-  ShopifyPageTemplateName,
-  ShopifyRouteTemplates,
-  ShopifyStandardRouteMatch,
-  ShopifyStandardRouteName,
-} from "./types";
+export type { ShopifyRouteTemplates, ShopifyStandardRouteMatch } from "./types";

--- a/packages/hydrogen/src/core/standard-routes/path.ts
+++ b/packages/hydrogen/src/core/standard-routes/path.ts
@@ -8,7 +8,7 @@ export function prependPathPrefix(pathname: string, pathPrefix: string | undefin
 export function normalizePathPrefix(pathPrefix: string | undefined): string {
   if (!pathPrefix) return "";
 
-  const trimmedPathPrefix = pathPrefix.replace(/^\/+|\/+$/g, "");
+  const trimmedPathPrefix = pathPrefix.trim().replace(/^\/+|\/+$/g, "");
   return trimmedPathPrefix ? `/${trimmedPathPrefix}` : "";
 }
 

--- a/packages/hydrogen/src/core/url.ts
+++ b/packages/hydrogen/src/core/url.ts
@@ -2,7 +2,6 @@ export const SFAPI_RE = /^\/api\/(unstable|2\d{3}-\d{2})\/graphql\.json$/;
 export const SHOPIFY_API_PROXY_PREFIX = "/__shopify";
 export const SHOPIFY_API_PROXY_RE = /^\/__shopify(?:\/|$)/;
 export const MCP_RE = /^\/api\/mcp$/;
-export const CART_RE = /^\/api\/cart$/;
 export const CHECKOUT_RE = /^\/checkout$/;
 export const CART_PERMALINK_RE = /^\/cart\/\d+:\d+(?:,\d+:\d+)*$/;
 export const AGENT_BUYER_CLAIMS_RE =

--- a/packages/hydrogen/src/core/utils/index.ts
+++ b/packages/hydrogen/src/core/utils/index.ts
@@ -1,3 +1,0 @@
-export { loadScript } from "./load-script";
-export { parseGid, type ShopifyGid } from "./parse-gid";
-export { isObjectRecord } from "./record";

--- a/packages/hydrogen/src/core/utils/parse-gid.ts
+++ b/packages/hydrogen/src/core/utils/parse-gid.ts
@@ -3,7 +3,7 @@
  * Parses Shopify Global IDs (GIDs) into their component parts.
  */
 
-export type ShopifyGid = Pick<URL, "search" | "searchParams" | "hash"> & {
+type ShopifyGid = Pick<URL, "search" | "searchParams" | "hash"> & {
   id: string;
   resource: string | null;
   resourceId: string | null;

--- a/packages/hydrogen/src/graphql/index.ts
+++ b/packages/hydrogen/src/graphql/index.ts
@@ -2,7 +2,6 @@ export { gql } from "./graphql";
 export type {
   AnyStorefrontQueryString,
   ComposedSource,
-  FragmentSources,
   SourceOf,
   StorefrontQueryString,
 } from "./graphql";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,9 +303,6 @@ importers:
         specifier: ^3.5.0
         version: 3.5.33(typescript@5.9.3)
     devDependencies:
-      '@0no-co/graphqlsp':
-        specifier: ^1.15.4
-        version: 1.15.4(graphql@16.13.2)(typescript@5.9.3)
       '@graphql-codegen/cli':
         specifier: ^7.0.0
         version: 7.0.0(@parcel/watcher@2.5.6)(@types/node@25.8.0)(crossws@0.3.5)(graphql@16.13.2)(typescript@5.9.3)


### PR DESCRIPTION
TL;DR: Cleans up the Hydrogen preview package before release by removing code that nothing uses — dead files, helpers nobody calls, exports nothing consumes — and fixing one small bug found along the way.

## What this changes

- Deletes source files that have no importers anywhere.
- Stops exporting internal symbols that are only used where they're defined, and prunes re-exports that every consumer bypasses.
- Removes an unused dev dependency.
- Consolidates two near-identical path-prefix helpers into one, fixing a bug where whitespace-padded locale prefixes produced malformed URLs.
- Renames two identically named shop-ID helpers that do opposite things, so they no longer look interchangeable.

No public API changes — everything removed or hidden was unreachable from the published entrypoints.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. Internal refactor only: no new or removed public exports, no migration needed.

## Testing

Every removal was verified by static analysis followed by multiple independent code reviews (including empirically testing the risky deletions against the real build). Full gate is green: package build, type tests, all unit tests (including two new tests covering the path-prefix fix), lint, and typechecks across every example app.

## Out of scope

- One internal barrel remains for now; it becomes removable once its consumers are migrated to direct imports (follow-up).
- Two unrelated pre-existing issues were discovered but intentionally not fixed here: the codegen formatting step always fails because of a formatter ignore rule, and some generated schema types are stale as a result.
