### PR TITLE
Strip Cloudflare client IP from Shopify proxy

### DIFF
--- a/.changeset/clean-proxies-connect.md
+++ b/.changeset/clean-proxies-connect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Prevent the Shopify API proxy from forwarding Cloudflare's client IP header to Shopify.

--- a/packages/hydrogen/src/core/headers.ts
+++ b/packages/hydrogen/src/core/headers.ts
@@ -25,6 +25,7 @@ export type StandardHeaderName =
   | "access-control-request-headers"
   | "access-control-request-method"
   | typeof CACHE_CONTROL_HEADER
+  | "cf-connecting-ip"
   | "connection"
   | "content-length"
   | "content-type"
@@ -126,6 +127,7 @@ export const AJAX_API_REQUEST_HEADER_ALLOWLIST = defineHeaderList(
 );
 
 export const SHOPIFY_API_PROXY_REQUEST_HEADER_DENYLIST = defineHeaderList(
+  "cf-connecting-ip",
   "connection",
   "content-length",
   "host",

--- a/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
@@ -147,6 +147,7 @@ describe("handleShopifyApiProxy", () => {
   });
 
   it.each([
+    "cf-connecting-ip",
     "connection",
     "content-length",
     "host",


### PR DESCRIPTION
TL;DR: Fix Shopify API proxy requests in the React Router template by preventing Cloudflare's client IP metadata from being forwarded to Shopify.

## Before

The React Router template uses MiniOxygen, which includes `cf-connecting-ip` on incoming requests to emulate a Cloudflare Worker environment. Requests such as `GET /__shopify/cart.js` forwarded that header to Shopify. Shopify then rejected the resulting `/cart.json` request with Cloudflare error 1000, "DNS points to prohibited IP."

## After

The Shopify API proxy removes `cf-connecting-ip` before forwarding the request. The same proxied cart request returns its JSON response successfully.

## What this changes

- Adds `cf-connecting-ip` to the known header names and Shopify API proxy denylist.
- Covers the header in the proxy's problematic-header regression test.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. This fixes proxy behavior without adding or changing public APIs.

## Risk

- The upstream Shopify request no longer receives Cloudflare's client IP header. This header is infrastructure metadata and should not be forwarded across proxy boundaries.

## How to Test

1. Run `pnpm run examples:secrets:decrypt` to configure the React Router template for the preview shop.
2. Run `pnpm --filter @shopify/hydrogen build`.
3. Run `pnpm dev:rr`.
4. Open the browser console and run `await fetch('/__shopify/cart.js')`.
5. Confirm the response is `200` with JSON cart data instead of a `403` Cloudflare error page.
