### PR TITLE
Accept any Storefront client in handleShopifyRedirects

### DIFF
--- a/.changeset/redirects-any-client.md
+++ b/.changeset/redirects-any-client.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+`handleShopifyRedirects` now accepts any Storefront client instead of requiring a private one. The redirect lookup only queries `urlRedirects`, which needs no token, so public — including tokenless — clients work. A token-backed client is still recommended for real stores.

--- a/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
@@ -45,9 +45,9 @@ const redirect = await handleShopifyRedirects({
 
 ## Rules
 
-- Default to one request-scoped private Storefront client per request when buyer context exists.
-- Route handlers and cart server handlers accept any provided Storefront client when public or no-buyer-context access is intentional.
-- Resolve trusted `buyerIp` before creating a private client and pass it to `createShopifyRequestContext`. Use the `hydrogen-storefront-client` buyer-IP guidance for the app's deployment.
+- Default to one request-scoped public Storefront client per request; `publicStorefrontToken` may be undefined for tokenless access (all mock.shop supports). Recommend a token-backed client once the app targets a real store, and upgrade to a private client when a private token and trusted buyer context exist.
+- Route handlers, cart server handlers, and `handleShopifyRedirects` accept any provided Storefront client.
+- When creating a private client, resolve trusted `buyerIp` first and pass it to `createShopifyRequestContext`. Use the `hydrogen-storefront-client` buyer-IP guidance for the app's deployment.
 - Create `requestContext` with `createShopifyRequestContext({ request, i18n, buyerIp })` where buyer context exists and the framework exposes a real `Request`; use `request: { headers }` only when no `Request` exists.
 - Pass the same request-scoped `requestContext`, `storefrontClient`, and `sessionManager` into `handleShopifyRoutes` and registered handler groups.
 - Call `handleShopifyRoutes` without awaiting it immediately. It returns `null` synchronously when no route matches; only return or await the promise after checking that it is truthy.

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
@@ -30,7 +30,7 @@ try {
 
 Prefer this over adding `.catch()` only to the returned promise: the request-level boundary also handles synchronous setup and validation errors.
 
-Resolve `buyerIp` with the app's trusted deployment header before creating the private client. Use the buyer-IP guidance from `hydrogen-storefront-client`.
+The scaffold defaults to a public client; `PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` per the `hydrogen-storefront-client` buyer-IP guidance.
 
 ```ts
 import {
@@ -46,19 +46,17 @@ const cartHandlers = createCartServerHandlers();
 const predictiveSearchHandlers = createPredictiveSearchServerHandlers();
 
 export async function handleRequest(request: Request, next: () => Promise<Response>) {
-  const buyerIp = getBuyerIp(request.headers);
   const requestContext = createShopifyRequestContext({
     request,
     i18n: { country: "US", language: "EN" },
-    buyerIp,
   });
   const sessionManager = await createSessionManager(request);
   const storefrontClient = createStorefrontClient({
-    type: "private",
+    type: "public",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
-      privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
+      publicStorefrontToken: process.env.PUBLIC_STOREFRONT_API_TOKEN,
     },
   });
 
@@ -89,7 +87,7 @@ React Router framework mode needs:
 - Verify `future.v8_middleware: true` is set in `react-router.config.ts`.
 - A final splat route such as `route("*", "routes/catchall.tsx")`.
 - Root-route middleware that creates the Storefront client, runs Hydrogen routes, stores the client in context, and applies response headers after `next()`.
-- Trusted buyer-IP resolution before `createStorefrontClient`; use the buyer-IP guidance from `hydrogen-storefront-client`.
+- A public Storefront client by default; when upgrading to `type: "private"`, resolve trusted `buyerIp` before `createStorefrontClient` per the buyer-IP guidance from `hydrogen-storefront-client`.
 
 ```tsx
 import {
@@ -106,19 +104,17 @@ const predictiveSearchHandlers = createPredictiveSearchServerHandlers();
 
 export const middleware: Route.MiddlewareFunction[] = [
   async ({ context, request }, next) => {
-    const buyerIp = getBuyerIp(request.headers);
     const requestContext = createShopifyRequestContext({
       request,
       i18n: { country: "US", language: "EN" },
-      buyerIp,
     });
     const sessionManager = await createSessionManager(request);
     const storefrontClient = createStorefrontClient({
-      type: "private",
+      type: "public",
       requestContext,
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
-        privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
+        publicStorefrontToken: process.env.PUBLIC_STOREFRONT_API_TOKEN,
       },
     });
 

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
@@ -6,9 +6,9 @@ Next splits Hydrogen routing across `proxy.ts` and `app/not-found.tsx`.
 
 `proxy.ts` can short-circuit before routing, so put `handleShopifyRoutes` there. In Next 16+, the file is `proxy.ts` and the exported function is named `proxy`; older Next projects may use `middleware.ts` with an exported `middleware` function. It cannot inspect the routed response, so forward the original URL to not-found UI.
 
-Resolve `buyerIp` from the app's trusted deployment headers before creating the private client. Use the buyer-IP guidance from `hydrogen-storefront-client`.
+The scaffold defaults to a public client; `NEXT_PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` from the app's trusted deployment headers per the buyer-IP guidance from `hydrogen-storefront-client`.
 
-This shape assumes app-owned server-only helpers for `getBuyerIp`, `customerSession`, and `createSessionManager`. Do not import those names from Hydrogen.
+This shape assumes app-owned server-only helpers for `customerSession` and `createSessionManager`. Do not import those names from Hydrogen.
 
 ```ts
 import {
@@ -24,18 +24,16 @@ const cartHandlers = createCartServerHandlers();
 const customerAccountHandlers = createCustomerAccountServerHandlers({ customerSession });
 
 export async function proxy(request: NextRequest) {
-  const buyerIp = getBuyerIp(request.headers);
   const requestContext = createShopifyRequestContext({
     request,
     i18n: { country: "US", language: "EN" },
-    buyerIp,
   });
   const storefrontClient = createStorefrontClient({
-    type: "private",
+    type: "public",
     requestContext,
     config: {
       storeDomain: process.env.NEXT_PUBLIC_STORE_DOMAIN!,
-      privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
+      publicStorefrontToken: process.env.NEXT_PUBLIC_STOREFRONT_API_TOKEN,
     },
   });
   const sessionManager = await createSessionManager(request);
@@ -113,7 +111,7 @@ With `cacheComponents: true`, keep request-time work in an async child under `<S
 
 ## Storefront Client
 
-In server components, use a cached server-only factory that reads `headers()` and creates a private request-scoped client. In `proxy.ts`, use the actual `NextRequest` so URL, signal, and forwarded headers are preserved. `requestContext.getForwardedRequestHeaders()` carries the original URL through `x-storefront-url` for `not-found.tsx`.
+In server components, use a cached server-only factory that reads `headers()` and creates a request-scoped client (public by default). In `proxy.ts`, use the actual `NextRequest` so URL, signal, and forwarded headers are preserved. `requestContext.getForwardedRequestHeaders()` carries the original URL through `x-storefront-url` for `not-found.tsx`.
 
 When a Server Component or layout reads Customer Account session state under Cache Components, put that read below an explicit dynamic boundary (`connection()` + `<Suspense>`). Do not rely on static route-segment config that Cache Components rejects.
 

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
@@ -19,7 +19,7 @@ Nuxt needs three pieces:
 
 Create `server/middleware/shopify.ts`:
 
-Resolve `buyerIp` from the app's trusted deployment headers before creating the private client. Use the buyer-IP guidance from `hydrogen-storefront-client`.
+The scaffold defaults to a public client; `PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` from the app's trusted deployment headers per the buyer-IP guidance from `hydrogen-storefront-client`.
 
 Create an app-owned request-scoped `sessionManager` before `handleShopifyRoutes`.
 
@@ -29,21 +29,19 @@ import {
   createStorefrontClient,
   createShopifyRequestContext,
   handleShopifyRoutes,
-  type ShopifyRequestContextWithBuyerIp,
+  type ShopifyRequestContext,
 } from "@shopify/hydrogen";
 
 const cartHandlers = createCartServerHandlers();
 
 export default defineEventHandler(async (event) => {
   const request = toWebRequest(event);
-  const buyerIp = getBuyerIp(request.headers);
   const requestContext = createShopifyRequestContext({
     request,
     i18n: { country: "US", language: "EN" },
-    buyerIp,
   });
   const sessionManager = await createSessionManager(request);
-  const storefrontClient = createPrivateStorefrontClient(requestContext);
+  const storefrontClient = createPublicStorefrontClient(requestContext);
 
   const shopifyRoute = handleShopifyRoutes({
     request,
@@ -58,13 +56,13 @@ export default defineEventHandler(async (event) => {
   event.context.storefrontClient = storefrontClient;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
+function createPublicStorefrontClient(requestContext: ShopifyRequestContext) {
   return createStorefrontClient({
-    type: "private",
+    type: "public",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
-      privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
+      publicStorefrontToken: process.env.PUBLIC_STOREFRONT_API_TOKEN,
     },
   });
 }

--- a/packages/hydrogen/skills/hydrogen-setup/steps/2-scaffold.md
+++ b/packages/hydrogen/skills/hydrogen-setup/steps/2-scaffold.md
@@ -33,9 +33,12 @@ Use these canonical environment variable names throughout the app (kept in sync 
 
 If the framework requires a prefix to expose client-side variables, preserve the canonical suffix and add only the required framework prefix. Never expose `PRIVATE_STOREFRONT_API_TOKEN` to the client.
 
+List `PUBLIC_STOREFRONT_API_TOKEN` in the app's env example file as a commented-out entry (`# PUBLIC_STOREFRONT_API_TOKEN=`). The Storefront client accepts `undefined` as tokenless access, which is all mock.shop supports, so the scaffold works before the user has tokens and upgrades in place when they add one. Do not write an uncommented empty assignment (`PUBLIC_STOREFRONT_API_TOKEN=`): env loaders parse that as an empty string, and the client rejects empty tokens. Recommend filling it in (or switching to a private client) once the app targets a real store.
+
 ### Continue when
 
 - [ ] Env vars follow the canonical names (plus any required framework prefix)
+- [ ] `PUBLIC_STOREFRONT_API_TOKEN` is listed commented-out in the env example until the user provides a token
 - [ ] `PRIVATE_STOREFRONT_API_TOKEN` is not exposed to the client
 
 ## Keep Environment Access Server-Side

--- a/packages/hydrogen/skills/hydrogen-storefront-client/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/SKILL.md
@@ -37,13 +37,15 @@ Environment variables are still a **server-side input boundary**. Do not read `p
 
 | Type | Access | Best for |
 |------|--------|----------|
-| `"public"` | Public token, or tokenless | Browser-side fetches with server-provided public config |
+| `"public"` | Public token, or tokenless | Default scaffold; browser-side fetches; tokenless mock.shop |
 | `"private"` | Private token with trusted `buyerIp` | SSR with buyer context |
 | `"private_no_buyer_context"` | Private token without buyer context | Prerendering, background jobs, webhooks |
 
-Token-based Storefront API access is required for product tags, metaobjects, metafields, menus, and customers. Public and private tokens can query the same token-required fields; the difference is whether the token is safe to expose and whether the request has trusted buyer context.
+Default to a public client. `publicStorefrontToken` accepts `undefined`, which means tokenless access — there is no rate limit for tokenless clients, and it is all mock.shop supports. Always recommend a token-backed client (public or private) once the app targets a real store: token-based Storefront API access is required for product tags, metaobjects, metafields, menus, and customers. Public and private tokens can query the same token-required fields; the difference is whether the token is safe to expose and whether the request has trusted buyer context.
 
-### Public client
+### Public client (default)
+
+Wire `publicStorefrontToken` from the canonical env variable without asserting it exists. When `PUBLIC_STOREFRONT_API_TOKEN` is unset the client runs tokenless, so the same scaffold works against mock.shop before the user has tokens and upgrades in place when they add one. In env example files list the variable commented out (`# PUBLIC_STOREFRONT_API_TOKEN=`) rather than as an empty assignment: env loaders parse `PUBLIC_STOREFRONT_API_TOKEN=` as an empty string, and the client rejects empty tokens.
 
 This example belongs in a server-only module unless the config values are explicitly passed into browser code by a server boundary.
 
@@ -60,14 +62,14 @@ const client = createStorefrontClient({
   requestContext,
   config: {
     storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
-    publicStorefrontToken: process.env.PUBLIC_STOREFRONT_API_TOKEN!,
+    publicStorefrontToken: process.env.PUBLIC_STOREFRONT_API_TOKEN,
   },
 });
 ```
 
-### Private client (SSR)
+### Private client (SSR upgrade)
 
-Requires `buyerIp` to forward trusted buyer context. Resolve request-derived values before creating the client:
+Use when the app has a private token and trusted buyer context. Requires `buyerIp` to forward trusted buyer context. Resolve request-derived values before creating the client:
 
 ```ts
 import { createStorefrontClient, createShopifyRequestContext } from "@shopify/hydrogen";
@@ -102,7 +104,7 @@ Hydrogen does not infer buyer IP headers. Apps decide how to build `buyerIp` bas
 - Vercel: `x-forwarded-for`
 - Fly.io: `Fly-Client-IP` (parse `X-Forwarded-For` only when another reverse proxy sits in front)
 
-Use the same request-scoped Storefront client for Hydrogen route handlers, cart server handlers, and server data loaders when they share the same request data. Route and cart handlers accept any provided Storefront client. Redirect handlers still require a private server-side client.
+Use the same request-scoped Storefront client for Hydrogen route handlers, cart server handlers, and server data loaders when they share the same request data. Route, cart, and redirect handlers all accept any provided Storefront client.
 
 When using `handleShopifyRoutes`, pass the trusted `buyerIp` into `createShopifyRequestContext`. Both the SFAPI proxy and direct `client.graphql()` calls source buyer identity from that request context.
 

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/astro.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/astro.md
@@ -2,9 +2,9 @@
 
 Astro pages run their frontmatter on the server, so `Astro.request` and `Astro.clientAddress` are available — but only on **server-rendered** pages. Prerendered pages have no request at all.
 
-## SSR with trusted buyer context
+## SSR
 
-Use `Astro.locals` to pass the storefront client from middleware to pages. The middleware creates the client once per request with buyer IP resolved from `Astro.clientAddress`.
+Use `Astro.locals` to pass the storefront client from middleware to pages. The middleware creates the client once per request. The scaffold defaults to a public client; `PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` (e.g. from `Astro.clientAddress`) per the `hydrogen-storefront-client` buyer-IP guidance.
 
 ```ts
 // src/middleware.ts
@@ -15,18 +15,16 @@ import {
 } from "@shopify/hydrogen";
 
 export const onRequest = defineMiddleware(async (context, next) => {
-  const buyerIp = context.clientAddress;
   const requestContext = createShopifyRequestContext({
     request: context.request,
     i18n: { country: "US", language: "EN" },
-    buyerIp,
   });
   const client = createStorefrontClient({
-    type: "private",
+    type: "public",
     requestContext,
     config: {
       storeDomain: import.meta.env.PUBLIC_STORE_DOMAIN,
-      privateStorefrontToken: import.meta.env.PRIVATE_STOREFRONT_API_TOKEN,
+      publicStorefrontToken: import.meta.env.PUBLIC_STOREFRONT_API_TOKEN,
     },
   });
 
@@ -40,11 +38,11 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
 ```ts
 // src/env.d.ts — type the locals object
-import type { RequestScopedPrivateStorefrontClient } from "@shopify/hydrogen";
+import type { StorefrontClient } from "@shopify/hydrogen";
 
 declare namespace App {
   interface Locals {
-    storefront: RequestScopedPrivateStorefrontClient;
+    storefront: StorefrontClient;
   }
 }
 ```
@@ -68,7 +66,7 @@ const { data } = await Astro.locals.storefront.graphql(PRODUCT_QUERY, {
 <h1>{data?.product?.title}</h1>
 ```
 
-This requires `output: "server"` in `astro.config.mjs` (all pages SSR by default). Individual pages that don't need buyer IP can opt into static prerendering with `export const prerender = true`.
+This requires `output: "server"` in `astro.config.mjs` (all pages SSR by default). Individual pages that don't need request-time data can opt into static prerendering with `export const prerender = true`.
 
 ## Static pages (no buyer IP)
 

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/nextjs.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/nextjs.md
@@ -1,8 +1,8 @@
 # Next.js App Router
 
-## Dynamic pages (trusted buyer context)
+## Dynamic pages
 
-Next.js server components don't receive a `Request` object, but private clients need a request-derived buyer IP. The pattern: a server-only cached factory that reads `headers()`, creates a request context from those headers, resolves buyer IP from trusted request data, and creates a private client for that RSC request.
+Next.js server components don't receive a `Request` object. The pattern: a server-only cached factory that reads `headers()`, creates a request context from those headers, and creates a request-scoped client for that RSC request. The scaffold defaults to a public client; `NEXT_PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` per the `hydrogen-storefront-client` buyer-IP guidance (e.g. from trusted `x-forwarded-for` data).
 
 ```ts
 // lib/storefront.ts
@@ -13,25 +13,19 @@ import {
   createShopifyRequestContext,
 } from "@shopify/hydrogen";
 
-const FIRST_FORWARDED_FOR_VALUE_INDEX = 0;
-
 export const getStorefrontClient = cache(async () => {
   const requestHeaders = await headers();
-  const forwardedForValues = requestHeaders.get("x-forwarded-for")?.split(",");
-  const buyerIp = forwardedForValues?.[FIRST_FORWARDED_FOR_VALUE_INDEX]?.trim();
-  if (!buyerIp) throw new Error("buyer IP is required for private SFAPI clients");
   const requestContext = createShopifyRequestContext({
     request: { headers: requestHeaders },
     i18n: { country: "US", language: "EN" },
-    buyerIp,
   });
 
   return createStorefrontClient({
-    type: "private",
+    type: "public",
     requestContext,
     config: {
       storeDomain: process.env.NEXT_PUBLIC_STORE_DOMAIN!,
-      privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
+      publicStorefrontToken: process.env.NEXT_PUBLIC_STOREFRONT_API_TOKEN,
     },
   });
 });
@@ -58,7 +52,7 @@ export default async function ProductPage({ params }: { params: Promise<{ handle
 }
 ```
 
-The private client is created inside the request path because `buyerIp` and `requestContext` are static on the client. Calling `headers()` makes this page dynamic. Route handlers and proxy files receive the actual `Request`; pass that request and the trusted `buyerIp` to `createShopifyRequestContext({ request, i18n, buyerIp })` there so the request URL and `request.signal` are preserved.
+The client is created inside the request path because `requestContext` is static on the client. Calling `headers()` makes this page dynamic. Route handlers and proxy files receive the actual `Request`; pass that request to `createShopifyRequestContext({ request, i18n })` there so the request URL and `request.signal` are preserved. When upgrading to a private client, also pass the trusted `buyerIp` (`createShopifyRequestContext({ request, i18n, buyerIp })`).
 
 ## Static pages (no buyer IP)
 
@@ -112,7 +106,7 @@ export default async function CollectionPage({ params }: { params: Promise<{ han
 }
 ```
 
-This component never touches request-time APIs (`headers()`, `cookies()`, `searchParams`). With Cache Components, wrap catalog reads in explicit `"use cache"` functions and choose a `cacheLife` / `cacheTag`; do not use route-segment `revalidate`. All requests share one throttle bucket - fine for pages that serve the same data to every visitor. Use a per-request `private` client from `getStorefrontClient()` when you need per-buyer isolation or personalized data.
+This component never touches request-time APIs (`headers()`, `cookies()`, `searchParams`). With Cache Components, wrap catalog reads in explicit `"use cache"` functions and choose a `cacheLife` / `cacheTag`; do not use route-segment `revalidate`. All requests share one throttle bucket - fine for pages that serve the same data to every visitor. Use a per-request client from `getStorefrontClient()` (upgraded to `private`) when you need per-buyer isolation or personalized data.
 
 ## `use cache` does not serialize `URLSearchParams`
 

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/nuxt.md
@@ -2,48 +2,46 @@
 
 Nuxt needs separate server and client Storefront clients:
 
-- Server requests use a request-scoped private client created in Nitro middleware.
+- Server requests use a request-scoped public client created in Nitro middleware.
 - Browser refetches use a public client whose `fetch` routes through the same-origin Hydrogen SFAPI proxy.
 
 Use the `hydrogen-request-handlers` skill when wiring middleware, response-header propagation, and 404 redirects.
 
 ## Server Client
 
-Create the private client in server middleware where Nuxt exposes the incoming request:
+Create the client in server middleware where Nuxt exposes the incoming request. `PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` per the `hydrogen-storefront-client` buyer-IP guidance:
 
 ```ts
 import {
   createStorefrontClient,
   createShopifyRequestContext,
-  type ShopifyRequestContextWithBuyerIp,
+  type ShopifyRequestContext,
 } from "@shopify/hydrogen";
 
 export default defineEventHandler((event) => {
   const request = toWebRequest(event);
-  const buyerIp = getBuyerIp(request.headers);
   const requestContext = createShopifyRequestContext({
     request,
     i18n: { country: "US", language: "EN" },
-    buyerIp,
   });
 
-  event.context.storefrontClient = createPrivateStorefrontClient(requestContext);
+  event.context.storefrontClient = createPublicStorefrontClient(requestContext);
   event.context.shopifyRequestContext = requestContext;
 });
 
-function createPrivateStorefrontClient(requestContext: ShopifyRequestContextWithBuyerIp) {
+function createPublicStorefrontClient(requestContext: ShopifyRequestContext) {
   return createStorefrontClient({
-    type: "private",
+    type: "public",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
-      privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
+      publicStorefrontToken: process.env.PUBLIC_STOREFRONT_API_TOKEN,
     },
   });
 }
 ```
 
-Use a project helper for `getBuyerIp`. Do not infer buyer IP from untrusted headers unless the deployment's proxy chain is known.
+When upgrading to a private client, use a project helper for `getBuyerIp`. Do not infer buyer IP from untrusted headers unless the deployment's proxy chain is known.
 
 ## Server Injection
 
@@ -104,7 +102,7 @@ export default defineNuxtPlugin(() => {
 
 ## Query Usage
 
-In server pages, prefer the injected private client:
+In server pages, prefer the injected server client:
 
 ```ts
 const { $storefrontClient } = useNuxtApp();

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/react-router.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/react-router.md
@@ -1,13 +1,13 @@
 # React Router 7
 
-Middleware creates a per-request private client with buyer IP already resolved from trusted headers. `requestContext` carries request lifecycle headers and captures SFAPI response headers so middleware can merge them into the final response.
+Middleware creates a per-request public client. `requestContext` carries request lifecycle headers and captures SFAPI response headers so middleware can merge them into the final response. `PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` per the `hydrogen-storefront-client` buyer-IP guidance.
 
 ```ts
 // app/storefront.context.ts
 import { createContext } from "react-router";
-import type { RequestScopedPrivateStorefrontClient } from "@shopify/hydrogen";
+import type { StorefrontClient } from "@shopify/hydrogen";
 
-export const storefrontContext = createContext<RequestScopedPrivateStorefrontClient>();
+export const storefrontContext = createContext<StorefrontClient>();
 ```
 
 This `createContext` is React Router's request context for passing values from middleware to loaders; it is not React's component `createContext`.
@@ -25,20 +25,17 @@ export const storefrontMiddleware: Route.MiddlewareFunction = async (
   { request, context },
   next,
 ) => {
-  const buyerIp = request.headers.get("cf-connecting-ip");
-  if (!buyerIp) throw new Error("cf-connecting-ip is required for private SFAPI clients");
   const requestContext = createShopifyRequestContext({
     request,
     i18n: { country: "US", language: "EN" },
-    buyerIp,
   });
 
   const client = createStorefrontClient({
-    type: "private",
+    type: "public",
     requestContext,
     config: {
       storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
-      privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
+      publicStorefrontToken: process.env.PUBLIC_STOREFRONT_API_TOKEN,
     },
   });
 
@@ -81,4 +78,4 @@ export async function loader({ context, params }: Route.LoaderArgs) {
 }
 ```
 
-Because `buyerIp` and `requestContext` are resolved in the middleware, loaders don't need to pass `request` to `graphql()` — the client is ready to use directly from context. The request context captures SFAPI response headers, and the middleware merges them after `next()` returns so `Set-Cookie` and other headers propagate to the browser without each loader handling them.
+Because `requestContext` is created in the middleware, loaders don't need to pass `request` to `graphql()` — the client is ready to use directly from context. The request context captures SFAPI response headers, and the middleware merges them after `next()` returns so `Set-Cookie` and other headers propagate to the browser without each loader handling them.

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/solidstart.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/solidstart.md
@@ -2,9 +2,9 @@
 
 SolidStart uses Vinxi (Nitro under the hood) and provides middleware via `createMiddleware`. Server-side data fetching happens in `query()` functions marked with `"use server"`, where `getRequestEvent()` gives access to the request.
 
-## SSR with trusted buyer context
+## SSR
 
-The middleware creates the client per-request and attaches it to `event.locals`. Server functions retrieve it via `getRequestEvent()`.
+The middleware creates the client per-request and attaches it to `event.locals`. Server functions retrieve it via `getRequestEvent()`. The scaffold defaults to a public client; `PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` per the `hydrogen-storefront-client` buyer-IP guidance.
 
 ```ts
 // src/middleware.ts
@@ -16,20 +16,17 @@ import {
 
 export default createMiddleware({
   onRequest: (event) => {
-    const buyerIp = event.request.headers.get("cf-connecting-ip");
-    if (!buyerIp) throw new Error("cf-connecting-ip is required for private SFAPI clients");
     const requestContext = createShopifyRequestContext({
       request: event.request,
       i18n: { country: "US", language: "EN" },
-      buyerIp,
     });
 
     const client = createStorefrontClient({
-      type: "private",
+      type: "public",
       requestContext,
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
-        privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
+        publicStorefrontToken: process.env.PUBLIC_STOREFRONT_API_TOKEN,
       },
     });
 
@@ -41,14 +38,14 @@ export default createMiddleware({
 ```ts
 // src/lib/storefront.ts — helper to retrieve the client in server functions
 import { getRequestEvent } from "solid-js/web";
-import type { RequestScopedPrivateStorefrontClient } from "@shopify/hydrogen";
+import type { StorefrontClient } from "@shopify/hydrogen";
 
-export function getStorefront(): RequestScopedPrivateStorefrontClient {
+export function getStorefront(): StorefrontClient {
   const event = getRequestEvent();
   if (!event?.locals?.storefront) {
     throw new Error("Storefront client not found — is the middleware registered?");
   }
-  return event.locals.storefront as RequestScopedPrivateStorefrontClient;
+  return event.locals.storefront as StorefrontClient;
 }
 ```
 
@@ -104,20 +101,17 @@ import {
 
 export default createMiddleware({
   onRequest: (event) => {
-    const buyerIp = event.request.headers.get("cf-connecting-ip");
-    if (!buyerIp) throw new Error("cf-connecting-ip is required for private SFAPI clients");
     const requestContext = createShopifyRequestContext({
       request: event.request,
       i18n: { country: "US", language: "EN" },
-      buyerIp,
     });
 
     const client = createStorefrontClient({
-      type: "private",
+      type: "public",
       requestContext,
       config: {
         storeDomain: process.env.PUBLIC_STORE_DOMAIN!,
-        privateStorefrontToken: process.env.PRIVATE_STOREFRONT_API_TOKEN!,
+        publicStorefrontToken: process.env.PUBLIC_STOREFRONT_API_TOKEN,
       },
     });
 
@@ -134,4 +128,4 @@ export default createMiddleware({
 
 - **`"use server"` boundary is mandatory** — `getRequestEvent()` only works inside a `"use server"` function. Calling it outside (e.g. in a component body) returns `undefined` and the storefront client lookup silently fails.
 - **`event.nativeEvent` breaks tree-shaking** — accessing the underlying H3 event from Vinxi pulls in the entire H3 runtime. Only use it in server-only files if you need Nitro-specific features.
-- **No built-in `getClientAddress()`** — unlike SvelteKit, SolidStart doesn't have a convenience method for the client IP. Do not trust generic proxy headers unless your deployment strips or overwrites them; build `buyerIp` from request data your deployment controls.
+- **No built-in `getClientAddress()`** — relevant when upgrading to a private client: unlike SvelteKit, SolidStart doesn't have a convenience method for the client IP. Do not trust generic proxy headers unless your deployment strips or overwrites them; build `buyerIp` from request data your deployment controls.

--- a/packages/hydrogen/skills/hydrogen-storefront-client/references/sveltekit.md
+++ b/packages/hydrogen/skills/hydrogen-storefront-client/references/sveltekit.md
@@ -2,14 +2,16 @@
 
 ## Contents
 
-- SSR with buyer isolation
+- SSR
 - Forwarding response headers
 - Static pages (no buyer IP)
 - Footguns
 
 SvelteKit's `handle` hook in `hooks.server.ts` runs on every server request and receives an `event` object with the full `Request`, cookies, and client address. Use `event.locals` to pass the storefront client to `load` functions.
 
-## SSR with trusted buyer context
+## SSR
+
+The scaffold defaults to a public client; `PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports) — read it through `$env/dynamic/public`, since `$env/static/public` fails the build for unset vars. Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` (e.g. from `event.getClientAddress()`) per the `hydrogen-storefront-client` buyer-IP guidance.
 
 ```ts
 // src/hooks.server.ts
@@ -18,22 +20,20 @@ import {
   createStorefrontClient,
   createShopifyRequestContext,
 } from "@shopify/hydrogen";
-import { PRIVATE_STOREFRONT_API_TOKEN } from "$env/static/private";
+import { env } from "$env/dynamic/public";
 import { PUBLIC_STORE_DOMAIN } from "$env/static/public";
 
 export const handle: Handle = async ({ event, resolve }) => {
-  const buyerIp = event.getClientAddress();
   const requestContext = createShopifyRequestContext({
     request: event.request,
     i18n: { country: "US", language: "EN" },
-    buyerIp,
   });
   const client = createStorefrontClient({
-    type: "private",
+    type: "public",
     requestContext,
     config: {
       storeDomain: PUBLIC_STORE_DOMAIN,
-      privateStorefrontToken: PRIVATE_STOREFRONT_API_TOKEN,
+      publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
     },
   });
 
@@ -47,12 +47,12 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 ```ts
 // src/app.d.ts — type the locals object
-import type { RequestScopedPrivateStorefrontClient } from "@shopify/hydrogen";
+import type { StorefrontClient } from "@shopify/hydrogen";
 
 declare global {
   namespace App {
     interface Locals {
-      storefront: RequestScopedPrivateStorefrontClient;
+      storefront: StorefrontClient;
     }
   }
 }
@@ -87,23 +87,21 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 
 ```ts
 // src/hooks.server.ts — response header propagation
-import { PRIVATE_STOREFRONT_API_TOKEN } from "$env/static/private";
+import { env } from "$env/dynamic/public";
 import { PUBLIC_STORE_DOMAIN } from "$env/static/public";
 
 export const handle: Handle = async ({ event, resolve }) => {
-  const buyerIp = event.getClientAddress();
   const requestContext = createShopifyRequestContext({
     request: event.request,
     i18n: { country: "US", language: "EN" },
-    buyerIp,
   });
 
   const client = createStorefrontClient({
-    type: "private",
+    type: "public",
     requestContext,
     config: {
       storeDomain: PUBLIC_STORE_DOMAIN,
-      privateStorefrontToken: PRIVATE_STOREFRONT_API_TOKEN,
+      publicStorefrontToken: env.PUBLIC_STOREFRONT_API_TOKEN,
     },
   });
 
@@ -167,5 +165,5 @@ export const load: PageServerLoad = async ({ params }) => {
 
 ## Footguns
 
-- **`event.getClientAddress()` needs proxy config** — behind a reverse proxy, the raw address is the proxy's IP, not the buyer's. Set the `ADDRESS_HEADER` env var (e.g. `ADDRESS_HEADER=X-Forwarded-For`) and `XFF_DEPTH` to the number of trusted proxies so SvelteKit reads the correct IP from the right end of the header.
+- **`event.getClientAddress()` needs proxy config** — relevant when upgrading to a private client that resolves `buyerIp` from it. Behind a reverse proxy, the raw address is the proxy's IP, not the buyer's. Set the `ADDRESS_HEADER` env var (e.g. `ADDRESS_HEADER=X-Forwarded-For`) and `XFF_DEPTH` to the number of trusted proxies so SvelteKit reads the correct IP from the right end of the header.
 - **`filterSerializedResponseHeaders` is unrelated** — this option on `resolve()` controls which headers from SvelteKit's internal `fetch()` calls are serialized into the HTML for client-side hydration. It does not affect the actual HTTP response headers. Don't confuse it with forwarding SFAPI headers.

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-redirects.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-redirects.test.ts
@@ -26,6 +26,16 @@ function createPrivateStorefrontClient(request: Request, i18n: I18nConfig = DEFA
   });
 }
 
+function createTokenlessPublicStorefrontClient(request: Request, i18n: I18nConfig = DEFAULT_I18N) {
+  return createStorefrontClient({
+    type: "public",
+    requestContext: createShopifyRequestContext({ request, i18n }),
+    config: {
+      storeDomain: defaultConfig.storeDomain,
+    },
+  });
+}
+
 function redirectOptions(
   request: Request,
   options: Partial<Parameters<typeof handleShopifyRedirects>[0]> = {},
@@ -95,6 +105,31 @@ describe("handleShopifyRedirects", () => {
     expect(result.headers.get("location")).toBe("/new-page");
     expect(result.headers.get("server-timing")).toBe("shopify;dur=10");
     expect(result.headers.getSetCookie()).toEqual(["tracking=1; Path=/; Secure"]);
+  });
+
+  it("returns URL redirect using a tokenless public client", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: {
+            urlRedirects: {
+              edges: [{ node: { target: "/new-page" } }],
+            },
+          },
+        }),
+      ),
+    );
+
+    const request = new Request("https://my-app.com/old-page");
+    const result = await handleShopifyRedirects(
+      redirectOptions(request, {
+        storefrontClient: createTokenlessPublicStorefrontClient(request),
+      }),
+    );
+
+    assert(result, "expected URL redirect response");
+    expect(result.status).toBe(301);
+    expect(result.headers.get("location")).toBe("/new-page");
   });
 
   it("uses a query param redirect without querying the Storefront API", async () => {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-redirects.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-redirects.ts
@@ -1,4 +1,4 @@
-import type { PrivateStorefrontClient } from "../../client";
+import type { StorefrontClient } from "../../client";
 import { getLogger } from "../logging";
 import type { ShopifyRouteTemplates } from "../standard-routes/index";
 import { handleAdminRedirect } from "./interceptors/admin-redirect";
@@ -11,7 +11,7 @@ const log = getLogger("redirects");
 
 export type RedirectOptions = {
   request: Request;
-  storefrontClient: PrivateStorefrontClient;
+  storefrontClient: StorefrontClient;
   routeTemplates: ShopifyRouteTemplates;
 };
 

--- a/packages/hydrogen/src/core/request-routing/interceptors/standard-routes.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/standard-routes.ts
@@ -1,4 +1,4 @@
-import type { PrivateStorefrontClient } from "../../../client";
+import type { StorefrontClient } from "../../../client";
 import {
   getStandardRouteTarget,
   isStandardRouteSelfRedirect,
@@ -12,7 +12,7 @@ export function handleStandardRouteRedirects({
   routeTemplates,
 }: {
   request: Request;
-  storefrontClient: PrivateStorefrontClient;
+  storefrontClient: StorefrontClient;
   routeTemplates: ShopifyRouteTemplates;
 }): Response | null {
   const url = new URL(request.url);


### PR DESCRIPTION
TL;DR: `handleShopifyRedirects` required a `PrivateStorefrontClient`, but nothing in the redirect flow needs private access. The constraint was purely type-level: the interceptors only use `.graphql()` (the `urlRedirects` query, which needs no token), `.storeUrl`, and `.requestContext` — all present on every client type. This widens the option to accept any Storefront client, and moves the packaged skills to a public-client-by-default scaffold now that tokenless Storefront API access is no longer rate limited.

## Before

```ts
export type RedirectOptions = {
  request: Request;
  storefrontClient: PrivateStorefrontClient;
  routeTemplates: ShopifyRouteTemplates;
};
```

Skills scaffolded a request-scoped private client everywhere, which forced apps to resolve `buyerIp` and hold a private token before anything worked — and pushed workarounds like faking a private token to run against mock.shop.

## After

```ts
export type RedirectOptions = {
  request: Request;
  storefrontClient: StorefrontClient;
  routeTemplates: ShopifyRouteTemplates;
};
```

Skills scaffold a public client wired to `PUBLIC_STOREFRONT_API_TOKEN` without asserting it exists. Unset means tokenless access, which is all mock.shop supports, so a fresh scaffold works with zero tokens and upgrades in place when the user adds one. Skills still recommend a token-backed client for real stores, and keep the private client (with `buyerIp` guidance) as the SSR upgrade path.

## What this changes

- `RedirectOptions.storefrontClient` widens from `PrivateStorefrontClient` to `StorefrontClient` (same in the `standard-routes` interceptor). No runtime change — there was never a private-only check.
- Adds a test covering `handleShopifyRedirects` with a tokenless public client.
- `hydrogen-storefront-client` skill: public client is the documented default; removes the stale "Redirect handlers still require a private server-side client" rule; env example guidance says to list `PUBLIC_STOREFRONT_API_TOKEN` commented out (an uncommented `VAR=` parses as an empty string, which the client rejects).
- `hydrogen-request-handlers` skill: default is one request-scoped public client per request; all handlers (routes, cart, redirects) accept any client; `buyerIp` resolution now documented as part of the private upgrade.
- All framework references (React Router, Next.js, Nuxt, Astro, SvelteKit, SolidStart) scaffold the public client and drop `buyerIp` from the default path. The SvelteKit ref moves the token to `$env/dynamic/public` because `$env/static` imports fail the build for unset vars.
- `hydrogen-setup` scaffold step gains the commented-out token env convention as a checklist item.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. Widening a function input is non-breaking: every existing caller passing a private client still compiles. `private_no_buyer_context` prerender guidance is untouched.

## Out of scope

- `templates/react-router` still fakes a private token (`"mock-private-token"`) in mock.shop mode — it can now use a tokenless public client instead. Follow-up.
- `templates/nextjs`, `examples/*`, and the repo-root template skills keep their private-client wiring for now.

## How to Test

1. Run `pnpm install && pnpm build:pkgs`.
2. Create a script that builds a `type: "public"` client with no `publicStorefrontToken` for `storeDomain: "hydrogen-preview.myshopify.com"` and calls `handleShopifyRedirects` with `new Request("https://any.example/redirect")` and empty route templates.
3. Confirm it returns a `301` with `location: /` (the `/redirect` → `/` URL redirect configured in that store's admin). Verified locally with exactly this setup.
