### PR TITLE
Expose standard pathname from route matches

### DIFF
--- a/.changeset/calm-routes-match.md
+++ b/.changeset/calm-routes-match.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": minor
+---
+
+Return the standard pathname and the standard and custom route templates from `Shopify.routes.match()`.

--- a/packages/hydrogen/src/core/shopify-scripts.test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts.test.ts
@@ -88,12 +88,12 @@ describe("shopify scripts", () => {
     window.Shopify?.navigate?.("/products/snowboard");
 
     expect(navigate).toHaveBeenCalledWith("/products/snowboard");
-    expect(window.Shopify?.routes.match?.("/products/snowboard")).toEqual({
+    expect(window.Shopify?.routes.match?.("/products/snowboard")).toMatchObject({
       route: "product",
       pageTemplateName: "product",
       params: { productHandle: "snowboard" },
     });
-    expect(window.Shopify?.routes.match?.("/")).toEqual({
+    expect(window.Shopify?.routes.match?.("/")).toMatchObject({
       route: "index",
       pageTemplateName: "index",
       params: {},
@@ -104,27 +104,27 @@ describe("shopify scripts", () => {
   it("sets default Shopify route hooks when route templates are omitted", async () => {
     await initializeShopifyScripts({ webMcp: false });
 
-    expect(window.Shopify?.routes.match?.("/products/snowboard")).toEqual({
+    expect(window.Shopify?.routes.match?.("/products/snowboard")).toMatchObject({
       route: "product",
       pageTemplateName: "product",
       params: { productHandle: "snowboard" },
     });
-    expect(window.Shopify?.routes.match?.("/cart")).toEqual({
+    expect(window.Shopify?.routes.match?.("/cart")).toMatchObject({
       route: "cart",
       pageTemplateName: "cart",
       params: {},
     });
-    expect(window.Shopify?.routes.match?.("/products")).toEqual({
+    expect(window.Shopify?.routes.match?.("/products")).toMatchObject({
       route: "collectionList",
       pageTemplateName: "list-collections",
       params: {},
     });
-    expect(window.Shopify?.routes.match?.("/policies/privacy-policy")).toEqual({
+    expect(window.Shopify?.routes.match?.("/policies/privacy-policy")).toMatchObject({
       route: "policy",
       pageTemplateName: "policy",
       params: { policyHandle: "privacy-policy" },
     });
-    expect(window.Shopify?.routes.match?.("/search?q=snowboard")).toEqual({
+    expect(window.Shopify?.routes.match?.("/search?q=snowboard")).toMatchObject({
       route: "search",
       pageTemplateName: "search",
       params: {},
@@ -197,6 +197,11 @@ describe("shopify scripts", () => {
       route: "product",
       pageTemplateName: "product",
       params: { productHandle: "snowboard" },
+      standardPathname: "/fr-ca/products/snowboard",
+      templates: {
+        standard: "/products/:productHandle",
+        custom: "/p/:productHandle",
+      },
     });
     expect(
       (window.Shopify?.routes as Record<string, unknown> | undefined)?.templates,

--- a/packages/hydrogen/src/core/shopify-scripts/page-view.test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/page-view.test.ts
@@ -99,7 +99,12 @@ describe("Shopify page view events", () => {
         ? {
             route: "productInCollection" as const,
             pageTemplateName: "product" as const,
-            params: { productHandle: "snowboard" },
+            params: { collectionHandle: "winter", productHandle: "snowboard" },
+            standardPathname: "/collections/winter/products/snowboard",
+            templates: {
+              standard: "/collections/:collectionHandle/products/:productHandle",
+              custom: "/collections/:collectionHandle/products/:productHandle",
+            },
           }
         : null,
     );

--- a/packages/hydrogen/src/core/standard-routes.test.ts
+++ b/packages/hydrogen/src/core/standard-routes.test.ts
@@ -80,6 +80,11 @@ describe("standard routes", () => {
       route: "product",
       pageTemplateName: "product",
       params: { productHandle: "snow board" },
+      standardPathname: "/products/snow%20board",
+      templates: {
+        standard: "/products/:productHandle",
+        custom: "/p/:productHandle",
+      },
     });
     expect(
       matchStandardRouteUrl({
@@ -90,6 +95,11 @@ describe("standard routes", () => {
       route: "article",
       pageTemplateName: "article",
       params: { blogHandle: "news", articleHandle: "waxing guide" },
+      standardPathname: "/blogs/news/waxing%20guide",
+      templates: {
+        standard: "/blogs/:blogHandle/:articleHandle",
+        custom: "/journal/:blogHandle/:articleHandle",
+      },
     });
   });
 
@@ -102,11 +112,21 @@ describe("standard routes", () => {
       route: "product",
       pageTemplateName: "product",
       params: { productHandle: "snowboard" },
+      standardPathname: "/products/snowboard",
+      templates: {
+        standard: "/products/:productHandle",
+        custom: "/p/:productHandle",
+      },
     });
     expect(matchStandardRouteUrl({ routeTemplates, url: "/collections/winter" })).toEqual({
       route: "collection",
       pageTemplateName: "collection",
       params: { collectionHandle: "winter" },
+      standardPathname: "/collections/winter",
+      templates: {
+        standard: "/collections/:collectionHandle",
+        custom: "/collections/:collectionHandle",
+      },
     });
   });
 
@@ -116,12 +136,12 @@ describe("standard routes", () => {
       productInCollection: "/products/:productHandle",
     });
 
-    expect(matchStandardRouteUrl({ routeTemplates, url: "/pages/privacy-policy" })).toEqual({
+    expect(matchStandardRouteUrl({ routeTemplates, url: "/pages/privacy-policy" })).toMatchObject({
       route: "page",
       pageTemplateName: "page",
       params: { pageHandle: "privacy-policy" },
     });
-    expect(matchStandardRouteUrl({ routeTemplates, url: "/products/snowboard" })).toEqual({
+    expect(matchStandardRouteUrl({ routeTemplates, url: "/products/snowboard" })).toMatchObject({
       route: "product",
       pageTemplateName: "product",
       params: { productHandle: "snowboard" },
@@ -137,6 +157,8 @@ describe("standard routes", () => {
       route: "index",
       pageTemplateName: "index",
       params: {},
+      standardPathname: "/",
+      templates: { standard: "/", custom: "/" },
     });
     expect(
       matchStandardRouteUrl({
@@ -144,7 +166,13 @@ describe("standard routes", () => {
         routeTemplates,
         url: "/fr-ca/",
       }),
-    ).toEqual({ route: "index", pageTemplateName: "index", params: {} });
+    ).toEqual({
+      route: "index",
+      pageTemplateName: "index",
+      params: {},
+      standardPathname: "/fr-ca/",
+      templates: { standard: "/", custom: "/" },
+    });
   });
 
   it.each([
@@ -183,7 +211,7 @@ describe("standard routes", () => {
   ] as const)("matches the Liquid page template for $url", ({ url, expected }) => {
     const routeTemplates = createShopifyRouteTemplates({});
 
-    expect(matchStandardRouteUrl({ routeTemplates, url })).toEqual(expected);
+    expect(matchStandardRouteUrl({ routeTemplates, url })).toMatchObject(expected);
   });
 
   it("matches configured storefront utility routes", () => {
@@ -194,22 +222,24 @@ describe("standard routes", () => {
       search: "/find",
     });
 
-    expect(matchStandardRouteUrl({ routeTemplates, url: "/basket" })).toEqual({
+    expect(matchStandardRouteUrl({ routeTemplates, url: "/basket" })).toMatchObject({
       route: "cart",
       pageTemplateName: "cart",
       params: {},
     });
-    expect(matchStandardRouteUrl({ routeTemplates, url: "/catalog" })).toEqual({
+    expect(matchStandardRouteUrl({ routeTemplates, url: "/catalog" })).toMatchObject({
       route: "collectionList",
       pageTemplateName: "list-collections",
       params: {},
     });
-    expect(matchStandardRouteUrl({ routeTemplates, url: "/legal/terms-of-service" })).toEqual({
-      route: "policy",
-      pageTemplateName: "policy",
-      params: { policyHandle: "terms-of-service" },
-    });
-    expect(matchStandardRouteUrl({ routeTemplates, url: "/find?q=snowboard" })).toEqual({
+    expect(matchStandardRouteUrl({ routeTemplates, url: "/legal/terms-of-service" })).toMatchObject(
+      {
+        route: "policy",
+        pageTemplateName: "policy",
+        params: { policyHandle: "terms-of-service" },
+      },
+    );
+    expect(matchStandardRouteUrl({ routeTemplates, url: "/find?q=snowboard" })).toMatchObject({
       route: "search",
       pageTemplateName: "search",
       params: {},
@@ -221,6 +251,16 @@ describe("standard routes", () => {
 
     expect(resolveStandardRouteUrl({ routeTemplates, url: "/collections" })).toBe("/catalog");
     expect(resolveStandardRouteUrl({ routeTemplates, url: "/products" })).toBe("/catalog");
+    expect(matchStandardRouteUrl({ routeTemplates, url: "/products" })).toEqual({
+      route: "collectionList",
+      pageTemplateName: "list-collections",
+      params: {},
+      standardPathname: "/collections",
+      templates: {
+        standard: "/collections",
+        custom: "/catalog",
+      },
+    });
   });
 
   it("resolves standard route URLs with an i18n path prefix", () => {
@@ -252,6 +292,11 @@ describe("standard routes", () => {
       route: "productInCollection",
       pageTemplateName: "product",
       params: { collectionHandle: "winter", productHandle: "snowboard" },
+      standardPathname: "/fr-ca/collections/winter/products/snowboard",
+      templates: {
+        standard: "/collections/:collectionHandle/products/:productHandle",
+        custom: "/c/:collectionHandle/p/:productHandle",
+      },
     });
   });
 

--- a/packages/hydrogen/src/core/standard-routes/match.ts
+++ b/packages/hydrogen/src/core/standard-routes/match.ts
@@ -1,3 +1,4 @@
+import { buildStandardRouteTarget } from "./build";
 import { DEFAULT_STANDARD_ROUTES, isStandardRouteName, isStandardRouteParamName } from "./defaults";
 import { parseSameOriginUrl, stripI18nPathPrefix, stripTrailingSlash } from "./path";
 import type {
@@ -32,16 +33,42 @@ export function matchStandardRouteUrl({
   if (!parsedUrl) return null;
 
   const pathname = stripI18nPathPrefix(stripTrailingSlash(parsedUrl.pathname), pathPrefix);
-  if (pathname === "/") return { route: "index", pageTemplateName: "index", params: {} };
+  if (pathname === "/") {
+    return addStandardRouteContext(
+      { route: "index", pageTemplateName: "index", params: {} },
+      pathPrefix,
+      routeTemplates,
+    );
+  }
 
-  return (
+  const match =
     matchStandardRouteTemplates(
       parsedUrl.pathname,
       pathPrefix,
       (route) => DEFAULT_STANDARD_ROUTES[route],
     ) ??
-    matchStandardRouteTemplates(parsedUrl.pathname, pathPrefix, (route) => [routeTemplates[route]])
-  );
+    matchStandardRouteTemplates(parsedUrl.pathname, pathPrefix, (route) => [routeTemplates[route]]);
+
+  return match ? addStandardRouteContext(match, pathPrefix, routeTemplates) : null;
+}
+
+function addStandardRouteContext(
+  match: Pick<ShopifyStandardRouteMatch, "pageTemplateName" | "params" | "route">,
+  pathPrefix: string | undefined,
+  routeTemplates: ShopifyRouteTemplates,
+): ShopifyStandardRouteMatch {
+  const standardTemplate = match.route === "index" ? "/" : DEFAULT_STANDARD_ROUTES[match.route][0];
+  const customTemplate =
+    match.route === "index" ? standardTemplate : (routeTemplates[match.route] ?? standardTemplate);
+
+  return {
+    ...match,
+    standardPathname: buildStandardRouteTarget(standardTemplate, match.params, pathPrefix),
+    templates: {
+      standard: standardTemplate,
+      custom: customTemplate,
+    },
+  };
 }
 
 /**
@@ -55,7 +82,10 @@ export function matchStandardRouteTemplates(
   pathname: string,
   pathPrefix: string | undefined,
   getTemplatesForRoute: (route: StandardRouteName) => ReadonlyArray<string | undefined>,
-): ShopifyStandardRouteMatch<StandardRouteName> | null {
+): Pick<
+  ShopifyStandardRouteMatch<StandardRouteName>,
+  "pageTemplateName" | "params" | "route"
+> | null {
   const normalizedPathname = stripI18nPathPrefix(stripTrailingSlash(pathname), pathPrefix);
 
   for (const route in DEFAULT_STANDARD_ROUTES) {

--- a/packages/hydrogen/src/core/standard-routes/types.ts
+++ b/packages/hydrogen/src/core/standard-routes/types.ts
@@ -125,7 +125,12 @@ export type StandardRouteOptions = Pick<I18nConfig, "pathPrefix">;
 export type ShopifyStandardRouteMatch<
   TRoute extends ShopifyStandardRouteName = ShopifyStandardRouteName,
 > = {
+  standardPathname: string;
   params: StandardRouteParams;
   route: TRoute;
   pageTemplateName: ShopifyPageTemplateName<TRoute>;
+  templates: {
+    standard: string;
+    custom: string;
+  };
 };

--- a/packages/hydrogen/src/react/shopify-scripts.test.tsx
+++ b/packages/hydrogen/src/react/shopify-scripts.test.tsx
@@ -284,6 +284,11 @@ describe("ShopifyScripts", () => {
         route: "product",
         pageTemplateName: "product",
         params: { productHandle: "snowboard" },
+        standardPathname: "/products/snowboard",
+        templates: {
+          standard: "/products/:productHandle",
+          custom: "/p/:productHandle",
+        },
       });
       expect(window.Shopify?.routes.resolve?.("/products/snowboard")).toBe("/p/snowboard");
     });

--- a/packages/hydrogen/src/vue/shopify-scripts.test.ts
+++ b/packages/hydrogen/src/vue/shopify-scripts.test.ts
@@ -140,6 +140,11 @@ describe("ShopifyScripts", () => {
         route: "product",
         pageTemplateName: "product",
         params: { productHandle: "snowboard" },
+        standardPathname: "/products/snowboard",
+        templates: {
+          standard: "/products/:productHandle",
+          custom: "/p/:productHandle",
+        },
       });
       expect(window.Shopify?.routes.resolve?.("/products/snowboard")).toBe("/p/snowboard");
     });


### PR DESCRIPTION
## Summary

- Return `standardPathname` from `Shopify.routes.match()`.
- Return the effective standard and custom templates as grouped match metadata.
- Cover configured, default, localized, index, utility, and legacy storefront routes.

## Why

Consumers sometimes need to move between an application's custom URL shape and Shopify's standard storefront routes. Returning the normalized standard pathname and both templates from the existing match operation avoids duplicating route-template parsing outside Hydrogen.

## Testing

- `pnpm --filter @shopify/hydrogen typecheck`
- Focused Vitest suite: 68 tests passed
- `pnpm exec oxlint` on changed Hydrogen files
- `pnpm exec oxfmt --check` on changed files
