### PR TITLE
Fix optimistic cart line ordering

### DIFF
--- a/.changeset/optimistic-cart-order.md
+++ b/.changeset/optimistic-cart-order.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Reduce reordering when optimistic cart additions resolve, and include selected options and product handles in pending product form additions.

--- a/packages/hydrogen/src/core/cart/cart-transactions.test.ts
+++ b/packages/hydrogen/src/core/cart/cart-transactions.test.ts
@@ -265,15 +265,15 @@ describe("transaction cart store", () => {
     transportDeferreds[0].resolve(serverResult([lineA]));
     await removeLine;
     expect(store.getState().data.lines.nodes.map((line) => line.id)).toEqual([
-      "line-a",
       "optimistic:variant-c",
+      "line-a",
     ]);
 
-    addition.resolve(serverResult([lineA, lineB, lineC]));
+    addition.resolve(serverResult([lineC, lineA, lineB]));
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(store.getState().data.lines.nodes.map((line) => line.id)).toEqual(["line-a", "line-c"]);
+    expect(store.getState().data.lines.nodes.map((line) => line.id)).toEqual(["line-c", "line-a"]);
   });
 
   it("matches add projections by selling plan", async () => {
@@ -289,20 +289,20 @@ describe("transaction cart store", () => {
       addition,
     );
     expect(store.getState().data.lines.nodes).toEqual([
-      makeLine("line-plan-a", 1, merchandiseId, planA),
       makeLine(`optimistic:${merchandiseId}:${planB}`, 1, merchandiseId, planB),
+      makeLine("line-plan-a", 1, merchandiseId, planA),
     ]);
 
     addition.resolve(
       serverResult([
-        makeLine("line-plan-a", 1, merchandiseId, planA),
         makeLine("line-plan-b", 1, merchandiseId, planB),
+        makeLine("line-plan-a", 1, merchandiseId, planA),
       ]),
     );
     await Promise.resolve();
     expect(store.getState().data.lines.nodes).toEqual([
-      makeLine("line-plan-a", 1, merchandiseId, planA),
       makeLine("line-plan-b", 1, merchandiseId, planB),
+      makeLine("line-plan-a", 1, merchandiseId, planA),
     ]);
 
     dispatchAdd(
@@ -310,7 +310,9 @@ describe("transaction cart store", () => {
       [product(merchandiseId)],
       createDeferred<unknown>(),
     );
-    expect(store.getState().data.lines.nodes[0].quantity).toBe(2);
+    expect(
+      store.getState().data.lines.nodes.find((line) => line.id === "line-plan-a")?.quantity,
+    ).toBe(2);
   });
 
   it("matches add projections by attributes", async () => {
@@ -325,23 +327,23 @@ describe("transaction cart store", () => {
       [product(merchandiseId)],
       addition,
     );
-    expect(store.getState().data.lines.nodes[0].quantity).toBe(1);
-    const optimisticLine = store.getState().data.lines.nodes[1];
+    expect(store.getState().data.lines.nodes[1].quantity).toBe(1);
+    const optimisticLine = store.getState().data.lines.nodes[0];
     expect(optimisticLine.id.startsWith(`optimistic:${merchandiseId}:`)).toBe(true);
     expect(optimisticLine.id).not.toContain("gift");
     expect(optimisticLine).toMatchObject({ quantity: 1, attributes: regularAttributes });
 
     addition.resolve(
       serverResult([
-        makeLine("line-gift", 1, merchandiseId, undefined, giftAttributes),
         makeLine("line-regular", 1, merchandiseId, undefined, regularAttributes),
+        makeLine("line-gift", 1, merchandiseId, undefined, giftAttributes),
       ]),
     );
     await Promise.resolve();
 
     expect(store.getState().data.lines.nodes).toEqual([
-      makeLine("line-gift", 1, merchandiseId, undefined, giftAttributes),
       makeLine("line-regular", 1, merchandiseId, undefined, regularAttributes),
+      makeLine("line-gift", 1, merchandiseId, undefined, giftAttributes),
     ]);
   });
 
@@ -366,11 +368,11 @@ describe("transaction cart store", () => {
     const addition = createDeferred<unknown>();
     dispatchAdd([{ merchandiseId: "variant-b", quantity: 1 }], [product("variant-b")], addition);
 
-    addition.resolve(serverResult([makeMinimalLine("line-a", 1), makeMinimalLine("line-b", 1)]));
+    addition.resolve(serverResult([makeMinimalLine("line-b", 1), makeMinimalLine("line-a", 1)]));
     await Promise.resolve();
 
-    expect(store.getState().data.lines.nodes.map((line) => line.id)).toEqual(["line-a", "line-b"]);
-    expect(store.getState().data.lines.nodes[1].merchandise?.id).toBe("variant-b");
+    expect(store.getState().data.lines.nodes.map((line) => line.id)).toEqual(["line-b", "line-a"]);
+    expect(store.getState().data.lines.nodes[0].merchandise?.id).toBe("variant-b");
   });
 
   it("does not let one keyed line abort an unrelated line", async () => {

--- a/packages/hydrogen/src/core/cart/cart.test.ts
+++ b/packages/hydrogen/src/core/cart/cart.test.ts
@@ -3445,6 +3445,50 @@ describe("add-to-cart optimistic updates", () => {
   const VARIANT_123 = "gid://shopify/ProductVariant/123";
   const VARIANT_456 = "gid://shopify/ProductVariant/456";
 
+  it("prepends multiple optimistic lines in server order", async () => {
+    store.hydrate(
+      makeCartState({
+        lines: [makeLine({ id: "line-existing", quantity: 1 })],
+        totalQuantity: 1,
+      }),
+    );
+
+    const externalPromise = mockUpdateCart(
+      {
+        lines: [
+          { merchandiseId: VARIANT_123, quantity: 1 },
+          { merchandiseId: VARIANT_456, quantity: 2 },
+        ],
+      },
+      withProducts(productDetail(VARIANT_123), productDetail(VARIANT_456)),
+    );
+
+    expect(getCartLines(store.getState().data).map((line) => line.id)).toEqual([
+      `optimistic:${VARIANT_456}`,
+      `optimistic:${VARIANT_123}`,
+      "line-existing",
+    ]);
+
+    resolveUpdate(
+      0,
+      serverResult({
+        totalQuantity: 4,
+        lines: [
+          lineWithMerchandise("line-456", 2, VARIANT_456),
+          lineWithMerchandise("line-123", 1, VARIANT_123),
+          makeLine({ id: "line-existing", quantity: 1 }),
+        ],
+      }),
+    );
+    await externalPromise;
+
+    expect(getCartLines(store.getState().data).map((line) => line.id)).toEqual([
+      "line-456",
+      "line-123",
+      "line-existing",
+    ]);
+  });
+
   it("matching merchandiseId: optimistically increments quantity and marks pending", async () => {
     store.hydrate(
       makeCartState({
@@ -3625,9 +3669,9 @@ describe("add-to-cart optimistic updates", () => {
       withProducts(productDetail(VARIANT_456)),
     );
 
-    expect(getCartLines(store.getState().data)).toHaveLength(2);
-    expect(getCartLines(store.getState().data)[0].quantity).toBe(5);
-    expect(getCartLines(store.getState().data).find((l) => l.id === optimisticId)).toBeDefined();
+    const optimisticLines = getCartLines(store.getState().data);
+    expect(optimisticLines.map((line) => line.id)).toEqual([optimisticId, "line-1"]);
+    expect(optimisticLines[1].quantity).toBe(5);
     expect(store.getState().data.totalQuantity).toBe(6);
     expect(store.getState().pending.lines).toContain("line-1");
     expect(store.getState().pending.lines).toContain(optimisticId);
@@ -3680,7 +3724,7 @@ describe("add-to-cart optimistic updates", () => {
       withProducts(productDetail(VARIANT_456)),
     );
 
-    expect(getCartLines(store.getState().data)[0].quantity).toBe(5);
+    expect(getCartLines(store.getState().data).find((l) => l.id === "line-1")?.quantity).toBe(5);
     expect(getCartLines(store.getState().data).find((l) => l.id === optimisticId)).toBeDefined();
     expect(store.getState().data.totalQuantity).toBe(6);
 

--- a/packages/hydrogen/src/core/cart/cart.test.ts
+++ b/packages/hydrogen/src/core/cart/cart.test.ts
@@ -3609,7 +3609,13 @@ describe("add-to-cart optimistic updates", () => {
 
     const externalPromise = mockUpdateCart(
       { lines: [{ merchandiseId: VARIANT_456, quantity: 1 }] },
-      withProducts(productDetail(VARIANT_456, { price: { amount: "10", currencyCode: "USD" } })),
+      withProducts(
+        productDetail(VARIANT_456, {
+          product: { title: "T-Shirt", handle: "t-shirt" },
+          selectedOptions: [{ name: "Size", value: "Small" }],
+          price: { amount: "10", currencyCode: "USD" },
+        }),
+      ),
     );
 
     expect(getCartLines(store.getState().data)).toHaveLength(2);
@@ -3617,6 +3623,8 @@ describe("add-to-cart optimistic updates", () => {
     assert(optimisticLine, "expected optimistic line to exist");
     expect(optimisticLine.quantity).toBe(1);
     expect(optimisticLine.merchandise?.product.title).toBe("T-Shirt");
+    expect(optimisticLine.merchandise?.product.handle).toBe("t-shirt");
+    expect(optimisticLine.merchandise?.selectedOptions).toEqual([{ name: "Size", value: "Small" }]);
     expect(optimisticLine.cost.totalAmount.amount).toBe("10");
     expect(store.getState().pending.lines).toContain(optimisticId);
     expect(store.getState().data.totalQuantity).toBe(4);

--- a/packages/hydrogen/src/core/cart/cart.ts
+++ b/packages/hydrogen/src/core/cart/cart.ts
@@ -868,7 +868,7 @@ function withAdditionMerchandise(
   return { ...line, merchandise: merchandise as unknown as CartLine["merchandise"] };
 }
 
-function replaceOrAppendLine(
+function replaceOrPrependLine(
   lines: CartLine[],
   previous: CartLine | undefined,
   next: CartLine,
@@ -877,7 +877,7 @@ function replaceOrAppendLine(
   if (lines.some((line) => line.id === next.id)) {
     return lines.map((line) => (line.id === next.id ? next : line));
   }
-  return [...lines, next];
+  return [next, ...lines];
 }
 
 function mergeAddResponseLines(
@@ -905,7 +905,7 @@ function mergeAddResponseLines(
     const previous =
       findLineForAddition(lines, addition) ?? lines.find((line) => line.id === serverLine.id);
     const next = withAdditionMerchandise(serverLine, addition, payload.products);
-    lines = replaceOrAppendLine(lines, previous, mergeServerLine(previous, next));
+    lines = replaceOrPrependLine(lines, previous, mergeServerLine(previous, next));
   }
 
   return lines;
@@ -1006,7 +1006,6 @@ export const CART_TRANSACTION_TYPES = defineTransactionTypes({
           currencyCode: "",
         };
         lines = [
-          ...lines,
           {
             id: optimisticLineId(addition),
             quantity: addition.quantity,
@@ -1022,6 +1021,7 @@ export const CART_TRANSACTION_TYPES = defineTransactionTypes({
               compareAtAmountPerQuantity: null,
             },
           },
+          ...lines,
         ];
         linesChanged = true;
       }

--- a/packages/hydrogen/src/core/product/product-form.test.ts
+++ b/packages/hydrogen/src/core/product/product-form.test.ts
@@ -1392,7 +1392,8 @@ describe("createProductFormStore", () => {
           {
             id: "v-red",
             title: "Red",
-            product: { title: undefined },
+            product: { title: undefined, handle: "shirt" },
+            selectedOptions: [{ name: "Color", value: "Red" }],
             image: undefined,
             price: { amount: "10.00", currencyCode: "USD" },
           },
@@ -1429,7 +1430,8 @@ describe("createProductFormStore", () => {
           {
             id: "v-red",
             title: "Red",
-            product: { title: "Cozy Shirt" },
+            product: { title: "Cozy Shirt", handle: "shirt" },
+            selectedOptions: [{ name: "Color", value: "Red" }],
             image: { url: "https://cdn.example.com/shirt.jpg", altText: "Red shirt" },
             price: { amount: "10.00", currencyCode: "USD" },
           },

--- a/packages/hydrogen/src/core/product/product-form.ts
+++ b/packages/hydrogen/src/core/product/product-form.ts
@@ -331,7 +331,10 @@ function buildAddToCartDetail<TProduct extends ProductInput>(
       {
         id: selectedVariant.id,
         title: selectedVariant.title,
-        product: selectedVariant.product ? { title: selectedVariant.product.title } : undefined,
+        product: selectedVariant.product
+          ? { title: selectedVariant.product.title, handle: selectedVariant.product.handle }
+          : undefined,
+        selectedOptions: selectedVariant.selectedOptions,
         image: selectedVariant.image,
         price: selectedVariant.price,
       },


### PR DESCRIPTION
TL;DR: Optimistic cart additions now match SFAPI newest-first ordering, and product-form additions include the merchandise fields needed while pending.

## Before

New optimistic lines were appended to the cart. Batched additions could reorder when the server response resolved, and product-form additions omitted selected options and product handles until reconciliation.

## After

New optimistic and resolved lines are prepended in reverse input order. Product-form details now include `selectedOptions` and `product.handle`, so pending lines can render variant details and product links immediately.

## What this changes

- Aligns optimistic and resolved cart line ordering with SFAPI.
- Preserves ordering through transaction settlement and concurrent cart updates.
- Includes selected options and product handles in product-form cart details.
- Covers ordering before and after reconciliation, including the pending feedback from the source PR.

## Developer impact

Includes a patch changeset for `@shopify/hydrogen`. No new exports or breaking API changes.

## UX impact

New cart lines appear in their final position immediately, avoiding reorder flicker. Variant details and product links can render during the optimistic state.

## Risk

The ordering follows the newest-first batched-add behaviour verified against SFAPI in the source PR.