### PR TITLE
Declare library GraphQL documents with gql()

### DIFF
--- a/.changeset/gql-declared-documents.md
+++ b/.changeset/gql-declared-documents.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Declare all library GraphQL documents with `gql()` so the gql.tada plugin validates them, and add a `gql(document, fragments)` overload that composes additional fragments onto an already-declared document while preserving inferred types.

--- a/packages/hydrogen/src/core/cart/queries.ts
+++ b/packages/hydrogen/src/core/cart/queries.ts
@@ -9,7 +9,6 @@ import type { CartData, CartLineConnection } from "./state";
 
 const CART_FRAGMENT_NAME = "CartFragment";
 const CART_FRAGMENT_TYPE = "Cart";
-const HYDROGEN_CART_FRAGMENT_NAME = "HydrogenCartFragment";
 
 type FragmentContract = {
   readonly name: string;
@@ -21,11 +20,9 @@ const CART_FRAGMENT_CONTRACT = {
   typeName: CART_FRAGMENT_TYPE,
 } as const satisfies FragmentContract;
 
-const HYDROGEN_CART_FRAGMENT_SPREAD = `...${HYDROGEN_CART_FRAGMENT_NAME}`;
-const CART_FRAGMENT_SPREAD = `...${CART_FRAGMENT_NAME}`;
 const CART_FRAGMENT_PATTERN = createFragmentPattern(CART_FRAGMENT_CONTRACT);
 
-const HYDROGEN_CART_FRAGMENT_SOURCE = /* GraphQL */ `
+const HYDROGEN_CART_FRAGMENT = gql(`
   fragment HydrogenCartFragment on Cart {
     id
     checkoutUrl
@@ -115,33 +112,24 @@ const HYDROGEN_CART_FRAGMENT_SOURCE = /* GraphQL */ `
       code
     }
   }
-`;
+`);
 
-const CART_QUERY_SOURCE = /* GraphQL */ `
-  query Cart($id: ID!, $country: CountryCode, $language: LanguageCode)
+const CART_QUERY = gql(
+  `query Cart($id: ID!, $country: CountryCode, $language: LanguageCode)
   @inContext(country: $country, language: $language) {
     cart(id: $id) {
-      ${HYDROGEN_CART_FRAGMENT_SPREAD}
+      ...HydrogenCartFragment
     }
-  }
-`;
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
 
-const CUSTOM_CART_QUERY_SOURCE = /* GraphQL */ `
-  query Cart($id: ID!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
-    cart(id: $id) {
-      ${HYDROGEN_CART_FRAGMENT_SPREAD}
-      ${CART_FRAGMENT_SPREAD}
-    }
-  }
-`;
-
-const CART_CREATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartCreate($input: CartInput!, $country: CountryCode, $language: LanguageCode)
+const CART_CREATE_MUTATION = gql(
+  `mutation CartCreate($input: CartInput!, $country: CountryCode, $language: LanguageCode)
   @inContext(country: $country, language: $language) {
     cartCreate(input: $input) {
       cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
+        ...HydrogenCartFragment
       }
       userErrors {
         code
@@ -153,6 +141,130 @@ const CART_CREATE_MUTATION_SOURCE = /* GraphQL */ `
         message
         target
       }
+    }
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
+
+const CART_LINES_ADD_MUTATION = gql(
+  `mutation CartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    cartLinesAdd(cartId: $cartId, lines: $lines) {
+      cart {
+        ...HydrogenCartFragment
+      }
+      userErrors {
+        code
+        field
+        message
+      }
+      warnings {
+        code
+        message
+        target
+      }
+    }
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
+
+const CART_LINES_UPDATE_MUTATION = gql(
+  `mutation CartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    cartLinesUpdate(cartId: $cartId, lines: $lines) {
+      cart {
+        ...HydrogenCartFragment
+      }
+      userErrors {
+        code
+        field
+        message
+      }
+      warnings {
+        code
+        message
+        target
+      }
+    }
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
+
+const CART_LINES_REMOVE_MUTATION = gql(
+  `mutation CartLinesRemove($cartId: ID!, $lineIds: [ID!]!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
+      cart {
+        ...HydrogenCartFragment
+      }
+      userErrors {
+        code
+        field
+        message
+      }
+      warnings {
+        code
+        message
+        target
+      }
+    }
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
+
+const CART_DISCOUNT_CODES_UPDATE_MUTATION = gql(
+  `mutation CartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!]!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
+      cart {
+        ...HydrogenCartFragment
+      }
+      userErrors {
+        code
+        field
+        message
+      }
+      warnings {
+        code
+        message
+        target
+      }
+    }
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
+
+const CART_NOTE_UPDATE_MUTATION = gql(
+  `mutation CartNoteUpdate($cartId: ID!, $note: String!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    cartNoteUpdate(cartId: $cartId, note: $note) {
+      cart {
+        ...HydrogenCartFragment
+      }
+      userErrors {
+        code
+        field
+        message
+      }
+      warnings {
+        code
+        message
+        target
+      }
+    }
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
+
+// The custom variants spread the consumer's `CartFragment`, which only exists
+// at runtime, so they cannot be declared with `gql()` here. They stay as raw
+// sources composed with the consumer's fragment in `createCartQueries`.
+const CUSTOM_CART_QUERY_SOURCE = /* GraphQL */ `
+  query Cart($id: ID!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    cart(id: $id) {
+      ...HydrogenCartFragment
+      ...CartFragment
     }
   }
 `;
@@ -162,29 +274,8 @@ const CUSTOM_CART_CREATE_MUTATION_SOURCE = /* GraphQL */ `
   @inContext(country: $country, language: $language) {
     cartCreate(input: $input) {
       cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
-        ${CART_FRAGMENT_SPREAD}
-      }
-      userErrors {
-        code
-        field
-        message
-      }
-      warnings {
-        code
-        message
-        target
-      }
-    }
-  }
-`;
-
-const CART_LINES_ADD_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
-    cartLinesAdd(cartId: $cartId, lines: $lines) {
-      cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
+        ...HydrogenCartFragment
+        ...CartFragment
       }
       userErrors {
         code
@@ -201,33 +292,16 @@ const CART_LINES_ADD_MUTATION_SOURCE = /* GraphQL */ `
 `;
 
 const CUSTOM_CART_LINES_ADD_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
+  mutation CartLinesAdd(
+    $cartId: ID!
+    $lines: [CartLineInput!]!
+    $country: CountryCode
+    $language: LanguageCode
+  ) @inContext(country: $country, language: $language) {
     cartLinesAdd(cartId: $cartId, lines: $lines) {
       cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
-        ${CART_FRAGMENT_SPREAD}
-      }
-      userErrors {
-        code
-        field
-        message
-      }
-      warnings {
-        code
-        message
-        target
-      }
-    }
-  }
-`;
-
-const CART_LINES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
-    cartLinesUpdate(cartId: $cartId, lines: $lines) {
-      cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
+        ...HydrogenCartFragment
+        ...CartFragment
       }
       userErrors {
         code
@@ -244,33 +318,16 @@ const CART_LINES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
 `;
 
 const CUSTOM_CART_LINES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
+  mutation CartLinesUpdate(
+    $cartId: ID!
+    $lines: [CartLineUpdateInput!]!
+    $country: CountryCode
+    $language: LanguageCode
+  ) @inContext(country: $country, language: $language) {
     cartLinesUpdate(cartId: $cartId, lines: $lines) {
       cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
-        ${CART_FRAGMENT_SPREAD}
-      }
-      userErrors {
-        code
-        field
-        message
-      }
-      warnings {
-        code
-        message
-        target
-      }
-    }
-  }
-`;
-
-const CART_LINES_REMOVE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartLinesRemove($cartId: ID!, $lineIds: [ID!]!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
-    cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
-      cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
+        ...HydrogenCartFragment
+        ...CartFragment
       }
       userErrors {
         code
@@ -287,33 +344,16 @@ const CART_LINES_REMOVE_MUTATION_SOURCE = /* GraphQL */ `
 `;
 
 const CUSTOM_CART_LINES_REMOVE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartLinesRemove($cartId: ID!, $lineIds: [ID!]!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
+  mutation CartLinesRemove(
+    $cartId: ID!
+    $lineIds: [ID!]!
+    $country: CountryCode
+    $language: LanguageCode
+  ) @inContext(country: $country, language: $language) {
     cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
       cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
-        ${CART_FRAGMENT_SPREAD}
-      }
-      userErrors {
-        code
-        field
-        message
-      }
-      warnings {
-        code
-        message
-        target
-      }
-    }
-  }
-`;
-
-const CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!]!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
-    cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
-      cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
+        ...HydrogenCartFragment
+        ...CartFragment
       }
       userErrors {
         code
@@ -330,33 +370,16 @@ const CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
 `;
 
 const CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!]!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
+  mutation CartDiscountCodesUpdate(
+    $cartId: ID!
+    $discountCodes: [String!]!
+    $country: CountryCode
+    $language: LanguageCode
+  ) @inContext(country: $country, language: $language) {
     cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
       cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
-        ${CART_FRAGMENT_SPREAD}
-      }
-      userErrors {
-        code
-        field
-        message
-      }
-      warnings {
-        code
-        message
-        target
-      }
-    }
-  }
-`;
-
-const CART_NOTE_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartNoteUpdate($cartId: ID!, $note: String!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
-    cartNoteUpdate(cartId: $cartId, note: $note) {
-      cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
+        ...HydrogenCartFragment
+        ...CartFragment
       }
       userErrors {
         code
@@ -373,12 +396,16 @@ const CART_NOTE_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
 `;
 
 const CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartNoteUpdate($cartId: ID!, $note: String!, $country: CountryCode, $language: LanguageCode)
