### PR TITLE
Support HTTP/2 requests in MiniOxygen

### DIFF
--- a/.changeset/tidy-otters-request.md
+++ b/.changeset/tidy-otters-request.md
@@ -1,0 +1,5 @@
+---
+'@shopify/mini-oxygen': patch
+---
+
+Support HTTP/2 requests in MiniOxygen's Vite request conversion.

--- a/packages/mini-oxygen/src/vite/utils.test.ts
+++ b/packages/mini-oxygen/src/vite/utils.test.ts
@@ -59,10 +59,33 @@ describe('utils', () => {
       expect(webReq.constructor.name).toBe('Request');
       expect(webReq.method).toBe('POST');
       expect(webReq.headers.get('content-type')).toBe('application/json');
+      expect(webReq.headers.get('host')).toBe('localhost:3000');
       expect(webReq.url).toBe('http://localhost:3000/test');
     });
 
-    it('should throw error if host header is missing', () => {
+    it('should convert an HTTP/2 request using the authority pseudo-header', () => {
+      const nodeReq = {
+        url: '/test',
+        method: 'GET',
+        headers: {
+          ':authority': 'localtest.me:5173',
+          ':method': 'GET',
+          ':path': '/test',
+          ':scheme': 'https',
+          accept: 'text/html',
+        },
+      } as unknown as IncomingMessage;
+
+      const webReq = toWeb(nodeReq);
+
+      expect(webReq.url).toBe('http://localtest.me:5173/test');
+      expect(webReq.headers.get('host')).toBe('localtest.me:5173');
+      expect([...webReq.headers.keys()]).not.toContainEqual(
+        expect.stringMatching(/^:/),
+      );
+    });
+
+    it('should throw error if host and authority headers are missing', () => {
       const nodeReq = {
         url: '/test',
         headers: {},
@@ -84,6 +107,29 @@ describe('utils', () => {
 
       const webReq = toWeb(nodeReq);
       expect(webReq.body).toBeNull();
+    });
+
+    it('should preserve Node header precedence when merging headers', () => {
+      const nodeReq = {
+        url: '/test',
+        method: 'GET',
+        headers: {
+          ':authority': 'authority.example.com',
+          host: 'localhost:3000',
+          'x-test': 'node',
+        },
+      } as unknown as IncomingMessage;
+
+      const webReq = toWeb(nodeReq, {
+        host: 'override.example.com',
+        'x-test': 'provided',
+        'x-provided': 'value',
+      });
+
+      expect(webReq.headers.get('host')).toBe('localhost:3000');
+      expect(webReq.url).toBe('http://localhost:3000/test');
+      expect(webReq.headers.get('x-test')).toBe('node');
+      expect(webReq.headers.get('x-provided')).toBe('value');
     });
   });
 

--- a/packages/mini-oxygen/src/vite/utils.ts
+++ b/packages/mini-oxygen/src/vite/utils.ts
@@ -23,13 +23,24 @@ export function toURL(req: string | IncomingMessage = '/', origin?: string) {
  * Turns a Node request into a Web request by using native Node APIs.
  */
 export function toWeb(req: IncomingMessage, headers?: Record<string, string>) {
-  if (!req.headers.host) {
+  const authorityHeader = req.headers.host || req.headers[':authority'];
+  const authority = Array.isArray(authorityHeader)
+    ? authorityHeader[0]
+    : authorityHeader;
+  if (!authority) {
     throw new Error('Request must contain a host header.');
   }
 
-  return new Request(toURL(req), {
+  const requestHeaders = Object.fromEntries(
+    Object.entries({...headers, ...(req.headers as object)}).filter(
+      ([name]) => !name.startsWith(':'),
+    ),
+  );
+  requestHeaders.host = authority;
+
+  return new Request(toURL(req, `http://${authority}`), {
     method: req.method,
-    headers: {...headers, ...(req.headers as object)},
+    headers: requestHeaders,
     body: req.headers['content-length']
       ? (Readable.toWeb(req) as unknown as BodyInit)
       : undefined,


### PR DESCRIPTION
## Why

Vite HTTPS can negotiate HTTP/2. Those requests use the `:authority` pseudo-header instead of `host`, so MiniOxygen currently rejects them with `Request must contain a host header.` HTTP/2 pseudo-headers also cannot be passed to the WHATWG `Headers` constructor.

## What changed

- fall back to `:authority` when `host` is absent
- expose the resolved authority as the normalised `host` header
- remove HTTP/2 pseudo-headers before constructing the Web `Request`
- preserve HTTP/1.1 behaviour and existing header merge precedence