### PR TITLE
feat(cart): add server-only cart metafield intents to /api/cart

### DIFF
--- a/.changeset/cool-carts-remember.md
+++ b/.changeset/cool-carts-remember.md
@@ -1,0 +1,7 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Add server-only cart metafield support to the cart API. `POST /api/cart` now accepts a `metafields-set` intent (JSON `{ metafields: [{ key, type, value }] }` or form fields `metafieldKey`/`metafieldType`/`metafieldValue`) and a `metafield-delete` intent (JSON `{ deleteMetafield: "namespace.key" }` or form field `metafieldKey`). The server injects the cart id as `ownerId` and refetches the cart after mutating, so responses keep the same shape as other cart mutations and include metafields selected by a custom `CartFragment`. Setting metafields without an existing cart creates one via `cartCreate`. Adds the `CartMetafieldInput` exported type.
+
+Metafields are not supported by Standard Actions (cart ajax), so they do not flow through the optimistic client cart store.

--- a/examples/hydrogen/app/components/CartDeliveryInstructions.tsx
+++ b/examples/hydrogen/app/components/CartDeliveryInstructions.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+
+import { useCart } from "~/lib/cart";
+
+// Cart metafields are server-only: the Storefront cart ajax API (Standard
+// Actions) does not support them, so this form bypasses the optimistic cart
+// store and posts JSON directly to /api/cart. The POST response includes the
+// refetched cart (extended with the metafield via the custom CartFragment in
+// app/lib/cart-handlers.ts), which this component keeps in local state — the
+// cart store itself is not updated, so its copy of the metafields stays stale
+// until its next natural revalidation. Each mounted instance (cart page and
+// cart aside) tracks its own saves.
+//
+// To copy the instructions onto the order at checkout, the store must define
+// a `custom.delivery_instructions` metafield with the cart-to-order copyable
+// capability enabled:
+// https://shopify.dev/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable
+// Without the definition, saving to the cart still works but nothing is
+// copied to the order.
+const CART_ENDPOINT = "/api/cart";
+const DELIVERY_INSTRUCTIONS_NAMESPACE = "custom";
+const DELIVERY_INSTRUCTIONS_KEY = "delivery_instructions";
+const DELIVERY_INSTRUCTIONS_METAFIELD_KEY = `${DELIVERY_INSTRUCTIONS_NAMESPACE}.${DELIVERY_INSTRUCTIONS_KEY}`;
+const DELIVERY_INSTRUCTIONS_METAFIELD_TYPE = "multi_line_text_field";
+
+type CartMetafields = Array<{ namespace: string; key: string; value: string } | null> | null;
+
+type CartApiResponse = {
+  cart?: { metafields?: CartMetafields } | null;
+  userErrors?: Array<{ message: string }>;
+  error?: { message: string };
+};
+
+type SaveState = { status: "idle" | "saving" | "saved" } | { status: "error"; message: string };
+
+function findDeliveryInstructions(metafields: CartMetafields | undefined): string {
+  return (
+    metafields?.find(
+      (metafield) =>
+        metafield?.namespace === DELIVERY_INSTRUCTIONS_NAMESPACE &&
+        metafield.key === DELIVERY_INSTRUCTIONS_KEY,
+    )?.value ?? ""
+  );
+}
+
+export function CartDeliveryInstructions() {
+  const storeMetafields = useCart((cart) => cart.data.metafields);
+  const [saveState, setSaveState] = useState<SaveState>({ status: "idle" });
+  // Local override of the cart store's metafields after a save/remove; null
+  // means "no save happened yet, use the store's data".
+  const [localMetafields, setLocalMetafields] = useState<CartMetafields>(null);
+
+  const savedInstructions = findDeliveryInstructions(localMetafields ?? storeMetafields);
+
+  async function submitToCartApi(body: Record<string, unknown>) {
+    setSaveState({ status: "saving" });
+    try {
+      const response = await fetch(CART_ENDPOINT, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const result = (await response.json()) as CartApiResponse;
+      const errorMessage = result.error?.message ?? result.userErrors?.[0]?.message;
+      if (!response.ok || errorMessage) {
+        setSaveState({ status: "error", message: errorMessage ?? "Something went wrong." });
+        return;
+      }
+      setLocalMetafields(result.cart?.metafields ?? []);
+      setSaveState({ status: "saved" });
+    } catch {
+      setSaveState({ status: "error", message: "Network error. Please try again." });
+    }
+  }
+
+  function handleSave(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const instructions = String(new FormData(event.currentTarget).get("instructions") ?? "");
+
+    // Saving an empty value means "no instructions" — delete instead of
+    // storing an empty metafield.
+    if (instructions.trim() === "") {
+      if (savedInstructions) void handleRemove();
+      return;
+    }
+
+    void submitToCartApi({
+      metafields: [
+        {
+          key: DELIVERY_INSTRUCTIONS_METAFIELD_KEY,
+          type: DELIVERY_INSTRUCTIONS_METAFIELD_TYPE,
+          value: instructions,
+        },
+      ],
+    });
+  }
+
+  function handleRemove() {
+    return submitToCartApi({ deleteMetafield: DELIVERY_INSTRUCTIONS_METAFIELD_KEY });
+  }
+
+  const isSaving = saveState.status === "saving";
+
+  return (
+    <section aria-label="Delivery instructions">
+      <h5>Delivery instructions</h5>
+      <form onSubmit={handleSave}>
+        <textarea
+          name="instructions"
+          rows={3}
+          defaultValue={savedInstructions}
+          key={savedInstructions}
+          disabled={isSaving}
+          placeholder="e.g. Leave the package at the back door"
+          aria-label="Delivery instructions"
+        />
+        <button type="submit" disabled={isSaving}>
+          {isSaving ? "Saving…" : "Save instructions"}
+        </button>
+        {savedInstructions ? (
+          <button type="button" disabled={isSaving} onClick={() => void handleRemove()}>
+            Remove instructions
+          </button>
+        ) : null}
+      </form>
+      <p role="status">
+        {saveState.status === "saved" ? "Saved." : null}
+        {saveState.status === "error" ? saveState.message : null}
+      </p>
+    </section>
+  );
+}

--- a/examples/hydrogen/app/components/CartDeliveryInstructions.tsx
+++ b/examples/hydrogen/app/components/CartDeliveryInstructions.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { FormEvent } from "react";
 
 import { useCart } from "~/lib/cart";
+import { cartHandlers } from "~/lib/cart-handlers";
 
 // Cart metafields are server-only: the Storefront cart ajax API (Standard
 // Actions) does not support them, so this form bypasses the optimistic cart
@@ -18,7 +19,7 @@ import { useCart } from "~/lib/cart";
 // https://shopify.dev/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable
 // Without the definition, saving to the cart still works but nothing is
 // copied to the order.
-const CART_ENDPOINT = "/api/cart";
+const CART_ENDPOINT = cartHandlers.post.pathname;
 const DELIVERY_INSTRUCTIONS_NAMESPACE = "custom";
 const DELIVERY_INSTRUCTIONS_KEY = "delivery_instructions";
 const DELIVERY_INSTRUCTIONS_METAFIELD_KEY = `${DELIVERY_INSTRUCTIONS_NAMESPACE}.${DELIVERY_INSTRUCTIONS_KEY}`;

--- a/examples/hydrogen/app/components/CartSummary.tsx
+++ b/examples/hydrogen/app/components/CartSummary.tsx
@@ -1,6 +1,7 @@
 import type { CartData, MoneyV2 } from "@shopify/hydrogen";
 import { useId } from "react";
 
+import { CartDeliveryInstructions } from "~/components/CartDeliveryInstructions";
 import type { CartLayout } from "~/components/CartMain";
 import { useCartForm } from "~/lib/cart";
 import { formatMoney } from "~/lib/money";
@@ -32,6 +33,7 @@ export function CartSummary({ cart, layout, totalsPending }: CartSummaryProps) {
         discountsHeadingId={discountsHeadingId}
         discountCodeInputId={discountCodeInputId}
       />
+      <CartDeliveryInstructions />
       <CartCheckoutActions checkoutUrl={cart.checkoutUrl} />
     </div>
   );

--- a/examples/hydrogen/app/lib/cart-handlers.ts
+++ b/examples/hydrogen/app/lib/cart-handlers.ts
@@ -1,3 +1,16 @@
-import { createCartServerHandlers } from "@shopify/hydrogen";
+import { createCartServerHandlers, gql } from "@shopify/hydrogen";
 
-export const cartHandlers = createCartServerHandlers();
+// Extends every cart query/mutation response with the delivery instructions
+// metafield so it can be rendered from cart data (see CartDeliveryInstructions).
+const CART_FRAGMENT = gql(`
+  fragment CartFragment on Cart {
+    metafields(identifiers: [{ namespace: "custom", key: "delivery_instructions" }]) {
+      namespace
+      key
+      type
+      value
+    }
+  }
+`);
+
+export const cartHandlers = createCartServerHandlers({ fragment: CART_FRAGMENT });

--- a/packages/hydrogen/src/core/cart/actions.test.ts
+++ b/packages/hydrogen/src/core/cart/actions.test.ts
@@ -172,6 +172,103 @@ describe("parseCartRequest", () => {
     });
   });
 
