### PR TITLE
Use document navigation for Shopify server handoffs

### DIFF
--- a/.changeset/hard-navigations-handoff.md
+++ b/.changeset/hard-navigations-handoff.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Use document navigation for Shopify checkout and cart permalink routes so Hydrogen can complete its server redirect handoff.

--- a/.changeset/hard-navigations-handoff.md
+++ b/.changeset/hard-navigations-handoff.md
@@ -2,4 +2,4 @@
 '@shopify/hydrogen': patch
 ---
 
-Use document navigation for Shopify checkout and cart permalink routes so Hydrogen can complete its server redirect handoff.
+Use document navigation for Shopify checkout, cart permalink, and Customer Account handoff routes so Hydrogen can complete its server redirects.

--- a/packages/hydrogen/src/core/request-routing/interceptors/checkout.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/checkout.ts
@@ -1,7 +1,7 @@
 import type { StorefrontClient } from "../../../client";
 import { getCart, getCartId } from "../../cart/get-cart";
 import { getLogger } from "../../logging";
-import { CART_PERMALINK_RE, CHECKOUT_RE } from "../../url";
+import { CHECKOUT_RE, isHydrogenServerHandoffPath } from "../../url";
 import type { HydrogenRouteInterceptor } from "../route-types";
 
 const log = getLogger("checkout");
