### PR TITLE
Prefer buyer-claims route in agent proxy tests

### DIFF
--- a/packages/hydrogen/src/core/request-routing/interceptors/agent-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/agent-proxy.test.ts
@@ -112,7 +112,7 @@ describe("handleAgentProxy", () => {
   });
 
   it("forwards the embedding parent origin through a browser-forbidden Sec header", async () => {
-    await handleAgentProxy(createRequest("/agent/handoff", "https://headless.example"));
+    await handleAgentProxy(createRequest("/agent/buyer-claims", "https://headless.example"));
 
     const call = mockFetch.mock.calls[0];
     assert(call, "expected fetch to be called");
@@ -122,7 +122,7 @@ describe("handleAgentProxy", () => {
   });
 
   it("forwards explicit-port loopback origins for local development", async () => {
-    await handleAgentProxy(createRequest("/agent/handoff", "http://localhost:3000"));
+    await handleAgentProxy(createRequest("/agent/buyer-claims", "http://localhost:3000"));
 
     const call = mockFetch.mock.calls[0];
     assert(call, "expected fetch to be called");
@@ -132,7 +132,7 @@ describe("handleAgentProxy", () => {
   });
 
   it("does not allow incoming headers to override the request origin", async () => {
-    const request = new Request("https://headless.example/agent/handoff", {
+    const request = new Request("https://headless.example/agent/buyer-claims", {
       headers: {
         [SHOPIFY_CHAT_FRAME_ORIGIN_HEADER]: "https://attacker.example",
       },

--- a/packages/hydrogen/src/core/url.ts
+++ b/packages/hydrogen/src/core/url.ts
@@ -4,6 +4,7 @@ export const SHOPIFY_API_PROXY_RE = /^\/__shopify(?:\/|$)/;
 export const MCP_RE = /^\/api\/mcp$/;
 export const CHECKOUT_RE = /^\/checkout$/;
 export const CART_PERMALINK_RE = /^\/cart\/\d+:\d+(?:,\d+:\d+)*$/;
+// `handoff` is a legacy rollout alias; `buyer-claims` is the canonical route.
 export const AGENT_BUYER_CLAIMS_RE =
   /^(?:\/[a-z]{2}(?:-[a-z]{2})?)?\/agent\/(?:handoff|buyer-claims)(?:\.[^/.]+)?\/?$/i;
 export const AJAX_CART_RE =


### PR DESCRIPTION


### WHY are these changes introduced?

The Storefront Agent proxy already accepts both `/agent/handoff` and `/agent/buyer-claims`. `buyer-claims` is the canonical route; `handoff` stays as a legacy rollout alias until the rename bakes. The behavior tests still used `handoff`, which read as the default.

### WHAT is this pull request doing?

- Uses `/agent/buyer-claims` in the three proxy behavior tests (origin forwarding, loopback origins, header-override guard).
- Documents in `url.ts` that `handoff` is a legacy alias and `buyer-claims` is canonical.
- Leaves the route-coverage table exercising both routes.

No changeset. Tests and a code comment only; the runtime contract is unchanged.

### HOW to test your changes?

- [ ] `pnpm test` in `packages/hydrogen` covers `request-routing/interceptors/agent-proxy.test.ts`.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — none, test-only
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes — not required, test/comment only
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation — comment in `url.ts` covers it
