### PR TITLE
Proxy Shopify well-known resources

### DIFF
--- a/.changeset/well-known-proxy.md
+++ b/.changeset/well-known-proxy.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Proxy allowlisted Shopify well-known resources through `handleShopifyRoutes`.

--- a/packages/hydrogen/src/core/headers.ts
+++ b/packages/hydrogen/src/core/headers.ts
@@ -126,7 +126,10 @@ export const AJAX_API_REQUEST_HEADER_ALLOWLIST = defineHeaderList(
   "x-requested-with",
 );
 
-export const SHOPIFY_API_PROXY_REQUEST_HEADER_DENYLIST = defineHeaderList(
+// Hop-by-hop headers must not be forwarded by proxies. `host` and
+// `content-length` are also removed so fetch can derive them for the upstream
+// request. See https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1
+export const PROXY_REQUEST_HEADER_DENYLIST = defineHeaderList(
   "cf-connecting-ip",
   "connection",
   "content-length",

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -101,6 +101,30 @@ describe("handleShopifyRoutes", () => {
     expect(result).toBeInstanceOf(Response);
   });
 
+  it("returns the Apple Pay domain association from the Online Store origin", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("association-file", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+
+    const result = await handleShopifyRoutes({
+      request: new Request(
+        "https://my-app.com/.well-known/apple-developer-merchantid-domain-association",
+      ),
+    });
+
+    assert(result, "expected association response");
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL(
+        "https://test-store.myshopify.com/.well-known/apple-developer-merchantid-domain-association",
+      ),
+      expect.objectContaining({ redirect: "follow" }),
+    );
+    expect(await result.text()).toBe("association-file");
+  });
+
   it("rewrites cart.js AJAX requests to cart.json", async () => {
     await handleShopifyRoutes({
       request: new Request("https://my-app.com/en/cart.js?locale=en"),

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
@@ -4,6 +4,7 @@ import { handleShopifyApiProxy } from "./interceptors/api-proxy";
 import { handleCheckoutRedirect } from "./interceptors/checkout";
 import { handleMcpProxy } from "./interceptors/mcp-proxy";
 import { handleSfapiProxy } from "./interceptors/sfapi-proxy";
+import { handleWellKnownProxy } from "./interceptors/well-known";
 import { handleShopifyRouteHandlers } from "./registered-routes";
 import type { HydrogenRouteHandler, HydrogenRouteInterceptor } from "./route-types";
 import { safeApplyResponseHeaders } from "./safe-apply-response-headers";
@@ -13,6 +14,7 @@ const SHOPIFY_ROUTE_INTERCEPTORS = [
   handleSfapiProxy,
   handleShopifyRouteHandlers,
   handleCheckoutRedirect,
+  handleWellKnownProxy,
   handleMcpProxy,
   handleAgentProxy,
   handleAjaxApi,

--- a/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.ts
@@ -1,11 +1,11 @@
-import { SHOPIFY_API_PROXY_REQUEST_HEADER_DENYLIST } from "../../headers";
+import { PROXY_REQUEST_HEADER_DENYLIST } from "../../headers";
 import { SHOPIFY_API_PROXY_PREFIX, SHOPIFY_API_PROXY_RE } from "../../url";
 import { rewriteShopifyJsPathname } from "./ajax-api";
 import { createProxyInterceptor } from "./proxy";
 
 export const handleShopifyApiProxy = createProxyInterceptor({
   match: SHOPIFY_API_PROXY_RE,
-  headers: { deny: SHOPIFY_API_PROXY_REQUEST_HEADER_DENYLIST },
+  headers: { deny: PROXY_REQUEST_HEADER_DENYLIST },
   rewritePathname: (pathname) => {
     const upstreamPathname =
       "/" + pathname.slice(SHOPIFY_API_PROXY_PREFIX.length).replace(/^\/+/, "");

--- a/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
@@ -14,7 +14,9 @@ type ProxyHeaderOptions = (
 type ProxyDescriptor = {
   headers: ProxyHeaderOptions;
   match: RegExp;
+  methods?: readonly string[];
   formatError?: (message: string) => unknown;
+  redirect?: RequestRedirect;
   scope: string;
   timeoutMs?: number;
   rewritePathname?: (pathname: string) => string;
@@ -27,6 +29,7 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
   return (url, options) => {
     const { request, storefrontClient } = options;
     if (!descriptor.match.test(url.pathname)) return null;
+    if (descriptor.methods && !descriptor.methods.includes(request.method)) return null;
 
     let upstreamUrl: URL;
     let init: RequestInit & { duplex?: "half" };
@@ -42,7 +45,7 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
         body: request.body,
         headers: forwardedHeaders,
         signal: AbortSignal.timeout(descriptor.timeoutMs ?? PROXY_TIMEOUT_MS),
-        redirect: "manual",
+        redirect: descriptor.redirect ?? "manual",
       };
 
       // Node's fetch requires this when forwarding a streaming request body.

--- a/packages/hydrogen/src/core/request-routing/interceptors/well-known.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/well-known.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { configureLogging, resetLoggingForTests } from "../../logging";
+import { createShopifyRequestContext } from "../../request-context";
+import { assert, createTestLogger } from "../../test-utils";
+import { handleWellKnownProxy as handleWellKnownProxyImpl } from "./well-known";
+
+const STORE_URL = "https://test-store.myshopify.com";
+const ASSOCIATION_PATH = "/.well-known/apple-developer-merchantid-domain-association";
+
+function handleWellKnownProxy(request: Request) {
+  const requestContext = createShopifyRequestContext({
+    request,
+    i18n: { country: "US", language: "EN" },
+  });
+
+  return handleWellKnownProxyImpl(new URL(request.url), {
+    request,
+    requestContext,
+    sessionManager: {
+      getSessionOrigin: () => new URL(request.url).origin,
+      getSessionItem: () => undefined,
+      setSessionItem: () => undefined,
+      removeSessionItem: () => undefined,
+    },
+    storefrontClient: {
+      type: "private",
+      i18n: { country: "US", language: "EN", pathPrefix: "" },
+      storeUrl: STORE_URL,
+      apiUrl: `${STORE_URL}/api/2026-04/graphql.json`,
+      requestContext,
+      graphql: vi.fn(),
+    },
+  });
+}
+
+describe("handleWellKnownProxy", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockResolvedValue(
+      new Response("association-file", {
+        status: 200,
+        headers: {
+          "cache-control": "public, max-age=3600",
+          "content-type": "text/plain",
+          "set-cookie": "upstream-cookie=secret",
+          "x-upstream-internal": "secret",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    resetLoggingForTests();
+  });
+
+  it("proxies an allowlisted well-known path to the Online Store origin", async () => {
+    const result = await handleWellKnownProxy(
+      new Request(`https://headless.example${ASSOCIATION_PATH}?source=apple`),
+    );
+
+    assert(result, "expected association response");
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const [url, init] = call;
+    expect(url.href).toBe(`${STORE_URL}${ASSOCIATION_PATH}?source=apple`);
+    expect(init.redirect).toBe("follow");
+    expect(await result.text()).toBe("association-file");
+  });
+
+  it("does not shadow similar well-known paths", async () => {
+    for (const path of [
+      `${ASSOCIATION_PATH}/`,
+      `${ASSOCIATION_PATH}.txt`,
+      "/.well-known/other-association",
+    ]) {
+      const result = await handleWellKnownProxy(new Request(`https://headless.example${path}`));
+      expect(result, `expected ${path} not to be proxied`).toBeNull();
+    }
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards methods so the Online Store origin determines their behavior", async () => {
+    const result = await handleWellKnownProxy(
+      new Request(`https://headless.example${ASSOCIATION_PATH}`, { method: "POST" }),
+    );
+
+    assert(result, "expected upstream response");
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL(`${STORE_URL}${ASSOCIATION_PATH}`),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("forwards request headers like the Shopify API proxy", async () => {
+    await handleWellKnownProxy(
+      new Request(`https://headless.example${ASSOCIATION_PATH}`, {
+        headers: {
+          accept: "text/plain",
+          cookie: "customer=secret",
+          authorization: "Bearer secret",
+          "user-agent": "apple-validator",
+        },
+      }),
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const headers = new Headers(call[1].headers);
+    expect(headers.get("accept")).toBe("text/plain");
+    expect(headers.get("user-agent")).toBe("apple-validator");
+    expect(headers.get("cookie")).toBe("customer=secret");
+    expect(headers.get("authorization")).toBe("Bearer secret");
+    expect(headers.get("Custom-Storefront-Request-Group-ID")).not.toBeNull();
+    expect(headers.get("Sec-Shopify-Storefront-Origin")).toBe("https://headless.example");
+  });
+
+  it("preserves upstream response headers", async () => {
+    const result = await handleWellKnownProxy(
+      new Request(`https://headless.example${ASSOCIATION_PATH}`),
+    );
+
+    assert(result, "expected association response");
+    expect(result.headers.get("content-type")).toBe("text/plain");
+    expect(result.headers.get("cache-control")).toBe("public, max-age=3600");
+    expect(result.headers.get("set-cookie")).toBe("upstream-cookie=secret");
+    expect(result.headers.get("x-upstream-internal")).toBe("secret");
+  });
+
+  it("returns a 502 response and logs upstream failures", async () => {
+    const logger = createTestLogger();
+    configureLogging({ logger });
+    const error = new Error("Connection refused");
+    mockFetch.mockRejectedValueOnce(error);
+
+    const result = await handleWellKnownProxy(
+      new Request(`https://headless.example${ASSOCIATION_PATH}`),
+    );
+
+    assert(result, "expected proxy error response");
+    expect(result.status).toBe(502);
+    expect(logger.error).toHaveBeenCalledWith("request failed", {
+      scope: "well-known-proxy",
+      error,
+    });
+  });
+});

--- a/packages/hydrogen/src/core/request-routing/interceptors/well-known.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/well-known.ts
@@ -1,0 +1,14 @@
+import { PROXY_REQUEST_HEADER_DENYLIST } from "../../headers";
+import { WELL_KNOWN_RE } from "../../url";
+import { createProxyInterceptor } from "./proxy";
+
+/**
+ * Serves allowlisted Shopify well-known resources from the headless storefront
+ * origin so services can verify the customer-facing hostname.
+ */
+export const handleWellKnownProxy = createProxyInterceptor({
+  match: WELL_KNOWN_RE,
+  headers: { deny: PROXY_REQUEST_HEADER_DENYLIST },
+  redirect: "follow",
+  scope: "well-known-proxy",
+});

--- a/packages/hydrogen/src/core/url.ts
+++ b/packages/hydrogen/src/core/url.ts
@@ -6,6 +6,7 @@ export const CHECKOUT_RE = /^\/checkout$/;
 export const CART_PERMALINK_RE = /^\/cart\/\d+:\d+(?:,\d+:\d+)*$/;
 export const AGENT_BUYER_CLAIMS_RE =
   /^(?:\/[a-z]{2}(?:-[a-z]{2})?)?\/agent\/(?:handoff|buyer-claims)(?:\.[^/.]+)?\/?$/i;
+export const WELL_KNOWN_RE = /^\/\.well-known\/(?:apple-developer-merchantid-domain-association)$/;
 export const AJAX_CART_RE =
   /^(?:\/[a-z]{2}(?:-[a-z]{2})?)?\/cart(?:\.(?:js|json)|\/(?:add|update|change|clear)(?:\.(?:js|json))?)$/i;
 


### PR DESCRIPTION
TL;DR: Serve explicitly allowlisted Shopify well-known resources from the headless storefront origin so services such as Apple Pay can verify the customer-facing domain.

## Before

Requests for the Apple merchant domain association file reached the Hydrogen application instead of Shopify. The file was only available from the underlying myshopify.com domain.

## After

handleShopifyRoutes proxies /.well-known/apple-developer-merchantid-domain-association to Shopify and serves the response from the headless storefront domain.

## What this changes

- Adds a generic well-known proxy interceptor with an explicit path allowlist.
- Follows Shopify redirects on the server before returning the response.
- Reuses the shared proxy request-header denylist, including stripping request-derived Cloudflare client IP headers.
- Adds request-routing coverage for matching, forwarding, redirects, methods, query parameters, headers, and failures.

## Developer impact

Includes a patch changeset for @shopify/hydrogen. This adds automatic routing behavior through handleShopifyRoutes without adding a new public API.

## Risk

- Only explicitly allowlisted well-known paths are proxied. Adding another resource requires updating the route matcher.
- Upstream response headers and cookies retain the existing Shopify proxy behavior.

## How to Test

1. Build the Hydrogen package with pnpm --dir packages/hydrogen build.
2. Start the React Router template with a real Shopify storefront domain configured.
3. Open http://localhost:5173/.well-known/apple-developer-merchantid-domain-association.
4. Confirm the request returns 200 with the Apple merchant association body from the local storefront origin.