@@ -10,7 +10,7 @@ export const handleCheckoutRedirect: HydrogenRouteInterceptor = (
   url,
   { request, storefrontClient },
 ) => {
-  if (!CHECKOUT_RE.test(url.pathname) && !CART_PERMALINK_RE.test(url.pathname)) {
+  if (!isHydrogenServerHandoffPath(url.pathname)) {
     return null;
   }
 

--- a/packages/hydrogen/src/core/shopify-scripts.test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts.test.ts
@@ -178,6 +178,55 @@ describe("shopify scripts", () => {
     expect(navigate).toHaveBeenCalledWith("/fr-ca/p/snowboard?variant=1#reviews");
   });
 
+  it("uses document navigation for checkout instead of the supplied navigator", async () => {
+    const navigate = vi.fn();
+    const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});
+
+    await initializeShopifyScripts({ navigate, routes: emptyRouteTemplates, webMcp: false });
+
+    window.Shopify?.routes.navigate?.("/checkout");
+
+    expect(assign).toHaveBeenCalledWith("/checkout");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("preserves checkout search parameters and hash during document navigation", async () => {
+    const navigate = vi.fn();
+    const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});
+
+    await initializeShopifyScripts({ navigate, routes: emptyRouteTemplates, webMcp: false });
+
+    window.Shopify?.routes.navigate?.("/checkout?discount=SAVE10#payment");
+
+    expect(assign).toHaveBeenCalledWith("/checkout?discount=SAVE10#payment");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("uses document navigation for cart permalinks", async () => {
+    const navigate = vi.fn();
+    const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});
+
+    await initializeShopifyScripts({ navigate, routes: emptyRouteTemplates, webMcp: false });
+
+    window.Shopify?.routes.navigate?.("/cart/123:2,456:1?discount=SAVE10#cart");
+
+    expect(assign).toHaveBeenCalledWith("/cart/123:2,456:1?discount=SAVE10#cart");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the cart page SPA-navigable and resolves its custom route", async () => {
+    const navigate = vi.fn();
+    const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});
+    const routeTemplates = createShopifyRouteTemplates({ cart: "/bag" });
+
+    await initializeShopifyScripts({ navigate, routes: routeTemplates, webMcp: false });
+
+    window.Shopify?.routes.navigate?.("/cart?discount=SAVE10#items");
+
+    expect(navigate).toHaveBeenCalledWith("/bag?discount=SAVE10#items");
+    expect(assign).not.toHaveBeenCalled();
+  });
+
   it("sets Shopify standard route resolver from route templates", async () => {
     const routeTemplates = createShopifyRouteTemplates({
       product: "/p/:productHandle",

--- a/packages/hydrogen/src/core/shopify-scripts.test.ts
+++ b/packages/hydrogen/src/core/shopify-scripts.test.ts
@@ -214,6 +214,23 @@ describe("shopify scripts", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
+  it.each([
+    "/account/login?return_to=%2Faccount#login",
+    "/account/authorize?code=code-123&state=state-123#callback",
+    "/account/logout#logout",
+    "/account/refresh?return_to=%2Faccount#refresh",
+  ])("uses document navigation for Customer Account handoff %s", async (url) => {
+    const navigate = vi.fn();
+    const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});
+
+    await initializeShopifyScripts({ navigate, routes: emptyRouteTemplates, webMcp: false });
+
+    window.Shopify?.routes.navigate?.(url);
+
+    expect(assign).toHaveBeenCalledWith(url);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   it("keeps the cart page SPA-navigable and resolves its custom route", async () => {
     const navigate = vi.fn();
     const assign = vi.spyOn(window.location, "assign").mockImplementation(() => {});

--- a/packages/hydrogen/src/core/shopify-scripts/global.ts
+++ b/packages/hydrogen/src/core/shopify-scripts/global.ts
@@ -5,7 +5,7 @@ import {
   resolveStandardRouteUrl,
   type ShopifyRouteTemplates,
 } from "../standard-routes/index";
-import { SHOPIFY_API_PROXY_PREFIX } from "../url";
+import { SHOPIFY_API_PROXY_PREFIX, isHydrogenServerHandoffPath } from "../url";
 import initializeShopifyGlobal from "./global-script" with { type: "script" };
 import type { ShopifyScriptsI18n } from "./types";
 import type { ShopifyScriptsShop } from "./types";
@@ -80,10 +80,32 @@ export function configureShopifyRouting({
   shopify.routes.match = (url) => matchStandardRouteUrl(getRouteOptions(url));
   shopify.routes.resolve = (url) => resolveStandardRouteUrl(getRouteOptions(url));
 
-  const navigateTo = navigate ?? ((url: string) => window.location.assign(url));
-  shopify.routes.navigate = (url) => navigateTo(shopify.routes?.resolve?.(url) ?? url);
+  const navigateTo = navigate ?? documentNavigate;
+  shopify.routes.navigate = (url) => {
+    if (shouldHandoff(url)) {
+      return documentNavigate(url);
+    }
+
+    return navigateTo(shopify.routes?.resolve?.(url) ?? url);
+  };
   // Deprecated, kept for temporary backwards compat with WebMCP
   shopify.navigate = shopify.routes.navigate;
+}
+
+function documentNavigate(url: string): void {
+  window.location.assign(url);
+}
+
+function shouldHandoff(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url, window.location.href);
+
+    return (
+      parsedUrl.origin === window.location.origin && isHydrogenServerHandoffPath(parsedUrl.pathname)
+    );
+  } catch {
+    return false;
+  }
 }
 
 function getShopifyRoutesRoot(pathPrefix: I18nConfig["pathPrefix"]): string {

--- a/packages/hydrogen/src/core/url.ts
+++ b/packages/hydrogen/src/core/url.ts
@@ -4,6 +4,17 @@ export const SHOPIFY_API_PROXY_RE = /^\/__shopify(?:\/|$)/;
 export const MCP_RE = /^\/api\/mcp$/;
 export const CHECKOUT_RE = /^\/checkout$/;
 export const CART_PERMALINK_RE = /^\/cart\/\d+:\d+(?:,\d+:\d+)*$/;
+
+/**
+ * Returns whether Hydrogen owns the pathname as a document-level server handoff.
+ *
+ * Keep this aligned with the routes intercepted before framework routing. API and protocol
+ * interceptors are intentionally excluded because they are not browser navigation destinations.
+ */
+export function isHydrogenServerHandoffPath(pathname: string): boolean {
+  return CHECKOUT_RE.test(pathname) || CART_PERMALINK_RE.test(pathname);
+}
+
 export const AGENT_BUYER_CLAIMS_RE =
   /^(?:\/[a-z]{2}(?:-[a-z]{2})?)?\/agent\/(?:handoff|buyer-claims)(?:\.[^/.]+)?\/?$/i;
 export const AJAX_CART_RE =

--- a/packages/hydrogen/src/core/url.ts
+++ b/packages/hydrogen/src/core/url.ts
@@ -4,15 +4,29 @@ export const SHOPIFY_API_PROXY_RE = /^\/__shopify(?:\/|$)/;
 export const MCP_RE = /^\/api\/mcp$/;
 export const CHECKOUT_RE = /^\/checkout$/;
 export const CART_PERMALINK_RE = /^\/cart\/\d+:\d+(?:,\d+:\d+)*$/;
+export const CUSTOMER_ACCOUNT_PATHS = {
+  authorize: "/account/authorize",
+  login: "/account/login",
+  logout: "/account/logout",
+  refresh: "/account/refresh",
+} as const;
+
+const CUSTOMER_ACCOUNT_HANDOFF_PATHS: ReadonlySet<string> = new Set(
+  Object.values(CUSTOMER_ACCOUNT_PATHS),
+);
 
 /**
- * Returns whether Hydrogen owns the pathname as a document-level server handoff.
+ * Returns whether the pathname conventionally represents a Hydrogen document-level server handoff.
  *
  * Keep this aligned with the routes intercepted before framework routing. API and protocol
  * interceptors are intentionally excluded because they are not browser navigation destinations.
  */
 export function isHydrogenServerHandoffPath(pathname: string): boolean {
-  return CHECKOUT_RE.test(pathname) || CART_PERMALINK_RE.test(pathname);
+  return (
+    CHECKOUT_RE.test(pathname) ||
+    CART_PERMALINK_RE.test(pathname) ||
+    CUSTOMER_ACCOUNT_HANDOFF_PATHS.has(pathname)
+  );
 }
 
 export const AGENT_BUYER_CLAIMS_RE =

--- a/packages/hydrogen/src/customer-account/session.ts
+++ b/packages/hydrogen/src/customer-account/session.ts
@@ -7,12 +7,13 @@ import {
   type ShopifyRouteRedirectResult,
   type ShopifyRouteSessionManager,
 } from "../core/request-routing/registered-routes";
+import { CUSTOMER_ACCOUNT_PATHS } from "../core/url";
 import { CustomerAccountApiError, CustomerAccountOAuthError } from "./errors";
 
-export const CUSTOMER_ACCOUNT_AUTHORIZE_PATH = "/account/authorize" as const;
-export const CUSTOMER_ACCOUNT_LOGIN_PATH = "/account/login" as const;
-export const CUSTOMER_ACCOUNT_LOGOUT_PATH = "/account/logout" as const;
-export const CUSTOMER_ACCOUNT_REFRESH_PATH = "/account/refresh" as const;
+export const CUSTOMER_ACCOUNT_AUTHORIZE_PATH = CUSTOMER_ACCOUNT_PATHS.authorize;
+export const CUSTOMER_ACCOUNT_LOGIN_PATH = CUSTOMER_ACCOUNT_PATHS.login;
+export const CUSTOMER_ACCOUNT_LOGOUT_PATH = CUSTOMER_ACCOUNT_PATHS.logout;
+export const CUSTOMER_ACCOUNT_REFRESH_PATH = CUSTOMER_ACCOUNT_PATHS.refresh;
 
 const CUSTOMER_ACCOUNT_SESSION_KEY = "customerAccount";
 const DEFAULT_LOGIN_RETURN_TO_PATH = "/account";


### PR DESCRIPTION
TL;DR: Make `Shopify.routes.navigate()` use document navigation for same-origin Hydrogen server handoffs while retaining framework SPA navigation for app-owned storefront routes.

Agents can delegate same-origin links such as `/checkout` or `/account/login` to `Shopify.routes.navigate()`. Passing these routes to React Router, Next, SvelteKit, or another SPA navigator may issue a framework data request instead of the document request Hydrogen needs to complete checkout and Customer Account redirects.

## Before

Every route used the supplied framework navigator after standard-route resolution, including checkout, cart permalinks, and Customer Account handler paths.

## After

Exact `/checkout` requests, cart permalinks such as `/cart/123:1`, and Hydrogen's fixed Customer Account handler paths use `window.location.assign()`. Other storefront routes, including `/cart`, continue through standard-route resolution and the supplied SPA navigator.

## What this changes

- Shares one Hydrogen server-handoff pathname matcher between client navigation and the checkout interceptor.
- Uses a shared source of truth for the fixed Customer Account handler paths.
- Uses document navigation only for same-origin checkout, cart-permalink, and Customer Account handoffs.
- Preserves search parameters and hashes.
- Adds coverage for document navigation, standard-route resolution, `/cart`, and the no-navigator fallback.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. There are no new public exports or migration steps; existing framework integrations can continue passing their SPA navigator to `ShopifyScripts` or `initializeShopifyScripts()`.

## UX impact

Navigation initiated by Shopify storefront components can now reach checkout, cart permalink, and Customer Account destinations reliably instead of being interpreted as an in-app framework transition.

## Out of scope

- Configurable route ownership for apps that provide their own checkout or Customer Account handler paths.
- Changes to Storefront Components or agent navigation behavior.

## Risk

- The fixed Customer Account paths use document navigation even when an app does not register the built-in handlers. An app that owns one of those exact paths gets a full reload instead of an SPA transition.
- `/cart` remains intentionally excluded because it commonly belongs to the app.

## How to Test

1. Configure the Hydrogen example with storefront and Customer Account credentials, then run `pnpm dev:hydrogen`.
2. Add an item to the cart.
3. In the browser console, run `Shopify.routes.navigate('/checkout?source=navigation-test#handoff')`.
4. Confirm the browser requests the Hydrogen `/checkout` document and follows its redirect to checkout.
5. Return to the storefront and run `Shopify.routes.navigate('/account/login?return_to=/account')`.
6. Confirm the browser requests the Hydrogen login document and follows its redirect to Shopify's hosted login.
7. Return to the storefront and run `Shopify.routes.navigate('/cart')`.
8. Confirm the app cart page uses the normal client-side transition.
