### PR TITLE
Stop sending redundant client IP header

### DIFF
--- a/.changeset/quiet-dogs-listen.md
+++ b/.changeset/quiet-dogs-listen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Remove unused header passed to SFAPI.

--- a/packages/hydrogen/src/client/client.test.ts
+++ b/packages/hydrogen/src/client/client.test.ts
@@ -256,7 +256,7 @@ describe("createStorefrontClient", () => {
       expect(headers.get("Shopify-Storefront-Private-Token")).toBe("priv-token-456");
     });
 
-    it("sends buyer meta headers for private client", async () => {
+    it("sends buyer metadata for private client", async () => {
       const requestContext = createShopifyRequestContext({
         request: new Request("https://example.com", {
           headers: { "request-id": "request-context-group" },
@@ -272,7 +272,6 @@ describe("createStorefrontClient", () => {
 
       const headers = getHeaders(mockFetch);
       expect(headers.get("Shopify-Storefront-Buyer-IP")).toBe("10.0.0.1");
-      expect(headers.get("X-Shopify-Client-IP")).toBe("10.0.0.1");
       expect(headers.get("Custom-Storefront-Request-Group-ID")).toBe("request-context-group");
     });
 

--- a/packages/hydrogen/src/client/client.ts
+++ b/packages/hydrogen/src/client/client.ts
@@ -12,7 +12,6 @@ import {
   SDK_VARIANT_HEADER,
   SDK_VARIANT_SOURCE_HEADER,
   SDK_VERSION_HEADER,
-  SHOPIFY_CLIENT_IP_HEADER,
   SHOPIFY_STOREFRONT_S_HEADER,
   SHOPIFY_STOREFRONT_Y_HEADER,
   STOREFRONT_ACCESS_TOKEN_HEADER,
@@ -58,7 +57,6 @@ const REQUEST_IDENTITY_HEADERS = new Set([
   "cookie",
   REQUEST_GROUP_ID_HEADER.toLowerCase(),
   STOREFRONT_BUYER_IP_HEADER.toLowerCase(),
-  SHOPIFY_CLIENT_IP_HEADER.toLowerCase(),
   SHOPIFY_UNIQUE_TOKEN_HEADER.toLowerCase(),
   SHOPIFY_VISIT_TOKEN_HEADER.toLowerCase(),
   SHOPIFY_STOREFRONT_Y_HEADER.toLowerCase(),
@@ -176,7 +174,6 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
       throw new TypeError("requestContext.buyerIp is required for private Storefront API clients");
     }
     requestHeaders.set(STOREFRONT_BUYER_IP_HEADER, buyerIp);
-    requestHeaders.set(SHOPIFY_CLIENT_IP_HEADER, buyerIp);
   }
 
   async function graphql(

--- a/packages/hydrogen/src/core/headers.ts
+++ b/packages/hydrogen/src/core/headers.ts
@@ -7,7 +7,6 @@ export const SDK_VARIANT_HEADER = "X-SDK-Variant";
 export const SDK_VARIANT_SOURCE_HEADER = "X-SDK-Variant-Source";
 export const SDK_VERSION_HEADER = "X-SDK-Version";
 export const SHOPIFY_CHAT_FRAME_ORIGIN_HEADER = "Sec-Shopify-Chat-Frame-Origin";
-export const SHOPIFY_CLIENT_IP_HEADER = "X-Shopify-Client-IP";
 export const SHOPIFY_STOREFRONT_ORIGIN_HEADER = "Sec-Shopify-Storefront-Origin";
 export const SHOPIFY_STOREFRONT_S_HEADER = "Shopify-Storefront-S";
 export const SHOPIFY_STOREFRONT_Y_HEADER = "Shopify-Storefront-Y";
@@ -52,7 +51,6 @@ export type ShopifyHeaderName =
   | typeof SDK_VARIANT_SOURCE_HEADER
   | typeof SDK_VERSION_HEADER
   | typeof SHOPIFY_CHAT_FRAME_ORIGIN_HEADER
-  | typeof SHOPIFY_CLIENT_IP_HEADER
   | typeof SHOPIFY_STOREFRONT_ORIGIN_HEADER
   | typeof SHOPIFY_STOREFRONT_S_HEADER
   | typeof SHOPIFY_STOREFRONT_Y_HEADER

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -133,7 +133,6 @@ describe("handleShopifyRoutes", () => {
 
     const [, init] = mockFetch.mock.calls[0];
     const headers = new Headers(init.headers);
-    expect(headers.get("X-Shopify-Client-IP")).toBeNull();
     expect(headers.get("x-forwarded-for")).toBeNull();
   });
 

--- a/packages/hydrogen/src/core/request-routing/interceptors/mcp-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/mcp-proxy.test.ts
@@ -167,7 +167,6 @@ describe("handleMcpProxy", () => {
     const [, init] = call;
     const headers = new Headers(init.headers);
     expect(headers.get("X-Shopify-Storefront-Access-Token")).toBeNull();
-    expect(headers.get("X-Shopify-Client-IP")).toBeNull();
     expect(headers.get("x-forwarded-for")).toBeNull();
   });
 

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 
-import {
-  SHOPIFY_CLIENT_IP_HEADER,
-  STOREFRONT_BUYER_IP_HEADER,
-  STOREFRONT_PRIVATE_TOKEN_HEADER,
-} from "../../headers";
+import { STOREFRONT_BUYER_IP_HEADER, STOREFRONT_PRIVATE_TOKEN_HEADER } from "../../headers";
 import { configureLogging, resetLoggingForTests } from "../../logging";
 import { createShopifyRequestContext } from "../../request-context";
 import { assert, createTestLogger } from "../../test-utils";
@@ -291,12 +287,11 @@ describe("handleSfapiProxy", () => {
     const [, init] = call;
     const headers = new Headers(init.headers);
     expect(headers.get(STOREFRONT_BUYER_IP_HEADER)).toBe(trustedBuyerIp);
-    expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBe(trustedBuyerIp);
     expect(headers.get("x-forwarded-for")).toBeNull();
   });
 
   it.each(["public", "private_no_buyer_context"] as const)(
-    "adds request context buyer IP headers for %s clients",
+    "adds the request context buyer IP header for %s clients",
     async (clientType) => {
       const trustedBuyerIp = "1.2.3.4";
       const browserBuyerIp = "5.6.7.8";
@@ -315,11 +310,10 @@ describe("handleSfapiProxy", () => {
       const [, init] = call;
       const headers = new Headers(init.headers);
       expect(headers.get(STOREFRONT_BUYER_IP_HEADER)).toBe(trustedBuyerIp);
-      expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBe(trustedBuyerIp);
     },
   );
 
-  it("does not add buyer IP headers without request context buyer IP", async () => {
+  it("does not add a buyer IP header without request context buyer IP", async () => {
     const browserBuyerIp = "5.6.7.8";
 
     await handleSfapiProxyWithClientType(
@@ -334,7 +328,6 @@ describe("handleSfapiProxy", () => {
     const [, init] = call;
     const headers = new Headers(init.headers);
     expect(headers.get(STOREFRONT_BUYER_IP_HEADER)).toBeNull();
-    expect(headers.get(SHOPIFY_CLIENT_IP_HEADER)).toBeNull();
   });
 
   it("returns 500 when request header preparation fails", async () => {

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
@@ -1,8 +1,4 @@
-import {
-  SFAPI_REQUEST_HEADER_ALLOWLIST,
-  SHOPIFY_CLIENT_IP_HEADER,
-  STOREFRONT_BUYER_IP_HEADER,
-} from "../../headers";
+import { SFAPI_REQUEST_HEADER_ALLOWLIST, STOREFRONT_BUYER_IP_HEADER } from "../../headers";
 import { SFAPI_RE } from "../../url";
 import { createProxyInterceptor } from "./proxy";
 
@@ -12,11 +8,9 @@ export const handleSfapiProxy = createProxyInterceptor({
     allow: SFAPI_REQUEST_HEADER_ALLOWLIST,
     prepare: (headers, { requestContext, storefrontClient }) => {
       headers.delete(STOREFRONT_BUYER_IP_HEADER);
-      headers.delete(SHOPIFY_CLIENT_IP_HEADER);
       const { buyerIp } = requestContext;
       if (buyerIp) {
         headers.set(STOREFRONT_BUYER_IP_HEADER, buyerIp);
-        headers.set(SHOPIFY_CLIENT_IP_HEADER, buyerIp);
         return;
       }
       if (storefrontClient.type === "private") {


### PR DESCRIPTION
TL;DR: Hydrogen currently adds `X-Shopify-Client-IP` to Storefront API requests using the buyer IP. This header is owned by the Shopify runtime and should not be set by Hydrogen.

## What this changes

- Stops setting the extra client IP header in direct private Storefront API requests.
- Stops setting the same header in SFAPI proxy requests.
- Continues setting the documented `Shopify-Storefront-Buyer-IP` header when buyer context is available.
- Removes the internal header constant and related test expectations.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. Storefront API requests no longer include the extra runtime-owned header. There are no new public APIs or migration steps.

## Risk

- Low. Both direct and proxied Storefront API paths retain the documented buyer IP behavior.
