### PR TITLE
feat: javascript origin flag in `customer-account-push` hydrogen CLI command

### DIFF
--- a/.changeset/bright-origins-push.md
+++ b/.changeset/bright-origins-push.md
@@ -2,4 +2,4 @@
 '@shopify/cli-hydrogen': patch
 ---
 
-Add a `--javascript-origin` override to `hydrogen customer-account push` for local HTTPS storefronts that use a portful development origin.
+New flag `--javascript-origin` override to `hydrogen customer-account-push`. Not providing it still defaults to `--dev-origin`.

--- a/.changeset/bright-origins-push.md
+++ b/.changeset/bright-origins-push.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Add a `--javascript-origin` override to `hydrogen customer-account push` for local HTTPS storefronts that use a portful development origin.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -220,6 +220,13 @@
           "multiple": false,
           "type": "option"
         },
+        "javascript-origin": {
+          "description": "The origin to register as the allowed JavaScript origin for the Customer Account API OAuth flow. Defaults to --dev-origin. Must not include a port (Shopify rejects origins with ports); use this to register a portless origin while keeping a portful --dev-origin.",
+          "name": "javascript-origin",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "relative-redirect-uri": {
           "description": "The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'",
           "name": "relative-redirect-uri",

--- a/packages/cli/src/commands/hydrogen/customer-account/push.test.ts
+++ b/packages/cli/src/commands/hydrogen/customer-account/push.test.ts
@@ -1,0 +1,117 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {type AdminSession, login} from '../../../lib/auth.js';
+import {replaceCustomerApplicationUrls} from '../../../lib/graphql/admin/customer-application-update.js';
+import {setCustomerAccountConfig} from '../../../lib/shopify-config.js';
+import {runCustomerAccountPush} from './push.js';
+
+vi.mock('../../../lib/auth.js');
+vi.mock('../../../lib/graphql/admin/customer-application-update.js');
+vi.mock('../../../lib/shopify-config.js');
+
+const ADMIN_SESSION: AdminSession = {
+  token: 'token',
+  storeFqdn: 'example.myshopify.com',
+};
+const STOREFRONT_ID = 'gid://shopify/HydrogenStorefront/1';
+const DEV_ORIGIN = 'https://localtest.me:5173';
+const JAVASCRIPT_ORIGIN = 'https://localtest.me';
+const PREVIOUS_CONFIG = {
+  redirectUri: 'https://previous.example/account/authorize',
+  javascriptOrigin: 'https://previous.example',
+  logoutUri: 'https://previous.example',
+};
+const SHOPIFY_CONFIG = {
+  shop: 'example.myshopify.com',
+  shopName: 'Example',
+  email: 'developer@example.com',
+  storefront: {
+    id: STOREFRONT_ID,
+    title: 'Example storefront',
+    customerAccountConfig: PREVIOUS_CONFIG,
+  },
+};
+
+describe('runCustomerAccountPush', () => {
+  beforeEach(() => {
+    vi.mocked(login).mockResolvedValue({
+      session: ADMIN_SESSION,
+      config: SHOPIFY_CONFIG,
+    });
+    vi.mocked(replaceCustomerApplicationUrls).mockResolvedValue({
+      success: true,
+      userErrors: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults the JavaScript origin to the development origin', async () => {
+    await runCustomerAccountPush({devOrigin: DEV_ORIGIN});
+
+    expect(replaceCustomerApplicationUrls).toHaveBeenCalledWith(
+      ADMIN_SESSION,
+      STOREFRONT_ID,
+      expect.objectContaining({
+        javascriptOrigin: expect.objectContaining({add: [DEV_ORIGIN]}),
+      }),
+    );
+  });
+
+  it('uses the JavaScript origin override with portful redirect and logout URIs', async () => {
+    await runCustomerAccountPush({
+      devOrigin: DEV_ORIGIN,
+      javascriptOrigin: JAVASCRIPT_ORIGIN,
+    });
+
+    expect(replaceCustomerApplicationUrls).toHaveBeenCalledWith(
+      ADMIN_SESSION,
+      STOREFRONT_ID,
+      {
+        redirectUri: {
+          add: [`${DEV_ORIGIN}/account/authorize`],
+          removeRegex: PREVIOUS_CONFIG.redirectUri,
+        },
+        javascriptOrigin: {
+          add: [JAVASCRIPT_ORIGIN],
+          removeRegex: PREVIOUS_CONFIG.javascriptOrigin,
+        },
+        logoutUris: {
+          add: [DEV_ORIGIN],
+          removeRegex: PREVIOUS_CONFIG.logoutUri,
+        },
+      },
+    );
+  });
+
+  it('persists the overridden JavaScript origin', async () => {
+    await runCustomerAccountPush({
+      devOrigin: DEV_ORIGIN,
+      javascriptOrigin: JAVASCRIPT_ORIGIN,
+    });
+
+    expect(setCustomerAccountConfig).toHaveBeenCalledWith(process.cwd(), {
+      redirectUri: `${DEV_ORIGIN}/account/authorize`,
+      javascriptOrigin: JAVASCRIPT_ORIGIN,
+      logoutUri: DEV_ORIGIN,
+    });
+  });
+
+  it('removes the previously stored JavaScript origin', async () => {
+    await runCustomerAccountPush({
+      devOrigin: DEV_ORIGIN,
+      javascriptOrigin: JAVASCRIPT_ORIGIN,
+    });
+
+    expect(replaceCustomerApplicationUrls).toHaveBeenCalledWith(
+      ADMIN_SESSION,
+      STOREFRONT_ID,
+      expect.objectContaining({
+        javascriptOrigin: expect.objectContaining({
+          removeRegex: PREVIOUS_CONFIG.javascriptOrigin,
+        }),
+      }),
+    );
+  });
+});

--- a/packages/cli/src/commands/hydrogen/customer-account/push.ts
+++ b/packages/cli/src/commands/hydrogen/customer-account/push.ts
@@ -26,6 +26,10 @@ export default class CustomerAccountPush extends Command {
       description: 'The development domain of your application.',
       required: true,
     }),
+    'javascript-origin': Flags.string({
+      description:
+        'The origin to register as the allowed JavaScript origin for the Customer Account API OAuth flow. Defaults to --dev-origin. Must not include a port (Shopify rejects origins with ports); use this to register a portless origin while keeping a portful --dev-origin.',
+    }),
     'relative-redirect-uri': Flags.string({
       description:
         "The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'",
@@ -46,12 +50,14 @@ export async function runCustomerAccountPush({
   path: root = process.cwd(),
   storefrontId: storefrontIdFromFlag,
   devOrigin,
+  javascriptOrigin: javascriptOriginFromArg,
   redirectUriRelativeUrl = '/account/authorize',
   logoutUriRelativeUrl,
 }: {
   path?: string;
   storefrontId?: string;
   devOrigin: string;
+  javascriptOrigin?: string;
   redirectUriRelativeUrl?: string;
   logoutUriRelativeUrl?: string;
   removeRegex?: string;
@@ -68,7 +74,7 @@ export async function runCustomerAccountPush({
     const redirectUri = redirectUriRelativeUrl
       ? new URL(redirectUriRelativeUrl, devOrigin).toString()
       : devOrigin;
-    const javascriptOrigin = devOrigin;
+    const javascriptOrigin = javascriptOriginFromArg ?? devOrigin;
     const logoutUri = logoutUriRelativeUrl
       ? new URL(logoutUriRelativeUrl, devOrigin).toString()
       : devOrigin;


### PR DESCRIPTION
## Why

Local HTTPS development needs a portful callback/logout URL, while Shopify requires the Customer Account API JavaScript origin to be portless. `customer-account push` currently derives all three values from `--dev-origin`, so it cannot represent that configuration.

## What changed

- Add an optional `--javascript-origin` flag that defaults to `--dev-origin`.
- Persist the overridden origin so existing replacement and cleanup behaviour remains unchanged.
- Add focused coverage for fallback, override, persistence, and prior-value removal.
- Regenerate the oclif manifest and add a patch changeset for `@shopify/cli-hydrogen` only.

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm --dir packages/cli exec vitest run src/commands/hydrogen/customer-account/push.test.ts --test-timeout=60000`
- `SHOPIFY_UNIT_TEST=1 LANG=en-US.UTF-8 pnpm --dir packages/cli exec vitest run src/commands/hydrogen/dev.test.ts --test-timeout=120000`

### Live Customer Account API spike

Tested against `hydrogen-preview.myshopify.com` with Hydrogen-channel storefronts:

- `javascriptOrigin: https://localtest.me:5173` returned `success: false`, code `INVALID`, field `urlsReplaceInput.javascriptOrigin`, message: `Javascript origin is not valid. Please only specify a hostname.`
- The mixed target values returned `success: true` with no user errors:
  - Callback URI: `https://localtest.me:5173/account/authorize`
  - JavaScript origin: `https://localtest.me`
  - Logout URI: `https://localtest.me:5173`
- A local HTTPS React Router storefront completed login, the `/account/authorize` callback, and logout with those values.
- Running the built command without `--javascript-origin` against an existing portless `tryhydrogen.dev` origin succeeded, confirming the fallback behaviour.
- Temporary spike URL changes were removed and the linked storefront's prior tunnel configuration was restored.

## Release follow-up

After this merges and `@shopify/cli-hydrogen` is published, follow `.claude/commands/shopify-cli-update.md` to bump the exact published version in `Shopify/cli` and release it as a patch of the current Shopify CLI minor. The released Hydrogen CLI version is not known until the release PR merges.
