### PR TITLE
Add storefront ID to Storefront API requests

### DIFF
--- a/.changeset/storefront-id-analytics.md
+++ b/.changeset/storefront-id-analytics.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": minor
+---
+
+Add an optional `storefrontId` to `createStorefrontClient` so direct and proxied Storefront API requests include the trusted `Shopify-Storefront-Id` header for cart analytics attribution.

--- a/packages/hydrogen/src/client/client.test.ts
+++ b/packages/hydrogen/src/client/client.test.ts
@@ -227,6 +227,18 @@ describe("createStorefrontClient", () => {
       expect(headers.get("X-Shopify-Storefront-Access-Token")).toBe("pub-token-123");
     });
 
+    it("sends the configured storefront ID header", async () => {
+      const client = createPublicClient({
+        storefrontId: "1000014875",
+        fetch: mockFetch,
+      });
+      await client.graphql(SHOP_QUERY);
+
+      const headers = getHeaders(mockFetch);
+      expect(headers.get("Shopify-Storefront-Id")).toBe("1000014875");
+      expect(client.storefrontId).toBe("1000014875");
+    });
+
     it("sends request context headers", async () => {
       const requestContext = createTestRequestContext(
         new Request("https://example.com", {
@@ -937,6 +949,7 @@ function createPublicClient(
     storeDomain?: string;
     apiVersion?: string;
     publicStorefrontToken?: string;
+    storefrontId?: string;
     fetch?: typeof globalThis.fetch;
     cache?: CacheInstance;
     requestContext?: ShopifyRequestContext;
@@ -950,6 +963,7 @@ function createPublicClient(
       storeDomain: overrides.storeDomain ?? "test.myshopify.com",
       apiVersion: overrides.apiVersion,
       publicStorefrontToken: overrides.publicStorefrontToken ?? "test-pub-token",
+      storefrontId: overrides.storefrontId,
       fetch: overrides.fetch,
       cache: overrides.cache,
       defaultTimeoutInMs: overrides.defaultTimeoutInMs,

--- a/packages/hydrogen/src/client/client.ts
+++ b/packages/hydrogen/src/client/client.ts
@@ -17,6 +17,7 @@ import {
   SHOPIFY_STOREFRONT_Y_HEADER,
   STOREFRONT_ACCESS_TOKEN_HEADER,
   STOREFRONT_BUYER_IP_HEADER,
+  STOREFRONT_ID_HEADER,
   STOREFRONT_PRIVATE_TOKEN_HEADER,
   SHOPIFY_UNIQUE_TOKEN_HEADER,
   SHOPIFY_VISIT_TOKEN_HEADER,
@@ -139,6 +140,9 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
   const staticHeaders: Record<string, string> = {
     "content-type": "application/json",
   };
+  if (config.storefrontId) {
+    staticHeaders[STOREFRONT_ID_HEADER] = config.storefrontId;
+  }
 
   switch (clientType) {
     case "private":
@@ -318,6 +322,7 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
     graphql: graphql as StorefrontClient["graphql"],
     apiUrl,
     storeUrl,
+    storefrontId: config.storefrontId,
     requestContext,
   };
 }

--- a/packages/hydrogen/src/client/client.type-test.ts
+++ b/packages/hydrogen/src/client/client.type-test.ts
@@ -173,6 +173,7 @@ describe('type tests', () => {
         config: {
           storeDomain: 'test.myshopify.com',
           publicStorefrontToken: 'pub-token',
+          storefrontId: '1000014875',
           fetch: globalThis.fetch,
           defaultTimeoutInMs: 5000,
         },
@@ -186,6 +187,7 @@ describe('type tests', () => {
         config: {
           storeDomain: 'test.myshopify.com',
           privateStorefrontToken: 'priv-token',
+          storefrontId: '1000014875',
           fetch: globalThis.fetch,
           defaultTimeoutInMs: 5000,
         },
@@ -199,6 +201,7 @@ describe('type tests', () => {
         config: {
           storeDomain: 'test.myshopify.com',
           privateStorefrontToken: 'priv-token',
+          storefrontId: '1000014875',
           fetch: globalThis.fetch,
           defaultTimeoutInMs: 5000,
         },

--- a/packages/hydrogen/src/client/types.ts
+++ b/packages/hydrogen/src/client/types.ts
@@ -57,6 +57,11 @@ export interface GraphQLFormattedError {
 type CommonOptions = {
   storeDomain: string;
   /**
+   * Identifies the Hydrogen storefront making Storefront API requests so Shopify can attribute
+   * cart analytics to the correct storefront.
+   */
+  storefrontId?: string;
+  /**
    * Storefront API version used in the GraphQL endpoint path (`/api/<version>/graphql.json`).
    * Defaults to the version baked into the package. To send some queries to a different endpoint
    * version (e.g. `unstable`), create a second `createStorefrontClient` instance with that
@@ -210,6 +215,7 @@ export type StorefrontClient<
   ) => Promise<StorefrontGraphqlResult<ResolveDoc<Doc>>>;
   apiUrl: string;
   storeUrl: string;
+  storefrontId?: string;
   requestContext: RequestContext;
 };
 

--- a/packages/hydrogen/src/core/headers.ts
+++ b/packages/hydrogen/src/core/headers.ts
@@ -9,6 +9,7 @@ export const SDK_VERSION_HEADER = "X-SDK-Version";
 export const SHOPIFY_CHAT_FRAME_ORIGIN_HEADER = "Sec-Shopify-Chat-Frame-Origin";
 export const SHOPIFY_CLIENT_IP_HEADER = "X-Shopify-Client-IP";
 export const SHOPIFY_STOREFRONT_ORIGIN_HEADER = "Sec-Shopify-Storefront-Origin";
+export const STOREFRONT_ID_HEADER = "Shopify-Storefront-Id";
 export const SHOPIFY_STOREFRONT_S_HEADER = "Shopify-Storefront-S";
 export const SHOPIFY_STOREFRONT_Y_HEADER = "Shopify-Storefront-Y";
 export const SHOPIFY_UNIQUE_TOKEN_HEADER = "X-Shopify-UniqueToken";
@@ -60,6 +61,7 @@ export type ShopifyHeaderName =
   | typeof SHOPIFY_VISIT_TOKEN_HEADER
   | typeof STOREFRONT_ACCESS_TOKEN_HEADER
   | typeof STOREFRONT_BUYER_IP_HEADER
+  | typeof STOREFRONT_ID_HEADER
   | typeof STOREFRONT_PRIVATE_TOKEN_HEADER
   | typeof STOREFRONT_URL_HEADER;
 

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   SHOPIFY_CLIENT_IP_HEADER,
   STOREFRONT_BUYER_IP_HEADER,
+  STOREFRONT_ID_HEADER,
   STOREFRONT_PRIVATE_TOKEN_HEADER,
 } from "../../headers";
 import { configureLogging, resetLoggingForTests } from "../../logging";
@@ -24,7 +25,12 @@ function createRequest(
   });
 }
 
-function handleSfapiProxy(request: Request, storeUrl = defaultStoreUrl, buyerIp = defaultBuyerIp) {
+function handleSfapiProxy(
+  request: Request,
+  storeUrl = defaultStoreUrl,
+  buyerIp = defaultBuyerIp,
+  storefrontId?: string,
+) {
   const requestContext = createShopifyRequestContext({
     request,
     i18n: { country: "US", language: "EN" },
@@ -39,6 +45,7 @@ function handleSfapiProxy(request: Request, storeUrl = defaultStoreUrl, buyerIp 
       i18n: { country: "US", language: "EN", pathPrefix: "" },
       storeUrl,
       apiUrl: `${storeUrl}/api/2026-04/graphql.json`,
+      storefrontId,
       requestContext,
       graphql: vi.fn(),
     },
@@ -272,6 +279,25 @@ describe("handleSfapiProxy", () => {
     const [, init] = call;
     const headers = new Headers(init.headers);
     expect(headers.get(STOREFRONT_PRIVATE_TOKEN_HEADER)).toBe(privateToken);
+  });
+
+  it("uses the configured storefront ID instead of a browser-supplied value", async () => {
+    const configuredStorefrontId = "1000014875";
+
+    await handleSfapiProxy(
+      createRequest("/api/2025-01/graphql.json", {
+        headers: { [STOREFRONT_ID_HEADER]: "untrusted-browser-value" },
+      }),
+      defaultStoreUrl,
+      defaultBuyerIp,
+      configuredStorefrontId,
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const [, init] = call;
+    const headers = new Headers(init.headers);
+    expect(headers.get(STOREFRONT_ID_HEADER)).toBe(configuredStorefrontId);
   });
 
   it("uses the request context buyer IP instead of browser-supplied buyer IP", async () => {

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
@@ -2,6 +2,7 @@ import {
   SFAPI_REQUEST_HEADER_ALLOWLIST,
   SHOPIFY_CLIENT_IP_HEADER,
   STOREFRONT_BUYER_IP_HEADER,
+  STOREFRONT_ID_HEADER,
 } from "../../headers";
 import { SFAPI_RE } from "../../url";
 import { createProxyInterceptor } from "./proxy";
@@ -11,6 +12,11 @@ export const handleSfapiProxy = createProxyInterceptor({
   headers: {
     allow: SFAPI_REQUEST_HEADER_ALLOWLIST,
     prepare: (headers, { requestContext, storefrontClient }) => {
+      headers.delete(STOREFRONT_ID_HEADER);
+      if (storefrontClient.storefrontId) {
+        headers.set(STOREFRONT_ID_HEADER, storefrontClient.storefrontId);
+      }
+
       headers.delete(STOREFRONT_BUYER_IP_HEADER);
       headers.delete(SHOPIFY_CLIENT_IP_HEADER);
       const { buyerIp } = requestContext;

--- a/scripts/decrypt-example-secrets.ts
+++ b/scripts/decrypt-example-secrets.ts
@@ -120,6 +120,7 @@ function getTemplateEnvFileTargets(): EnvFileTarget[] {
   return [
     createEnvFileTarget(resolve(templatesDir, "react-router"), {
       PUBLIC_STORE_DOMAIN: storefrontConfig.storeDomain,
+      PUBLIC_STOREFRONT_ID: shop.storefrontId,
     }),
     createEnvFileTarget(resolve(templatesDir, "nextjs"), {
       SESSION_SECRET: customerAccountConfig.sessionSecret,

--- a/templates/nextjs/lib/public-storefront.ts
+++ b/templates/nextjs/lib/public-storefront.ts
@@ -1,6 +1,6 @@
 import { createShopifyRequestContext, createStorefrontClient } from "@shopify/hydrogen";
 
-import { defaultI18n, storefrontConfig } from "./config";
+import { defaultI18n, shop, storefrontConfig } from "./config";
 
 /**
  * Browser-safe public Storefront client (`hydrogen-storefront-client` /
@@ -43,5 +43,6 @@ export const publicStorefrontClient = createStorefrontClient({
   config: {
     storeDomain: storefrontConfig.storeDomain,
     publicStorefrontToken: storefrontConfig.publicStorefrontToken ?? "",
+    storefrontId: shop.storefrontId,
   },
 });

--- a/templates/nextjs/lib/storefront-config.ts
+++ b/templates/nextjs/lib/storefront-config.ts
@@ -1,4 +1,4 @@
-import { storefrontConfig } from "./config";
+import { shop, storefrontConfig } from "./config";
 import { getOptionalPrivateStorefrontToken } from "./env";
 
 /**
@@ -23,6 +23,7 @@ const SESSION_SECRET_MIN_LENGTH = 32;
 export type ResolvedStorefrontConfig = {
   storeDomain: string;
   privateStorefrontToken: string;
+  storefrontId?: string;
 };
 
 let mockShopFallbackWarned = false;
@@ -70,5 +71,9 @@ export function resolveStorefrontConfig(): ResolvedStorefrontConfig {
       "NEXT_PUBLIC_STORE_DOMAIN is required when PRIVATE_STOREFRONT_API_TOKEN is set.",
     );
   }
-  return { storeDomain, privateStorefrontToken };
+  return {
+    storeDomain,
+    privateStorefrontToken,
+    storefrontId: shop.storefrontId || undefined,
+  };
 }

--- a/templates/nextjs/lib/storefront-static.ts
+++ b/templates/nextjs/lib/storefront-static.ts
@@ -22,7 +22,7 @@ const requestContext = createShopifyRequestContext({
   i18n: DEFAULT_MARKET,
 });
 
-const { storeDomain, privateStorefrontToken } = resolveStorefrontConfig();
+const { storeDomain, privateStorefrontToken, storefrontId } = resolveStorefrontConfig();
 
 export const staticStorefrontClient = createStorefrontClient({
   type: "private_no_buyer_context",
@@ -30,5 +30,6 @@ export const staticStorefrontClient = createStorefrontClient({
   config: {
     storeDomain,
     privateStorefrontToken,
+    storefrontId,
   },
 });

--- a/templates/nextjs/lib/storefront.ts
+++ b/templates/nextjs/lib/storefront.ts
@@ -32,7 +32,7 @@ export const getStorefrontClient = cache(
       buyerIp,
     });
 
-    const { storeDomain, privateStorefrontToken } = resolveStorefrontConfig();
+    const { storeDomain, privateStorefrontToken, storefrontId } = resolveStorefrontConfig();
 
     return createStorefrontClient({
       type: "private",
@@ -40,6 +40,7 @@ export const getStorefrontClient = cache(
       config: {
         storeDomain,
         privateStorefrontToken,
+        storefrontId,
       },
     });
   },

--- a/templates/nextjs/proxy.ts
+++ b/templates/nextjs/proxy.ts
@@ -40,7 +40,7 @@ export async function proxy(request: NextRequest) {
     buyerIp,
   });
 
-  const { storeDomain, privateStorefrontToken } = resolveStorefrontConfig();
+  const { storeDomain, privateStorefrontToken, storefrontId } = resolveStorefrontConfig();
 
   const storefrontClient = createStorefrontClient({
     type: "private",
@@ -48,6 +48,7 @@ export async function proxy(request: NextRequest) {
     config: {
       storeDomain,
       privateStorefrontToken,
+      storefrontId,
     },
   });
 

--- a/templates/react-router/.env.example
+++ b/templates/react-router/.env.example
@@ -9,7 +9,8 @@
 # Force the tokenless mock.shop demo (also the default when no token is set).
 # MOCK_SHOP=1
 
-# Real store (server-only). Set both for real-store mode. On Oxygen, a linked
-# storefront injects these for you.
+# Real store. Set all three for real-store mode. On Oxygen, a linked storefront
+# injects these for you.
 PUBLIC_STORE_DOMAIN=
+PUBLIC_STOREFRONT_ID=
 PRIVATE_STOREFRONT_API_TOKEN=

--- a/templates/react-router/README.md
+++ b/templates/react-router/README.md
@@ -42,11 +42,11 @@ cp .env.example .env
 npm run dev
 ```
 
-**Against a real store** — set your store domain and a **private** Storefront API
-token, then run normally:
+**Against a real store** — set your store domain, storefront ID, and a **private**
+Storefront API token, then run normally:
 
 ```bash
-cp .env.example .env   # set PUBLIC_STORE_DOMAIN + PRIVATE_STOREFRONT_API_TOKEN
+cp .env.example .env   # set PUBLIC_STORE_DOMAIN + PUBLIC_STOREFRONT_ID + PRIVATE_STOREFRONT_API_TOKEN
 npm run dev               # Vite/Mini Oxygen loads .env into the worker environment
 ```
 

--- a/templates/react-router/app/lib/env.ts
+++ b/templates/react-router/app/lib/env.ts
@@ -5,6 +5,7 @@ export type Env = {
   PRIVATE_STOREFRONT_API_TOKEN?: string;
   PUBLIC_CHECKOUT_DOMAIN?: string;
   PUBLIC_STORE_DOMAIN?: string;
+  PUBLIC_STOREFRONT_ID?: string;
 };
 
 export const envContext = createContext<Env>();

--- a/templates/react-router/app/lib/storefront.ts
+++ b/templates/react-router/app/lib/storefront.ts
@@ -12,6 +12,7 @@ import {
   getBuyerIp,
   getPrivateStorefrontToken,
   getStoreDomain,
+  shop,
   storefrontConfig,
   shouldUseMockShop,
 } from "~/lib/shop";
@@ -47,6 +48,7 @@ export function createRequestStorefrontClient(
     config: {
       storeDomain,
       privateStorefrontToken,
+      storefrontId: shop.storefrontId,
     },
   });
 }

--- a/templates/react-router/app/lib/storefront.ts
+++ b/templates/react-router/app/lib/storefront.ts
@@ -12,7 +12,6 @@ import {
   getBuyerIp,
   getPrivateStorefrontToken,
   getStoreDomain,
-  shop,
   storefrontConfig,
   shouldUseMockShop,
 } from "~/lib/shop";
@@ -48,7 +47,7 @@ export function createRequestStorefrontClient(
     config: {
       storeDomain,
       privateStorefrontToken,
-      storefrontId: shop.storefrontId,
+      storefrontId: usingMockShop ? undefined : env.PUBLIC_STOREFRONT_ID,
     },
   });
 }


### PR DESCRIPTION
TL;DR: Allow Hydrogen storefront clients to identify their storefront on Storefront API requests so Shopify can attribute cart analytics correctly.

This header was set by hydrogen-react before, and it seems to be useful for cart analytics.

## Before

`createStorefrontClient` had no storefront identity configuration, and the preview package did not send `Shopify-Storefront-Id` on direct or proxied SFAPI requests.

## After

```ts
createStorefrontClient({
  // ...
  config: {
    storeDomain,
    privateStorefrontToken,
    storefrontId: shop.storefrontId,
  },
});
```

Direct SFAPI calls include the configured header. The SFAPI proxy replaces any browser-supplied value with the trusted client configuration.

## What this changes

- Adds optional `storefrontId` configuration to `createStorefrontClient`.
- Sends `Shopify-Storefront-Id` on direct Storefront API requests.
- Applies the trusted configured ID to proxied Storefront API requests.
- Reuses the React Router template's existing `shop.storefrontId` value.

## Developer impact

Includes a **minor** changeset for `@shopify/hydrogen` because this adds an optional public client configuration field. Existing clients continue to work without changes.

## Risk

- An incorrectly configured storefront ID could attribute analytics to the wrong storefront. The header remains optional and is only sourced from explicit client configuration.