+  describe("JSON — metafield payloads", () => {
+    it("parses metafields array as metafields-set", async () => {
+      const { action } = await parseCartRequest(
+        jsonRequest({
+          metafields: [{ key: "custom.gift", type: "boolean", value: "true" }],
+        }),
+      );
+      expect(action).toEqual({
+        intent: "metafields-set",
+        metafields: [{ key: "custom.gift", type: "boolean", value: "true" }],
+      });
+    });
+
+    it("parses multiple metafields in one request", async () => {
+      const { action } = await parseCartRequest(
+        jsonRequest({
+          metafields: [
+            { key: "custom.gift", type: "boolean", value: "true" },
+            { key: "custom.note", type: "single_line_text_field", value: "hi" },
+          ],
+        }),
+      );
+      expect(action).toEqual({
+        intent: "metafields-set",
+        metafields: [
+          { key: "custom.gift", type: "boolean", value: "true" },
+          { key: "custom.note", type: "single_line_text_field", value: "hi" },
+        ],
+      });
+    });
+
+    it("strips unknown fields such as ownerId from metafield entries", async () => {
+      const { action } = await parseCartRequest(
+        jsonRequest({
+          metafields: [
+            {
+              key: "custom.gift",
+              type: "boolean",
+              value: "true",
+              ownerId: "gid://shopify/Cart/hijack",
+            },
+          ],
+        }),
+      );
+      expect(action).toEqual({
+        intent: "metafields-set",
+        metafields: [{ key: "custom.gift", type: "boolean", value: "true" }],
+      });
+    });
+
+    it("parses deleteMetafield string as metafield-delete", async () => {
+      const { action } = await parseCartRequest(jsonRequest({ deleteMetafield: "custom.gift" }));
+      expect(action).toEqual({ intent: "metafield-delete", key: "custom.gift" });
+    });
+
+    it("rejects empty metafields array", async () => {
+      await expect(parseCartRequest(jsonRequest({ metafields: [] }))).rejects.toThrow(
+        /metafields/i,
+      );
+    });
+
+    it("rejects metafield entries missing key", async () => {
+      await expect(
+        parseCartRequest(jsonRequest({ metafields: [{ type: "boolean", value: "true" }] })),
+      ).rejects.toThrow(/key/i);
+    });
+
+    it("rejects metafield entries missing type", async () => {
+      await expect(
+        parseCartRequest(jsonRequest({ metafields: [{ key: "custom.gift", value: "true" }] })),
+      ).rejects.toThrow(/type/i);
+    });
+
+    it("rejects metafield entries missing value", async () => {
+      await expect(
+        parseCartRequest(jsonRequest({ metafields: [{ key: "custom.gift", type: "boolean" }] })),
+      ).rejects.toThrow(/value/i);
+    });
+
+    it("rejects empty deleteMetafield string", async () => {
+      await expect(parseCartRequest(jsonRequest({ deleteMetafield: "" }))).rejects.toThrow(
+        /deleteMetafield/i,
+      );
+    });
+
+    it("preserves cartId alongside metafields", async () => {
+      const parsed = await parseCartRequest(
+        jsonRequest({
+          cartId: "gid://shopify/Cart/body-cart",
+          metafields: [{ key: "custom.gift", type: "boolean", value: "true" }],
+        }),
+      );
+      expect(parsed.cartId).toBe("gid://shopify/Cart/body-cart");
+      expect(parsed.action.intent).toBe("metafields-set");
+    });
+  });
+
   describe("JSON — cartId metadata", () => {
     it("preserves full cart GID from the body", async () => {
       const parsed = await parseCartRequest(
@@ -548,6 +645,87 @@ describe("parseCartRequest", () => {
     it("note-update without note field rejects", async () => {
       await expect(parseCartRequest(formRequest({ intent: "note-update" }))).rejects.toThrow(
         /note/i,
+      );
+    });
+  });
+
+  describe("FormData — metafield intents", () => {
+    it("metafields-set produces a single-metafield set action", async () => {
+      const { action } = await parseCartRequest(
+        formRequest({
+          intent: "metafields-set",
+          metafieldKey: "custom.gift",
+          metafieldType: "boolean",
+          metafieldValue: "true",
+        }),
+      );
+      expect(action).toEqual({
+        intent: "metafields-set",
+        metafields: [{ key: "custom.gift", type: "boolean", value: "true" }],
+      });
+    });
+
+    it("metafields-set with empty metafieldValue is valid", async () => {
+      const { action } = await parseCartRequest(
+        formRequest({
+          intent: "metafields-set",
+          metafieldKey: "custom.note",
+          metafieldType: "single_line_text_field",
+          metafieldValue: "",
+        }),
+      );
+      expect(action).toEqual({
+        intent: "metafields-set",
+        metafields: [{ key: "custom.note", type: "single_line_text_field", value: "" }],
+      });
+    });
+
+    it("metafields-set without metafieldKey rejects", async () => {
+      await expect(
+        parseCartRequest(
+          formRequest({
+            intent: "metafields-set",
+            metafieldType: "boolean",
+            metafieldValue: "true",
+          }),
+        ),
+      ).rejects.toThrow(/metafieldKey/i);
+    });
+
+    it("metafields-set without metafieldType rejects", async () => {
+      await expect(
+        parseCartRequest(
+          formRequest({
+            intent: "metafields-set",
+            metafieldKey: "custom.gift",
+            metafieldValue: "true",
+          }),
+        ),
+      ).rejects.toThrow(/metafieldType/i);
+    });
+
+    it("metafields-set without metafieldValue rejects", async () => {
+      await expect(
+        parseCartRequest(
+          formRequest({
+            intent: "metafields-set",
+            metafieldKey: "custom.gift",
+            metafieldType: "boolean",
+          }),
+        ),
+      ).rejects.toThrow(/metafieldValue/i);
+    });
+
+    it("metafield-delete produces a delete action", async () => {
+      const { action } = await parseCartRequest(
+        formRequest({ intent: "metafield-delete", metafieldKey: "custom.gift" }),
+      );
+      expect(action).toEqual({ intent: "metafield-delete", key: "custom.gift" });
+    });
+
+    it("metafield-delete without metafieldKey rejects", async () => {
+      await expect(parseCartRequest(formRequest({ intent: "metafield-delete" }))).rejects.toThrow(
+        /metafieldKey/i,
       );
     });
   });

--- a/packages/hydrogen/src/core/cart/actions.ts
+++ b/packages/hydrogen/src/core/cart/actions.ts
@@ -1,3 +1,4 @@
+import type { CartInputMetafieldInput } from "../../graphql/generated/storefront-api-types";
 import { normalizeCartId } from "./cookie";
 
 export type CartLineAddInput = {
@@ -14,11 +15,7 @@ export type CartLineUpdateInput = {
   sellingPlanId?: string;
 };
 
-export type CartMetafieldInput = {
-  key: string;
-  type: string;
-  value: string;
-};
+export type CartMetafieldInput = CartInputMetafieldInput;
 
 export type CartAction =
   | { intent: "add"; lines: CartLineAddInput[] }

--- a/packages/hydrogen/src/core/cart/actions.ts
+++ b/packages/hydrogen/src/core/cart/actions.ts
@@ -14,6 +14,12 @@ export type CartLineUpdateInput = {
   sellingPlanId?: string;
 };
 
+export type CartMetafieldInput = {
+  key: string;
+  type: string;
+  value: string;
+};
+
 export type CartAction =
   | { intent: "add"; lines: CartLineAddInput[] }
   | { intent: "update"; lines: CartLineUpdateInput[] }
@@ -21,7 +27,9 @@ export type CartAction =
   | { intent: "discount-update"; discountCodes: string[] }
   | { intent: "discount-apply"; code: string }
   | { intent: "discount-remove"; code: string }
-  | { intent: "note-update"; note: string };
+  | { intent: "note-update"; note: string }
+  | { intent: "metafields-set"; metafields: CartMetafieldInput[] }
+  | { intent: "metafield-delete"; key: string };
 
 type ParsedCartRequest = {
   action: CartAction;
@@ -74,8 +82,22 @@ function parseJsonBody(body: unknown): ParsedCartRequest {
     };
   }
 
+  if ("metafields" in body && Array.isArray(body.metafields)) {
+    return { action: parseMetafieldsSet(body.metafields), cartId };
+  }
+
+  if ("deleteMetafield" in body) {
+    assertString(body.deleteMetafield, "deleteMetafield");
+    if (body.deleteMetafield === "") {
+      throw new CartActionError('"deleteMetafield" must be a non-empty metafield key.');
+    }
+    return { action: { intent: "metafield-delete", key: body.deleteMetafield }, cartId };
+  }
+
   if (!("lines" in body) || !Array.isArray(body.lines)) {
-    throw new CartActionError('Request body must contain "lines", "discountCodes", or "note".');
+    throw new CartActionError(
+      'Request body must contain "lines", "discountCodes", "note", "metafields", or "deleteMetafield".',
+    );
   }
 
   const lines = body.lines as unknown[];
@@ -147,6 +169,22 @@ function partitionLines(rawLines: unknown[]): CartAction {
   return { intent: "remove", lineIds: removeIds };
 }
 
+function parseMetafieldsSet(rawMetafields: unknown[]): CartAction {
+  if (rawMetafields.length === 0) {
+    throw new CartActionError("Metafields array must not be empty.");
+  }
+
+  const metafields = rawMetafields.map((raw): CartMetafieldInput => {
+    assertObject(raw);
+    assertString(raw.key, "metafields[].key");
+    assertString(raw.type, "metafields[].type");
+    assertString(raw.value, "metafields[].value");
+    return { key: raw.key, type: raw.type, value: raw.value };
+  });
+
+  return { intent: "metafields-set", metafields };
+}
+
 function extractOptionalLineFields(
   line: Record<string, unknown>,
 ): Pick<CartLineAddInput, "attributes" | "sellingPlanId"> {
@@ -173,6 +211,7 @@ function extractOptionalLineFields(
 //   Discount bulk:  no FormData equivalent — forms handle one code at a time
 //   Attributes:     not supported in FormData (nested objects can't be expressed in flat fields)
 //   Selling plan:   add only — no way to change selling plan on existing line via form
+//   Metafields:     one metafield per submission (flat metafieldKey/Type/Value fields)
 //
 // Design decisions:
 //   - `intent` field disambiguates operations (forms need explicit routing; JSON infers from structure)
@@ -216,9 +255,38 @@ function parseFormData(form: FormData): CartAction {
     return parseNoteIntent(form);
   }
 
+  if (intent === "metafields-set") {
+    return parseMetafieldsSetIntent(form);
+  }
+
+  if (intent === "metafield-delete") {
+    return { intent: "metafield-delete", key: requireMetafieldKey(form, intent) };
+  }
+
   throw new CartActionError(
-    `Unknown intent "${intent}". Expected one of: add, increase, decrease, remove, set, discount-apply, discount-remove, note-update.`,
+    `Unknown intent "${intent}". Expected one of: add, increase, decrease, remove, set, discount-apply, discount-remove, note-update, metafields-set, metafield-delete.`,
   );
+}
+
+function parseMetafieldsSetIntent(form: FormData): CartAction {
+  const key = requireMetafieldKey(form, "metafields-set");
+  const type = formString(form, "metafieldType");
+  if (!type) {
+    throw new CartActionError('Intent "metafields-set" requires a "metafieldType" field.');
+  }
+  const value = form.get("metafieldValue");
+  if (value === null) {
+    throw new CartActionError('Intent "metafields-set" requires a "metafieldValue" field.');
+  }
+  return { intent: "metafields-set", metafields: [{ key, type, value: String(value) }] };
+}
+
+function requireMetafieldKey(form: FormData, intent: string): string {
+  const key = formString(form, "metafieldKey");
+  if (!key) {
+    throw new CartActionError(`Intent "${intent}" requires a "metafieldKey" field.`);
+  }
+  return key;
 }
 
 function parseLineIntent(intent: string, form: FormData): CartAction {

--- a/packages/hydrogen/src/core/cart/index.ts
+++ b/packages/hydrogen/src/core/cart/index.ts
@@ -9,7 +9,12 @@ export { createCartFormRegister } from "./form";
 export type { CartFormRegister, QuantityInputAttributes, SetButtonAttributes } from "./form";
 export { attachQuantityInput } from "./attach-quantity-input";
 export { parseCartRequest } from "./actions";
-export type { CartAction, CartLineAddInput, CartLineUpdateInput } from "./actions";
+export type {
+  CartAction,
+  CartLineAddInput,
+  CartLineUpdateInput,
+  CartMetafieldInput,
+} from "./actions";
 export { cartQueries } from "./queries";
 export { createCartCookie } from "./cookie";
 export type {

--- a/packages/hydrogen/src/core/cart/queries.test.ts
+++ b/packages/hydrogen/src/core/cart/queries.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { gql } from "../../graphql";
-import { cartQueries, makeCartQueries } from "./queries";
+import {
+  cartMetafieldDeleteMutation,
+  cartMetafieldsSetMutation,
+  cartQueries,
+  makeCartQueries,
+} from "./queries";
 
 const customCartFragment = gql(`
   fragment CartFragment on Cart {
@@ -75,6 +80,24 @@ describe("cartQueries", () => {
 
     for (const query of Object.values(customQueries)) {
       expect(query).toContain("quantityAvailable");
+    }
+  });
+
+  it("declares Storefront API context on metafield mutations", () => {
+    for (const mutation of [cartMetafieldsSetMutation, cartMetafieldDeleteMutation]) {
+      expect(mutation).toContain("$country: CountryCode");
+      expect(mutation).toContain("$language: LanguageCode");
+      expect(mutation).toContain("@inContext(country: $country, language: $language)");
+    }
+  });
+
+  it("keeps metafield mutations free of cart fragment spreads", () => {
+    // cartMetafieldsSet and cartMetafieldDelete responses contain no cart
+    // object, so there is no cart selection to spread fragments into.
+    for (const mutation of [cartMetafieldsSetMutation, cartMetafieldDeleteMutation]) {
+      expect(mutation).toContain("userErrors");
+      expect(mutation).not.toContain("...HydrogenCartFragment");
+      expect(mutation).not.toContain("...CartFragment");
     }
   });
 

--- a/packages/hydrogen/src/core/cart/queries.ts
+++ b/packages/hydrogen/src/core/cart/queries.ts
@@ -423,6 +423,49 @@ const DEFAULT_CART_QUERIES = {
 
 type DefaultCartQueries = typeof DEFAULT_CART_QUERIES;
 
+// cartMetafieldsSet and cartMetafieldDelete are the only SFAPI cart mutations
+// whose responses contain no cart object, only userErrors. With no cart
+// selection to spread fragments into, these mutation strings are identical
+// whether or not a custom CartFragment is configured, so they are plain
+// constants outside makeCartQueries. The server handler refetches the cart
+// after mutating to return up-to-date cart data.
+const CART_METAFIELDS_SET_MUTATION_SOURCE = /* GraphQL */ `
+  mutation CartMetafieldsSet(
+    $metafields: [CartMetafieldsSetInput!]!
+    $country: CountryCode
+    $language: LanguageCode
+  ) @inContext(country: $country, language: $language) {
+    cartMetafieldsSet(metafields: $metafields) {
+      userErrors {
+        code
+        elementIndex
+        field
+        message
+      }
+    }
+  }
+`;
+
+const CART_METAFIELD_DELETE_MUTATION_SOURCE = /* GraphQL */ `
+  mutation CartMetafieldDelete(
+    $input: CartMetafieldDeleteInput!
+    $country: CountryCode
+    $language: LanguageCode
+  ) @inContext(country: $country, language: $language) {
+    cartMetafieldDelete(input: $input) {
+      userErrors {
+        code
+        field
+        message
+      }
+    }
+  }
+`;
+
+export const cartMetafieldsSetMutation = gql(CART_METAFIELDS_SET_MUTATION_SOURCE);
+
+export const cartMetafieldDeleteMutation = gql(CART_METAFIELD_DELETE_MUTATION_SOURCE);
+
 type QueryFor<
   Source extends string,
   Fragments extends readonly AnyStorefrontQueryString[],

--- a/packages/hydrogen/src/core/cart/queries.type-test.ts
+++ b/packages/hydrogen/src/core/cart/queries.type-test.ts
@@ -3,7 +3,12 @@ import type { ResultOf, VariablesOf } from "gql.tada";
 
 import type { StorefrontGraphqlResult } from "../../client";
 import { gql } from "../../graphql";
-import type { CartDataForOptions, cartQueries } from "./queries";
+import type {
+  CartDataForOptions,
+  cartMetafieldDeleteMutation,
+  cartMetafieldsSetMutation,
+  cartQueries,
+} from "./queries";
 import { makeCartQueries } from "./queries";
 
 const customCartFragment = gql(`
@@ -39,6 +44,17 @@ const inventoryCartFragment = gql(`
   }
 `);
 const inventoryCartQueries = makeCartQueries({ fragment: inventoryCartFragment });
+
+const metafieldsCartFragment = gql(`
+  fragment CartFragment on Cart {
+    metafields(identifiers: [{ namespace: "custom", key: "gift" }]) {
+      namespace
+      key
+      type
+      value
+    }
+  }
+`);
 
 type CartWithLines = {
   lines: { nodes: Array<{ merchandise?: unknown }> };
@@ -118,6 +134,29 @@ describe("cart query result types", () => {
     type R = ResultOf<typeof cartQueries.cartNoteUpdate>;
     expectTypeOf<R>().toHaveProperty("cartNoteUpdate");
   });
+
+  it("cartMetafieldsSet returns userErrors and no cart", () => {
+    type R = ResultOf<typeof cartMetafieldsSetMutation>;
+    type Payload = NonNullable<R["cartMetafieldsSet"]>;
+    expectTypeOf<Payload>().toHaveProperty("userErrors");
+    expectTypeOf<keyof Payload>().not.toEqualTypeOf<"cart">();
+  });
+
+  it("cartMetafieldDelete returns userErrors and no cart", () => {
+    type R = ResultOf<typeof cartMetafieldDeleteMutation>;
+    type Payload = NonNullable<R["cartMetafieldDelete"]>;
+    expectTypeOf<Payload>().toHaveProperty("userErrors");
+    expectTypeOf<keyof Payload>().not.toEqualTypeOf<"cart">();
+  });
+
+  it("metafields cart fragments flow into cart query and handler data types", () => {
+    const metafieldsCartQueries = makeCartQueries({ fragment: metafieldsCartFragment });
+    type R = ResultOf<typeof metafieldsCartQueries.cart>;
+    type Cart = CartDataForOptions<{ readonly fragment: typeof metafieldsCartFragment }>;
+
+    expectTypeOf<NonNullable<R["cart"]>>().toHaveProperty("metafields");
+    expectTypeOf<Cart>().toHaveProperty("metafields");
+  });
 });
 
 describe("cart query variable types", () => {
@@ -162,6 +201,18 @@ describe("cart query variable types", () => {
     type V = VariablesOf<typeof cartQueries.cartNoteUpdate>;
     expectTypeOf<V>().toHaveProperty("cartId");
     expectTypeOf<V>().toHaveProperty("note");
+  });
+
+  it("cartMetafieldsSet requires metafields with ownerId", () => {
+    type V = VariablesOf<typeof cartMetafieldsSetMutation>;
+    expectTypeOf<V>().toHaveProperty("metafields");
+    expectTypeOf<V["metafields"][number]>().toHaveProperty("ownerId");
+  });
+
+  it("cartMetafieldDelete requires input with ownerId and key", () => {
+    type V = VariablesOf<typeof cartMetafieldDeleteMutation>;
+    expectTypeOf<V["input"]>().toHaveProperty("ownerId");
+    expectTypeOf<V["input"]>().toHaveProperty("key");
   });
 });
 

--- a/packages/hydrogen/src/core/cart/route.test.ts
+++ b/packages/hydrogen/src/core/cart/route.test.ts
@@ -207,7 +207,8 @@ describe("createCartServerHandlers", () => {
       if (result.type !== "error") throw new Error("expected error result");
       expect(result.error).toEqual({
         code: "invalid_cart_request",
-        message: 'Request body must contain "lines", "discountCodes", or "note".',
+        message:
+          'Request body must contain "lines", "discountCodes", "note", "metafields", or "deleteMetafield".',
       });
       expect("status" in result).toBe(false);
     });
@@ -645,6 +646,144 @@ describe("createCartServerHandlers", () => {
     });
   });
 
+  describe("POST — JSON metafields", () => {
+    const GIFT_METAFIELD = { key: "custom.gift", type: "boolean", value: "true" };
+
+    it("sets metafields with injected ownerId then refetches the cart", async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockGqlResponse({ cartMetafieldsSet: { userErrors: [] } }))
+        .mockResolvedValueOnce(mockGqlResponse({ cart: MOCK_CART }));
+
+      const result = await handleCartRequest(
+        createJsonPostRequest({ metafields: [GIFT_METAFIELD] }, "cart=123"),
+        defaultConfig,
+      );
+
+      assert(result, "expected a response");
+      expect(result.status).toBe(200);
+
+      const body = await result.json();
+      expect(body.cart).toEqual(MOCK_CART);
+      expect(body.userErrors).toEqual([]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [, mutationInit] = mockFetch.mock.calls[0];
+      const mutationBody = JSON.parse(mutationInit.body);
+      expect(mutationBody.query).toContain("cartMetafieldsSet");
+      expect(mutationBody.variables.metafields).toEqual([
+        { ...GIFT_METAFIELD, ownerId: "gid://shopify/Cart/123" },
+      ]);
+
+      const [, refetchInit] = mockFetch.mock.calls[1];
+      const refetchBody = JSON.parse(refetchInit.body);
+      expect(refetchBody.query).toContain("query Cart");
+      expect(refetchBody.variables.id).toBe("gid://shopify/Cart/123");
+    });
+
+    it("creates a cart with metafields when no cart exists", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockGqlResponse({ cartCreate: { cart: MOCK_CART, userErrors: [] } }),
+      );
+
+      const result = await handleCartRequest(
+        createJsonPostRequest({ metafields: [GIFT_METAFIELD] }),
+        defaultConfig,
+      );
+
+      assert(result, "expected a response");
+      expect(result.status).toBe(200);
+      expect(result.headers.get("set-cookie")).toContain("cart=");
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0];
+      const gqlBody = JSON.parse(init.body);
+      expect(gqlBody.query).toContain("cartCreate");
+      expect(gqlBody.variables.input.metafields).toEqual([GIFT_METAFIELD]);
+    });
+
+    it("returns metafield userErrors alongside the refetched cart", async () => {
+      const userErrors = [
+        { code: "INVALID_TYPE", elementIndex: 0, field: ["type"], message: "Invalid type" },
+      ];
+      mockFetch
+        .mockResolvedValueOnce(mockGqlResponse({ cartMetafieldsSet: { userErrors } }))
+        .mockResolvedValueOnce(mockGqlResponse({ cart: MOCK_CART }));
+
+      const result = await handleCartRequest(
+        createJsonPostRequest({ metafields: [GIFT_METAFIELD] }, "cart=123"),
+        defaultConfig,
+      );
+
+      assert(result, "expected a response");
+      expect(result.status).toBe(200);
+      const body = await result.json();
+      expect(body.userErrors).toEqual(userErrors);
+      expect(body.cart).toEqual(MOCK_CART);
+    });
+
+    it("deletes a metafield by key then refetches the cart", async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockGqlResponse({ cartMetafieldDelete: { userErrors: [] } }))
+        .mockResolvedValueOnce(mockGqlResponse({ cart: MOCK_CART }));
+
+      const result = await handleCartRequest(
+        createJsonPostRequest({ deleteMetafield: "custom.gift" }, "cart=123"),
+        defaultConfig,
+      );
+
+      assert(result, "expected a response");
+      expect(result.status).toBe(200);
+
+      const body = await result.json();
+      expect(body.cart).toEqual(MOCK_CART);
+      expect(body.userErrors).toEqual([]);
+
+      const [, init] = mockFetch.mock.calls[0];
+      const gqlBody = JSON.parse(init.body);
+      expect(gqlBody.query).toContain("cartMetafieldDelete");
+      expect(gqlBody.variables.input).toEqual({
+        ownerId: "gid://shopify/Cart/123",
+        key: "custom.gift",
+      });
+    });
+
+    it("returns 400 missing_cart for metafield-delete without a cart", async () => {
+      const result = await handleCartRequest(
+        createJsonPostRequest({ deleteMetafield: "custom.gift" }),
+        defaultConfig,
+      );
+
+      assert(result, "expected a response");
+      expect(result.status).toBe(400);
+      const body = await result.json();
+      expect(body.error.code).toBe("missing_cart");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 303 redirect for FormData metafields-set", async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockGqlResponse({ cartMetafieldsSet: { userErrors: [] } }))
+        .mockResolvedValueOnce(mockGqlResponse({ cart: MOCK_CART }));
+
+      const result = await handleCartRequest(
+        createFormPostRequest(
+          {
+            intent: "metafields-set",
+            metafieldKey: "custom.gift",
+            metafieldType: "boolean",
+            metafieldValue: "true",
+          },
+          { cookies: "cart=123", referer: "https://my-app.com/cart" },
+        ),
+        defaultConfig,
+      );
+
+      assert(result, "expected a response");
+      expect(result.status).toBe(303);
+      expect(result.headers.get("location")).toBe(`${APP_ORIGIN}/cart`);
+    });
+  });
+
   describe("POST — JSON error handling", () => {
     it("returns 400 for invalid request body", async () => {
       const result = await handleCartRequest(createJsonPostRequest({}), defaultConfig);
@@ -653,7 +792,8 @@ describe("createCartServerHandlers", () => {
       const body = await result.json();
       expect(body.error).toEqual({
         code: "invalid_cart_request",
-        message: 'Request body must contain "lines", "discountCodes", or "note".',
+        message:
+          'Request body must contain "lines", "discountCodes", "note", "metafields", or "deleteMetafield".',
       });
     });
 

--- a/packages/hydrogen/src/core/cart/server-handlers.ts
+++ b/packages/hydrogen/src/core/cart/server-handlers.ts
@@ -12,10 +12,12 @@ import type {
 } from "../request-routing/registered-routes";
 import { createCallableRouteHandler } from "../request-routing/registered-routes";
 import { parseCartRequest } from "./actions";
-import type { CartAction, CartLineAddInput } from "./actions";
+import type { CartAction, CartLineAddInput, CartMetafieldInput } from "./actions";
 import { getCartIdFromCookie, createCartCookie } from "./cookie";
 import { getCart, getCartId, type CartDataFromQuery } from "./get-cart";
 import {
+  cartMetafieldDeleteMutation,
+  cartMetafieldsSetMutation,
   cartQueries,
   makeCartQueries,
   type CartDataForOptions,
@@ -177,7 +179,7 @@ async function handlePost(
   const cookieCartId = getCartIdFromCookie(request);
   const cartId = bodyCartId ?? cookieCartId;
 
-  if (action.intent !== "add" && !cartId) {
+  if (!CART_CREATING_INTENTS.has(action.intent) && !cartId) {
     if (isFormRequest) return redirectResult(redirectTarget);
     return errorResult("missing_cart", "No cart exists. Add an item first.");
   }
@@ -254,6 +256,9 @@ function createMutationResult(
   };
 }
 
+// Intents that fall back to cartCreate when no cart exists yet.
+const CART_CREATING_INTENTS: ReadonlySet<CartAction["intent"]> = new Set(["add", "metafields-set"]);
+
 type CartMutationClient = Pick<StorefrontClient, "graphql">;
 
 async function executeMutation(
@@ -266,8 +271,12 @@ async function executeMutation(
     return executeAdd(action.lines, cartId, storefront, queries);
   }
 
+  if (action.intent === "metafields-set") {
+    return executeMetafieldsSet(action.metafields, cartId, storefront, queries);
+  }
+
   if (!cartId) {
-    throw new Error("cartId is required for non-add mutations");
+    throw new Error("cartId is required for mutations that cannot create a cart");
   }
 
   switch (action.intent) {
@@ -303,6 +312,14 @@ async function executeMutation(
       const { cart, userErrors, warnings } = assertMutationData(result, "cartNoteUpdate");
       return createMutationResult(cart, userErrors, warnings, result.headers);
     }
+    case "metafield-delete": {
+      const result = await storefront.graphql(cartMetafieldDeleteMutation, {
+        variables: { input: { ownerId: cartId, key: action.key } },
+      });
+      const { userErrors } = assertMutationData(result, "cartMetafieldDelete");
+      return refetchCartAfterMetafieldMutation(cartId, userErrors, storefront, queries);
+    }
+
     default: {
       const _exhaustive: never = action;
       throw new Error(`Unhandled cart action intent: ${(_exhaustive as CartAction).intent}`);
@@ -329,6 +346,40 @@ async function executeAdd(
   });
   const { cart, userErrors, warnings } = assertMutationData(result, "cartCreate");
   return createMutationResult(cart, userErrors, warnings, result.headers);
+}
+
+// cartMetafieldsSet/cartMetafieldDelete return no cart in their payloads — only
+// userErrors — so the cart is refetched to keep MutationResult uniform across intents.
+async function refetchCartAfterMetafieldMutation(
+  cartId: string,
+  userErrors: unknown,
+  storefront: CartMutationClient,
+  queries: RuntimeCartQueries,
+): Promise<MutationResult> {
+  const result = await storefront.graphql(queries.cart, { variables: { id: cartId } });
+  const { cart } = assertGraphQLData(result);
+  return createMutationResult(cart, userErrors, [], result.headers);
+}
+
+async function executeMetafieldsSet(
+  metafields: CartMetafieldInput[],
+  cartId: string | null,
+  storefront: CartMutationClient,
+  queries: RuntimeCartQueries,
+): Promise<MutationResult> {
+  if (!cartId) {
+    const result = await storefront.graphql(queries.cartCreate, {
+      variables: { input: { metafields } },
+    });
+    const { cart, userErrors, warnings } = assertMutationData(result, "cartCreate");
+    return createMutationResult(cart, userErrors, warnings, result.headers);
+  }
+
+  const result = await storefront.graphql(cartMetafieldsSetMutation, {
+    variables: { metafields: metafields.map((metafield) => ({ ...metafield, ownerId: cartId })) },
+  });
+  const { userErrors } = assertMutationData(result, "cartMetafieldsSet");
+  return refetchCartAfterMetafieldMutation(cartId, userErrors, storefront, queries);
 }
 
 async function executeDiscountModify(

--- a/packages/hydrogen/src/core/index.ts
+++ b/packages/hydrogen/src/core/index.ts
@@ -82,7 +82,7 @@ export { createCartFormRegister } from "./cart";
 export type { CartFormRegister, QuantityInputAttributes, SetButtonAttributes } from "./cart";
 export { attachQuantityInput } from "./cart";
 export { parseCartRequest } from "./cart";
-export type { CartAction, CartLineAddInput, CartLineUpdateInput } from "./cart";
+export type { CartAction, CartLineAddInput, CartLineUpdateInput, CartMetafieldInput } from "./cart";
 export { cartQueries, createCartCookie } from "./cart";
 export { getCartId, getCart, createCartServerHandlers } from "./cart";
 export type {


### PR DESCRIPTION
TL;DR: The preview cart API had no way to set or delete cart metafields. Standard Actions (cart ajax) doesn't support metafields, so this adds server-only `metafields-set` and `metafield-delete` intents to `/api/cart`, plus an example that uses them for buyer delivery instructions that copy onto the order.

## Before

`POST /api/cart` only understood line, discount, and note operations. Setting a cart metafield required writing a custom route with raw Storefront API mutations, including the awkward part: `cartMetafieldsSet` and `cartMetafieldDelete` are the only cart mutations whose responses contain no cart object, only `userErrors`.

## After

```jsonc
// set (JSON body shape is structure-inferred, like note/discountCodes/lines)
{ "metafields": [{ "key": "custom.delivery_instructions", "type": "multi_line_text_field", "value": "Leave at back door" }] }

// delete
{ "deleteMetafield": "custom.delivery_instructions" }
```

Forms are supported too, one metafield per submission: `intent=metafields-set` with `metafieldKey` / `metafieldType` / `metafieldValue` fields, and `intent=metafield-delete` with `metafieldKey`.

## What this changes

- `actions.ts`: parses the two new intents from JSON and FormData. The parser rebuilds each metafield as exactly `{key, type, value}` — a client can't smuggle in an `ownerId`; the server injects it from the resolved cart id.
- `queries.ts`: adds the two mutations as standalone constants. Their responses have no cart object, so no cart fragment applies and they live outside `makeCartQueries`, preserving the invariant that every `cartQueries` document spreads the cart fragments.
- `server-handlers.ts`: after mutating, the handler refetches the cart with `queries.cart` so every intent returns the same uniform result shape — and the refetch carries the user's custom `CartFragment`, so the response includes the metafields just written. `metafields-set` without an existing cart falls back to `cartCreate({ metafields })`, matching old Hydrogen.
- Example: new `CartDeliveryInstructions` component in the cart summary. It posts JSON with `fetch` (no navigation) and renders the saved value from the POST response. `cart-handlers.ts` now passes a `CartFragment` selecting the metafield, demonstrating typed read-back end to end.

## Developer impact

- New exported type: `CartMetafieldInput`. The `CartAction` union gains two members.
- Metafields are **server-only**: they don't ride the optimistic cart store because Standard Actions has no metafields payload or event. The example documents this and shows the pattern (local state from the POST response).
- **No changeset included yet** — this should get a **minor** changeset for `@shopify/hydrogen` (additive API surface: new intents and a new exported type).

## UX impact

Example only: the cart page and aside get a "Delivery instructions" textarea with save/remove buttons, a disabled-while-saving state, and a `role="status"` message for saved/error feedback.

## Out of scope

- Other server-only cart operations old Hydrogen supported (attributes, gift cards, buyer identity, delivery addresses/options). Metafields are the only cart mutations returning no cart payload, so the refetch pattern here doesn't need generalizing to those.
- Optimistic client-store support — blocked on Standard Actions.

## Risk

- Each metafield set/delete costs an extra Storefront API round trip (mutation + cart refetch). Accepted to keep the mutation result shape uniform across intents.
- The example's cart store keeps a stale copy of metafields after a save; each mounted instance (page and aside) tracks its own saves until the store's next revalidation.

## How to Test

1. Run `pnpm install && pnpm --filter @shopify/hydrogen build` to rebuild the package.
2. Create local env files for the example (`examples/hydrogen/.env`) pointing at a store, and start the example hydrogen dev server.
3. Open `http://localhost:5173`, add a product to the cart, and open `/cart`.
4. Under Totals, enter delivery instructions and select **Save instructions**. Confirm "Saved." appears without a page reload.
5. Reload the page. Confirm the saved instructions render from cart data.
6. Select **Remove instructions**. Confirm the value clears and the remove button disappears.
7. To verify order copy: the store needs an **order** metafield definition for `custom.delivery_instructions` with the cart-to-order copyable capability enabled. Place a test order and check the order's metafields in admin.