-  @inContext(country: $country, language: $language) {
+  mutation CartNoteUpdate(
+    $cartId: ID!
+    $note: String!
+    $country: CountryCode
+    $language: LanguageCode
+  ) @inContext(country: $country, language: $language) {
     cartNoteUpdate(cartId: $cartId, note: $note) {
       cart {
-        ${HYDROGEN_CART_FRAGMENT_SPREAD}
-        ${CART_FRAGMENT_SPREAD}
+        ...HydrogenCartFragment
+        ...CartFragment
       }
       userErrors {
         code
@@ -394,7 +421,17 @@ const CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
   }
 `;
 
-const HYDROGEN_CART_FRAGMENT = gql(HYDROGEN_CART_FRAGMENT_SOURCE);
+const DEFAULT_CART_QUERIES = {
+  cart: CART_QUERY,
+  cartCreate: CART_CREATE_MUTATION,
+  cartLinesAdd: CART_LINES_ADD_MUTATION,
+  cartLinesUpdate: CART_LINES_UPDATE_MUTATION,
+  cartLinesRemove: CART_LINES_REMOVE_MUTATION,
+  cartDiscountCodesUpdate: CART_DISCOUNT_CODES_UPDATE_MUTATION,
+  cartNoteUpdate: CART_NOTE_UPDATE_MUTATION,
+} as const;
+
+type DefaultCartQueries = typeof DEFAULT_CART_QUERIES;
 
 type QueryFor<
   Source extends string,
@@ -407,46 +444,36 @@ type QueryFor<
 >;
 
 type CartFragmentDocument = AnyStorefrontQueryString;
-type CartQueriesForSources<
-  Fragments extends readonly AnyStorefrontQueryString[],
-  CartQuerySource extends string,
-  CartCreateMutationSource extends string,
-  CartLinesAddMutationSource extends string,
-  CartLinesUpdateMutationSource extends string,
-  CartLinesRemoveMutationSource extends string,
-  CartDiscountCodesUpdateMutationSource extends string,
-  CartNoteUpdateMutationSource extends string,
-> = {
-  readonly cart: QueryFor<CartQuerySource, Fragments>;
-  readonly cartCreate: QueryFor<CartCreateMutationSource, Fragments>;
-  readonly cartLinesAdd: QueryFor<CartLinesAddMutationSource, Fragments>;
-  readonly cartLinesUpdate: QueryFor<CartLinesUpdateMutationSource, Fragments>;
-  readonly cartLinesRemove: QueryFor<CartLinesRemoveMutationSource, Fragments>;
-  readonly cartDiscountCodesUpdate: QueryFor<CartDiscountCodesUpdateMutationSource, Fragments>;
-  readonly cartNoteUpdate: QueryFor<CartNoteUpdateMutationSource, Fragments>;
+
+type CustomQueryFor<Source extends string, TCartFragment extends CartFragmentDocument> = QueryFor<
+  Source,
+  readonly [typeof HYDROGEN_CART_FRAGMENT, TCartFragment]
+>;
+
+type CartQueriesForFragment<TCartFragment extends CartFragmentDocument> = {
+  readonly cart: CustomQueryFor<typeof CUSTOM_CART_QUERY_SOURCE, TCartFragment>;
+  readonly cartCreate: CustomQueryFor<typeof CUSTOM_CART_CREATE_MUTATION_SOURCE, TCartFragment>;
+  readonly cartLinesAdd: CustomQueryFor<
+    typeof CUSTOM_CART_LINES_ADD_MUTATION_SOURCE,
+    TCartFragment
+  >;
+  readonly cartLinesUpdate: CustomQueryFor<
+    typeof CUSTOM_CART_LINES_UPDATE_MUTATION_SOURCE,
+    TCartFragment
+  >;
+  readonly cartLinesRemove: CustomQueryFor<
+    typeof CUSTOM_CART_LINES_REMOVE_MUTATION_SOURCE,
+    TCartFragment
+  >;
+  readonly cartDiscountCodesUpdate: CustomQueryFor<
+    typeof CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE,
+    TCartFragment
+  >;
+  readonly cartNoteUpdate: CustomQueryFor<
+    typeof CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE,
+    TCartFragment
+  >;
 };
-
-type CartQueriesForFragment<TCartFragment extends CartFragmentDocument> = CartQueriesForSources<
-  readonly [typeof HYDROGEN_CART_FRAGMENT, TCartFragment],
-  typeof CUSTOM_CART_QUERY_SOURCE,
-  typeof CUSTOM_CART_CREATE_MUTATION_SOURCE,
-  typeof CUSTOM_CART_LINES_ADD_MUTATION_SOURCE,
-  typeof CUSTOM_CART_LINES_UPDATE_MUTATION_SOURCE,
-  typeof CUSTOM_CART_LINES_REMOVE_MUTATION_SOURCE,
-  typeof CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE,
-  typeof CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE
->;
-
-type DefaultCartQueries = CartQueriesForSources<
-  readonly [typeof HYDROGEN_CART_FRAGMENT],
-  typeof CART_QUERY_SOURCE,
-  typeof CART_CREATE_MUTATION_SOURCE,
-  typeof CART_LINES_ADD_MUTATION_SOURCE,
-  typeof CART_LINES_UPDATE_MUTATION_SOURCE,
-  typeof CART_LINES_REMOVE_MUTATION_SOURCE,
-  typeof CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE,
-  typeof CART_NOTE_UPDATE_MUTATION_SOURCE
->;
 
 type CartDataFromCartQuery<TQuery extends AnyStorefrontQueryString> =
   TQuery extends StorefrontQueryString<infer Result, infer _Variables, string>
@@ -504,34 +531,6 @@ function createFragmentPattern({ name, typeName }: FragmentContract): RegExp {
   return new RegExp(`fragment\\s+${name}\\s+on\\s+${typeName}`);
 }
 
-function createDefaultCartQueries(): DefaultCartQueries {
-  const fragments = [HYDROGEN_CART_FRAGMENT] as const;
-
-  const cart = gql(CART_QUERY_SOURCE, fragments);
-
-  const cartCreate = gql(CART_CREATE_MUTATION_SOURCE, fragments);
-
-  const cartLinesAdd = gql(CART_LINES_ADD_MUTATION_SOURCE, fragments);
-
-  const cartLinesUpdate = gql(CART_LINES_UPDATE_MUTATION_SOURCE, fragments);
-
-  const cartLinesRemove = gql(CART_LINES_REMOVE_MUTATION_SOURCE, fragments);
-
-  const cartDiscountCodesUpdate = gql(CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE, fragments);
-
-  const cartNoteUpdate = gql(CART_NOTE_UPDATE_MUTATION_SOURCE, fragments);
-
-  return {
-    cart,
-    cartCreate,
-    cartLinesAdd,
-    cartLinesUpdate,
-    cartLinesRemove,
-    cartDiscountCodesUpdate,
-    cartNoteUpdate,
-  } as const;
-}
-
 function createCartQueries<const TCartFragment extends CartFragmentDocument>(
   cartFragment: TCartFragment,
 ): CartQueriesForFragment<TCartFragment> {
@@ -572,7 +571,7 @@ export function makeCartQueries(options?: CreateCartQueriesOptions) {
     return createCartQueries(options.fragment);
   }
 
-  return createDefaultCartQueries();
+  return DEFAULT_CART_QUERIES;
 }
 
 export const cartQueries = makeCartQueries();

--- a/packages/hydrogen/src/core/cart/queries.ts
+++ b/packages/hydrogen/src/core/cart/queries.ts
@@ -2,6 +2,7 @@ import {
   gql,
   type AnyStorefrontQueryString,
   type ComposedSource,
+  type SourceOf,
   type StorefrontQueryString,
 } from "../../graphql";
 import type { InferResult, InferVariables } from "../../graphql";
@@ -257,25 +258,28 @@ const CART_NOTE_UPDATE_MUTATION = gql(
 );
 
 // The custom variants spread the consumer's `CartFragment`, which only exists
-// at runtime, so they cannot be declared with `gql()` here. They stay as raw
-// sources composed with the consumer's fragment in `createCartQueries`.
-const CUSTOM_CART_QUERY_SOURCE = /* GraphQL */ `
-  query Cart($id: ID!, $country: CountryCode, $language: LanguageCode)
+// at runtime. Its spread is interpolated on purpose: the gql.tada plugin skips
+// documents containing interpolations instead of flagging an unknown fragment,
+// while TypeScript still resolves the full literal source type. The consumer's
+// fragment is composed in at runtime by `createCartQueries`.
+const CUSTOM_CART_QUERY = gql(
+  `query Cart($id: ID!, $country: CountryCode, $language: LanguageCode)
   @inContext(country: $country, language: $language) {
     cart(id: $id) {
       ...HydrogenCartFragment
-      ...CartFragment
+      ...${CART_FRAGMENT_NAME}
     }
-  }
-`;
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
 
-const CUSTOM_CART_CREATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartCreate($input: CartInput!, $country: CountryCode, $language: LanguageCode)
+const CUSTOM_CART_CREATE_MUTATION = gql(
+  `mutation CartCreate($input: CartInput!, $country: CountryCode, $language: LanguageCode)
   @inContext(country: $country, language: $language) {
     cartCreate(input: $input) {
       cart {
         ...HydrogenCartFragment
-        ...CartFragment
+        ...${CART_FRAGMENT_NAME}
       }
       userErrors {
         code
@@ -288,20 +292,17 @@ const CUSTOM_CART_CREATE_MUTATION_SOURCE = /* GraphQL */ `
         target
       }
     }
-  }
-`;
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
 
-const CUSTOM_CART_LINES_ADD_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartLinesAdd(
-    $cartId: ID!
-    $lines: [CartLineInput!]!
-    $country: CountryCode
-    $language: LanguageCode
-  ) @inContext(country: $country, language: $language) {
+const CUSTOM_CART_LINES_ADD_MUTATION = gql(
+  `mutation CartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
     cartLinesAdd(cartId: $cartId, lines: $lines) {
       cart {
         ...HydrogenCartFragment
-        ...CartFragment
+        ...${CART_FRAGMENT_NAME}
       }
       userErrors {
         code
@@ -314,20 +315,17 @@ const CUSTOM_CART_LINES_ADD_MUTATION_SOURCE = /* GraphQL */ `
         target
       }
     }
-  }
-`;
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
 
-const CUSTOM_CART_LINES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartLinesUpdate(
-    $cartId: ID!
-    $lines: [CartLineUpdateInput!]!
-    $country: CountryCode
-    $language: LanguageCode
-  ) @inContext(country: $country, language: $language) {
+const CUSTOM_CART_LINES_UPDATE_MUTATION = gql(
+  `mutation CartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
     cartLinesUpdate(cartId: $cartId, lines: $lines) {
       cart {
         ...HydrogenCartFragment
-        ...CartFragment
+        ...${CART_FRAGMENT_NAME}
       }
       userErrors {
         code
@@ -340,20 +338,17 @@ const CUSTOM_CART_LINES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
         target
       }
     }
-  }
-`;
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
 
-const CUSTOM_CART_LINES_REMOVE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartLinesRemove(
-    $cartId: ID!
-    $lineIds: [ID!]!
-    $country: CountryCode
-    $language: LanguageCode
-  ) @inContext(country: $country, language: $language) {
+const CUSTOM_CART_LINES_REMOVE_MUTATION = gql(
+  `mutation CartLinesRemove($cartId: ID!, $lineIds: [ID!]!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
     cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
       cart {
         ...HydrogenCartFragment
-        ...CartFragment
+        ...${CART_FRAGMENT_NAME}
       }
       userErrors {
         code
@@ -366,20 +361,17 @@ const CUSTOM_CART_LINES_REMOVE_MUTATION_SOURCE = /* GraphQL */ `
         target
       }
     }
-  }
-`;
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
 
-const CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartDiscountCodesUpdate(
-    $cartId: ID!
-    $discountCodes: [String!]!
-    $country: CountryCode
-    $language: LanguageCode
-  ) @inContext(country: $country, language: $language) {
+const CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION = gql(
+  `mutation CartDiscountCodesUpdate($cartId: ID!, $discountCodes: [String!]!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
     cartDiscountCodesUpdate(cartId: $cartId, discountCodes: $discountCodes) {
       cart {
         ...HydrogenCartFragment
-        ...CartFragment
+        ...${CART_FRAGMENT_NAME}
       }
       userErrors {
         code
@@ -392,20 +384,17 @@ const CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
         target
       }
     }
-  }
-`;
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
 
-const CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
-  mutation CartNoteUpdate(
-    $cartId: ID!
-    $note: String!
-    $country: CountryCode
-    $language: LanguageCode
-  ) @inContext(country: $country, language: $language) {
+const CUSTOM_CART_NOTE_UPDATE_MUTATION = gql(
+  `mutation CartNoteUpdate($cartId: ID!, $note: String!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
     cartNoteUpdate(cartId: $cartId, note: $note) {
       cart {
         ...HydrogenCartFragment
-        ...CartFragment
+        ...${CART_FRAGMENT_NAME}
       }
       userErrors {
         code
@@ -418,8 +407,9 @@ const CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE = /* GraphQL */ `
         target
       }
     }
-  }
-`;
+  }`,
+  [HYDROGEN_CART_FRAGMENT],
+);
 
 const DEFAULT_CART_QUERIES = {
   cart: CART_QUERY,
@@ -445,34 +435,22 @@ type QueryFor<
 
 type CartFragmentDocument = AnyStorefrontQueryString;
 
-type CustomQueryFor<Source extends string, TCartFragment extends CartFragmentDocument> = QueryFor<
-  Source,
-  readonly [typeof HYDROGEN_CART_FRAGMENT, TCartFragment]
->;
+type CustomQueryFor<
+  Document extends AnyStorefrontQueryString,
+  TCartFragment extends CartFragmentDocument,
+> = QueryFor<SourceOf<Document>, readonly [TCartFragment]>;
 
 type CartQueriesForFragment<TCartFragment extends CartFragmentDocument> = {
-  readonly cart: CustomQueryFor<typeof CUSTOM_CART_QUERY_SOURCE, TCartFragment>;
-  readonly cartCreate: CustomQueryFor<typeof CUSTOM_CART_CREATE_MUTATION_SOURCE, TCartFragment>;
-  readonly cartLinesAdd: CustomQueryFor<
-    typeof CUSTOM_CART_LINES_ADD_MUTATION_SOURCE,
-    TCartFragment
-  >;
-  readonly cartLinesUpdate: CustomQueryFor<
-    typeof CUSTOM_CART_LINES_UPDATE_MUTATION_SOURCE,
-    TCartFragment
-  >;
-  readonly cartLinesRemove: CustomQueryFor<
-    typeof CUSTOM_CART_LINES_REMOVE_MUTATION_SOURCE,
-    TCartFragment
-  >;
+  readonly cart: CustomQueryFor<typeof CUSTOM_CART_QUERY, TCartFragment>;
+  readonly cartCreate: CustomQueryFor<typeof CUSTOM_CART_CREATE_MUTATION, TCartFragment>;
+  readonly cartLinesAdd: CustomQueryFor<typeof CUSTOM_CART_LINES_ADD_MUTATION, TCartFragment>;
+  readonly cartLinesUpdate: CustomQueryFor<typeof CUSTOM_CART_LINES_UPDATE_MUTATION, TCartFragment>;
+  readonly cartLinesRemove: CustomQueryFor<typeof CUSTOM_CART_LINES_REMOVE_MUTATION, TCartFragment>;
   readonly cartDiscountCodesUpdate: CustomQueryFor<
-    typeof CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE,
+    typeof CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION,
     TCartFragment
   >;
-  readonly cartNoteUpdate: CustomQueryFor<
-    typeof CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE,
-    TCartFragment
-  >;
+  readonly cartNoteUpdate: CustomQueryFor<typeof CUSTOM_CART_NOTE_UPDATE_MUTATION, TCartFragment>;
 };
 
 type CartDataFromCartQuery<TQuery extends AnyStorefrontQueryString> =
@@ -534,21 +512,21 @@ function createFragmentPattern({ name, typeName }: FragmentContract): RegExp {
 function createCartQueries<const TCartFragment extends CartFragmentDocument>(
   cartFragment: TCartFragment,
 ): CartQueriesForFragment<TCartFragment> {
-  const fragments = [HYDROGEN_CART_FRAGMENT, cartFragment] as const;
+  const fragments = [cartFragment] as const;
 
-  const cart = gql(CUSTOM_CART_QUERY_SOURCE, fragments);
+  const cart = gql(CUSTOM_CART_QUERY, fragments);
 
-  const cartCreate = gql(CUSTOM_CART_CREATE_MUTATION_SOURCE, fragments);
+  const cartCreate = gql(CUSTOM_CART_CREATE_MUTATION, fragments);
 
-  const cartLinesAdd = gql(CUSTOM_CART_LINES_ADD_MUTATION_SOURCE, fragments);
+  const cartLinesAdd = gql(CUSTOM_CART_LINES_ADD_MUTATION, fragments);
 
-  const cartLinesUpdate = gql(CUSTOM_CART_LINES_UPDATE_MUTATION_SOURCE, fragments);
+  const cartLinesUpdate = gql(CUSTOM_CART_LINES_UPDATE_MUTATION, fragments);
 
-  const cartLinesRemove = gql(CUSTOM_CART_LINES_REMOVE_MUTATION_SOURCE, fragments);
+  const cartLinesRemove = gql(CUSTOM_CART_LINES_REMOVE_MUTATION, fragments);
 
-  const cartDiscountCodesUpdate = gql(CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION_SOURCE, fragments);
+  const cartDiscountCodesUpdate = gql(CUSTOM_CART_DISCOUNT_CODES_UPDATE_MUTATION, fragments);
 
-  const cartNoteUpdate = gql(CUSTOM_CART_NOTE_UPDATE_MUTATION_SOURCE, fragments);
+  const cartNoteUpdate = gql(CUSTOM_CART_NOTE_UPDATE_MUTATION, fragments);
 
   return {
     cart,

--- a/packages/hydrogen/src/core/predictive-search/queries.ts
+++ b/packages/hydrogen/src/core/predictive-search/queries.ts
@@ -6,12 +6,6 @@ import {
 } from "../../graphql";
 import type { InferResult, InferVariables } from "../../graphql";
 
-const HYDROGEN_PRODUCT_FRAGMENT_NAME = "HydrogenPredictiveSearchProductFragment";
-const HYDROGEN_COLLECTION_FRAGMENT_NAME = "HydrogenPredictiveSearchCollectionFragment";
-const HYDROGEN_PAGE_FRAGMENT_NAME = "HydrogenPredictiveSearchPageFragment";
-const HYDROGEN_ARTICLE_FRAGMENT_NAME = "HydrogenPredictiveSearchArticleFragment";
-const HYDROGEN_QUERY_FRAGMENT_NAME = "HydrogenPredictiveSearchQueryFragment";
-
 const PRODUCT_FRAGMENT_NAME = "PredictiveSearchProductFragment";
 const COLLECTION_FRAGMENT_NAME = "PredictiveSearchCollectionFragment";
 const PAGE_FRAGMENT_NAME = "PredictiveSearchPageFragment";
@@ -60,7 +54,10 @@ const QUERY_CONTRACT = {
   typeName: QUERY_TYPE_NAME,
 } as const satisfies FragmentContract;
 
-const PREDICTIVE_SEARCH_QUERY_SOURCE = `
+// Spreads the consumer-overridable fragments (e.g. PredictiveSearchProductFragment),
+// which only exist at runtime, so it cannot be declared with `gql()` here. It stays
+// a raw source composed with the resolved fragments in `makePredictiveSearchQueries`.
+const PREDICTIVE_SEARCH_QUERY_SOURCE = /* GraphQL */ `
   query PredictiveSearch(
     $country: CountryCode
     $language: LanguageCode
@@ -72,36 +69,36 @@ const PREDICTIVE_SEARCH_QUERY_SOURCE = `
     $unavailableProducts: SearchUnavailableProductsType
   ) @inContext(country: $country, language: $language) {
     predictiveSearch(
-      limit: $limit,
-      limitScope: $limitScope,
-      query: $term,
-      types: $types,
-      searchableFields: $searchableFields,
-      unavailableProducts: $unavailableProducts,
+      limit: $limit
+      limitScope: $limitScope
+      query: $term
+      types: $types
+      searchableFields: $searchableFields
+      unavailableProducts: $unavailableProducts
     ) {
       articles {
-        ...${HYDROGEN_ARTICLE_FRAGMENT_NAME}
-        ...${ARTICLE_FRAGMENT_NAME}
+        ...HydrogenPredictiveSearchArticleFragment
+        ...PredictiveSearchArticleFragment
       }
       collections {
-        ...${HYDROGEN_COLLECTION_FRAGMENT_NAME}
-        ...${COLLECTION_FRAGMENT_NAME}
+        ...HydrogenPredictiveSearchCollectionFragment
+        ...PredictiveSearchCollectionFragment
       }
       pages {
-        ...${HYDROGEN_PAGE_FRAGMENT_NAME}
-        ...${PAGE_FRAGMENT_NAME}
+        ...HydrogenPredictiveSearchPageFragment
+        ...PredictiveSearchPageFragment
       }
       products {
-        ...${HYDROGEN_PRODUCT_FRAGMENT_NAME}
-        ...${PRODUCT_FRAGMENT_NAME}
+        ...HydrogenPredictiveSearchProductFragment
+        ...PredictiveSearchProductFragment
       }
       queries {
-        ...${HYDROGEN_QUERY_FRAGMENT_NAME}
-        ...${QUERY_FRAGMENT_NAME}
+        ...HydrogenPredictiveSearchQueryFragment
+        ...PredictiveSearchQueryFragment
       }
     }
   }
-` as const;
+`;
 
 const HYDROGEN_PRODUCT_FRAGMENT = gql(`
   fragment HydrogenPredictiveSearchProductFragment on Product {

--- a/packages/hydrogen/src/core/predictive-search/queries.ts
+++ b/packages/hydrogen/src/core/predictive-search/queries.ts
@@ -2,6 +2,7 @@ import {
   gql,
   type AnyStorefrontQueryString,
   type ComposedSource,
+  type SourceOf,
   type StorefrontQueryString,
 } from "../../graphql";
 import type { InferResult, InferVariables } from "../../graphql";
@@ -53,52 +54,6 @@ const QUERY_CONTRACT = {
   name: QUERY_FRAGMENT_NAME,
   typeName: QUERY_TYPE_NAME,
 } as const satisfies FragmentContract;
-
-// Spreads the consumer-overridable fragments (e.g. PredictiveSearchProductFragment),
-// which only exist at runtime, so it cannot be declared with `gql()` here. It stays
-// a raw source composed with the resolved fragments in `makePredictiveSearchQueries`.
-const PREDICTIVE_SEARCH_QUERY_SOURCE = /* GraphQL */ `
-  query PredictiveSearch(
-    $country: CountryCode
-    $language: LanguageCode
-    $limit: Int
-    $limitScope: PredictiveSearchLimitScope
-    $term: String!
-    $types: [PredictiveSearchType!]
-    $searchableFields: [SearchableField!]
-    $unavailableProducts: SearchUnavailableProductsType
-  ) @inContext(country: $country, language: $language) {
-    predictiveSearch(
-      limit: $limit
-      limitScope: $limitScope
-      query: $term
-      types: $types
-      searchableFields: $searchableFields
-      unavailableProducts: $unavailableProducts
-    ) {
-      articles {
-        ...HydrogenPredictiveSearchArticleFragment
-        ...PredictiveSearchArticleFragment
-      }
-      collections {
-        ...HydrogenPredictiveSearchCollectionFragment
-        ...PredictiveSearchCollectionFragment
-      }
-      pages {
-        ...HydrogenPredictiveSearchPageFragment
-        ...PredictiveSearchPageFragment
-      }
-      products {
-        ...HydrogenPredictiveSearchProductFragment
-        ...PredictiveSearchProductFragment
-      }
-      queries {
-        ...HydrogenPredictiveSearchQueryFragment
-        ...PredictiveSearchQueryFragment
-      }
-    }
-  }
-`;
 
 const HYDROGEN_PRODUCT_FRAGMENT = gql(`
   fragment HydrogenPredictiveSearchProductFragment on Product {
@@ -181,6 +136,61 @@ const HYDROGEN_QUERY_FRAGMENT = gql(`
   }
 `);
 
+// The consumer-overridable fragment spreads (e.g. PredictiveSearchProductFragment)
+// are interpolated on purpose: those fragments only exist at runtime, and the
+// gql.tada plugin skips documents containing interpolations instead of flagging
+// unknown fragments, while TypeScript still resolves the full literal source type.
+// The resolved fragments are composed in at runtime by `makePredictiveSearchQueries`.
+const PREDICTIVE_SEARCH_QUERY = gql(
+  `query PredictiveSearch(
+    $country: CountryCode
+    $language: LanguageCode
+    $limit: Int
+    $limitScope: PredictiveSearchLimitScope
+    $term: String!
+    $types: [PredictiveSearchType!]
+    $searchableFields: [SearchableField!]
+    $unavailableProducts: SearchUnavailableProductsType
+  ) @inContext(country: $country, language: $language) {
+    predictiveSearch(
+      limit: $limit
+      limitScope: $limitScope
+      query: $term
+      types: $types
+      searchableFields: $searchableFields
+      unavailableProducts: $unavailableProducts
+    ) {
+      articles {
+        ...HydrogenPredictiveSearchArticleFragment
+        ...${ARTICLE_FRAGMENT_NAME}
+      }
+      collections {
+        ...HydrogenPredictiveSearchCollectionFragment
+        ...${COLLECTION_FRAGMENT_NAME}
+      }
+      pages {
+        ...HydrogenPredictiveSearchPageFragment
+        ...${PAGE_FRAGMENT_NAME}
+      }
+      products {
+        ...HydrogenPredictiveSearchProductFragment
+        ...${PRODUCT_FRAGMENT_NAME}
+      }
+      queries {
+        ...HydrogenPredictiveSearchQueryFragment
+        ...${QUERY_FRAGMENT_NAME}
+      }
+    }
+  }`,
+  [
+    HYDROGEN_PRODUCT_FRAGMENT,
+    HYDROGEN_COLLECTION_FRAGMENT,
+    HYDROGEN_PAGE_FRAGMENT,
+    HYDROGEN_ARTICLE_FRAGMENT,
+    HYDROGEN_QUERY_FRAGMENT,
+  ],
+);
+
 const DEFAULT_PRODUCT_FRAGMENT = gql(`
   fragment PredictiveSearchProductFragment on Product {
     id
@@ -236,11 +246,6 @@ type FragmentForOptions<
   : TDefault;
 
 type PredictiveSearchQueryFragmentsForOptions<TOptions> = [
-  typeof HYDROGEN_PRODUCT_FRAGMENT,
-  typeof HYDROGEN_COLLECTION_FRAGMENT,
-  typeof HYDROGEN_PAGE_FRAGMENT,
-  typeof HYDROGEN_ARTICLE_FRAGMENT,
-  typeof HYDROGEN_QUERY_FRAGMENT,
   FragmentForOptions<TOptions, "product", typeof DEFAULT_PRODUCT_FRAGMENT>,
   FragmentForOptions<TOptions, "collection", typeof DEFAULT_COLLECTION_FRAGMENT>,
   FragmentForOptions<TOptions, "page", typeof DEFAULT_PAGE_FRAGMENT>,
@@ -249,7 +254,7 @@ type PredictiveSearchQueryFragmentsForOptions<TOptions> = [
 ];
 
 type PredictiveSearchQuerySourceForOptions<TOptions> = ComposedSource<
-  typeof PREDICTIVE_SEARCH_QUERY_SOURCE,
+  SourceOf<typeof PREDICTIVE_SEARCH_QUERY>,
   PredictiveSearchQueryFragmentsForOptions<TOptions>
 >;
 
@@ -280,11 +285,6 @@ function resolveFragments(fragments: PredictiveSearchFragments | undefined) {
   if (fragments?.query) assertFragmentContract(fragments.query, QUERY_CONTRACT);
 
   return [
-    HYDROGEN_PRODUCT_FRAGMENT,
-    HYDROGEN_COLLECTION_FRAGMENT,
-    HYDROGEN_PAGE_FRAGMENT,
-    HYDROGEN_ARTICLE_FRAGMENT,
-    HYDROGEN_QUERY_FRAGMENT,
     fragments?.product ?? DEFAULT_PRODUCT_FRAGMENT,
     fragments?.collection ?? DEFAULT_COLLECTION_FRAGMENT,
     fragments?.page ?? DEFAULT_PAGE_FRAGMENT,
@@ -299,7 +299,7 @@ export function makePredictiveSearchQueries<
 export function makePredictiveSearchQueries(): PredictiveSearchQueriesForOptions<undefined>;
 export function makePredictiveSearchQueries(options?: CreatePredictiveSearchQueriesOptions) {
   return {
-    predictiveSearch: gql(PREDICTIVE_SEARCH_QUERY_SOURCE, resolveFragments(options?.fragments)),
+    predictiveSearch: gql(PREDICTIVE_SEARCH_QUERY, resolveFragments(options?.fragments)),
   } as PredictiveSearchQueriesForOptions<typeof options>;
 }
 

--- a/packages/hydrogen/src/graphql/graphql.ts
+++ b/packages/hydrogen/src/graphql/graphql.ts
@@ -57,6 +57,22 @@ export type ComposedSource<
 > = FragmentSources<Fragments> extends "" ? Source : `${Source}\n${FragmentSources<Fragments>}`;
 
 type StorefrontGql = {
+  // Composes an already-declared document with additional fragments. Declared
+  // before the raw-source overloads so branded documents recover their literal
+  // source through SourceOf instead of binding Source to the branded type,
+  // which would degrade ComposedSource and kill inference.
+  <
+    const Document extends AnyStorefrontQueryString,
+    const Fragments extends readonly AnyStorefrontQueryString[],
+    const DocumentSource extends string = ComposedSource<SourceOf<Document>, Fragments>,
+  >(
+    document: Document,
+    fragments: Fragments,
+  ): StorefrontQueryString<
+    InferResult<DocumentSource>,
+    InferVariables<DocumentSource>,
+    DocumentSource
+  >;
   <const Source extends string>(
     source: Source,
   ): StorefrontQueryString<InferResult<Source>, InferVariables<Source>, Source>;


### PR DESCRIPTION
TL;DR: GraphQL documents inside the library were declared as `/* GraphQL */` string constants, invisible to the gql.tada TS plugin — no autocomplete, no schema validation, and every operation existed twice (a `*_SOURCE` string plus a separate `gql()` wrap). Every document is now declared with `gql()` directly, so the plugin validates the fully-static ones and the double constants are gone.

## Before

```ts
const CART_QUERY_SOURCE = /* GraphQL */ `
  query Cart($id: ID!, ...) {
    cart(id: $id) {
      ${HYDROGEN_CART_FRAGMENT_SPREAD}
    }
  }
`;
// ...later, in a factory:
const cart = gql(CART_QUERY_SOURCE, [HYDROGEN_CART_FRAGMENT]);
```

Unchecked by the gql.tada plugin (not inside a `gql()` call, and interpolated spreads), and each operation needs both a source constant and a composed document.

## After

```ts
const CART_QUERY = gql(
  `query Cart($id: ID!, ...) {
    cart(id: $id) {
      ...HydrogenCartFragment
    }
  }`,
  [HYDROGEN_CART_FRAGMENT],
);
```

One declaration per operation. `gql.tada check` validates the document against the schema and resolves the fragment from the second argument; editors get autocomplete inside the literal.

## What this changes

- `cart/queries.ts`: the Hydrogen cart fragment and all 7 default operations are single `gql()` declarations. The 7 `CUSTOM_*` variants (which spread the consumer's `CartFragment`) are also `gql()` documents with the hydrogen fragment baked in; only the consumer fragment is composed at runtime.
- `predictive-search/queries.ts`: same treatment; the query document bakes in the 5 hydrogen fragments, and `resolveFragments` only resolves the 5 consumer-overridable slots.
- `graphql.ts`: new `gql(document, fragments)` overload that composes extra fragments onto an already-declared document. It recovers the literal source type via `SourceOf` so `ComposedSource` inference keeps working (passing a branded document to the raw-string overload degraded the type to `string`).
- Consumer-owned fragment spreads (e.g. `...${CART_FRAGMENT_NAME}`) are interpolated **on purpose**: those fragments only exist at runtime, and the plugin skips documents containing interpolations instead of flagging unknown fragments. TypeScript still resolves the full literal type, and the spread is now tied to the contract-name constant so they cannot drift apart.
- Composed runtime query strings are byte-identical to before, so no request behavior changes.
- The predictive-search query source was previously shipping unminified (no `/* GraphQL */` marker and outside a `gql()` call); it is now picked up by the minify plugin.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. The `gql(document, fragments)` overload is additive; no existing export or runtime contract changes.

## Out of scope

- Wiring `gql.tada check` into CI. Nothing runs it today, so the new validation is editor/manual only. It currently reports two pre-existing errors in test files (`client.test.ts` unused variable, `graphql.test.ts` intentionally unknown fragment) that would need fixing first.
- The hand-written cart/product state types (`state.ts`) that mirror the fragments.

## How to Test

1. Run `pnpm install`.
2. Open `packages/hydrogen/src/core/cart/queries.ts` in an editor with the TS plugin active.
3. Add a field inside the `CART_QUERY` document, e.g. `cart(id: $id) { totalQuanti… }` — you should get schema autocomplete, and a typo should be flagged.
4. From `packages/hydrogen`, run `pnpm exec gql.tada check --tsconfig tsconfig.json` — the only errors reported are the two pre-existing test-file ones listed above, none in `src/core/**`.
