### PR TITLE
Add support for variant id product URLs via redirect

### DIFF
--- a/.changeset/accept-variant-id.md
+++ b/.changeset/accept-variant-id.md
@@ -4,7 +4,7 @@
 
 Accept Liquid-style `?variant=<numeric id>` links on product pages.
 
-- `handleShopifyRoutes({routeTemplates})` now 302-redirects `?variant=` product URLs to the canonical option-params URL (`/products/x?variant=123` → `/products/x?Color=Red&Size=M`), resolving the variant through the Storefront API, following combined-listing variants to their own product page, and stripping unknown or deleted variant ids. When both `variant` and option params are present, the variant wins.
+- `handleShopifyRoutes({routeTemplates})` now 302-redirects `?variant=` product URLs to the canonical option-params URL (`/products/x?variant=123` → `/products/x?Color=Red&Size=M`), resolving the variant through the Storefront API with `Cache.long()` when the client has a cache adapter, following combined-listing variants to their own product page, and stripping unknown or deleted variant ids. When both `variant` and option params are present, the variant wins.
 - `buildProductSelectionSearchParams({style?, selectedOptions, variant?, optionNames, base?})` builds selection link search params, scrubbing stale option and `variant` params while preserving unrelated ones. `style: "variant"` emits a shareable `?variant=<numeric id>` link, falling back to option params when no variant is resolved.
 - `getSelectedProductOptions` now treats the `variant` search param as reserved and never returns it as an option.
 - Registered route redirects can now set an explicit `status` restricted to `301 | 302 | 303 | 307 | 308`.

--- a/.changeset/accept-variant-id.md
+++ b/.changeset/accept-variant-id.md
@@ -4,7 +4,7 @@
 
 Accept Liquid-style `?variant=<numeric id>` links on product pages.
 
-- `acceptProductVariantId({routeTemplates, pathPrefix?, cache?})` returns a match handler for `handleShopifyRoutes` `handlers` that 302-redirects `?variant=` product URLs to the canonical option-params URL (`/products/x?variant=123` → `/products/x?Color=Red&Size=M`), resolving the variant through the Storefront API, following combined-listing variants to their own product page, and stripping unknown or deleted variant ids. When both `variant` and option params are present, the variant wins.
+- `handleShopifyRoutes({routeTemplates})` now 302-redirects `?variant=` product URLs to the canonical option-params URL (`/products/x?variant=123` → `/products/x?Color=Red&Size=M`), resolving the variant through the Storefront API, following combined-listing variants to their own product page, and stripping unknown or deleted variant ids. When both `variant` and option params are present, the variant wins.
 - `buildProductSelectionSearchParams({style?, selectedOptions, variant?, optionNames, base?})` builds selection link search params, scrubbing stale option and `variant` params while preserving unrelated ones. `style: "variant"` emits a shareable `?variant=<numeric id>` link, falling back to option params when no variant is resolved.
 - `getSelectedProductOptions` now treats the `variant` search param as reserved and never returns it as an option.
-- `handleShopifyRoutes` `handlers` now also accepts match handlers — `(url, context) => null | Promise<ShopifyRouteHandlerResult>` — that claim requests by URL shape instead of exact pathname, and redirect results can set an explicit `status`.
+- Registered route redirects can now set an explicit `status` restricted to `301 | 302 | 303 | 307 | 308`.

--- a/.changeset/accept-variant-id.md
+++ b/.changeset/accept-variant-id.md
@@ -1,0 +1,10 @@
+---
+'@shopify/hydrogen': minor
+---
+
+Accept Liquid-style `?variant=<numeric id>` links on product pages.
+
+- `acceptProductVariantId({routeTemplates, pathPrefix?, cache?})` returns a match handler for `handleShopifyRoutes` `handlers` that 302-redirects `?variant=` product URLs to the canonical option-params URL (`/products/x?variant=123` → `/products/x?Color=Red&Size=M`), resolving the variant through the Storefront API, following combined-listing variants to their own product page, and stripping unknown or deleted variant ids. When both `variant` and option params are present, the variant wins.
+- `buildProductSelectionSearchParams({style?, selectedOptions, variant?, optionNames, base?})` builds selection link search params, scrubbing stale option and `variant` params while preserving unrelated ones. `style: "variant"` emits a shareable `?variant=<numeric id>` link, falling back to option params when no variant is resolved.
+- `getSelectedProductOptions` now treats the `variant` search param as reserved and never returns it as an option.
+- `handleShopifyRoutes` `handlers` now also accepts match handlers — `(url, context) => null | Promise<ShopifyRouteHandlerResult>` — that claim requests by URL shape instead of exact pathname, and redirect results can set an explicit `status`.

--- a/examples/astro/src/middleware.ts
+++ b/examples/astro/src/middleware.ts
@@ -6,8 +6,6 @@ import {
   createStorefrontCacheAdapter,
 } from "@shared/storefront-cache";
 import {
-  acceptProductVariantId,
-  Cache,
   createCartServerHandlers,
   createStorefrontClient,
   createShopifyRequestContext,
@@ -42,11 +40,8 @@ export const onRequest = defineMiddleware(async ({ locals, request }, next) => {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [
-      acceptProductVariantId({ routeTemplates, cache: Cache.long() }),
-      cartHandlers,
-      customerSessionHandlers,
-    ],
+    routeTemplates,
+    handlers: [cartHandlers, customerSessionHandlers],
   });
   if (shopifyRoute) return shopifyRoute;
 

--- a/examples/astro/src/middleware.ts
+++ b/examples/astro/src/middleware.ts
@@ -6,6 +6,8 @@ import {
   createStorefrontCacheAdapter,
 } from "@shared/storefront-cache";
 import {
+  acceptProductVariantId,
+  Cache,
   createCartServerHandlers,
   createStorefrontClient,
   createShopifyRequestContext,
@@ -40,7 +42,11 @@ export const onRequest = defineMiddleware(async ({ locals, request }, next) => {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [cartHandlers, customerSessionHandlers],
+    handlers: [
+      acceptProductVariantId({ routeTemplates, cache: Cache.long() }),
+      cartHandlers,
+      customerSessionHandlers,
+    ],
   });
   if (shopifyRoute) return shopifyRoute;
 

--- a/examples/hydrogen/app/lib/variants.ts
+++ b/examples/hydrogen/app/lib/variants.ts
@@ -1,4 +1,4 @@
-import type { SelectedOption } from "@shopify/hydrogen";
+import { buildProductSelectionSearchParams, type SelectedOption } from "@shopify/hydrogen";
 import { useMemo } from "react";
 import { useLocation } from "react-router";
 
@@ -29,19 +29,17 @@ export function getVariantUrl({
   selectedOptions?: SelectedOption[];
 }) {
   const match = /(\/[a-zA-Z]{2}-[a-zA-Z]{2}\/)/g.exec(pathname);
-  const isLocalePathname = match && match.length > 0;
+  const localePrefix = match?.[0] ?? "/";
 
-  const path = isLocalePathname ? `${match![0]}products/${handle}` : `/products/${handle}`;
+  const path = `${localePrefix}products/${handle}`;
 
-  optionNames?.forEach((name) => {
-    searchParams.delete(name);
+  const params = buildProductSelectionSearchParams({
+    selectedOptions: selectedOptions ?? [],
+    optionNames: optionNames ?? [],
+    base: searchParams,
   });
 
-  selectedOptions?.forEach((option) => {
-    searchParams.set(option.name, option.value);
-  });
+  const searchString = params.toString();
 
-  const searchString = searchParams.toString();
-
-  return path + (searchString ? "?" + searchParams.toString() : "");
+  return path + (searchString ? "?" + searchString : "");
 }

--- a/examples/hydrogen/server.ts
+++ b/examples/hydrogen/server.ts
@@ -1,7 +1,6 @@
 import { getBuyerIp } from "@shared/buyer-ip";
 import { getPrivateStorefrontToken } from "@shared/private-env";
 import {
-  acceptProductVariantId,
   createPredictiveSearchServerHandlers,
   createShopifyRequestContext,
   handleShopifyRedirects,
@@ -71,12 +70,8 @@ export default {
         requestContext: shopifyRequestContext,
         sessionManager: customerSessionManager,
         storefrontClient,
-        handlers: [
-          acceptProductVariantId({ routeTemplates, pathPrefix: i18n.pathPrefix }),
-          cartHandlers,
-          predictiveSearchHandlers,
-          customerAccountHandlers,
-        ],
+        routeTemplates,
+        handlers: [cartHandlers, predictiveSearchHandlers, customerAccountHandlers],
       });
       if (shopifyRoute) return await shopifyRoute;
 

--- a/examples/hydrogen/server.ts
+++ b/examples/hydrogen/server.ts
@@ -1,6 +1,7 @@
 import { getBuyerIp } from "@shared/buyer-ip";
 import { getPrivateStorefrontToken } from "@shared/private-env";
 import {
+  acceptProductVariantId,
   createPredictiveSearchServerHandlers,
   createShopifyRequestContext,
   handleShopifyRedirects,
@@ -70,7 +71,12 @@ export default {
         requestContext: shopifyRequestContext,
         sessionManager: customerSessionManager,
         storefrontClient,
-        handlers: [cartHandlers, predictiveSearchHandlers, customerAccountHandlers],
+        handlers: [
+          acceptProductVariantId({ routeTemplates, pathPrefix: i18n.pathPrefix }),
+          cartHandlers,
+          predictiveSearchHandlers,
+          customerAccountHandlers,
+        ],
       });
       if (shopifyRoute) return await shopifyRoute;
 

--- a/examples/nuxt/components/ProductVariantSelector.vue
+++ b/examples/nuxt/components/ProductVariantSelector.vue
@@ -45,14 +45,14 @@ function queryToSearchParams(query: typeof route.query) {
   for (const [key, value] of Object.entries(query)) {
     const values = Array.isArray(value) ? value : [value];
     for (const item of values) {
-      if (item !== null && item !== undefined) params.append(key, item);
+      params.append(key, item ?? "");
     }
   }
   return params;
 }
 
 function searchParamsToQuery(params: URLSearchParams) {
-  const query: Record<string, string | string[]> = {};
+  const query: Record<string, string | string[]> = Object.create(null);
   for (const [key, value] of params) {
     const current = query[key];
     if (current === undefined) {

--- a/examples/nuxt/components/ProductVariantSelector.vue
+++ b/examples/nuxt/components/ProductVariantSelector.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { buildProductSelectionSearchParams } from "@shopify/hydrogen";
+
 import type { ProductData } from "~/storefront/product";
 import { useProductForm } from "~/storefront/product";
 
@@ -30,9 +32,37 @@ function variantRoute(selectedOptions: { name: string; value: string }[], handle
 }
 
 function variantQuery(selectedOptions: { name: string; value: string }[]) {
-  const query = { ...route.query };
-  for (const option of props.product.options) delete query[option.name];
-  for (const option of selectedOptions) query[option.name] = option.value;
+  const params = buildProductSelectionSearchParams({
+    selectedOptions,
+    optionNames: props.product.options.map((option) => option.name),
+    base: queryToSearchParams(route.query),
+  });
+  return searchParamsToQuery(params);
+}
+
+function queryToSearchParams(query: typeof route.query) {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    const values = Array.isArray(value) ? value : [value];
+    for (const item of values) {
+      if (item !== null && item !== undefined) params.append(key, item);
+    }
+  }
+  return params;
+}
+
+function searchParamsToQuery(params: URLSearchParams) {
+  const query: Record<string, string | string[]> = {};
+  for (const [key, value] of params) {
+    const current = query[key];
+    if (current === undefined) {
+      query[key] = value;
+    } else if (Array.isArray(current)) {
+      current.push(value);
+    } else {
+      query[key] = [current, value];
+    }
+  }
   return query;
 }
 </script>

--- a/examples/nuxt/pages/products/[handle].vue
+++ b/examples/nuxt/pages/products/[handle].vue
@@ -7,9 +7,7 @@ import { toFetchQuery } from "~/utils/fetch-query";
 const route = useRoute();
 const router = useRouter();
 const handle = computed(() => route.params.handle as string);
-const selectedOptionsKey = computed(() =>
-  queryToSearchParams(route.query).toString(),
-);
+const selectedOptionsKey = computed(() => queryToSearchParams(route.query).toString());
 const productApiPath = computed(() => `/api/products/${encodeURIComponent(handle.value)}` as const);
 
 const { data } = await useFetch(() => productApiPath.value, {

--- a/examples/nuxt/pages/products/[handle].vue
+++ b/examples/nuxt/pages/products/[handle].vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { buildProductSelectionSearchParams } from "@shopify/hydrogen";
+
 import { ProductProvider, type ProductVariantData } from "~/storefront/product";
 import { toFetchQuery } from "~/utils/fetch-query";
 
@@ -6,7 +8,7 @@ const route = useRoute();
 const router = useRouter();
 const handle = computed(() => route.params.handle as string);
 const selectedOptionsKey = computed(() =>
-  new URLSearchParams(route.query as Record<string, string>).toString(),
+  queryToSearchParams(route.query).toString(),
 );
 const productApiPath = computed(() => `/api/products/${encodeURIComponent(handle.value)}` as const);
 
@@ -47,9 +49,37 @@ function handleSelect(result: {
 }
 
 function variantQuery(nextSelectedOptions: { name: string; value: string }[]) {
-  const query = { ...route.query };
-  for (const option of product.value.options) delete query[option.name];
-  for (const option of nextSelectedOptions) query[option.name] = option.value;
+  const params = buildProductSelectionSearchParams({
+    selectedOptions: nextSelectedOptions,
+    optionNames: product.value.options.map((option) => option.name),
+    base: queryToSearchParams(route.query),
+  });
+  return searchParamsToQuery(params);
+}
+
+function queryToSearchParams(query: typeof route.query) {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    const values = Array.isArray(value) ? value : [value];
+    for (const item of values) {
+      if (item !== null && item !== undefined) params.append(key, item);
+    }
+  }
+  return params;
+}
+
+function searchParamsToQuery(params: URLSearchParams) {
+  const query: Record<string, string | string[]> = {};
+  for (const [key, value] of params) {
+    const current = query[key];
+    if (current === undefined) {
+      query[key] = value;
+    } else if (Array.isArray(current)) {
+      current.push(value);
+    } else {
+      query[key] = [current, value];
+    }
+  }
   return query;
 }
 </script>

--- a/examples/nuxt/pages/products/[handle].vue
+++ b/examples/nuxt/pages/products/[handle].vue
@@ -60,14 +60,14 @@ function queryToSearchParams(query: typeof route.query) {
   for (const [key, value] of Object.entries(query)) {
     const values = Array.isArray(value) ? value : [value];
     for (const item of values) {
-      if (item !== null && item !== undefined) params.append(key, item);
+      params.append(key, item ?? "");
     }
   }
   return params;
 }
 
 function searchParamsToQuery(params: URLSearchParams) {
-  const query: Record<string, string | string[]> = {};
+  const query: Record<string, string | string[]> = Object.create(null);
   for (const [key, value] of params) {
     const current = query[key];
     if (current === undefined) {

--- a/examples/nuxt/server/middleware/shopify.ts
+++ b/examples/nuxt/server/middleware/shopify.ts
@@ -1,7 +1,7 @@
 import { getBuyerIp } from "@shared/buyer-ip";
 import { defaultI18n, storefrontConfig } from "@shared/config";
 import { getPrivateStorefrontToken } from "@shared/private-env";
-import { handleShopifyRoutes } from "@shopify/hydrogen";
+import { acceptProductVariantId, handleShopifyRoutes } from "@shopify/hydrogen";
 import {
   createStorefrontClient,
   createShopifyRequestContext,
@@ -15,6 +15,7 @@ import {
   customerSessionHandlers,
 } from "../../storefront/customer-account";
 import { predictiveSearchHandlers } from "../../storefront/predictive-search-handlers";
+import { routeTemplates } from "../../utils/route-templates";
 
 export default defineEventHandler(async (event) => {
   const request = toWebRequest(event);
@@ -33,7 +34,12 @@ export default defineEventHandler(async (event) => {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [cartHandlers, predictiveSearchHandlers, customerSessionHandlers],
+    handlers: [
+      acceptProductVariantId({ routeTemplates }),
+      cartHandlers,
+      predictiveSearchHandlers,
+      customerSessionHandlers,
+    ],
   });
   if (shopifyRoute) {
     return sendWebResponse(event, await shopifyRoute);

--- a/examples/nuxt/server/middleware/shopify.ts
+++ b/examples/nuxt/server/middleware/shopify.ts
@@ -1,7 +1,7 @@
 import { getBuyerIp } from "@shared/buyer-ip";
 import { defaultI18n, storefrontConfig } from "@shared/config";
 import { getPrivateStorefrontToken } from "@shared/private-env";
-import { acceptProductVariantId, handleShopifyRoutes } from "@shopify/hydrogen";
+import { handleShopifyRoutes } from "@shopify/hydrogen";
 import {
   createStorefrontClient,
   createShopifyRequestContext,
@@ -34,12 +34,8 @@ export default defineEventHandler(async (event) => {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [
-      acceptProductVariantId({ routeTemplates }),
-      cartHandlers,
-      predictiveSearchHandlers,
-      customerSessionHandlers,
-    ],
+    routeTemplates,
+    handlers: [cartHandlers, predictiveSearchHandlers, customerSessionHandlers],
   });
   if (shopifyRoute) {
     return sendWebResponse(event, await shopifyRoute);

--- a/examples/solid-start/src/components/ProductPurchasePanel.tsx
+++ b/examples/solid-start/src/components/ProductPurchasePanel.tsx
@@ -1,4 +1,9 @@
-import { canAddToCart, createProductFormRegister, createProductFormStore } from "@shopify/hydrogen";
+import {
+  buildProductSelectionSearchParams,
+  canAddToCart,
+  createProductFormRegister,
+  createProductFormStore,
+} from "@shopify/hydrogen";
 import { useLocation, useNavigate } from "@solidjs/router";
 import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
 
@@ -69,9 +74,11 @@ export function ProductPurchasePanel(props: { product: ProductData }) {
   }
 
   function variantSearch(selectedOptions: { name: string; value: string }[]) {
-    const params = new URLSearchParams(location.search);
-    for (const option of props.product.options) params.delete(option.name);
-    for (const option of selectedOptions) params.set(option.name, option.value);
+    const params = buildProductSelectionSearchParams({
+      selectedOptions,
+      optionNames: props.product.options.map((option) => option.name),
+      base: new URLSearchParams(location.search),
+    });
     const search = params.toString();
     return search ? `?${search}` : "";
   }

--- a/examples/solid-start/src/middleware.ts
+++ b/examples/solid-start/src/middleware.ts
@@ -5,7 +5,7 @@ import {
   STOREFRONT_CACHE_MAX_ENTRIES,
   createStorefrontCacheAdapter,
 } from "@shared/storefront-cache";
-import { acceptProductVariantId, Cache, handleShopifyRoutes } from "@shopify/hydrogen";
+import { handleShopifyRoutes } from "@shopify/hydrogen";
 import {
   createCartServerHandlers,
   createStorefrontClient,
@@ -53,11 +53,8 @@ export default createMiddleware({
         requestContext,
         sessionManager,
         storefrontClient,
-        handlers: [
-          acceptProductVariantId({ routeTemplates, cache: Cache.long() }),
-          cartHandlers,
-          customerSessionHandlers,
-        ],
+        routeTemplates,
+        handlers: [cartHandlers, customerSessionHandlers],
       });
       if (shopifyRoute) return shopifyRoute;
 

--- a/examples/solid-start/src/middleware.ts
+++ b/examples/solid-start/src/middleware.ts
@@ -5,7 +5,7 @@ import {
   STOREFRONT_CACHE_MAX_ENTRIES,
   createStorefrontCacheAdapter,
 } from "@shared/storefront-cache";
-import { handleShopifyRoutes } from "@shopify/hydrogen";
+import { acceptProductVariantId, Cache, handleShopifyRoutes } from "@shopify/hydrogen";
 import {
   createCartServerHandlers,
   createStorefrontClient,
@@ -21,6 +21,7 @@ import {
   createRequestCustomerAccountClient,
   customerSessionHandlers,
 } from "./lib/customer-account";
+import { routeTemplates } from "./lib/route-templates";
 
 const PRIVATE_NO_STORE_CACHE_CONTROL = "private, no-store";
 
@@ -52,7 +53,11 @@ export default createMiddleware({
         requestContext,
         sessionManager,
         storefrontClient,
-        handlers: [cartHandlers, customerSessionHandlers],
+        handlers: [
+          acceptProductVariantId({ routeTemplates, cache: Cache.long() }),
+          cartHandlers,
+          customerSessionHandlers,
+        ],
       });
       if (shopifyRoute) return shopifyRoute;
 

--- a/examples/sveltekit/src/hooks.server.ts
+++ b/examples/sveltekit/src/hooks.server.ts
@@ -8,12 +8,7 @@ import {
   STOREFRONT_CACHE_MAX_ENTRIES,
   createStorefrontCacheAdapter,
 } from "@shared/storefront-cache";
-import {
-  acceptProductVariantId,
-  Cache,
-  handleShopifyRedirects,
-  handleShopifyRoutes,
-} from "@shopify/hydrogen";
+import { handleShopifyRedirects, handleShopifyRoutes } from "@shopify/hydrogen";
 import {
   createCartServerHandlers,
   createStorefrontClient,
@@ -44,11 +39,8 @@ export const handle: Handle = async ({ event, resolve }) => {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [
-      acceptProductVariantId({ routeTemplates, cache: Cache.long() }),
-      cartHandlers,
-      customerSessionHandlers,
-    ],
+    routeTemplates,
+    handlers: [cartHandlers, customerSessionHandlers],
   });
   if (shopifyRoute) return shopifyRoute;
 

--- a/examples/sveltekit/src/hooks.server.ts
+++ b/examples/sveltekit/src/hooks.server.ts
@@ -8,7 +8,12 @@ import {
   STOREFRONT_CACHE_MAX_ENTRIES,
   createStorefrontCacheAdapter,
 } from "@shared/storefront-cache";
-import { handleShopifyRedirects, handleShopifyRoutes } from "@shopify/hydrogen";
+import {
+  acceptProductVariantId,
+  Cache,
+  handleShopifyRedirects,
+  handleShopifyRoutes,
+} from "@shopify/hydrogen";
 import {
   createCartServerHandlers,
   createStorefrontClient,
@@ -39,7 +44,11 @@ export const handle: Handle = async ({ event, resolve }) => {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [cartHandlers, customerSessionHandlers],
+    handlers: [
+      acceptProductVariantId({ routeTemplates, cache: Cache.long() }),
+      cartHandlers,
+      customerSessionHandlers,
+    ],
   });
   if (shopifyRoute) return shopifyRoute;
 

--- a/examples/sveltekit/src/lib/components/ProductPurchasePanel.svelte
+++ b/examples/sveltekit/src/lib/components/ProductPurchasePanel.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import {
+		buildProductSelectionSearchParams,
 		canAddToCart,
 		createProductFormRegister,
 		createProductFormStore
@@ -76,9 +77,11 @@
 	}
 
 	function variantSearch(selectedOptions: { name: string; value: string }[]) {
-		const params = new URLSearchParams(currentSearch);
-		for (const option of product.options) params.delete(option.name);
-		for (const option of selectedOptions) params.set(option.name, option.value);
+		const params = buildProductSelectionSearchParams({
+			selectedOptions,
+			optionNames: product.options.map((option) => option.name),
+			base: new URLSearchParams(currentSearch)
+		});
 		const search = params.toString();
 		return search ? `?${search}` : '';
 	}

--- a/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
@@ -29,6 +29,24 @@ Request
 
 `handleShopifyRoutes` owns Hydrogen routes the framework should never see: SFAPI proxy URLs, `/checkout`, cart permalinks like `/cart/{variantId}:{quantity}`, AJAX cart URLs like `/cart.js` and `/cart/add.js`, `/api/mcp`, `/agent/*`, `/graphiql` in development, and app-registered handler groups such as `createCartServerHandlers()` or `createCustomerAccountServerHandlers()`.
 
+The `handlers` array also accepts match handlers — functions that claim requests by URL shape rather than exact pathname. Match handlers run before every exact-pathname handler group regardless of array position; multiple match handlers run in array order. `acceptProductVariantId({ routeTemplates, pathPrefix? })` is the packaged one: it accepts Liquid-style `?variant=<numeric id>` links on product pages and 302-redirects them to the canonical option-params URL (resolving the variant's selected options through the Storefront API, following combined-listing variants to their own product page, and stripping unknown variant ids). Non-GET/HEAD requests, non-product URLs, and malformed `variant` values fall through untouched.
+
+## Variant Id Redirects
+
+```ts
+const shopifyRoute = handleShopifyRoutes({
+  request,
+  requestContext,
+  sessionManager,
+  storefrontClient,
+  handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers],
+});
+```
+
+Pass `pathPrefix` (the request's `i18n.pathPrefix`, e.g. `"/fr-ca"`) when the app serves locale-prefixed URLs — without it, localized product URLs do not match the product route template and cross-product redirects would leave the localized tree.
+
+When the storefront client is created with a `cache` instance, pass `cache: Cache.long()` so repeated hits on the same variant link (campaign blasts) do not each pay a Storefront API lookup — a variant's selected options are near-immutable.
+
 `handleShopifyRedirects` is a post-routing 404 check for `/admin`, configured standard route redirects, Storefront URL redirects, and same-origin query-param redirects. Do not run it on every request.
 
 ## Standard Route Redirects
@@ -54,6 +72,7 @@ const redirect = await handleShopifyRedirects({
 - If the app has a request-level `try/catch` that converts errors into a `Response`, use `return await shopifyRoute` inside that boundary so rejected route promises reach the same error handling as synchronous setup failures. If the framework owns request error handling, return `shopifyRoute` directly. Do not add an inline `.catch()` unless the matched route intentionally needs different error handling.
 - Pass `request` and `storefrontClient` into `handleShopifyRedirects`; it does not receive a session manager.
 - Pass registered handler groups explicitly, for example `handlers: [cartHandlers, customerAccountHandlers]`.
+- Include `acceptProductVariantId({ routeTemplates })` in `handlers` so Liquid-parity `?variant=` product links resolve to canonical option params instead of passing through as ordinary product-page requests.
 - `handleShopifyRoutes` and `handleShopifyRedirects` apply request-context response headers before returning matched Shopify responses. Return those responses directly without calling `requestContext.applyResponseHeaders()` again.
 - Link and submit to Customer Account routes (`/account/login`, `/account/authorize`, `/account/refresh`, `/account/logout`) with plain HTML `<a>`/`<form>`, never the framework's client-side navigation component (`<Form>`/`<Link>` in React Router, `next/link` in Next.js, `NuxtLink` in Nuxt). The login and logout handlers return raw HTTP redirects to external Shopify URLs, which client-nav cannot process.
 - Apps authoring Customer Account API documents use the same packed Hydrogen TypeScript plugin as Storefront API documents. Add `@shopify/hydrogen/ts-plugin` to `tsconfig.json` `compilerOptions.plugins` and chain `hydrogen gql check` into a package script. Applies to every framework.
@@ -66,6 +85,7 @@ Use public package exports:
 
 ```ts
 import {
+  acceptProductVariantId,
   createCartServerHandlers,
   createPredictiveSearchServerHandlers,
   createShopifyRequestContext,
@@ -86,5 +106,6 @@ Run the app in dev and production modes, then check:
 4. `GET /account/login`, `GET /account/authorize`, `GET /account/refresh`, and `POST /account/logout` are handled before the app router when Customer Account handlers are registered.
 5. `GET /admin` returns a redirect to the shop admin URL.
 6. An unknown path returns the framework 404 when no Shopify redirect exists.
-7. Cart, predictive search, Customer Account, and SFAPI responses preserve `Set-Cookie` and `Server-Timing` headers where the framework exposes them.
-8. Authenticated Customer Account responses do not preserve public or CDN cache-control headers.
+7. `GET /products/{handle}?variant={numeric id}` returns a 302 to the option-params URL when `acceptProductVariantId` is registered; `?variant=garbage` falls through to the product page.
+8. Cart, predictive search, Customer Account, and SFAPI responses preserve `Set-Cookie` and `Server-Timing` headers where the framework exposes them.
+9. Authenticated Customer Account responses do not preserve public or CDN cache-control headers.

--- a/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
@@ -27,9 +27,7 @@ Request
   -> framework 404 page
 ```
 
-`handleShopifyRoutes` owns Hydrogen routes the framework should never see: SFAPI proxy URLs, `/checkout`, cart permalinks like `/cart/{variantId}:{quantity}`, AJAX cart URLs like `/cart.js` and `/cart/add.js`, `/api/mcp`, `/agent/*`, `/graphiql` in development, and app-registered handler groups such as `createCartServerHandlers()` or `createCustomerAccountServerHandlers()`.
-
-The `handlers` array also accepts match handlers — functions that claim requests by URL shape rather than exact pathname. Match handlers run before every exact-pathname handler group regardless of array position; multiple match handlers run in array order. `acceptProductVariantId({ routeTemplates, pathPrefix? })` is the packaged one: it accepts Liquid-style `?variant=<numeric id>` links on product pages and 302-redirects them to the canonical option-params URL (resolving the variant's selected options through the Storefront API, following combined-listing variants to their own product page, and stripping unknown variant ids). Non-GET/HEAD requests, non-product URLs, and malformed `variant` values fall through untouched.
+`handleShopifyRoutes` owns Hydrogen routes the framework should never see: SFAPI proxy URLs, `/checkout`, cart permalinks like `/cart/{variantId}:{quantity}`, AJAX cart URLs like `/cart.js` and `/cart/add.js`, `/api/mcp`, `/agent/*`, `/graphiql` in development, Liquid-style `?variant=<numeric id>` product URLs, and app-registered handler groups such as `createCartServerHandlers()` or `createCustomerAccountServerHandlers()`.
 
 ## Variant Id Redirects
 
@@ -39,19 +37,18 @@ const shopifyRoute = handleShopifyRoutes({
   requestContext,
   sessionManager,
   storefrontClient,
-  handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers],
+  routeTemplates,
+  handlers: [cartHandlers],
 });
 ```
 
-Pass `pathPrefix` (the request's `i18n.pathPrefix`, e.g. `"/fr-ca"`) when the app serves locale-prefixed URLs — without it, localized product URLs do not match the product route template and cross-product redirects would leave the localized tree.
-
-When the storefront client is created with a `cache` instance, pass `cache: Cache.long()` so repeated hits on the same variant link (campaign blasts) do not each pay a Storefront API lookup — a variant's selected options are near-immutable.
+Pass `routeTemplates` to `handleShopifyRoutes` so product `?variant=` links can be recognized before framework routing. `pathPrefix` is inferred from `requestContext.i18n.pathPrefix`, so localized product URLs stay in the localized tree.
 
 `handleShopifyRedirects` is a post-routing 404 check for `/admin`, configured standard route redirects, Storefront URL redirects, and same-origin query-param redirects. Do not run it on every request.
 
 ## Standard Route Redirects
 
-Use the local `hydrogen-routing` skill to create the shared `routeTemplates` manifest. This request-handler skill only wires that object into `handleShopifyRedirects` after the app router returns a 404.
+Use the local `hydrogen-routing` skill to create the shared `routeTemplates` manifest. Wire that object into both `handleShopifyRoutes` before routing and `handleShopifyRedirects` after the app router returns a 404.
 
 ```ts
 const redirect = await handleShopifyRedirects({
@@ -72,7 +69,7 @@ const redirect = await handleShopifyRedirects({
 - If the app has a request-level `try/catch` that converts errors into a `Response`, use `return await shopifyRoute` inside that boundary so rejected route promises reach the same error handling as synchronous setup failures. If the framework owns request error handling, return `shopifyRoute` directly. Do not add an inline `.catch()` unless the matched route intentionally needs different error handling.
 - Pass `request` and `storefrontClient` into `handleShopifyRedirects`; it does not receive a session manager.
 - Pass registered handler groups explicitly, for example `handlers: [cartHandlers, customerAccountHandlers]`.
-- Include `acceptProductVariantId({ routeTemplates })` in `handlers` so Liquid-parity `?variant=` product links resolve to canonical option params instead of passing through as ordinary product-page requests.
+- Pass `routeTemplates` into `handleShopifyRoutes` so Liquid-parity `?variant=` product links resolve to canonical option params instead of passing through as ordinary product-page requests.
 - `handleShopifyRoutes` and `handleShopifyRedirects` apply request-context response headers before returning matched Shopify responses. Return those responses directly without calling `requestContext.applyResponseHeaders()` again.
 - Link and submit to Customer Account routes (`/account/login`, `/account/authorize`, `/account/refresh`, `/account/logout`) with plain HTML `<a>`/`<form>`, never the framework's client-side navigation component (`<Form>`/`<Link>` in React Router, `next/link` in Next.js, `NuxtLink` in Nuxt). The login and logout handlers return raw HTTP redirects to external Shopify URLs, which client-nav cannot process.
 - Apps authoring Customer Account API documents use the same packed Hydrogen TypeScript plugin as Storefront API documents. Add `@shopify/hydrogen/ts-plugin` to `tsconfig.json` `compilerOptions.plugins` and chain `hydrogen gql check` into a package script. Applies to every framework.
@@ -85,7 +82,6 @@ Use public package exports:
 
 ```ts
 import {
-  acceptProductVariantId,
   createCartServerHandlers,
   createPredictiveSearchServerHandlers,
   createShopifyRequestContext,
@@ -106,6 +102,6 @@ Run the app in dev and production modes, then check:
 4. `GET /account/login`, `GET /account/authorize`, `GET /account/refresh`, and `POST /account/logout` are handled before the app router when Customer Account handlers are registered.
 5. `GET /admin` returns a redirect to the shop admin URL.
 6. An unknown path returns the framework 404 when no Shopify redirect exists.
-7. `GET /products/{handle}?variant={numeric id}` returns a 302 to the option-params URL when `acceptProductVariantId` is registered; `?variant=garbage` falls through to the product page.
+7. `GET /products/{handle}?variant={numeric id}` returns a 302 to the option-params URL when `routeTemplates` is passed to `handleShopifyRoutes`; `?variant=garbage` falls through to the product page.
 8. Cart, predictive search, Customer Account, and SFAPI responses preserve `Set-Cookie` and `Server-Timing` headers where the framework exposes them.
 9. Authenticated Customer Account responses do not preserve public or CDN cache-control headers.

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
@@ -32,6 +32,8 @@ Prefer this over adding `.catch()` only to the returned promise: the request-lev
 
 The scaffold defaults to a public client; `PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` per the `hydrogen-storefront-client` buyer-IP guidance.
 
+This shape assumes app-owned `getBuyerIp`, `createSessionManager`, and `routeTemplates` values.
+
 ```ts
 import {
   createCartServerHandlers,

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
@@ -34,6 +34,7 @@ The scaffold defaults to a public client; `PUBLIC_STOREFRONT_API_TOKEN` may be u
 
 ```ts
 import {
+  acceptProductVariantId,
   createCartServerHandlers,
   createPredictiveSearchServerHandlers,
   createStorefrontClient,
@@ -65,7 +66,7 @@ export async function handleRequest(request: Request, next: () => Promise<Respon
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [cartHandlers, predictiveSearchHandlers],
+    handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers, predictiveSearchHandlers],
   });
   if (shopifyRoute) return shopifyRoute;
 
@@ -91,6 +92,7 @@ React Router framework mode needs:
 
 ```tsx
 import {
+  acceptProductVariantId,
   createCartServerHandlers,
   createPredictiveSearchServerHandlers,
   createStorefrontClient,
@@ -123,7 +125,7 @@ export const middleware: Route.MiddlewareFunction[] = [
       requestContext,
       sessionManager,
       storefrontClient,
-      handlers: [cartHandlers, predictiveSearchHandlers],
+      handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers, predictiveSearchHandlers],
     });
     if (shopifyRoute) return shopifyRoute;
 
@@ -152,7 +154,7 @@ const shopifyRoute = handleShopifyRoutes({
   requestContext,
   sessionManager,
   storefrontClient,
-  handlers: [cartHandlers, predictiveSearchHandlers],
+  handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers, predictiveSearchHandlers],
 });
 if (shopifyRoute) return shopifyRoute;
 ```

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/frameworks.md
@@ -34,7 +34,6 @@ The scaffold defaults to a public client; `PUBLIC_STOREFRONT_API_TOKEN` may be u
 
 ```ts
 import {
-  acceptProductVariantId,
   createCartServerHandlers,
   createPredictiveSearchServerHandlers,
   createStorefrontClient,
@@ -66,7 +65,8 @@ export async function handleRequest(request: Request, next: () => Promise<Respon
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers, predictiveSearchHandlers],
+    routeTemplates,
+    handlers: [cartHandlers, predictiveSearchHandlers],
   });
   if (shopifyRoute) return shopifyRoute;
 
@@ -92,7 +92,6 @@ React Router framework mode needs:
 
 ```tsx
 import {
-  acceptProductVariantId,
   createCartServerHandlers,
   createPredictiveSearchServerHandlers,
   createStorefrontClient,
@@ -125,7 +124,8 @@ export const middleware: Route.MiddlewareFunction[] = [
       requestContext,
       sessionManager,
       storefrontClient,
-      handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers, predictiveSearchHandlers],
+      routeTemplates,
+      handlers: [cartHandlers, predictiveSearchHandlers],
     });
     if (shopifyRoute) return shopifyRoute;
 
@@ -154,7 +154,8 @@ const shopifyRoute = handleShopifyRoutes({
   requestContext,
   sessionManager,
   storefrontClient,
-  handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers, predictiveSearchHandlers],
+  routeTemplates,
+  handlers: [cartHandlers, predictiveSearchHandlers],
 });
 if (shopifyRoute) return shopifyRoute;
 ```

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
@@ -12,7 +12,6 @@ This shape assumes app-owned server-only helpers for `customerSession` and `crea
 
 ```ts
 import {
-  acceptProductVariantId,
   createCartServerHandlers,
   createShopifyRequestContext,
   createStorefrontClient,
@@ -47,7 +46,8 @@ export async function proxy(request: NextRequest) {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers, customerAccountHandlers],
+    routeTemplates,
+    handlers: [cartHandlers, customerAccountHandlers],
   });
   if (shopifyRoute) return shopifyRoute;
 

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
@@ -12,6 +12,7 @@ This shape assumes app-owned server-only helpers for `customerSession` and `crea
 
 ```ts
 import {
+  acceptProductVariantId,
   createCartServerHandlers,
   createShopifyRequestContext,
   createStorefrontClient,
@@ -46,7 +47,7 @@ export async function proxy(request: NextRequest) {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [cartHandlers, customerAccountHandlers],
+    handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers, customerAccountHandlers],
   });
   if (shopifyRoute) return shopifyRoute;
 

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nextjs.md
@@ -8,7 +8,7 @@ Next splits Hydrogen routing across `proxy.ts` and `app/not-found.tsx`.
 
 The scaffold defaults to a public client; `NEXT_PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` from the app's trusted deployment headers per the buyer-IP guidance from `hydrogen-storefront-client`.
 
-This shape assumes app-owned server-only helpers for `customerSession` and `createSessionManager`. Do not import those names from Hydrogen.
+This shape assumes app-owned server-only helpers and values for `customerSession`, `createSessionManager`, and `routeTemplates`. Do not import those names from Hydrogen.
 
 ```ts
 import {

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
@@ -21,7 +21,7 @@ Create `server/middleware/shopify.ts`:
 
 The scaffold defaults to a public client; `PUBLIC_STOREFRONT_API_TOKEN` may be unset, which means tokenless access (all mock.shop supports). Once the app has a private token and trusted buyer context, switch to `type: "private"` and resolve `buyerIp` from the app's trusted deployment headers per the buyer-IP guidance from `hydrogen-storefront-client`.
 
-Create an app-owned request-scoped `sessionManager` before `handleShopifyRoutes`.
+Create app-owned `sessionManager` and `routeTemplates` values before `handleShopifyRoutes`; the session manager must be request-scoped.
 
 ```ts
 import {

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
@@ -25,7 +25,6 @@ Create an app-owned request-scoped `sessionManager` before `handleShopifyRoutes`
 
 ```ts
 import {
-  acceptProductVariantId,
   createCartServerHandlers,
   createStorefrontClient,
   createShopifyRequestContext,
@@ -49,7 +48,8 @@ export default defineEventHandler(async (event) => {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers],
+    routeTemplates,
+    handlers: [cartHandlers],
   });
   if (shopifyRoute) return sendWebResponse(event, await shopifyRoute);
 

--- a/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/references/nuxt.md
@@ -25,6 +25,7 @@ Create an app-owned request-scoped `sessionManager` before `handleShopifyRoutes`
 
 ```ts
 import {
+  acceptProductVariantId,
   createCartServerHandlers,
   createStorefrontClient,
   createShopifyRequestContext,
@@ -48,7 +49,7 @@ export default defineEventHandler(async (event) => {
     requestContext,
     sessionManager,
     storefrontClient,
-    handlers: [cartHandlers],
+    handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers],
   });
   if (shopifyRoute) return sendWebResponse(event, await shopifyRoute);
 

--- a/packages/hydrogen/skills/hydrogen-routing/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-routing/SKILL.md
@@ -3,8 +3,8 @@ name: hydrogen-routing
 description: >
   Guide for Hydrogen route templates and Shopify storefront URL routing. Use when
   adding, modifying, or reviewing createShopifyRouteTemplates, routeTemplates,
-  custom Shopify resource or utility-page paths, standard route redirects,
-  ShopifyScripts routes, or predictive search result URLs.
+  custom Shopify resource or utility-page paths, handleShopifyRoutes,
+  standard route redirects, ShopifyScripts routes, or predictive search result URLs.
 ---
 
 # Hydrogen Routing
@@ -64,6 +64,21 @@ Supported placeholders are `:productHandle`, `:collectionHandle`, `:pageHandle`,
 ## Required Consumers
 
 Pass the same `routeTemplates` object to all relevant Hydrogen primitives, even when it is empty.
+
+### Shopify Routes
+
+Pass `routeTemplates` to `handleShopifyRoutes()` before framework routing so Liquid-style `?variant=<id>` product URLs are recognized at the app's product path:
+
+```ts
+const shopifyRoute = handleShopifyRoutes({
+  request,
+  requestContext,
+  sessionManager,
+  storefrontClient,
+  routeTemplates,
+  handlers: [cartHandlers],
+});
+```
 
 ### Redirects
 
@@ -129,6 +144,7 @@ createShopifyRouteTemplates({
 
 Hydrogen applies `i18n.pathPrefix` separately:
 
+- `handleShopifyRoutes()` reads it from `requestContext.i18n.pathPrefix` for product `?variant=` redirects.
 - `handleShopifyRedirects()` reads it from `storefrontClient.requestContext.i18n.pathPrefix`.
 - `ShopifyScripts` receives it through the `i18n` prop or option.
 - `getPredictiveSearchItemUrl()` receives it through `pathPrefix`.
@@ -139,7 +155,7 @@ Hydrogen applies `i18n.pathPrefix` separately:
 - Inspect the app's actual route files before adding a template key.
 - Create one `routeTemplates` manifest, even when it is empty.
 - Add only keys whose Shopify route is rendered at a non-standard pathname.
-- Reuse one `routeTemplates` object across redirects, ShopifyScripts, and predictive search.
+- Reuse one `routeTemplates` object across Shopify routes, redirects, ShopifyScripts, and predictive search.
 - Keep route templates serializable. Use strings, not callback functions.
 - Do not query Shopify to verify resource existence before redirecting a standard route. Redirect to the app route and let that route handle missing resources.
 - Do not include query strings or hashes in route templates. Consumers preserve or append query parameters separately.
@@ -148,6 +164,7 @@ Hydrogen applies `i18n.pathPrefix` separately:
 ## Anti-patterns
 
 - Passing route templates to `handleShopifyRedirects()` but not `ShopifyScripts`.
+- Passing route templates to `handleShopifyRedirects()` but not `handleShopifyRoutes()`.
 - Hard-coding predictive search links separately from `routeTemplates`.
 - Creating different template objects for different Hydrogen routing consumers.
 - Using callback URL builders for standard Shopify resources when a route template can describe the URL shape.

--- a/packages/hydrogen/skills/hydrogen-setup/steps/2-scaffold.md
+++ b/packages/hydrogen/skills/hydrogen-setup/steps/2-scaffold.md
@@ -10,7 +10,7 @@ Preserve the app's existing route shape when present. When there is no establish
 - `/products/{handle}` for product detail. Use plural `products`, not `/product`.
 - `/cart` for the full cart page.
 
-Hydrogen-owned handlers are not page routes: `/api/cart`, `/api/{api-version}/graphql.json`, `/checkout`, cart permalinks like `/cart/{variantId}:{quantity}`, AJAX cart URLs like `/cart.js` and `/cart/add.js`, `/api/mcp`, `/agent/*`, `/graphiql` in development, `/admin` redirects, and Storefront URL redirects belong in the `hydrogen-request-handlers` wiring.
+Hydrogen-owned handlers are not page routes: `/api/cart`, `/api/{api-version}/graphql.json`, `/checkout`, cart permalinks like `/cart/{variantId}:{quantity}`, AJAX cart URLs like `/cart.js` and `/cart/add.js`, `/api/mcp`, `/agent/*`, `/graphiql` in development, Liquid-style `?variant=<numeric id>` product redirects, `/admin` redirects, and Storefront URL redirects belong in the `hydrogen-request-handlers` wiring.
 
 Invoke the `hydrogen-routing` skill and create the shared route template manifest for Shopify resources such as products, collections, pages, blogs, or articles.
 

--- a/packages/hydrogen/skills/hydrogen-setup/steps/6-product-detail-page.md
+++ b/packages/hydrogen/skills/hydrogen-setup/steps/6-product-detail-page.md
@@ -31,6 +31,8 @@ const selectedOptions = getSelectedProductOptions({
 
 Passing `allowedOptionNames: []` filters out every option.
 
+The `variant` search param is reserved for Liquid-style numeric variant ids and is never treated as an option name. Register `acceptProductVariantId({ routeTemplates })` in `handleShopifyRoutes` `handlers` (see the local `hydrogen-request-handlers` skill) so `?variant=<id>` product links redirect to the canonical option-params URL before this loader runs.
+
 ### Minimum product query
 
 Extend and adjust fields as the UI needs them.
@@ -290,6 +292,7 @@ Wrap the page (or purchase panel) in `ProductProvider`. Sync the URL from `onSel
 
 ```vue
 <script setup lang="ts">
+import { buildProductSelectionSearchParams } from "@shopify/hydrogen";
 import { ProductProvider, type ProductData } from "~/storefront/product";
 
 const props = defineProps<{ product: ProductData }>();
@@ -302,11 +305,12 @@ function handleSelect(result: {
 }) {
   const targetHandle =
     result.selectedVariant?.product?.handle ?? props.product.handle;
-  const query = { ...route.query };
-  for (const option of props.product.options) delete query[option.name];
-  for (const option of result.selectedOptions) {
-    query[option.name] = option.value;
-  }
+  const params = buildProductSelectionSearchParams({
+    selectedOptions: result.selectedOptions,
+    optionNames: props.product.options.map((option) => option.name),
+    base: new URLSearchParams(route.query as Record<string, string>),
+  });
+  const query = Object.fromEntries(params);
   router.replace({ path: `/products/${targetHandle}`, query });
 }
 </script>

--- a/packages/hydrogen/skills/hydrogen-setup/steps/6-product-detail-page.md
+++ b/packages/hydrogen/skills/hydrogen-setup/steps/6-product-detail-page.md
@@ -308,10 +308,32 @@ function handleSelect(result: {
   const params = buildProductSelectionSearchParams({
     selectedOptions: result.selectedOptions,
     optionNames: props.product.options.map((option) => option.name),
-    base: new URLSearchParams(route.query as Record<string, string>),
+    base: queryToSearchParams(route.query),
   });
-  const query = Object.fromEntries(params);
+  const query = searchParamsToQuery(params);
   router.replace({ path: `/products/${targetHandle}`, query });
+}
+
+function queryToSearchParams(query: typeof route.query) {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    const values = Array.isArray(value) ? value : [value];
+    for (const item of values) {
+      params.append(key, item ?? "");
+    }
+  }
+  return params;
+}
+
+function searchParamsToQuery(params: URLSearchParams) {
+  const query: Record<string, string | string[]> = Object.create(null);
+  for (const [key, value] of params) {
+    const current = query[key];
+    if (current === undefined) query[key] = value;
+    else if (Array.isArray(current)) current.push(value);
+    else query[key] = [current, value];
+  }
+  return query;
 }
 </script>
 

--- a/packages/hydrogen/skills/hydrogen-setup/steps/6-product-detail-page.md
+++ b/packages/hydrogen/skills/hydrogen-setup/steps/6-product-detail-page.md
@@ -31,7 +31,7 @@ const selectedOptions = getSelectedProductOptions({
 
 Passing `allowedOptionNames: []` filters out every option.
 
-The `variant` search param is reserved for Liquid-style numeric variant ids and is never treated as an option name. Register `acceptProductVariantId({ routeTemplates })` in `handleShopifyRoutes` `handlers` (see the local `hydrogen-request-handlers` skill) so `?variant=<id>` product links redirect to the canonical option-params URL before this loader runs.
+The `variant` search param is reserved for Liquid-style numeric variant ids and is never treated as an option name. Pass `routeTemplates` to `handleShopifyRoutes` (see the local `hydrogen-request-handlers` skill) so `?variant=<id>` product links redirect to the canonical option-params URL before this loader runs.
 
 ### Minimum product query
 

--- a/packages/hydrogen/skills/hydrogen-variant-form/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-variant-form/SKILL.md
@@ -120,6 +120,23 @@ Provider bindings should hydrate automatically when the product's semantic ident
 
 Pass `allowedOptionNames` to filter search params to only known product option names, avoiding unrelated query parameters. Passing an empty array filters out every option.
 
+The `variant` param is reserved for Liquid-style numeric variant ids and is never treated as an option name. Server-side, `acceptProductVariantId` (see the local `hydrogen-request-handlers` skill) redirects `?variant=<id>` product URLs to their canonical option-params URL before the loader runs; when both `variant` and option params are present, the variant wins.
+
+## Building selection URLs
+
+`buildProductSelectionSearchParams({ style?, selectedOptions, variant?, optionNames, base? })` builds the search params for a selection link. It always removes the reserved `variant` param and every param named in `optionNames`/`selectedOptions` from `base` before writing the new selection, preserving unrelated params (`?ref=campaign`). Compose it with the app's product pathname:
+
+```ts
+const params = buildProductSelectionSearchParams({
+  selectedOptions: result.selectedOptions,
+  optionNames: product.options.map((option) => option.name),
+  base: new URLSearchParams(location.search),
+});
+const url = `/products/${handle}${params.size ? `?${params}` : ""}`;
+```
+
+Pass `style: "variant"` with a resolved `variant` to emit a shareable `?variant=<numeric id>` link instead of option params. When no variant is resolved (partial selection), the variant style falls back to option params — a variant link is not constructible. Prefer option-params links for in-app navigation; `?variant=` links cost a server redirect on landing.
+
 ---
 
 ## Rules
@@ -146,7 +163,7 @@ Pass `allowedOptionNames` to filter search params to only known product option n
 
 - **ALWAYS check `value.handle` against the current `product.handle`.** If they differ, the option value points to a different product in a combined listing. The UI must navigate to that product (full page navigation or a link component), not call `selectOption`.
 - **Use the framework's client-side link component for cross-product values when one exists.** Use the app's idiomatic navigation primitive. Use a raw `<a>` only when that is the app's established routing convention.
-- **Preserve non-option query params on combined-listing links.** When constructing the URL for a combined-listing link, carry forward existing search params (e.g. `?ref=campaign`) and replace only the option params. Two-pass URL construction: delete all option params first, then set the new ones — this prevents stale params when combined-listing products have different option names.
+- **Preserve non-option query params on combined-listing links.** When constructing the URL for a combined-listing link, carry forward existing search params (e.g. `?ref=campaign`) and replace only the option params. Use `buildProductSelectionSearchParams` with the current product's option names as `optionNames` — it deletes all option params (and any stale `variant` param) first, then sets the new ones, preventing stale params when combined-listing products have different option names.
 - **Ignore selected options that are not in the current product option matrix.** Divergent combined-listing child products can have different option names. A stale `Color=Black` param must not constrain a child product whose options are `Size` and `Mount`.
 
 ### Price display

--- a/packages/hydrogen/skills/hydrogen-variant-form/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-variant-form/SKILL.md
@@ -120,7 +120,7 @@ Provider bindings should hydrate automatically when the product's semantic ident
 
 Pass `allowedOptionNames` to filter search params to only known product option names, avoiding unrelated query parameters. Passing an empty array filters out every option.
 
-The `variant` param is reserved for Liquid-style numeric variant ids and is never treated as an option name. Server-side, `acceptProductVariantId` (see the local `hydrogen-request-handlers` skill) redirects `?variant=<id>` product URLs to their canonical option-params URL before the loader runs; when both `variant` and option params are present, the variant wins.
+The `variant` param is reserved for Liquid-style numeric variant ids and is never treated as an option name. Server-side, `handleShopifyRoutes({ routeTemplates })` (see the local `hydrogen-request-handlers` skill) redirects `?variant=<id>` product URLs to their canonical option-params URL before the loader runs; when both `variant` and option params are present, the variant wins.
 
 ## Building selection URLs
 

--- a/packages/hydrogen/skills/hydrogen-variant-form/references/nextjs.md
+++ b/packages/hydrogen/skills/hydrogen-variant-form/references/nextjs.md
@@ -165,15 +165,19 @@ Render same-product option values as GET links (`next/link`) so variant selectio
 Cross-product combined-listing values point at a different `value.handle` and navigate to that product. Prefer `next/link`; if using a button for cross-product navigation, keep it clearly outside the add-to-cart form and call `router.replace(...)`. Both use the same URL helper:
 
 ```tsx
+import { buildProductSelectionSearchParams, type SelectedOption } from "@shopify/hydrogen";
+
 function variantUrl(
   product: { handle: string; options: Array<{ name: string }> },
   selectedOptions: SelectedOption[],
   handle = product.handle,
   base: URLSearchParams | ReturnType<typeof useSearchParams> = new URLSearchParams(),
 ) {
-  const params = new URLSearchParams(base);
-  for (const option of product.options) params.delete(option.name);
-  for (const option of selectedOptions) params.set(option.name, option.value);
+  const params = buildProductSelectionSearchParams({
+    selectedOptions,
+    optionNames: product.options.map((option) => option.name),
+    base: new URLSearchParams(base),
+  });
   const query = params.toString();
   return `/products/${handle}${query ? `?${query}` : ""}`;
 }

--- a/packages/hydrogen/skills/hydrogen-variant-form/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-variant-form/references/nuxt.md
@@ -76,7 +76,7 @@ Same-product option values are GET links (`NuxtLink`) so selection degrades with
 </NuxtLink>
 ```
 
-Build route query objects with `buildProductSelectionSearchParams`, passing the product option names as `optionNames` and the current route query as `base`. This preserves non-option params while removing stale option params and the reserved `variant` param.
+Build route query objects with `buildProductSelectionSearchParams`, passing the product option names as `optionNames`. Convert Nuxt's current route query to `URLSearchParams` for `base` by appending every scalar or array value, then convert the returned params back to a Nuxt query object while preserving repeated keys. This preserves non-option params while removing stale option params and the reserved `variant` param.
 
 ## Add To Cart
 

--- a/packages/hydrogen/skills/hydrogen-variant-form/references/nuxt.md
+++ b/packages/hydrogen/skills/hydrogen-variant-form/references/nuxt.md
@@ -76,7 +76,7 @@ Same-product option values are GET links (`NuxtLink`) so selection degrades with
 </NuxtLink>
 ```
 
-Build route query objects by copying `route.query`, deleting all product option names, then setting selected option values. This preserves non-option params.
+Build route query objects with `buildProductSelectionSearchParams`, passing the product option names as `optionNames` and the current route query as `base`. This preserves non-option params while removing stale option params and the reserved `variant` param.
 
 ## Add To Cart
 

--- a/packages/hydrogen/src/client/client.ts
+++ b/packages/hydrogen/src/client/client.ts
@@ -63,8 +63,23 @@ const REQUEST_IDENTITY_HEADERS = new Set([
   SHOPIFY_STOREFRONT_Y_HEADER.toLowerCase(),
   SHOPIFY_STOREFRONT_S_HEADER.toLowerCase(),
 ]);
+const CACHE_ENABLED_GRAPHQL_CLIENTS = new WeakSet<StorefrontClient["graphql"]>();
+const SHOULD_CACHE_RESULT = Symbol();
+
+type ShouldCacheResult = (body: object) => boolean;
 
 class StorefrontCacheConfigError extends Error {}
+
+export function withStorefrontClientCache<TOptions extends object>(
+  client: Pick<StorefrontClient, "graphql">,
+  options: TOptions,
+  strategy: CachingStrategy,
+  shouldCacheResult?: ShouldCacheResult,
+): TOptions {
+  if (!CACHE_ENABLED_GRAPHQL_CLIENTS.has(client.graphql)) return options;
+
+  return { ...options, cache: strategy, [SHOULD_CACHE_RESULT]: shouldCacheResult };
+}
 
 /**
  * Creates a type-safe Storefront API client.
@@ -188,6 +203,7 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
       variables?: Record<string, unknown>;
       signal?: AbortSignal;
       cache?: CachingStrategy;
+      [SHOULD_CACHE_RESULT]?: ShouldCacheResult;
     };
 
     const queryText = typeof doc === "string" ? doc : (doc as unknown as string);
@@ -241,7 +257,13 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
         signal: externalSignals.length > 0 ? AbortSignal.any(externalSignals) : undefined,
       };
 
-      const cacheOptions = createStorefrontCacheOptions(apiUrl, init, queryText, opts.cache);
+      const cacheOptions = createStorefrontCacheOptions(
+        apiUrl,
+        init,
+        queryText,
+        opts.cache,
+        opts[SHOULD_CACHE_RESULT],
+      );
       const response = await (resolvedFetch as ResolvedStorefrontFetch)(apiUrl, init, cacheOptions);
 
       responseHeaders = response.headers;
@@ -313,7 +335,7 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
     };
   }
 
-  return {
+  const client: StorefrontClient = {
     type: clientType,
     i18n,
     graphql: graphql as StorefrontClient["graphql"],
@@ -322,6 +344,10 @@ export function createStorefrontClient(args: CreateStorefrontClientArgs): Storef
     storefrontId: config.storefrontId,
     requestContext,
   };
+
+  if (config.cache) CACHE_ENABLED_GRAPHQL_CLIENTS.add(client.graphql);
+
+  return client;
 }
 
 function buildVariables(
@@ -348,6 +374,7 @@ function createStorefrontCacheOptions(
   init: PlainRequestInit,
   queryText: string,
   strategy: CachingStrategy | undefined,
+  shouldCacheResult: ShouldCacheResult | undefined,
 ): FetchCacheOptions | undefined {
   if (!strategy) return undefined;
 
@@ -362,9 +389,11 @@ function createStorefrontCacheOptions(
       if (!json) return false;
 
       const body = await json().catch(() => undefined);
-      return (
-        typeof body === "object" && body != null && !Array.isArray(body) && !("errors" in body)
-      );
+      if (typeof body !== "object" || body == null || Array.isArray(body) || "errors" in body) {
+        return false;
+      }
+
+      return shouldCacheResult?.(body) ?? true;
     },
   };
 }

--- a/packages/hydrogen/src/core/index.ts
+++ b/packages/hydrogen/src/core/index.ts
@@ -12,10 +12,9 @@ export type {
   ShopifyRouteHandlerContext,
   ShopifyRouteHandlerGroup,
   ShopifyRouteHandlerResult,
-  ShopifyRouteHandlers,
   ShopifyRouteJsonResult,
-  ShopifyRouteMatchHandler,
   ShopifyRouteRedirectResult,
+  ShopifyRedirectStatus,
 } from "./request-routing/registered-routes";
 export { createStorefrontClient } from "../client/client";
 export { createShopifyRequestContext } from "./request-context";
@@ -187,8 +186,8 @@ export type {
   ValidProductSelectionResult,
   VariantSelectionResult,
 } from "./product";
-export { acceptProductVariantId, buildProductSelectionSearchParams } from "./product";
-export type { AcceptProductVariantIdOptions, ProductSelectionLinkStyle } from "./product";
+export { buildProductSelectionSearchParams } from "./product";
+export type { ProductSelectionLinkStyle } from "./product";
 export { getSelectedProductOptions } from "./product";
 export type {
   ProductInput,

--- a/packages/hydrogen/src/core/index.ts
+++ b/packages/hydrogen/src/core/index.ts
@@ -12,7 +12,9 @@ export type {
   ShopifyRouteHandlerContext,
   ShopifyRouteHandlerGroup,
   ShopifyRouteHandlerResult,
+  ShopifyRouteHandlers,
   ShopifyRouteJsonResult,
+  ShopifyRouteMatchHandler,
   ShopifyRouteRedirectResult,
 } from "./request-routing/registered-routes";
 export { createStorefrontClient } from "../client/client";
@@ -185,6 +187,8 @@ export type {
   ValidProductSelectionResult,
   VariantSelectionResult,
 } from "./product";
+export { acceptProductVariantId, buildProductSelectionSearchParams } from "./product";
+export type { AcceptProductVariantIdOptions, ProductSelectionLinkStyle } from "./product";
 export { getSelectedProductOptions } from "./product";
 export type {
   ProductInput,

--- a/packages/hydrogen/src/core/product/accept-variant-id.test.ts
+++ b/packages/hydrogen/src/core/product/accept-variant-id.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { StorefrontClient } from "../../client";
+import { createStorefrontClient, type StorefrontClient } from "../../client";
 import { StorefrontApiError } from "../../client/errors";
+import { Cache } from "../cache";
 import { configureLogging, resetLoggingForTests } from "../logging";
 import { createShopifyRequestContext, type I18nConfig } from "../request-context";
 import type { HydrogenRoutesOptions } from "../request-routing/route-types";
@@ -67,6 +68,39 @@ function createTestSessionManager() {
   };
 }
 
+function createCacheEnabledContext(node: typeof VARIANT_NODE | null) {
+  const values = new Map<string, unknown>();
+  const cache = {
+    get: vi.fn((key: string) => values.get(key)),
+    set: vi.fn((key: string, value: unknown) => {
+      values.set(key, value);
+    }),
+  };
+  const request = new Request("https://shop.com/products/snowboard?variant=42");
+  const requestContext = createShopifyRequestContext({ request, i18n: DEFAULT_I18N });
+  const storefrontClient = createStorefrontClient({
+    type: "public",
+    requestContext,
+    config: {
+      storeDomain: "shop.myshopify.com",
+      cache,
+      fetch: vi.fn().mockResolvedValue(Response.json({ data: { node } })),
+    },
+  });
+
+  return {
+    cache,
+    options: {
+      request,
+      requestContext,
+      storefrontClient,
+      sessionManager: createTestSessionManager(),
+      routeTemplates: {},
+    } satisfies HydrogenRoutesOptions,
+    url: new URL(request.url),
+  };
+}
+
 async function run(options: Parameters<typeof createContext>[0]) {
   const { options: routeOptions, url, graphql } = createContext(options);
   const result = handleProductVariantId(url, routeOptions);
@@ -109,6 +143,26 @@ describe("handleProductVariantId", () => {
     expect(graphql).toHaveBeenCalledWith(expect.anything(), {
       variables: { id: "gid://shopify/ProductVariant/41820371452004" },
     });
+  });
+
+  it("uses the long cache strategy when the storefront client has a cache adapter", async () => {
+    const { cache, options, url } = createCacheEnabledContext(VARIANT_NODE);
+
+    await handleProductVariantId(url, options);
+
+    expect(cache.set).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ strategy: Cache.long() }),
+      expect.any(Object),
+    );
+  });
+
+  it("does not cache unresolved variants", async () => {
+    const { cache, options, url } = createCacheEnabledContext(null);
+
+    await handleProductVariantId(url, options);
+
+    expect(cache.set).not.toHaveBeenCalled();
   });
 
   it("prefers the variant over option params already in the URL", async () => {

--- a/packages/hydrogen/src/core/product/accept-variant-id.test.ts
+++ b/packages/hydrogen/src/core/product/accept-variant-id.test.ts
@@ -30,7 +30,11 @@ function createContext({
   const request = new Request(url, { method });
   const context = {
     request,
-    storefrontClient: { graphql, i18n, storeUrl: "https://shop.myshopify.com" } as unknown as StorefrontClient,
+    storefrontClient: {
+      graphql,
+      i18n,
+      storeUrl: "https://shop.myshopify.com",
+    } as unknown as StorefrontClient,
   } as ShopifyRouteHandlerContext;
 
   return { context, graphql, url: new URL(url) };
@@ -193,10 +197,7 @@ describe("acceptProductVariantId", () => {
       graphql,
     });
 
-    await Promise.all([
-      handler(first.url, first.context),
-      handler(second.url, second.context),
-    ]);
+    await Promise.all([handler(first.url, first.context), handler(second.url, second.context)]);
 
     expect(graphql).toHaveBeenCalledOnce();
   });

--- a/packages/hydrogen/src/core/product/accept-variant-id.test.ts
+++ b/packages/hydrogen/src/core/product/accept-variant-id.test.ts
@@ -3,8 +3,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { StorefrontClient } from "../../client";
 import { StorefrontApiError } from "../../client/errors";
 import { configureLogging, resetLoggingForTests } from "../logging";
-import type { ShopifyRouteHandlerContext } from "../request-routing/route-types";
-import { acceptProductVariantId } from "./accept-variant-id";
+import { createShopifyRequestContext, type I18nConfig } from "../request-context";
+import type { HydrogenRoutesOptions } from "../request-routing/route-types";
+import type { ShopifyRouteTemplates } from "../standard-routes/types";
+import { handleProductVariantId } from "./accept-variant-id";
+
+const DEFAULT_I18N = { country: "US", language: "EN", pathPrefix: "" } as const;
 
 const VARIANT_NODE = {
   selectedOptions: [
@@ -19,44 +23,62 @@ function createContext({
   method = "GET",
   node = VARIANT_NODE,
   graphql = vi.fn().mockResolvedValue({ data: { node } }),
-  i18n = { country: "US", language: "EN" },
+  i18n = DEFAULT_I18N,
+  routeTemplates = {},
 }: {
   url: string;
   method?: string;
   node?: typeof VARIANT_NODE | null;
   graphql?: ReturnType<typeof vi.fn>;
-  i18n?: { country: string; language: string };
+  i18n?: I18nConfig;
+  routeTemplates?: ShopifyRouteTemplates;
 }) {
   const request = new Request(url, { method });
-  const context = {
+  const requestContext = createShopifyRequestContext({ request, i18n });
+  const storefrontClient = {
+    graphql,
+    i18n: requestContext.i18n,
+    storeUrl: "https://shop.myshopify.com",
+    requestContext,
+  } as unknown as StorefrontClient;
+  const options = {
     request,
-    storefrontClient: {
-      graphql,
-      i18n,
-      storeUrl: "https://shop.myshopify.com",
-    } as unknown as StorefrontClient,
-  } as ShopifyRouteHandlerContext;
+    requestContext,
+    storefrontClient,
+    sessionManager: createTestSessionManager(),
+    routeTemplates,
+  } satisfies HydrogenRoutesOptions;
 
-  return { context, graphql, url: new URL(url) };
+  return { graphql, options, url: new URL(url) };
 }
 
-async function run(
-  handler: ReturnType<typeof acceptProductVariantId>,
-  options: Parameters<typeof createContext>[0],
-) {
-  const { context, url, graphql } = createContext(options);
-  const result = handler(url, context);
+function createTestSessionManager() {
+  const data = new Map<string, unknown>();
+
+  return {
+    getSessionOrigin: () => "https://shop.com",
+    getSessionItem: (key: string) => data.get(key),
+    setSessionItem: (key: string, value: unknown) => {
+      data.set(key, value);
+    },
+    removeSessionItem: (key: string) => {
+      data.delete(key);
+    },
+  };
+}
+
+async function run(options: Parameters<typeof createContext>[0]) {
+  const { options: routeOptions, url, graphql } = createContext(options);
+  const result = handleProductVariantId(url, routeOptions);
   return { result: result ? await result : null, graphql };
 }
 
-describe("acceptProductVariantId", () => {
+describe("handleProductVariantId", () => {
   afterEach(() => {
     resetLoggingForTests();
   });
 
   it("passes through non-GET/HEAD requests, product-less URLs, and missing or malformed variant params", async () => {
-    const handler = acceptProductVariantId({ routeTemplates: {} });
-
     const cases = [
       { url: "https://shop.com/products/snowboard?variant=1", method: "POST" },
       { url: "https://shop.com/products/snowboard" },
@@ -69,171 +91,94 @@ describe("acceptProductVariantId", () => {
     ];
 
     for (const testCase of cases) {
-      const { result, graphql } = await run(handler, testCase);
+      const { result, graphql } = await run(testCase);
       expect(result, testCase.url).toBeNull();
       expect(graphql).not.toHaveBeenCalled();
     }
   });
 
   it("redirects to the same pathname with the variant's option params", async () => {
-    const handler = acceptProductVariantId({ routeTemplates: {} });
-
-    const { result, graphql } = await run(handler, {
+    const { result, graphql } = await run({
       url: "https://shop.com/products/snowboard?variant=41820371452004&ref=campaign",
     });
 
-    expect(result).toEqual({
-      type: "redirect",
-      status: 302,
-      location: "/products/snowboard?ref=campaign&Color=Red&Size=M",
-    });
+    expect(result?.status).toBe(302);
+    expect(result?.headers.get("location")).toBe(
+      "https://shop.com/products/snowboard?ref=campaign&Color=Red&Size=M",
+    );
     expect(graphql).toHaveBeenCalledWith(expect.anything(), {
       variables: { id: "gid://shopify/ProductVariant/41820371452004" },
     });
   });
 
   it("prefers the variant over option params already in the URL", async () => {
-    const handler = acceptProductVariantId({ routeTemplates: {} });
-
-    const { result } = await run(handler, {
+    const { result } = await run({
       url: "https://shop.com/products/snowboard?Color=Blue&variant=42",
     });
 
-    expect(result).toEqual({
-      type: "redirect",
-      status: 302,
-      location: "/products/snowboard?Color=Red&Size=M",
-    });
+    expect(result?.headers.get("location")).toBe(
+      "https://shop.com/products/snowboard?Color=Red&Size=M",
+    );
   });
 
   it("handles HEAD requests and collection-scoped product URLs", async () => {
-    const handler = acceptProductVariantId({ routeTemplates: {} });
-
-    const { result } = await run(handler, {
+    const { result } = await run({
       url: "https://shop.com/collections/sale/products/snowboard?variant=42",
       method: "HEAD",
     });
 
-    expect(result).toEqual({
-      type: "redirect",
-      status: 302,
-      location: "/collections/sale/products/snowboard?Color=Red&Size=M",
-    });
+    expect(result?.headers.get("location")).toBe(
+      "https://shop.com/collections/sale/products/snowboard?Color=Red&Size=M",
+    );
   });
 
   it("matches configured custom product templates", async () => {
-    const handler = acceptProductVariantId({
+    const { result } = await run({
+      url: "https://shop.com/p/snowboard?variant=42",
       routeTemplates: { product: "/p/:productHandle" },
     });
 
-    const { result } = await run(handler, { url: "https://shop.com/p/snowboard?variant=42" });
-
-    expect(result).toEqual({
-      type: "redirect",
-      status: 302,
-      location: "/p/snowboard?Color=Red&Size=M",
-    });
+    expect(result?.headers.get("location")).toBe("https://shop.com/p/snowboard?Color=Red&Size=M");
   });
 
   it("redirects to the variant's own product page for combined listings", async () => {
-    const handler = acceptProductVariantId({ routeTemplates: {} });
-
-    const { result } = await run(handler, {
+    const { result } = await run({
       url: "https://shop.com/products/combined-parent?variant=42",
     });
 
-    expect(result).toEqual({
-      type: "redirect",
-      status: 302,
-      location: "/products/snowboard?Color=Red&Size=M",
-    });
+    expect(result?.headers.get("location")).toBe(
+      "https://shop.com/products/snowboard?Color=Red&Size=M",
+    );
   });
 
   it("matches locale-prefixed URLs and keeps the prefix on cross-product redirects", async () => {
-    const handler = acceptProductVariantId({ routeTemplates: {}, pathPrefix: "/fr-ca" });
-
-    const samePage = await run(handler, {
+    const i18n = { country: "CA", language: "FR", pathPrefix: "/fr-ca" } as const;
+    const samePage = await run({
       url: "https://shop.com/fr-ca/products/snowboard?variant=42",
+      i18n,
     });
-    expect(samePage.result).toEqual({
-      type: "redirect",
-      status: 302,
-      location: "/fr-ca/products/snowboard?Color=Red&Size=M",
-    });
+    expect(samePage.result?.headers.get("location")).toBe(
+      "https://shop.com/fr-ca/products/snowboard?Color=Red&Size=M",
+    );
 
-    const crossProduct = await run(handler, {
+    const crossProduct = await run({
       url: "https://shop.com/fr-ca/products/combined-parent?variant=42",
+      i18n,
     });
-    expect(crossProduct.result).toEqual({
-      type: "redirect",
-      status: 302,
-      location: "/fr-ca/products/snowboard?Color=Red&Size=M",
-    });
-  });
-
-  it("forwards the caching strategy to the variant lookup", async () => {
-    const cache = { maxAge: 3600 };
-    const handler = acceptProductVariantId({ routeTemplates: {}, cache });
-
-    const { graphql } = await run(handler, {
-      url: "https://shop.com/products/snowboard?variant=42",
-    });
-
-    expect(graphql).toHaveBeenCalledWith(expect.anything(), {
-      variables: { id: "gid://shopify/ProductVariant/42" },
-      cache,
-    });
-  });
-
-  it("deduplicates concurrent variant lookups for the same store and variant", async () => {
-    const graphql = vi.fn().mockResolvedValue({ data: { node: VARIANT_NODE } });
-    const handler = acceptProductVariantId({ routeTemplates: {} });
-    const first = createContext({
-      url: "https://shop.com/products/snowboard?variant=42",
-      graphql,
-    });
-    const second = createContext({
-      url: "https://shop.com/products/snowboard?variant=42",
-      graphql,
-    });
-
-    await Promise.all([handler(first.url, first.context), handler(second.url, second.context)]);
-
-    expect(graphql).toHaveBeenCalledOnce();
-  });
-
-  it("scopes concurrent variant lookup dedupe by storefront i18n", async () => {
-    const graphql = vi.fn().mockResolvedValue({ data: { node: VARIANT_NODE } });
-    const handler = acceptProductVariantId({ routeTemplates: {} });
-    const us = createContext({
-      url: "https://shop.com/products/snowboard?variant=42",
-      graphql,
-      i18n: { country: "US", language: "EN" },
-    });
-    const ca = createContext({
-      url: "https://shop.com/products/snowboard?variant=42",
-      graphql,
-      i18n: { country: "CA", language: "FR" },
-    });
-
-    await Promise.all([handler(us.url, us.context), handler(ca.url, ca.context)]);
-
-    expect(graphql).toHaveBeenCalledTimes(2);
+    expect(crossProduct.result?.headers.get("location")).toBe(
+      "https://shop.com/fr-ca/products/snowboard?Color=Red&Size=M",
+    );
   });
 
   it("strips the variant param when the variant does not exist", async () => {
-    const handler = acceptProductVariantId({ routeTemplates: {} });
-
-    const { result } = await run(handler, {
+    const { result } = await run({
       url: "https://shop.com/products/snowboard?variant=42&ref=campaign",
       node: null,
     });
 
-    expect(result).toEqual({
-      type: "redirect",
-      status: 302,
-      location: "/products/snowboard?ref=campaign",
-    });
+    expect(result?.headers.get("location")).toBe(
+      "https://shop.com/products/snowboard?ref=campaign",
+    );
   });
 
   it("logs and strips the variant param when the lookup fails", async () => {
@@ -247,18 +192,13 @@ describe("acceptProductVariantId", () => {
     };
     configureLogging({ logger });
     const failure = new StorefrontApiError("SFAPI unavailable");
-    const handler = acceptProductVariantId({ routeTemplates: {} });
 
-    const { result } = await run(handler, {
+    const { result } = await run({
       url: "https://shop.com/products/snowboard?variant=42",
       graphql: vi.fn().mockRejectedValue(failure),
     });
 
-    expect(result).toEqual({
-      type: "redirect",
-      status: 302,
-      location: "/products/snowboard",
-    });
+    expect(result?.headers.get("location")).toBe("https://shop.com/products/snowboard");
     expect(logger.error).toHaveBeenCalledWith("variant id redirect lookup failed", {
       scope: "product",
       error: failure,
@@ -268,12 +208,11 @@ describe("acceptProductVariantId", () => {
 
   it("throws programming and configuration errors from the lookup", async () => {
     const failure = new Error("Storefront API cache options require a cache configured");
-    const handler = acceptProductVariantId({ routeTemplates: {} });
-    const { context, url } = createContext({
+    const { options, url } = createContext({
       url: "https://shop.com/products/snowboard?variant=42",
       graphql: vi.fn().mockRejectedValue(failure),
     });
 
-    await expect(handler(url, context)).rejects.toThrow(failure);
+    await expect(handleProductVariantId(url, options)).rejects.toThrow(failure);
   });
 });

--- a/packages/hydrogen/src/core/product/accept-variant-id.test.ts
+++ b/packages/hydrogen/src/core/product/accept-variant-id.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { StorefrontClient } from "../../client";
+import { StorefrontApiError } from "../../client/errors";
+import { configureLogging, resetLoggingForTests } from "../logging";
+import type { ShopifyRouteHandlerContext } from "../request-routing/route-types";
+import { acceptProductVariantId } from "./accept-variant-id";
+
+const VARIANT_NODE = {
+  selectedOptions: [
+    { name: "Color", value: "Red" },
+    { name: "Size", value: "M" },
+  ],
+  product: { handle: "snowboard" },
+};
+
+function createContext({
+  url,
+  method = "GET",
+  node = VARIANT_NODE,
+  graphql = vi.fn().mockResolvedValue({ data: { node } }),
+  i18n = { country: "US", language: "EN" },
+}: {
+  url: string;
+  method?: string;
+  node?: typeof VARIANT_NODE | null;
+  graphql?: ReturnType<typeof vi.fn>;
+  i18n?: { country: string; language: string };
+}) {
+  const request = new Request(url, { method });
+  const context = {
+    request,
+    storefrontClient: { graphql, i18n, storeUrl: "https://shop.myshopify.com" } as unknown as StorefrontClient,
+  } as ShopifyRouteHandlerContext;
+
+  return { context, graphql, url: new URL(url) };
+}
+
+async function run(
+  handler: ReturnType<typeof acceptProductVariantId>,
+  options: Parameters<typeof createContext>[0],
+) {
+  const { context, url, graphql } = createContext(options);
+  const result = handler(url, context);
+  return { result: result ? await result : null, graphql };
+}
+
+describe("acceptProductVariantId", () => {
+  afterEach(() => {
+    resetLoggingForTests();
+  });
+
+  it("passes through non-GET/HEAD requests, product-less URLs, and missing or malformed variant params", async () => {
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+
+    const cases = [
+      { url: "https://shop.com/products/snowboard?variant=1", method: "POST" },
+      { url: "https://shop.com/products/snowboard" },
+      { url: "https://shop.com/products/snowboard?variant=banana" },
+      { url: "https://shop.com/products/snowboard?variant=-1" },
+      { url: "https://shop.com/products/snowboard?variant=" },
+      { url: `https://shop.com/products/snowboard?variant=${"9".repeat(31)}` },
+      { url: "https://shop.com/collections/sale?variant=1" },
+      { url: "https://shop.com/pages/about?variant=1" },
+    ];
+
+    for (const testCase of cases) {
+      const { result, graphql } = await run(handler, testCase);
+      expect(result, testCase.url).toBeNull();
+      expect(graphql).not.toHaveBeenCalled();
+    }
+  });
+
+  it("redirects to the same pathname with the variant's option params", async () => {
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+
+    const { result, graphql } = await run(handler, {
+      url: "https://shop.com/products/snowboard?variant=41820371452004&ref=campaign",
+    });
+
+    expect(result).toEqual({
+      type: "redirect",
+      status: 302,
+      location: "/products/snowboard?ref=campaign&Color=Red&Size=M",
+    });
+    expect(graphql).toHaveBeenCalledWith(expect.anything(), {
+      variables: { id: "gid://shopify/ProductVariant/41820371452004" },
+    });
+  });
+
+  it("prefers the variant over option params already in the URL", async () => {
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+
+    const { result } = await run(handler, {
+      url: "https://shop.com/products/snowboard?Color=Blue&variant=42",
+    });
+
+    expect(result).toEqual({
+      type: "redirect",
+      status: 302,
+      location: "/products/snowboard?Color=Red&Size=M",
+    });
+  });
+
+  it("handles HEAD requests and collection-scoped product URLs", async () => {
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+
+    const { result } = await run(handler, {
+      url: "https://shop.com/collections/sale/products/snowboard?variant=42",
+      method: "HEAD",
+    });
+
+    expect(result).toEqual({
+      type: "redirect",
+      status: 302,
+      location: "/collections/sale/products/snowboard?Color=Red&Size=M",
+    });
+  });
+
+  it("matches configured custom product templates", async () => {
+    const handler = acceptProductVariantId({
+      routeTemplates: { product: "/p/:productHandle" },
+    });
+
+    const { result } = await run(handler, { url: "https://shop.com/p/snowboard?variant=42" });
+
+    expect(result).toEqual({
+      type: "redirect",
+      status: 302,
+      location: "/p/snowboard?Color=Red&Size=M",
+    });
+  });
+
+  it("redirects to the variant's own product page for combined listings", async () => {
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+
+    const { result } = await run(handler, {
+      url: "https://shop.com/products/combined-parent?variant=42",
+    });
+
+    expect(result).toEqual({
+      type: "redirect",
+      status: 302,
+      location: "/products/snowboard?Color=Red&Size=M",
+    });
+  });
+
+  it("matches locale-prefixed URLs and keeps the prefix on cross-product redirects", async () => {
+    const handler = acceptProductVariantId({ routeTemplates: {}, pathPrefix: "/fr-ca" });
+
+    const samePage = await run(handler, {
+      url: "https://shop.com/fr-ca/products/snowboard?variant=42",
+    });
+    expect(samePage.result).toEqual({
+      type: "redirect",
+      status: 302,
+      location: "/fr-ca/products/snowboard?Color=Red&Size=M",
+    });
+
+    const crossProduct = await run(handler, {
+      url: "https://shop.com/fr-ca/products/combined-parent?variant=42",
+    });
+    expect(crossProduct.result).toEqual({
+      type: "redirect",
+      status: 302,
+      location: "/fr-ca/products/snowboard?Color=Red&Size=M",
+    });
+  });
+
+  it("forwards the caching strategy to the variant lookup", async () => {
+    const cache = { maxAge: 3600 };
+    const handler = acceptProductVariantId({ routeTemplates: {}, cache });
+
+    const { graphql } = await run(handler, {
+      url: "https://shop.com/products/snowboard?variant=42",
+    });
+
+    expect(graphql).toHaveBeenCalledWith(expect.anything(), {
+      variables: { id: "gid://shopify/ProductVariant/42" },
+      cache,
+    });
+  });
+
+  it("deduplicates concurrent variant lookups for the same store and variant", async () => {
+    const graphql = vi.fn().mockResolvedValue({ data: { node: VARIANT_NODE } });
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+    const first = createContext({
+      url: "https://shop.com/products/snowboard?variant=42",
+      graphql,
+    });
+    const second = createContext({
+      url: "https://shop.com/products/snowboard?variant=42",
+      graphql,
+    });
+
+    await Promise.all([
+      handler(first.url, first.context),
+      handler(second.url, second.context),
+    ]);
+
+    expect(graphql).toHaveBeenCalledOnce();
+  });
+
+  it("scopes concurrent variant lookup dedupe by storefront i18n", async () => {
+    const graphql = vi.fn().mockResolvedValue({ data: { node: VARIANT_NODE } });
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+    const us = createContext({
+      url: "https://shop.com/products/snowboard?variant=42",
+      graphql,
+      i18n: { country: "US", language: "EN" },
+    });
+    const ca = createContext({
+      url: "https://shop.com/products/snowboard?variant=42",
+      graphql,
+      i18n: { country: "CA", language: "FR" },
+    });
+
+    await Promise.all([handler(us.url, us.context), handler(ca.url, ca.context)]);
+
+    expect(graphql).toHaveBeenCalledTimes(2);
+  });
+
+  it("strips the variant param when the variant does not exist", async () => {
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+
+    const { result } = await run(handler, {
+      url: "https://shop.com/products/snowboard?variant=42&ref=campaign",
+      node: null,
+    });
+
+    expect(result).toEqual({
+      type: "redirect",
+      status: 302,
+      location: "/products/snowboard?ref=campaign",
+    });
+  });
+
+  it("logs and strips the variant param when the lookup fails", async () => {
+    const logger = {
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    };
+    configureLogging({ logger });
+    const failure = new StorefrontApiError("SFAPI unavailable");
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+
+    const { result } = await run(handler, {
+      url: "https://shop.com/products/snowboard?variant=42",
+      graphql: vi.fn().mockRejectedValue(failure),
+    });
+
+    expect(result).toEqual({
+      type: "redirect",
+      status: 302,
+      location: "/products/snowboard",
+    });
+    expect(logger.error).toHaveBeenCalledWith("variant id redirect lookup failed", {
+      scope: "product",
+      error: failure,
+      variantId: "gid://shopify/ProductVariant/42",
+    });
+  });
+
+  it("throws programming and configuration errors from the lookup", async () => {
+    const failure = new Error("Storefront API cache options require a cache configured");
+    const handler = acceptProductVariantId({ routeTemplates: {} });
+    const { context, url } = createContext({
+      url: "https://shop.com/products/snowboard?variant=42",
+      graphql: vi.fn().mockRejectedValue(failure),
+    });
+
+    await expect(handler(url, context)).rejects.toThrow(failure);
+  });
+});

--- a/packages/hydrogen/src/core/product/accept-variant-id.ts
+++ b/packages/hydrogen/src/core/product/accept-variant-id.ts
@@ -3,11 +3,18 @@ import { StorefrontApiError, StorefrontTimeoutError } from "../../client/errors"
 import { gql } from "../../graphql";
 import type { CachingStrategy } from "../cache";
 import { getLogger } from "../logging";
-import type { ShopifyRouteHandlerResult, ShopifyRouteMatchHandler } from "../request-routing/route-types";
+import type {
+  ShopifyRouteHandlerResult,
+  ShopifyRouteMatchHandler,
+} from "../request-routing/route-types";
 import { getStandardRoute } from "../standard-routes/build";
 import { matchStandardRouteUrl } from "../standard-routes/match";
 import type { ShopifyRouteTemplates } from "../standard-routes/types";
-import { buildProductSelectionSearchParams, parseVariantSearchParam, VARIANT_SEARCH_PARAM } from "./url";
+import {
+  buildProductSelectionSearchParams,
+  parseVariantSearchParam,
+  VARIANT_SEARCH_PARAM,
+} from "./url";
 
 const log = getLogger("product");
 

--- a/packages/hydrogen/src/core/product/accept-variant-id.ts
+++ b/packages/hydrogen/src/core/product/accept-variant-id.ts
@@ -1,12 +1,8 @@
 import type { StorefrontClient } from "../../client";
-import { StorefrontApiError, StorefrontTimeoutError } from "../../client/errors";
+import { StorefrontApiError } from "../../client/errors";
 import { gql } from "../../graphql";
-import type { CachingStrategy } from "../cache";
 import { getLogger } from "../logging";
-import type {
-  ShopifyRouteHandlerResult,
-  ShopifyRouteMatchHandler,
-} from "../request-routing/route-types";
+import type { HydrogenRouteInterceptor } from "../request-routing/route-types";
 import { getStandardRoute } from "../standard-routes/build";
 import { matchStandardRouteUrl } from "../standard-routes/match";
 import type { ShopifyRouteTemplates } from "../standard-routes/types";
@@ -19,7 +15,6 @@ import {
 const log = getLogger("product");
 
 const HTTP_FOUND_STATUS = 302;
-const inFlightVariantLookups = new Map<string, Promise<SelectedOptionsVariant | null>>();
 
 const VARIANT_SELECTED_OPTIONS_QUERY = gql(`
   query VariantSelectedOptions($id: ID!, $country: CountryCode, $language: LanguageCode)
@@ -43,56 +38,15 @@ type SelectedOptionsVariant = {
   product: { handle: string };
 };
 
-export type AcceptProductVariantIdOptions = {
-  /**
-   * The app's route templates, used to recognize product page URLs and to build the
-   * redirect target when the variant belongs to a different product (combined listings).
-   */
-  routeTemplates: ShopifyRouteTemplates;
-  /**
-   * i18n path prefix of the current request (`i18n.pathPrefix`, e.g. `"/fr-ca"`), for apps
-   * serving locale-prefixed URLs. Omit it when the app does not prefix pathnames.
-   *
-   * It is needed in two places:
-   *
-   * 1. Recognizing product URLs: `/fr-ca/products/snowboard?variant=123` only matches the
-   *    product route template once the prefix is stripped, and Hydrogen cannot guess which
-   *    leading segments are locales (`/fr`, `/fr-ca`, `/en-gb/eu`, …).
-   * 2. Cross-product redirects: when the variant belongs to a different product (combined
-   *    listings), the target pathname is rebuilt from the product route template, and the
-   *    prefix must be prepended so the buyer stays in the localized tree.
-   *
-   * Same-product redirects reuse the request pathname, so the prefix survives those
-   * automatically.
-   *
-   * @example
-   * ```ts
-   * // Without pathPrefix, localized URLs pass through unhandled:
-   * //   /fr-ca/products/snowboard?variant=123 → no match → default variant renders
-   * // With pathPrefix: "/fr-ca":
-   * //   /fr-ca/products/snowboard?variant=123 → 302 /fr-ca/products/snowboard?Color=Red
-   * //   /fr-ca/products/snowboard?variant=456 → 302 /fr-ca/products/combined-parent?Size=M
-   * acceptProductVariantId({ routeTemplates, pathPrefix: i18n.pathPrefix });
-   * ```
-   */
-  pathPrefix?: string;
-  /**
-   * Caching strategy for the variant lookup, e.g. `Cache.long()`. A variant's selected
-   * options are near-immutable, so caching absorbs repeated lookups for hot campaign
-   * links. Requires a storefront client created with a `cache` instance; omit otherwise.
-   */
-  cache?: CachingStrategy;
-};
-
 /**
  * Accepts Liquid-style `?variant=<numeric id>` links on product pages by redirecting them
  * to the canonical option-params URL, e.g. `/products/snowboard?variant=123` →
  * `302 /products/snowboard?Color=Red&Size=M`.
  *
- * Pass the returned handler to `handleShopifyRoutes` via `handlers`. It claims only
- * GET/HEAD requests whose URL matches a product route template and carries a numeric
- * `variant` param; everything else falls through to the framework. When both `variant`
- * and option params are present, the variant wins and the option params are replaced.
+ * `handleShopifyRoutes` runs this before app routing. It claims only GET/HEAD requests
+ * whose URL matches a product route template and carries a numeric `variant` param;
+ * everything else falls through to the framework. When both `variant` and option params
+ * are present, the variant wins and the option params are replaced.
  * Unknown/deleted variant ids redirect to the same URL with the `variant` param stripped,
  * preserving any remaining params for the product loader. Params unrelated to the
  * selection (`?ref=campaign`) are preserved. On cross-product (combined listing) redirects,
@@ -100,45 +54,32 @@ export type AcceptProductVariantIdOptions = {
  * knows the target variant's options; loaders filtering with `allowedOptionNames` ignore
  * the leftovers.
  *
- * @example
- * ```ts
- * handleShopifyRoutes({
- *   request,
- *   requestContext,
- *   sessionManager,
- *   storefrontClient,
- *   handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers],
- * });
- * ```
+ * Configure the app's URL shape once with `handleShopifyRoutes({ routeTemplates })`.
  */
-export function acceptProductVariantId({
-  routeTemplates,
-  pathPrefix,
-  cache,
-}: AcceptProductVariantIdOptions): ShopifyRouteMatchHandler {
-  return (url, { request, storefrontClient }) => {
-    if (request.method !== "GET" && request.method !== "HEAD") return null;
+export const handleProductVariantId: HydrogenRouteInterceptor = (
+  url,
+  { request, requestContext, storefrontClient, routeTemplates = {} },
+) => {
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
 
-    const variantId = parseVariantSearchParam(url.searchParams.get(VARIANT_SEARCH_PARAM));
-    if (!variantId) return null;
+  const variantId = parseVariantSearchParam(url.searchParams.get(VARIANT_SEARCH_PARAM));
+  if (!variantId) return null;
 
-    const match = matchStandardRouteUrl({ routeTemplates, pathPrefix, url: url.href });
-    if (match?.pageTemplateName !== "product") return null;
+  const pathPrefix = requestContext.i18n.pathPrefix;
+  const match = matchStandardRouteUrl({ routeTemplates, pathPrefix, url: url.href });
+  if (match?.pageTemplateName !== "product") return null;
 
-    return resolveVariantRedirect({
-      cache,
-      pathPrefix,
-      requestedHandle: match.params.productHandle,
-      routeTemplates,
-      storefrontClient,
-      url,
-      variantId,
-    });
-  };
-}
+  return resolveVariantRedirect({
+    pathPrefix,
+    requestedHandle: match.params.productHandle,
+    routeTemplates,
+    storefrontClient,
+    url,
+    variantId,
+  });
+};
 
 async function resolveVariantRedirect({
-  cache,
   pathPrefix,
   requestedHandle,
   routeTemplates,
@@ -146,15 +87,14 @@ async function resolveVariantRedirect({
   url,
   variantId,
 }: {
-  cache: CachingStrategy | undefined;
   pathPrefix: string | undefined;
   requestedHandle: string | undefined;
   routeTemplates: ShopifyRouteTemplates;
   storefrontClient: StorefrontClient;
   url: URL;
   variantId: string;
-}): Promise<ShopifyRouteHandlerResult> {
-  const variant = await fetchVariantSelectedOptions(storefrontClient, variantId, cache);
+}): Promise<Response> {
+  const variant = await queryVariantSelectedOptions(storefrontClient, variantId);
 
   const searchParams = buildProductSelectionSearchParams({
     selectedOptions: variant?.selectedOptions ?? [],
@@ -173,45 +113,21 @@ async function resolveVariantRedirect({
       : url.pathname;
 
   const search = searchParams.toString();
-  return {
-    type: "redirect",
+  const location = search ? `${pathname}?${search}` : pathname;
+  return new Response(null, {
     status: HTTP_FOUND_STATUS,
-    location: search ? `${pathname}?${search}` : pathname,
-  };
-}
-
-async function fetchVariantSelectedOptions(
-  storefrontClient: StorefrontClient,
-  variantId: string,
-  cache: CachingStrategy | undefined,
-): Promise<SelectedOptionsVariant | null> {
-  const { country, language } = storefrontClient.i18n;
-  const cacheKey = `${storefrontClient.storeUrl}:${country ?? ""}:${language ?? ""}:${variantId}`;
-  const inFlight = inFlightVariantLookups.get(cacheKey);
-  if (inFlight) return inFlight;
-
-  const lookup = queryVariantSelectedOptions(storefrontClient, variantId, cache).finally(() => {
-    inFlightVariantLookups.delete(cacheKey);
+    headers: { location: new URL(location, url.origin).toString() },
   });
-  inFlightVariantLookups.set(cacheKey, lookup);
-  return lookup;
 }
 
 async function queryVariantSelectedOptions(
   storefrontClient: StorefrontClient,
   variantId: string,
-  cache: CachingStrategy | undefined,
 ): Promise<SelectedOptionsVariant | null> {
   try {
-    // Typed as a variable (not an object literal) so the optional `cache` key is
-    // assignable to clients whose graphql options do not declare it; the client
-    // validates cache usage at runtime.
-    const options: { variables: { id: string }; cache?: CachingStrategy } = {
+    const result = await storefrontClient.graphql(VARIANT_SELECTED_OPTIONS_QUERY, {
       variables: { id: variantId },
-    };
-    if (cache) options.cache = cache;
-
-    const result = await storefrontClient.graphql(VARIANT_SELECTED_OPTIONS_QUERY, options);
+    });
 
     if (result.errors) {
       log.error("variant id redirect lookup failed", { errors: result.errors, variantId });
@@ -221,7 +137,6 @@ async function queryVariantSelectedOptions(
     const node = result.data?.node;
     if (node && "selectedOptions" in node) return node;
   } catch (error) {
-    if (error instanceof StorefrontTimeoutError) throw error;
     if (!(error instanceof StorefrontApiError)) throw error;
 
     // Losing the requested selection beats failing the page: strip the param and render

--- a/packages/hydrogen/src/core/product/accept-variant-id.ts
+++ b/packages/hydrogen/src/core/product/accept-variant-id.ts
@@ -1,0 +1,232 @@
+import type { StorefrontClient } from "../../client";
+import { StorefrontApiError, StorefrontTimeoutError } from "../../client/errors";
+import { gql } from "../../graphql";
+import type { CachingStrategy } from "../cache";
+import { getLogger } from "../logging";
+import type { ShopifyRouteHandlerResult, ShopifyRouteMatchHandler } from "../request-routing/route-types";
+import { getStandardRoute } from "../standard-routes/build";
+import { matchStandardRouteUrl } from "../standard-routes/match";
+import type { ShopifyRouteTemplates } from "../standard-routes/types";
+import { buildProductSelectionSearchParams, parseVariantSearchParam, VARIANT_SEARCH_PARAM } from "./url";
+
+const log = getLogger("product");
+
+const HTTP_FOUND_STATUS = 302;
+const inFlightVariantLookups = new Map<string, Promise<SelectedOptionsVariant | null>>();
+
+const VARIANT_SELECTED_OPTIONS_QUERY = gql(`
+  query VariantSelectedOptions($id: ID!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    node(id: $id) {
+      ... on ProductVariant {
+        selectedOptions {
+          name
+          value
+        }
+        product {
+          handle
+        }
+      }
+    }
+  }
+`);
+
+type SelectedOptionsVariant = {
+  selectedOptions: { name: string; value: string }[];
+  product: { handle: string };
+};
+
+export type AcceptProductVariantIdOptions = {
+  /**
+   * The app's route templates, used to recognize product page URLs and to build the
+   * redirect target when the variant belongs to a different product (combined listings).
+   */
+  routeTemplates: ShopifyRouteTemplates;
+  /**
+   * i18n path prefix of the current request (`i18n.pathPrefix`, e.g. `"/fr-ca"`), for apps
+   * serving locale-prefixed URLs. Omit it when the app does not prefix pathnames.
+   *
+   * It is needed in two places:
+   *
+   * 1. Recognizing product URLs: `/fr-ca/products/snowboard?variant=123` only matches the
+   *    product route template once the prefix is stripped, and Hydrogen cannot guess which
+   *    leading segments are locales (`/fr`, `/fr-ca`, `/en-gb/eu`, …).
+   * 2. Cross-product redirects: when the variant belongs to a different product (combined
+   *    listings), the target pathname is rebuilt from the product route template, and the
+   *    prefix must be prepended so the buyer stays in the localized tree.
+   *
+   * Same-product redirects reuse the request pathname, so the prefix survives those
+   * automatically.
+   *
+   * @example
+   * ```ts
+   * // Without pathPrefix, localized URLs pass through unhandled:
+   * //   /fr-ca/products/snowboard?variant=123 → no match → default variant renders
+   * // With pathPrefix: "/fr-ca":
+   * //   /fr-ca/products/snowboard?variant=123 → 302 /fr-ca/products/snowboard?Color=Red
+   * //   /fr-ca/products/snowboard?variant=456 → 302 /fr-ca/products/combined-parent?Size=M
+   * acceptProductVariantId({ routeTemplates, pathPrefix: i18n.pathPrefix });
+   * ```
+   */
+  pathPrefix?: string;
+  /**
+   * Caching strategy for the variant lookup, e.g. `Cache.long()`. A variant's selected
+   * options are near-immutable, so caching absorbs repeated lookups for hot campaign
+   * links. Requires a storefront client created with a `cache` instance; omit otherwise.
+   */
+  cache?: CachingStrategy;
+};
+
+/**
+ * Accepts Liquid-style `?variant=<numeric id>` links on product pages by redirecting them
+ * to the canonical option-params URL, e.g. `/products/snowboard?variant=123` →
+ * `302 /products/snowboard?Color=Red&Size=M`.
+ *
+ * Pass the returned handler to `handleShopifyRoutes` via `handlers`. It claims only
+ * GET/HEAD requests whose URL matches a product route template and carries a numeric
+ * `variant` param; everything else falls through to the framework. When both `variant`
+ * and option params are present, the variant wins and the option params are replaced.
+ * Unknown/deleted variant ids redirect to the same URL with the `variant` param stripped,
+ * preserving any remaining params for the product loader. Params unrelated to the
+ * selection (`?ref=campaign`) are preserved. On cross-product (combined listing) redirects,
+ * params matching the *source* product's option names are not stripped — the handler only
+ * knows the target variant's options; loaders filtering with `allowedOptionNames` ignore
+ * the leftovers.
+ *
+ * @example
+ * ```ts
+ * handleShopifyRoutes({
+ *   request,
+ *   requestContext,
+ *   sessionManager,
+ *   storefrontClient,
+ *   handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers],
+ * });
+ * ```
+ */
+export function acceptProductVariantId({
+  routeTemplates,
+  pathPrefix,
+  cache,
+}: AcceptProductVariantIdOptions): ShopifyRouteMatchHandler {
+  return (url, { request, storefrontClient }) => {
+    if (request.method !== "GET" && request.method !== "HEAD") return null;
+
+    const variantId = parseVariantSearchParam(url.searchParams.get(VARIANT_SEARCH_PARAM));
+    if (!variantId) return null;
+
+    const match = matchStandardRouteUrl({ routeTemplates, pathPrefix, url: url.href });
+    if (match?.pageTemplateName !== "product") return null;
+
+    return resolveVariantRedirect({
+      cache,
+      pathPrefix,
+      requestedHandle: match.params.productHandle,
+      routeTemplates,
+      storefrontClient,
+      url,
+      variantId,
+    });
+  };
+}
+
+async function resolveVariantRedirect({
+  cache,
+  pathPrefix,
+  requestedHandle,
+  routeTemplates,
+  storefrontClient,
+  url,
+  variantId,
+}: {
+  cache: CachingStrategy | undefined;
+  pathPrefix: string | undefined;
+  requestedHandle: string | undefined;
+  routeTemplates: ShopifyRouteTemplates;
+  storefrontClient: StorefrontClient;
+  url: URL;
+  variantId: string;
+}): Promise<ShopifyRouteHandlerResult> {
+  const variant = await fetchVariantSelectedOptions(storefrontClient, variantId, cache);
+
+  const searchParams = buildProductSelectionSearchParams({
+    selectedOptions: variant?.selectedOptions ?? [],
+    optionNames: [],
+    base: url.searchParams,
+  });
+
+  const pathname =
+    variant && !isSameHandle(variant.product.handle, requestedHandle)
+      ? getStandardRoute(
+          routeTemplates,
+          "product",
+          { productHandle: variant.product.handle },
+          { pathPrefix },
+        )
+      : url.pathname;
+
+  const search = searchParams.toString();
+  return {
+    type: "redirect",
+    status: HTTP_FOUND_STATUS,
+    location: search ? `${pathname}?${search}` : pathname,
+  };
+}
+
+async function fetchVariantSelectedOptions(
+  storefrontClient: StorefrontClient,
+  variantId: string,
+  cache: CachingStrategy | undefined,
+): Promise<SelectedOptionsVariant | null> {
+  const { country, language } = storefrontClient.i18n;
+  const cacheKey = `${storefrontClient.storeUrl}:${country ?? ""}:${language ?? ""}:${variantId}`;
+  const inFlight = inFlightVariantLookups.get(cacheKey);
+  if (inFlight) return inFlight;
+
+  const lookup = queryVariantSelectedOptions(storefrontClient, variantId, cache).finally(() => {
+    inFlightVariantLookups.delete(cacheKey);
+  });
+  inFlightVariantLookups.set(cacheKey, lookup);
+  return lookup;
+}
+
+async function queryVariantSelectedOptions(
+  storefrontClient: StorefrontClient,
+  variantId: string,
+  cache: CachingStrategy | undefined,
+): Promise<SelectedOptionsVariant | null> {
+  try {
+    // Typed as a variable (not an object literal) so the optional `cache` key is
+    // assignable to clients whose graphql options do not declare it; the client
+    // validates cache usage at runtime.
+    const options: { variables: { id: string }; cache?: CachingStrategy } = {
+      variables: { id: variantId },
+    };
+    if (cache) options.cache = cache;
+
+    const result = await storefrontClient.graphql(VARIANT_SELECTED_OPTIONS_QUERY, options);
+
+    if (result.errors) {
+      log.error("variant id redirect lookup failed", { errors: result.errors, variantId });
+      return null;
+    }
+
+    const node = result.data?.node;
+    if (node && "selectedOptions" in node) return node;
+  } catch (error) {
+    if (error instanceof StorefrontTimeoutError) throw error;
+    if (!(error instanceof StorefrontApiError)) throw error;
+
+    // Losing the requested selection beats failing the page: strip the param and render
+    // the default variant instead of surfacing a 5xx for a lookup the buyer cannot retry.
+    log.error("variant id redirect lookup failed", { error, variantId });
+  }
+
+  return null;
+}
+
+function isSameHandle(variantProductHandle: string, requestedHandle: string | undefined): boolean {
+  return requestedHandle !== undefined
+    ? variantProductHandle.toLowerCase() === requestedHandle.toLowerCase()
+    : true;
+}

--- a/packages/hydrogen/src/core/product/accept-variant-id.ts
+++ b/packages/hydrogen/src/core/product/accept-variant-id.ts
@@ -1,6 +1,8 @@
 import type { StorefrontClient } from "../../client";
+import { withStorefrontClientCache } from "../../client/client";
 import { StorefrontApiError } from "../../client/errors";
 import { gql } from "../../graphql";
+import { Cache } from "../cache";
 import { getLogger } from "../logging";
 import type { HydrogenRouteInterceptor } from "../request-routing/route-types";
 import { getStandardRoute } from "../standard-routes/build";
@@ -125,9 +127,15 @@ async function queryVariantSelectedOptions(
   variantId: string,
 ): Promise<SelectedOptionsVariant | null> {
   try {
-    const result = await storefrontClient.graphql(VARIANT_SELECTED_OPTIONS_QUERY, {
-      variables: { id: variantId },
-    });
+    const result = await storefrontClient.graphql(
+      VARIANT_SELECTED_OPTIONS_QUERY,
+      withStorefrontClientCache(
+        storefrontClient,
+        { variables: { id: variantId } },
+        Cache.long(),
+        hasResolvedVariant,
+      ),
+    );
 
     if (result.errors) {
       log.error("variant id redirect lookup failed", { errors: result.errors, variantId });
@@ -145,6 +153,11 @@ async function queryVariantSelectedOptions(
   }
 
   return null;
+}
+
+function hasResolvedVariant(body: object): boolean {
+  if (!("data" in body) || typeof body.data !== "object" || body.data == null) return false;
+  return "node" in body.data && body.data.node != null;
 }
 
 function isSameHandle(variantProductHandle: string, requestedHandle: string | undefined): boolean {

--- a/packages/hydrogen/src/core/product/index.ts
+++ b/packages/hydrogen/src/core/product/index.ts
@@ -14,8 +14,6 @@ export type {
   VariantSelectionResult,
 } from "./product-form";
 export { getSelectedProductOptions } from "./options";
-export { acceptProductVariantId } from "./accept-variant-id";
-export type { AcceptProductVariantIdOptions } from "./accept-variant-id";
 export { buildProductSelectionSearchParams } from "./url";
 export type { ProductSelectionLinkStyle } from "./url";
 export { createProductFormRegister } from "./form";

--- a/packages/hydrogen/src/core/product/index.ts
+++ b/packages/hydrogen/src/core/product/index.ts
@@ -14,6 +14,10 @@ export type {
   VariantSelectionResult,
 } from "./product-form";
 export { getSelectedProductOptions } from "./options";
+export { acceptProductVariantId } from "./accept-variant-id";
+export type { AcceptProductVariantIdOptions } from "./accept-variant-id";
+export { buildProductSelectionSearchParams } from "./url";
+export type { ProductSelectionLinkStyle } from "./url";
 export { createProductFormRegister } from "./form";
 export type {
   ProductAddToCartProps,

--- a/packages/hydrogen/src/core/product/options.test.ts
+++ b/packages/hydrogen/src/core/product/options.test.ts
@@ -30,4 +30,17 @@ describe("getSelectedProductOptions", () => {
 
     expect(getSelectedProductOptions({ searchParams: params, allowedOptionNames: [] })).toEqual([]);
   });
+
+  it("never treats the reserved variant param as an option", () => {
+    const params = new URLSearchParams();
+    params.set("variant", "41820371452004");
+    params.set("Size", "M");
+
+    expect(getSelectedProductOptions({ searchParams: params })).toEqual([
+      { name: "Size", value: "M" },
+    ]);
+    expect(
+      getSelectedProductOptions({ searchParams: params, allowedOptionNames: ["variant", "Size"] }),
+    ).toEqual([{ name: "Size", value: "M" }]);
+  });
 });

--- a/packages/hydrogen/src/core/product/options.ts
+++ b/packages/hydrogen/src/core/product/options.ts
@@ -1,4 +1,5 @@
 import { getLogger } from "../logging";
+import { VARIANT_SEARCH_PARAM } from "./url";
 import type {
   ProductInput,
   ProductOptionValueFrom,
@@ -25,6 +26,10 @@ type EncodedVariantConstraint = {
  *
  * Each query parameter is treated as an option name/value pair
  * (e.g. `?Color=Red&Size=M` → `[{name:"Color",value:"Red"},{name:"Size",value:"M"}]`).
+ *
+ * The `variant` param is reserved for numeric variant ids (Liquid parity; see
+ * `acceptProductVariantId`) and is never treated as an option name, even when
+ * listed in `allowedOptionNames`.
  *
  * When `allowedOptionNames` is provided, the search params are filtered to only
  * entries whose decoded param name exactly matches a product option name.
@@ -58,6 +63,7 @@ export function getSelectedProductOptions({
   const selectedOptions: SelectedOption[] = [];
 
   for (const [name, value] of searchParams.entries()) {
+    if (name === VARIANT_SEARCH_PARAM) continue;
     if (allowedOptionNameSet && !allowedOptionNameSet.has(name)) continue;
     selectedOptions.push({ name, value });
   }

--- a/packages/hydrogen/src/core/product/options.ts
+++ b/packages/hydrogen/src/core/product/options.ts
@@ -1,5 +1,4 @@
 import { getLogger } from "../logging";
-import { VARIANT_SEARCH_PARAM } from "./url";
 import type {
   ProductInput,
   ProductOptionValueFrom,
@@ -9,6 +8,7 @@ import type {
   VariantOptionState,
   VariantOptionValueState,
 } from "./state";
+import { VARIANT_SEARCH_PARAM } from "./url";
 
 const log = getLogger("product");
 

--- a/packages/hydrogen/src/core/product/options.ts
+++ b/packages/hydrogen/src/core/product/options.ts
@@ -27,9 +27,8 @@ type EncodedVariantConstraint = {
  * Each query parameter is treated as an option name/value pair
  * (e.g. `?Color=Red&Size=M` → `[{name:"Color",value:"Red"},{name:"Size",value:"M"}]`).
  *
- * The `variant` param is reserved for numeric variant ids (Liquid parity; see
- * `acceptProductVariantId`) and is never treated as an option name, even when
- * listed in `allowedOptionNames`.
+ * The `variant` param is reserved for numeric variant ids (Liquid parity) and is
+ * never treated as an option name, even when listed in `allowedOptionNames`.
  *
  * When `allowedOptionNames` is provided, the search params are filtered to only
  * entries whose decoded param name exactly matches a product option name.

--- a/packages/hydrogen/src/core/product/url.test.ts
+++ b/packages/hydrogen/src/core/product/url.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProductSelectionSearchParams } from "./url";
+
+const SELECTED_OPTIONS = [
+  { name: "Color", value: "Red" },
+  { name: "Size", value: "M" },
+];
+
+describe("buildProductSelectionSearchParams", () => {
+  it("writes one param per selected option by default", () => {
+    const params = buildProductSelectionSearchParams({
+      selectedOptions: SELECTED_OPTIONS,
+      optionNames: ["Color", "Size"],
+    });
+
+    expect(params.toString()).toBe("Color=Red&Size=M");
+  });
+
+  it("writes a numeric variant param for the variant style", () => {
+    const params = buildProductSelectionSearchParams({
+      style: "variant",
+      selectedOptions: SELECTED_OPTIONS,
+      variant: { id: "gid://shopify/ProductVariant/41820371452004" },
+      optionNames: ["Color", "Size"],
+    });
+
+    expect(params.toString()).toBe("variant=41820371452004");
+  });
+
+  it("falls back to option params when the variant style has no resolved variant", () => {
+    const params = buildProductSelectionSearchParams({
+      style: "variant",
+      selectedOptions: [{ name: "Color", value: "Red" }],
+      variant: null,
+      optionNames: ["Color", "Size"],
+    });
+
+    expect(params.toString()).toBe("Color=Red");
+  });
+
+  it("falls back to option params for non-canonical variant ids", () => {
+    const params = buildProductSelectionSearchParams({
+      style: "variant",
+      selectedOptions: SELECTED_OPTIONS,
+      variant: { id: "gid://shopify/ProductVariant/not-numeric" },
+      optionNames: ["Color", "Size"],
+    });
+
+    expect(params.toString()).toBe("Color=Red&Size=M");
+  });
+
+  it("removes stale variant and option params from base while preserving the rest", () => {
+    const base = new URLSearchParams(
+      "variant=123&Color=Blue&Material=Wool&ref=campaign",
+    );
+
+    const params = buildProductSelectionSearchParams({
+      selectedOptions: SELECTED_OPTIONS,
+      optionNames: ["Color", "Size", "Material"],
+      base,
+    });
+
+    expect(params.toString()).toBe("ref=campaign&Color=Red&Size=M");
+    expect(base.toString()).toBe("variant=123&Color=Blue&Material=Wool&ref=campaign");
+  });
+
+  it("removes params named after the target selection across combined-listing products", () => {
+    const base = new URLSearchParams("Color=Blue&ref=campaign");
+
+    const params = buildProductSelectionSearchParams({
+      selectedOptions: [{ name: "Material", value: "Wool" }],
+      optionNames: ["Color"],
+      base,
+    });
+
+    expect(params.toString()).toBe("ref=campaign&Material=Wool");
+  });
+
+  it("removes stale option params when emitting a variant link", () => {
+    const base = new URLSearchParams("Color=Blue&Size=S&ref=campaign");
+
+    const params = buildProductSelectionSearchParams({
+      style: "variant",
+      selectedOptions: SELECTED_OPTIONS,
+      variant: { id: "gid://shopify/ProductVariant/42" },
+      optionNames: ["Color", "Size"],
+      base,
+    });
+
+    expect(params.toString()).toBe("ref=campaign&variant=42");
+  });
+});

--- a/packages/hydrogen/src/core/product/url.test.ts
+++ b/packages/hydrogen/src/core/product/url.test.ts
@@ -51,9 +51,7 @@ describe("buildProductSelectionSearchParams", () => {
   });
 
   it("removes stale variant and option params from base while preserving the rest", () => {
-    const base = new URLSearchParams(
-      "variant=123&Color=Blue&Material=Wool&ref=campaign",
-    );
+    const base = new URLSearchParams("variant=123&Color=Blue&Material=Wool&ref=campaign");
 
     const params = buildProductSelectionSearchParams({
       selectedOptions: SELECTED_OPTIONS,

--- a/packages/hydrogen/src/core/product/url.ts
+++ b/packages/hydrogen/src/core/product/url.ts
@@ -1,0 +1,93 @@
+import type { SelectedOption } from "./state";
+
+const VARIANT_GID_PREFIX = "gid://shopify/ProductVariant/";
+
+/**
+ * Reserved product-page search param carrying a numeric variant id (`?variant=41820371452004`),
+ * matching Liquid storefront URLs. Never treated as a product option name.
+ */
+export const VARIANT_SEARCH_PARAM = "variant";
+
+/**
+ * Converts a `?variant=` search param value into a variant id (gid).
+ *
+ * Anything that is not a plain positive integer of a plausible length is treated as absent
+ * (`null`) so malformed links degrade to the default variant instead of producing invalid
+ * API lookups or log spam.
+ */
+export function parseVariantSearchParam(value: string | null): string | null {
+  if (!value || !/^\d{1,30}$/.test(value)) return null;
+  return `${VARIANT_GID_PREFIX}${value}`;
+}
+
+/**
+ * Extracts the numeric `?variant=` search param value from a variant id (gid).
+ * Returns `null` for ids that are not canonical `gid://shopify/ProductVariant/<numeric>` ids.
+ */
+export function getVariantSearchParamValue(variantId: string): string | null {
+  if (!variantId.startsWith(VARIANT_GID_PREFIX)) return null;
+
+  const numericId = variantId.slice(VARIANT_GID_PREFIX.length);
+  return /^\d+$/.test(numericId) ? numericId : null;
+}
+
+export type ProductSelectionLinkStyle = "options" | "variant";
+
+/**
+ * Builds the search params for a product-page link representing a variant selection.
+ *
+ * Existing `base` params are preserved (`?ref=campaign` survives navigation), except the
+ * reserved `variant` param and every param named in `optionNames` or `selectedOptions`,
+ * which are always removed before the new selection is written. This keeps stale selection
+ * state from leaking between navigations, including across combined-listing products.
+ *
+ * Two link styles:
+ * - `"options"` (default): one param per selected option, e.g. `?Color=Red&Size=M`.
+ * - `"variant"`: a single `?variant=<numeric id>` param (Liquid parity), for shareable
+ *   links. Falls back to option params when `variant` is absent — a partial selection has
+ *   no matching variant, so a variant link is not constructible.
+ *
+ * @example
+ * ```ts
+ * const searchParams = buildProductSelectionSearchParams({
+ *   selectedOptions: result.selectedOptions,
+ *   variant: result.selectedVariant,
+ *   optionNames: product.options.map((option) => option.name),
+ *   base: new URLSearchParams(location.search),
+ * });
+ * const url = `/products/${handle}${searchParams.size ? `?${searchParams}` : ""}`;
+ * ```
+ */
+export function buildProductSelectionSearchParams({
+  style = "options",
+  selectedOptions,
+  variant,
+  optionNames,
+  base,
+}: {
+  style?: ProductSelectionLinkStyle;
+  selectedOptions: readonly SelectedOption[];
+  variant?: { id: string } | null;
+  optionNames: readonly string[];
+  base?: URLSearchParams;
+}): URLSearchParams {
+  const searchParams = new URLSearchParams(base);
+
+  searchParams.delete(VARIANT_SEARCH_PARAM);
+  for (const name of optionNames) searchParams.delete(name);
+  for (const option of selectedOptions) searchParams.delete(option.name);
+
+  const variantSearchParamValue =
+    style === "variant" && variant ? getVariantSearchParamValue(variant.id) : null;
+
+  if (variantSearchParamValue) {
+    searchParams.set(VARIANT_SEARCH_PARAM, variantSearchParamValue);
+    return searchParams;
+  }
+
+  for (const option of selectedOptions) {
+    searchParams.set(option.name, option.value);
+  }
+
+  return searchParams;
+}

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { createStorefrontClient } from "../../client/client";
 import { createCartServerHandlers } from "../cart/server-handlers";
-import { acceptProductVariantId } from "../product/accept-variant-id";
 import { createShopifyRequestContext } from "../request-context";
 import { assert } from "../test-utils";
 import { handleShopifyRoutes as handleShopifyRoutesImpl } from "./handle-shopify-routes";
@@ -293,6 +292,19 @@ describe("handleShopifyRoutes", () => {
     expect(result?.headers.get("location")).toBe("https://my-app.com/account?login=failed");
   });
 
+  it("throws for invalid registered handler redirect statuses", async () => {
+    const request = new Request("https://my-app.com/custom");
+    const handler = createShopifyRouteHandler("/custom", "GET", async () => ({
+      type: "redirect" as const,
+      status: 304 as never,
+      location: "/account?login=failed",
+    }));
+
+    await expect(handleShopifyRoutes({ request, handlers: [{ custom: handler }] })).rejects.toThrow(
+      "Invalid Shopify route redirect status 304",
+    );
+  });
+
   it("preserves registered handler absolute redirect Location headers", async () => {
     const request = new Request("https://my-app.com/custom");
     const handler = createShopifyRouteHandler("/custom", "GET", async () => ({
@@ -349,7 +361,7 @@ describe("handleShopifyRoutes", () => {
     expect(headers.get("X-Shopify-Storefront-Access-Token")).toBeNull();
   });
 
-  it("dispatches match handlers from the handlers array with their redirect status", async () => {
+  it("handles variant id product redirects before registered handlers", async () => {
     mockFetch.mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -366,41 +378,13 @@ describe("handleShopifyRoutes", () => {
 
     const result = await handleShopifyRoutes({
       request: new Request("https://my-app.com/products/snowboard?variant=42"),
-      handlers: [acceptProductVariantId({ routeTemplates: {} }), createCartServerHandlers()],
+      routeTemplates: {},
+      handlers: [createCartServerHandlers()],
     });
 
     assert(result, "expected a redirect response");
     expect(result.status).toBe(302);
     expect(result.headers.get("location")).toBe("https://my-app.com/products/snowboard?Color=Red");
-  });
-
-  it("falls through to exact-path handlers when no match handler claims the request", async () => {
-    const matchHandler = vi.fn().mockReturnValue(null);
-    const request = new Request("https://my-app.com/custom");
-    const handler = createShopifyRouteHandler("/custom", "GET", async () => ({
-      type: "json" as const,
-      data: { ok: true },
-    }));
-
-    const result = await handleShopifyRoutes({
-      request,
-      handlers: [matchHandler, { custom: handler }],
-    });
-
-    expect(matchHandler).toHaveBeenCalledOnce();
-    expect(result?.status).toBe(200);
-  });
-
-  it("returns null synchronously when neither match handlers nor exact-path handlers claim the request", () => {
-    const matchHandler = vi.fn().mockReturnValue(null);
-
-    const result = handleShopifyRoutes({
-      request: new Request("https://my-app.com/products/snowboard"),
-      handlers: [matchHandler],
-    });
-
-    expect(result).toBeNull();
-    expect(matchHandler).toHaveBeenCalledOnce();
   });
 
   it("returns null synchronously for non-matching URLs", () => {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { createStorefrontClient } from "../../client/client";
 import { createCartServerHandlers } from "../cart/server-handlers";
+import { acceptProductVariantId } from "../product/accept-variant-id";
 import { createShopifyRequestContext } from "../request-context";
 import { assert } from "../test-utils";
 import { handleShopifyRoutes as handleShopifyRoutesImpl } from "./handle-shopify-routes";
@@ -346,6 +347,60 @@ describe("handleShopifyRoutes", () => {
     expect(headers.get("Shopify-Storefront-Private-Token")).toBe("test-private-token");
     expect(headers.get("Shopify-Storefront-Buyer-IP")).toBe("10.0.0.2");
     expect(headers.get("X-Shopify-Storefront-Access-Token")).toBeNull();
+  });
+
+  it("dispatches match handlers from the handlers array with their redirect status", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            node: {
+              selectedOptions: [{ name: "Color", value: "Red" }],
+              product: { handle: "snowboard" },
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await handleShopifyRoutes({
+      request: new Request("https://my-app.com/products/snowboard?variant=42"),
+      handlers: [acceptProductVariantId({ routeTemplates: {} }), createCartServerHandlers()],
+    });
+
+    assert(result, "expected a redirect response");
+    expect(result.status).toBe(302);
+    expect(result.headers.get("location")).toBe("https://my-app.com/products/snowboard?Color=Red");
+  });
+
+  it("falls through to exact-path handlers when no match handler claims the request", async () => {
+    const matchHandler = vi.fn().mockReturnValue(null);
+    const request = new Request("https://my-app.com/custom");
+    const handler = createShopifyRouteHandler("/custom", "GET", async () => ({
+      type: "json" as const,
+      data: { ok: true },
+    }));
+
+    const result = await handleShopifyRoutes({
+      request,
+      handlers: [matchHandler, { custom: handler }],
+    });
+
+    expect(matchHandler).toHaveBeenCalledOnce();
+    expect(result?.status).toBe(200);
+  });
+
+  it("returns null synchronously when neither match handlers nor exact-path handlers claim the request", () => {
+    const matchHandler = vi.fn().mockReturnValue(null);
+
+    const result = handleShopifyRoutes({
+      request: new Request("https://my-app.com/products/snowboard"),
+      handlers: [matchHandler],
+    });
+
+    expect(result).toBeNull();
+    expect(matchHandler).toHaveBeenCalledOnce();
   });
 
   it("returns null synchronously for non-matching URLs", () => {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
@@ -1,3 +1,4 @@
+import { handleProductVariantId } from "../product/accept-variant-id";
 import { handleAgentProxy } from "./interceptors/agent-proxy";
 import { handleAjaxApi } from "./interceptors/ajax-api";
 import { handleShopifyApiProxy } from "./interceptors/api-proxy";
@@ -12,6 +13,7 @@ import { safeApplyResponseHeaders } from "./safe-apply-response-headers";
 const SHOPIFY_ROUTE_INTERCEPTORS = [
   handleShopifyApiProxy,
   handleSfapiProxy,
+  handleProductVariantId,
   handleShopifyRouteHandlers,
   handleCheckoutRedirect,
   handleWellKnownProxy,

--- a/packages/hydrogen/src/core/request-routing/registered-routes.ts
+++ b/packages/hydrogen/src/core/request-routing/registered-routes.ts
@@ -3,9 +3,8 @@ import type {
   HydrogenRouteInterceptor,
   ShopifyRouteHandler,
   ShopifyRouteHandlerContext,
-  ShopifyRouteHandlerGroup,
   ShopifyRouteHandlerResult,
-  ShopifyRouteMatchHandler,
+  ShopifyRedirectStatus,
 } from "./route-types";
 
 export type {
@@ -16,10 +15,9 @@ export type {
   ShopifyRouteHandlerContext,
   ShopifyRouteHandlerGroup,
   ShopifyRouteHandlerResult,
-  ShopifyRouteHandlers,
   ShopifyRouteJsonResult,
-  ShopifyRouteMatchHandler,
   ShopifyRouteRedirectResult,
+  ShopifyRedirectStatus,
   ShopifyRouteSessionManager,
 } from "./route-types";
 
@@ -27,6 +25,9 @@ const HTTP_OK_STATUS = 200;
 const HTTP_SEE_OTHER_STATUS = 303;
 const HTTP_METHOD_NOT_ALLOWED_STATUS = 405;
 const HTTP_BAD_REQUEST_STATUS = 400;
+const VALID_REDIRECT_STATUSES = [
+  301, 302, 303, 307, 308,
+] as const satisfies readonly ShopifyRedirectStatus[];
 
 export function createShopifyRouteHandler<
   const TPathname extends string,
@@ -57,19 +58,7 @@ export const handleShopifyRouteHandlers: HydrogenRouteInterceptor = (
   { request, sessionManager, storefrontClient, requestContext, handlers = [] },
 ) => {
   const context = { request, sessionManager, storefrontClient, requestContext };
-
-  for (const entry of handlers) {
-    if (!isMatchHandler(entry)) continue;
-
-    const resultPromise = entry(url, context);
-    if (resultPromise) {
-      return resultPromise.then((result) => createShopifyRouteResponse(result, request));
-    }
-  }
-
-  const routeHandlers = handlers
-    .filter((entry): entry is ShopifyRouteHandlerGroup => !isMatchHandler(entry))
-    .flatMap((group) => Object.values(group));
+  const routeHandlers = handlers.flatMap((group) => Object.values(group));
   if (routeHandlers.length === 0) return null;
 
   const pathMatches = routeHandlers.filter((entry) => entry.pathname === url.pathname);
@@ -84,18 +73,12 @@ export const handleShopifyRouteHandlers: HydrogenRouteInterceptor = (
   return match(context).then((result) => createShopifyRouteResponse(result, request));
 };
 
-function isMatchHandler(
-  entry: ShopifyRouteHandlerGroup | ShopifyRouteMatchHandler,
-): entry is ShopifyRouteMatchHandler {
-  return typeof entry === "function";
-}
-
 function createShopifyRouteResponse(result: ShopifyRouteHandlerResult, request: Request): Response {
   if (result.type === "redirect") {
     const headers = new Headers(result.headers);
     headers.set("location", resolveRedirectLocation(result.location, request));
     return new Response(null, {
-      status: result.status ?? HTTP_SEE_OTHER_STATUS,
+      status: getRedirectStatus(result.status),
       headers,
     });
   }
@@ -115,6 +98,17 @@ function createShopifyRouteResponse(result: ShopifyRouteHandlerResult, request: 
     status: HTTP_OK_STATUS,
     headers,
   });
+}
+
+function getRedirectStatus(status: ShopifyRedirectStatus | undefined): ShopifyRedirectStatus {
+  const redirectStatus = status ?? HTTP_SEE_OTHER_STATUS;
+  if (VALID_REDIRECT_STATUSES.some((validStatus) => validStatus === redirectStatus)) {
+    return redirectStatus;
+  }
+
+  throw new Error(
+    `Invalid Shopify route redirect status ${redirectStatus}. Expected one of: ${VALID_REDIRECT_STATUSES.join(", ")}.`,
+  );
 }
 
 function resolveRedirectLocation(location: string, request: Request): string {

--- a/packages/hydrogen/src/core/request-routing/registered-routes.ts
+++ b/packages/hydrogen/src/core/request-routing/registered-routes.ts
@@ -3,7 +3,9 @@ import type {
   HydrogenRouteInterceptor,
   ShopifyRouteHandler,
   ShopifyRouteHandlerContext,
+  ShopifyRouteHandlerGroup,
   ShopifyRouteHandlerResult,
+  ShopifyRouteMatchHandler,
 } from "./route-types";
 
 export type {
@@ -14,7 +16,9 @@ export type {
   ShopifyRouteHandlerContext,
   ShopifyRouteHandlerGroup,
   ShopifyRouteHandlerResult,
+  ShopifyRouteHandlers,
   ShopifyRouteJsonResult,
+  ShopifyRouteMatchHandler,
   ShopifyRouteRedirectResult,
   ShopifyRouteSessionManager,
 } from "./route-types";
@@ -52,7 +56,20 @@ export const handleShopifyRouteHandlers: HydrogenRouteInterceptor = (
   url,
   { request, sessionManager, storefrontClient, requestContext, handlers = [] },
 ) => {
-  const routeHandlers = handlers.flatMap((group) => Object.values(group));
+  const context = { request, sessionManager, storefrontClient, requestContext };
+
+  for (const entry of handlers) {
+    if (!isMatchHandler(entry)) continue;
+
+    const resultPromise = entry(url, context);
+    if (resultPromise) {
+      return resultPromise.then((result) => createShopifyRouteResponse(result, request));
+    }
+  }
+
+  const routeHandlers = handlers
+    .filter((entry): entry is ShopifyRouteHandlerGroup => !isMatchHandler(entry))
+    .flatMap((group) => Object.values(group));
   if (routeHandlers.length === 0) return null;
 
   const pathMatches = routeHandlers.filter((entry) => entry.pathname === url.pathname);
@@ -64,17 +81,21 @@ export const handleShopifyRouteHandlers: HydrogenRouteInterceptor = (
       new Response("Method Not Allowed", { status: HTTP_METHOD_NOT_ALLOWED_STATUS }),
     );
 
-  return match({ request, sessionManager, storefrontClient, requestContext }).then((result) =>
-    createShopifyRouteResponse(result, request),
-  );
+  return match(context).then((result) => createShopifyRouteResponse(result, request));
 };
+
+function isMatchHandler(
+  entry: ShopifyRouteHandlerGroup | ShopifyRouteMatchHandler,
+): entry is ShopifyRouteMatchHandler {
+  return typeof entry === "function";
+}
 
 function createShopifyRouteResponse(result: ShopifyRouteHandlerResult, request: Request): Response {
   if (result.type === "redirect") {
     const headers = new Headers(result.headers);
     headers.set("location", resolveRedirectLocation(result.location, request));
     return new Response(null, {
-      status: HTTP_SEE_OTHER_STATUS,
+      status: result.status ?? HTTP_SEE_OTHER_STATUS,
       headers,
     });
   }

--- a/packages/hydrogen/src/core/request-routing/route-types.ts
+++ b/packages/hydrogen/src/core/request-routing/route-types.ts
@@ -1,5 +1,6 @@
 import type { StorefrontClient } from "../../client";
 import type { ShopifyRequestContext } from "../request-context";
+import type { ShopifyRouteTemplates } from "../standard-routes/types";
 
 type Awaitable<T> = T | Promise<T>;
 
@@ -24,11 +25,13 @@ export type ShopifyRouteJsonResult<TData = unknown> = {
   headers?: HeadersInit;
 };
 
+export type ShopifyRedirectStatus = 301 | 302 | 303 | 307 | 308;
+
 export type ShopifyRouteRedirectResult = {
   type: "redirect";
   location: string;
   /** HTTP redirect status. Defaults to 303 (See Other). */
-  status?: number;
+  status?: ShopifyRedirectStatus;
   headers?: HeadersInit;
 };
 
@@ -66,27 +69,9 @@ export type ShopifyRouteHandler<
 
 export type ShopifyRouteHandlerGroup = Record<string, ShopifyRouteHandler>;
 
-/**
- * A route handler that decides its own match from the request URL instead of an exact
- * pathname, e.g. `acceptProductVariantId` matching any product page URL.
- *
- * Must decide synchronously: return `null` to pass the request through to the framework
- * (preserving the `handleShopifyRoutes` fast path), or a promise doing the actual work.
- * Unlike exact-pathname handlers, a match handler never produces `405 Method Not Allowed`;
- * requests it does not claim always fall through.
- *
- * Dispatch order: match handlers run before every exact-pathname handler group, regardless
- * of their position in the `handlers` array. Multiple match handlers run in array order.
- */
-export type ShopifyRouteMatchHandler = (
-  url: URL,
-  context: ShopifyRouteHandlerContext,
-) => null | Promise<ShopifyRouteHandlerResult>;
-
-export type ShopifyRouteHandlers = ShopifyRouteHandlerGroup | ShopifyRouteMatchHandler;
-
 export type HydrogenRoutesOptions = ShopifyRouteHandlerContext & {
-  handlers?: readonly ShopifyRouteHandlers[];
+  routeTemplates?: ShopifyRouteTemplates;
+  handlers?: readonly ShopifyRouteHandlerGroup[];
 };
 
 export type HydrogenRouteHandler<TExtraOptions extends object = object> = (

--- a/packages/hydrogen/src/core/request-routing/route-types.ts
+++ b/packages/hydrogen/src/core/request-routing/route-types.ts
@@ -27,6 +27,8 @@ export type ShopifyRouteJsonResult<TData = unknown> = {
 export type ShopifyRouteRedirectResult = {
   type: "redirect";
   location: string;
+  /** HTTP redirect status. Defaults to 303 (See Other). */
+  status?: number;
   headers?: HeadersInit;
 };
 
@@ -64,8 +66,27 @@ export type ShopifyRouteHandler<
 
 export type ShopifyRouteHandlerGroup = Record<string, ShopifyRouteHandler>;
 
+/**
+ * A route handler that decides its own match from the request URL instead of an exact
+ * pathname, e.g. `acceptProductVariantId` matching any product page URL.
+ *
+ * Must decide synchronously: return `null` to pass the request through to the framework
+ * (preserving the `handleShopifyRoutes` fast path), or a promise doing the actual work.
+ * Unlike exact-pathname handlers, a match handler never produces `405 Method Not Allowed`;
+ * requests it does not claim always fall through.
+ *
+ * Dispatch order: match handlers run before every exact-pathname handler group, regardless
+ * of their position in the `handlers` array. Multiple match handlers run in array order.
+ */
+export type ShopifyRouteMatchHandler = (
+  url: URL,
+  context: ShopifyRouteHandlerContext,
+) => null | Promise<ShopifyRouteHandlerResult>;
+
+export type ShopifyRouteHandlers = ShopifyRouteHandlerGroup | ShopifyRouteMatchHandler;
+
 export type HydrogenRoutesOptions = ShopifyRouteHandlerContext & {
-  handlers?: readonly ShopifyRouteHandlerGroup[];
+  handlers?: readonly ShopifyRouteHandlers[];
 };
 
 export type HydrogenRouteHandler<TExtraOptions extends object = object> = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,13 +49,13 @@ importers:
     dependencies:
       '@astrojs/node':
         specifier: ^10.0.6
-        version: 10.0.6(astro@6.2.2(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+        version: 10.0.6(astro@6.2.2(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
       '@shopify/hydrogen':
         specifier: workspace:*
         version: link:../../packages/hydrogen
       astro:
         specifier: ^6.1.10
-        version: 6.2.2(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.2.2(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       lru-cache:
         specifier: ^11.3.6
         version: 11.3.6
@@ -159,7 +159,7 @@ importers:
         version: link:../../packages/hydrogen
       nuxt:
         specifier: ^3.17.0
-        version: 3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0)
+        version: 3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0)
       vue:
         specifier: ^3.5.0
         version: 3.5.33(typescript@5.9.3)
@@ -169,7 +169,7 @@ importers:
     devDependencies:
       '@nuxt/fonts':
         specifier: ^0.11.0
-        version: 0.11.4(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+        version: 0.11.4(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.2.0
         version: 4.2.4(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
@@ -196,7 +196,7 @@ importers:
         version: 0.15.4(solid-js@1.9.12)
       '@solidjs/start':
         specifier: 1.3.2
-        version: 1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
       lru-cache:
         specifier: ^11.3.6
         version: 11.3.6
@@ -205,7 +205,7 @@ importers:
         version: 1.9.12
       vinxi:
         specifier: ^0.5.7
-        version: 0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+        version: 0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -348,12 +348,15 @@ importers:
       '@shopify/hydrogen':
         specifier: workspace:*
         version: link:../../packages/hydrogen
+      '@vercel/functions':
+        specifier: ^3.9.3
+        version: 3.9.3(ws@8.20.0)
       isbot:
         specifier: ^5
         version: 5.1.40
       next:
         specifier: 16.2.9
-        version: 16.2.9(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.2.9(@playwright/test@1.59.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: ^19.2.4
         version: 19.2.8
@@ -4563,15 +4566,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vercel/cli-config@0.2.0':
-    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==, tarball: https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz}
+  '@vercel/cli-config@0.2.3':
+    resolution: {integrity: sha512-Ggh0Wmi92TUkUexmSUPkkDtvJmbjUr7IvF5T3FkSsWrXXs3GFzOujfxFpECdJZpux1JG4SWDv9BT4w++TDgD6A==, tarball: https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.3.tgz}
 
-  '@vercel/cli-exec@1.0.0':
-    resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==, tarball: https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz}
+  '@vercel/cli-exec@1.0.1':
+    resolution: {integrity: sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==, tarball: https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.1.tgz}
     engines: {node: '>= 18'}
 
-  '@vercel/functions@3.7.4':
-    resolution: {integrity: sha512-BvHqiuWziXaApV/eazLc84cHzEpPyNGG2UUAg82x+VN2VTCtX/DKH7SKOb3PxpRL/27zxPz8ltdO6GoKj66DaA==, tarball: https://registry.npmjs.org/@vercel/functions/-/functions-3.7.4.tgz}
+  '@vercel/functions@3.9.3':
+    resolution: {integrity: sha512-cbzTdASCZDnufrABc8oO00e/FqlqFFSdld+iGZPhrWBDHP4Pu8ESKKYIzASqYvbYYUIWujBvEa5LLCcZzm7WEw==, tarball: https://registry.npmjs.org/@vercel/functions/-/functions-3.9.3.tgz}
     engines: {node: '>= 20'}
     peerDependencies:
       '@aws-sdk/credential-provider-web-identity': '*'
@@ -4587,8 +4590,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@vercel/oidc@3.7.1':
-    resolution: {integrity: sha512-RrSsVWbq3KLK5lJobyTPp3tSthNfUp+zWkXno5Wkko0oEW05rA4ngOrnVypP4+L8/Av89uPo2rWFmzL8iwnsmA==, tarball: https://registry.npmjs.org/@vercel/oidc/-/oidc-3.7.1.tgz}
+  '@vercel/oidc@3.8.4':
+    resolution: {integrity: sha512-FGNvVZ5pgX9FaBqkPt6VkYFZ6bWAMDzYi7nxW+1Xt+Z4fn5PuTULVwsxjKc+0uKhysyWBQmvsmM50Oh6C2/oMA==, tarball: https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.4.tgz}
     engines: {node: '>= 20'}
 
   '@vinxi/listhen@1.5.6':
@@ -10481,10 +10484,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/node@10.0.6(astro@6.2.2(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
+  '@astrojs/node@10.0.6(astro@6.2.2(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.9.0
-      astro: 6.2.2(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+      astro: 6.2.2(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       send: 1.2.1
       server-destroy: 1.0.1
     transitivePeerDependencies:
@@ -12346,7 +12349,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/fonts@0.11.4(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
+  '@nuxt/fonts@0.11.4(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
       '@nuxt/kit': 3.21.4(magicast@0.5.2)
@@ -12367,7 +12370,7 @@ snapshots:
       ufo: 1.6.4
       unifont: 0.4.1
       unplugin: 2.3.11
-      unstorage: 1.17.5(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
+      unstorage: 1.17.5(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12443,7 +12446,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@3.21.4(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.128.0)(rolldown@1.0.0-rc.17)(typescript@5.9.3)':
+  '@nuxt/nitro-server@3.21.4(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.128.0)(rolldown@1.0.0-rc.17)(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 3.21.4(magicast@0.5.2)
@@ -12460,8 +12463,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@vercel/functions@3.7.4(ws@8.20.0))(oxc-parser@0.128.0)(rolldown@1.0.0-rc.17)
-      nuxt: 3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0)
+      nitropack: 2.13.4(@vercel/functions@3.9.3(ws@8.20.0))(oxc-parser@0.128.0)(rolldown@1.0.0-rc.17)
+      nuxt: 3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0)
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -12469,7 +12472,7 @@ snapshots:
       std-env: 4.1.0
       ufo: 1.6.4
       unctx: 2.5.0
-      unstorage: 1.17.5(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
+      unstorage: 1.17.5(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
       vue: 3.5.33(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -12527,7 +12530,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/vite-builder@3.21.4(@types/node@25.8.0)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.3.3(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@3.21.4(@types/node@25.8.0)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.3.3(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 3.21.4(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.3)
@@ -12546,7 +12549,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -13607,11 +13610,11 @@ snapshots:
     dependencies:
       solid-js: 1.9.12
 
-  '@solidjs/start@1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
+  '@solidjs/start@1.3.2(solid-js@1.9.12)(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/server-functions-plugin': 1.121.21(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+      '@vinxi/server-components': 0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
       cookie-es: 2.0.1
       defu: 6.1.7
       error-stack-parser: 2.1.4
@@ -13623,7 +13626,7 @@ snapshots:
       source-map-js: 1.2.1
       terracotta: 1.1.0(solid-js@1.9.12)
       tinyglobby: 0.2.16
-      vinxi: 0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+      vinxi: 0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-solid: 2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
@@ -14126,23 +14129,20 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vercel/cli-config@0.2.0':
+  '@vercel/cli-config@0.2.3':
     dependencies:
       xdg-app-paths: 5.5.1
       zod: 4.1.11
-    optional: true
 
-  '@vercel/cli-exec@1.0.0':
+  '@vercel/cli-exec@1.0.1':
     dependencies:
       execa: 5.1.1
-    optional: true
 
-  '@vercel/functions@3.7.4(ws@8.20.0)':
+  '@vercel/functions@3.9.3(ws@8.20.0)':
     dependencies:
-      '@vercel/oidc': 3.7.1
+      '@vercel/oidc': 3.8.4
     optionalDependencies:
       ws: 8.20.0
-    optional: true
 
   '@vercel/nft@1.5.0(rollup@4.60.3)':
     dependencies:
@@ -14163,12 +14163,11 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/oidc@3.7.1':
+  '@vercel/oidc@3.8.4':
     dependencies:
-      '@vercel/cli-config': 0.2.0
-      '@vercel/cli-exec': 1.0.0
+      '@vercel/cli-config': 0.2.3
+      '@vercel/cli-exec': 1.0.1
       jose: 5.10.0
-    optional: true
 
   '@vinxi/listhen@1.5.6':
     dependencies:
@@ -14190,7 +14189,7 @@ snapshots:
       untun: 0.1.3
       uqr: 0.1.3
 
-  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/parser': 7.29.3
       acorn: 8.16.0
@@ -14201,18 +14200,18 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.11
       tslib: 2.8.1
-      vinxi: 0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+      vinxi: 0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vinxi/server-components@0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
+      '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
       acorn: 8.16.0
       acorn-loose: 8.5.2
       acorn-typescript: 1.4.13(acorn@8.16.0)
       astring: 1.9.0
       magicast: 0.2.11
       recast: 0.23.11
-      vinxi: 0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
+      vinxi: 0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))':
     dependencies:
@@ -14721,7 +14720,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@6.2.2(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0):
+  astro@6.2.2(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.9.0
@@ -14771,7 +14770,7 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
-      unstorage: 1.17.5(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
+      unstorage: 1.17.5(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
       vfile: 6.0.3
       vite: 7.3.2(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@7.3.2(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
@@ -15937,7 +15936,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -15960,7 +15959,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -15975,14 +15974,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -15997,7 +15996,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -17151,8 +17150,7 @@ snapshots:
 
   jju@1.4.0: {}
 
-  jose@5.10.0:
-    optional: true
+  jose@5.10.0: {}
 
   js-beautify@1.15.4:
     dependencies:
@@ -17997,7 +17995,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.2.9(@playwright/test@1.59.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -18006,7 +18004,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.8)
+      styled-jsx: 5.1.6(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -18022,7 +18020,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.13.4(@vercel/functions@3.7.4(ws@8.20.0))(oxc-parser@0.128.0)(rolldown@1.0.0-rc.17):
+  nitropack@2.13.4(@vercel/functions@3.9.3(ws@8.20.0))(oxc-parser@0.128.0)(rolldown@1.0.0-rc.17):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.3)
@@ -18089,7 +18087,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.2.0(oxc-parser@0.128.0)
       unplugin-utils: 0.3.1
-      unstorage: 1.17.5(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
+      unstorage: 1.17.5(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -18126,7 +18124,7 @@ snapshots:
       - supports-color
       - uploadthing
 
-  nitropack@2.13.4(@vercel/functions@3.7.4(ws@8.20.0))(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17):
+  nitropack@2.13.4(@vercel/functions@3.9.3(ws@8.20.0))(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.3)
@@ -18193,7 +18191,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.2.0(oxc-parser@0.135.0)
       unplugin-utils: 0.3.1
-      unstorage: 1.17.5(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
+      unstorage: 1.17.5(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -18303,16 +18301,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.35.1(@nuxt/schema@3.21.4)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.4(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.33(typescript@5.9.3))
       '@nuxt/kit': 3.21.4(magicast@0.5.2)
-      '@nuxt/nitro-server': 3.21.4(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.128.0)(rolldown@1.0.0-rc.17)(typescript@5.9.3)
+      '@nuxt/nitro-server': 3.21.4(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.128.0)(rolldown@1.0.0-rc.17)(typescript@5.9.3)
       '@nuxt/schema': 3.21.4
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@3.21.4(magicast@0.5.2))
-      '@nuxt/vite-builder': 3.21.4(@types/node@25.8.0)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.3.3(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)
+      '@nuxt/vite-builder': 3.21.4(@types/node@25.8.0)(eslint@9.39.4(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@3.21.4(@parcel/watcher@2.5.6)(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(@vue/compiler-sfc@3.5.33)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.10(@types/node@25.8.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@5.9.3))(yaml@2.9.0))(optionator@0.9.4)(oxlint@1.62.0)(rolldown@1.0.0-rc.17)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17)(rollup@4.60.3))(rollup@4.60.3)(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.3.3(typescript@5.9.3))(vue@3.5.33(typescript@5.9.3))(yaml@2.9.0)
       '@unhead/vue': 2.1.13(vue@3.5.33(typescript@5.9.3))
       '@vue/shared': 3.5.33
       c12: 3.3.4(magicast@0.5.2)
@@ -18551,8 +18549,7 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  os-paths@4.4.0:
-    optional: true
+  os-paths@4.4.0: {}
 
   outvariant@1.4.3: {}
 
@@ -19986,12 +19983,10 @@ snapshots:
 
   structured-clone-es@2.0.0: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.8):
+  styled-jsx@5.1.6(react@19.2.8):
     dependencies:
       client-only: 0.0.1
       react: 19.2.8
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   stylehacks@7.0.11(postcss@8.5.14):
     dependencies:
@@ -20575,7 +20570,7 @@ snapshots:
     dependencies:
       rolldown: 1.0.0-rc.17
 
-  unstorage@1.17.5(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1):
+  unstorage@1.17.5(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -20586,7 +20581,7 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
     optionalDependencies:
-      '@vercel/functions': 3.7.4(ws@8.20.0)
+      '@vercel/functions': 3.9.3(ws@8.20.0)
       db0: 0.3.4
       ioredis: 5.10.1
 
@@ -20661,7 +20656,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0):
+  vinxi@0.5.11(@types/node@25.8.0)(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -20682,7 +20677,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.13.4(@vercel/functions@3.7.4(ws@8.20.0))(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)
+      nitropack: 2.13.4(@vercel/functions@3.9.3(ws@8.20.0))(oxc-parser@0.135.0)(rolldown@1.0.0-rc.17)
       node-fetch-native: 1.6.7
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -20694,7 +20689,7 @@ snapshots:
       ufo: 1.6.4
       unctx: 2.5.0
       unenv: 1.10.0
-      unstorage: 1.17.5(@vercel/functions@3.7.4(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
+      unstorage: 1.17.5(@vercel/functions@3.9.3(ws@8.20.0))(db0@0.3.4)(ioredis@5.10.1)
       vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
       zod: 4.4.3
     transitivePeerDependencies:
@@ -21329,12 +21324,10 @@ snapshots:
     dependencies:
       os-paths: 4.4.0
       xdg-portable: 7.3.0
-    optional: true
 
   xdg-portable@7.3.0:
     dependencies:
       os-paths: 4.4.0
-    optional: true
 
   xxhash-wasm@1.1.0: {}
 
@@ -21438,8 +21431,7 @@ snapshots:
 
   zod@3.22.3: {}
 
-  zod@4.1.11:
-    optional: true
+  zod@4.1.11: {}
 
   zod@4.4.3: {}
 

--- a/skills/create-oxygen-template/reference/react-router-pattern.md
+++ b/skills/create-oxygen-template/reference/react-router-pattern.md
@@ -152,7 +152,7 @@ async function createAppLoadContext(
   executionContext: ExecutionContext,
 ) {
   const waitUntil = executionContext.waitUntil.bind(executionContext);
-  const cache = await caches.open("hydrogen");
+  const cache = await caches.open("hydrogen-v1");
   const context = new RouterContextProvider();
 
   context.set(envContext, env);
@@ -234,7 +234,7 @@ Oxygen is a Worker runtime. Do not create request-specific Shopify objects at mo
 - `createCustomerAccountClient(...)`
 - customer session managers
 - cart, predictive search, and customer account route handling inputs
-- `caches.open("hydrogen")` handles used with request-specific `waitUntil`
+- `caches.open("hydrogen-v1")` handles used with request-specific `waitUntil`
 
 Module scope is only appropriate for pure constants and stateless handler factories that do not capture request/env/session data. When in doubt, keep the object request-scoped until MiniOxygen runtime validation proves otherwise.
 
@@ -245,7 +245,7 @@ Keep request-time values in context instead of imported shared constants. Root m
 Hydrogen primitives that use cached fetches must receive an Oxygen-compatible cache created in the request flow:
 
 ```ts
-const cache = await caches.open("hydrogen");
+const cache = await caches.open("hydrogen-v1");
 const waitUntil = executionContext.waitUntil.bind(executionContext);
 ```
 

--- a/skills/create-vercel-template/SKILL.md
+++ b/skills/create-vercel-template/SKILL.md
@@ -68,7 +68,7 @@ must expose the template's required APIs, subpaths, TypeScript plugin, and schem
 - Keep `next`, `react`, `react-dom`, `@shopify/hydrogen` (`workspace:*`), `tailwindcss` /
   `@tailwindcss/postcss`, `eslint`, `eslint-config-next`.
 - Keep `"packageManager": "pnpm@10.33.0"` so the eventual standalone distribution uses the intended manager.
-- Do not add `@vercel/functions` unless the app reintroduces an explicit Storefront cache adapter; the current Next template uses Next Cache Components (`"use cache"`, `cacheLife`, `cacheTag`).
+- Keep `@vercel/functions` for the Storefront client's Vercel Runtime Cache adapter in `proxy.ts`.
 - Replace `typescript: catalog:` with a real npm range (e.g. `^5.9.3`).
 - Keep the `https:dev` script alongside `dev`, `build`, `start`, `lint`, and `typecheck`.
 - Deploy uses the Vercel CLI, not a build dependency: document `npx vercel` / `npx vercel --prod` (optionally add a
@@ -188,7 +188,7 @@ Additionally, keep `lib/route-templates.ts` unchanged — it is not `@shared/*`.
 
 ## Caching
 
-Do not ship an in-memory LRU cache. The current template uses Next-native cache points: `"use cache"`, `cacheLife`, and `cacheTag`. Under `cacheComponents: true`, `app/layout.tsx` is a static shell wrapping the per-request `AppShell` (cart seed + chrome) in `<Suspense>`; `AppShell` calls `connection()` for dynamic request data. Route-segment configs like `export const dynamic`/`fetchCache`/`revalidate` are NOT used because Cache Components rejects them.
+Do not ship an in-memory LRU cache. Page data uses Next-native cache points: `"use cache"`, `cacheLife`, and `cacheTag`. The Storefront client created in `proxy.ts` uses Vercel Runtime Cache from `getCache()` for Hydrogen-owned subrequests and passes `NextFetchEvent.waitUntil` for background writes. Under `cacheComponents: true`, `app/layout.tsx` is a static shell wrapping the per-request `AppShell` (cart seed + chrome) in `<Suspense>`; `AppShell` calls `connection()` for dynamic request data. Route-segment configs like `export const dynamic`/`fetchCache`/`revalidate` are NOT used because Cache Components rejects them.
 
 Verify the app still renders live data after the swap (see "Validation").
 

--- a/templates/nextjs/components/ProductDetails.tsx
+++ b/templates/nextjs/components/ProductDetails.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { canAddToCart, type SelectedOption } from "@shopify/hydrogen";
+import {
+  buildProductSelectionSearchParams,
+  canAddToCart,
+  type SelectedOption,
+} from "@shopify/hydrogen";
 import { ShopPayButton } from "@shopify/hydrogen/react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -323,9 +327,11 @@ function variantUrl(
   handle = product.handle,
   base: URLSearchParams | ReturnType<typeof useSearchParams> = new URLSearchParams(),
 ): string {
-  const params = new URLSearchParams(base);
-  for (const option of product.options) params.delete(option.name);
-  for (const option of selectedOptions) params.set(option.name, option.value);
+  const params = buildProductSelectionSearchParams({
+    selectedOptions,
+    optionNames: product.options.map((option) => option.name),
+    base: new URLSearchParams(base),
+  });
   const query = params.toString();
   return `/products/${handle}${query ? `?${query}` : ""}`;
 }

--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@shopify/hydrogen": "workspace:*",
+    "@vercel/functions": "^3.9.3",
     "isbot": "^5",
     "next": "16.2.9",
     "react": "^19.2.4",

--- a/templates/nextjs/proxy.ts
+++ b/templates/nextjs/proxy.ts
@@ -1,4 +1,5 @@
 import {
+  acceptProductVariantId,
   createShopifyRequestContext,
   createStorefrontClient,
   handleShopifyRoutes,
@@ -14,6 +15,7 @@ import {
 } from "@/lib/customer-account";
 import { getCustomerSessionHandlers } from "@/lib/customer-session-handlers";
 import { predictiveSearchHandlers } from "@/lib/predictive-search-handlers";
+import { routeTemplates } from "@/lib/route-templates";
 import { isCustomerAccountsAvailable, resolveStorefrontConfig } from "@/lib/storefront-config";
 
 /**
@@ -59,6 +61,7 @@ export async function proxy(request: NextRequest) {
     ? await createCustomerSessionManager(request)
     : createEphemeralSessionManager(request);
   const handlers = [
+    acceptProductVariantId({ routeTemplates }),
     cartHandlers,
     predictiveSearchHandlers,
     ...(customerAccountsAvailable ? [getCustomerSessionHandlers()] : []),

--- a/templates/nextjs/proxy.ts
+++ b/templates/nextjs/proxy.ts
@@ -1,5 +1,4 @@
 import {
-  acceptProductVariantId,
   createShopifyRequestContext,
   createStorefrontClient,
   handleShopifyRoutes,
@@ -61,7 +60,6 @@ export async function proxy(request: NextRequest) {
     ? await createCustomerSessionManager(request)
     : createEphemeralSessionManager(request);
   const handlers = [
-    acceptProductVariantId({ routeTemplates }),
     cartHandlers,
     predictiveSearchHandlers,
     ...(customerAccountsAvailable ? [getCustomerSessionHandlers()] : []),
@@ -72,10 +70,11 @@ export async function proxy(request: NextRequest) {
     requestContext,
     sessionManager,
     storefrontClient,
+    routeTemplates,
     handlers,
   });
   if (shopifyRoute) {
-    // Hydrogen-owned route (cart/predictive-search/SFAPI proxy/admin).
+    // Matched Hydrogen-owned route.
     // `handleShopifyRoutes` already applies SFAPI response headers onto the
     // short-circuited response internally, so no `applyResponseHeaders` here.
     return shopifyRoute;

--- a/templates/nextjs/proxy.ts
+++ b/templates/nextjs/proxy.ts
@@ -1,9 +1,11 @@
 import {
+  type CacheInstance,
   createShopifyRequestContext,
   createStorefrontClient,
   handleShopifyRoutes,
 } from "@shopify/hydrogen";
-import { NextResponse, type NextRequest } from "next/server";
+import { getCache } from "@vercel/functions";
+import { NextResponse, type NextFetchEvent, type NextRequest } from "next/server";
 
 import { getBuyerIp } from "@/lib/buyer-ip";
 import { cartHandlers } from "@/lib/cart-handlers";
@@ -33,7 +35,7 @@ import { isCustomerAccountsAvailable, resolveStorefrontConfig } from "@/lib/stor
  * shared `resolveStorefrontConfig()` falls back to `mock.shop` + its well-known
  * `mock-private-token` so the example runs with zero secrets.
  */
-export async function proxy(request: NextRequest) {
+export async function proxy(request: NextRequest, event: NextFetchEvent) {
   const buyerIp = getBuyerIp(request.headers);
   const requestContext = createShopifyRequestContext({
     request,
@@ -42,6 +44,12 @@ export async function proxy(request: NextRequest) {
   });
 
   const { storeDomain, privateStorefrontToken, storefrontId } = resolveStorefrontConfig();
+  const cache: CacheInstance | undefined = process.env.VERCEL
+    ? getCache({
+        namespace: "hydrogen-v1",
+        keyHashFunction: (key) => key,
+      })
+    : undefined;
 
   const storefrontClient = createStorefrontClient({
     type: "private",
@@ -50,6 +58,8 @@ export async function proxy(request: NextRequest) {
       storeDomain,
       privateStorefrontToken,
       storefrontId,
+      cache,
+      waitUntil: event.waitUntil.bind(event),
     },
   });
 

--- a/templates/react-router/app/lib/storefront.ts
+++ b/templates/react-router/app/lib/storefront.ts
@@ -1,4 +1,5 @@
 import {
+  type CacheInstance,
   createShopifyRequestContext,
   createStorefrontClient,
   type RequestScopedPrivateStorefrontClient,
@@ -27,6 +28,8 @@ function getMockBuyerIp(headers: Pick<Headers, "get">): string {
 export function createRequestStorefrontClient(
   request: Request,
   env: Env,
+  cache: CacheInstance,
+  waitUntil: ExecutionContext["waitUntil"],
 ): RequestScopedPrivateStorefrontClient {
   const usingMockShop = shouldUseMockShop(env);
   const buyerIp = usingMockShop ? getMockBuyerIp(request.headers) : getBuyerIp(request.headers);
@@ -48,6 +51,8 @@ export function createRequestStorefrontClient(
       storeDomain,
       privateStorefrontToken,
       storefrontId: usingMockShop ? undefined : env.PUBLIC_STOREFRONT_ID,
+      cache,
+      waitUntil,
     },
   });
 }

--- a/templates/react-router/app/root.tsx
+++ b/templates/react-router/app/root.tsx
@@ -1,4 +1,9 @@
-import { handleShopifyRedirects, handleShopifyRoutes, gql } from "@shopify/hydrogen";
+import {
+  acceptProductVariantId,
+  handleShopifyRedirects,
+  handleShopifyRoutes,
+  gql,
+} from "@shopify/hydrogen";
 import { ShopifyScripts } from "@shopify/hydrogen/react";
 import type { ReactNode } from "react";
 import {
@@ -59,7 +64,7 @@ export const middleware: Route.MiddlewareFunction[] = [
       requestContext,
       sessionManager,
       storefrontClient,
-      handlers: [cartHandlers],
+      handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers],
     });
 
     if (shopifyRoute) return shopifyRoute;

--- a/templates/react-router/app/root.tsx
+++ b/templates/react-router/app/root.tsx
@@ -1,9 +1,4 @@
-import {
-  acceptProductVariantId,
-  handleShopifyRedirects,
-  handleShopifyRoutes,
-  gql,
-} from "@shopify/hydrogen";
+import { handleShopifyRedirects, handleShopifyRoutes, gql } from "@shopify/hydrogen";
 import { ShopifyScripts } from "@shopify/hydrogen/react";
 import type { ReactNode } from "react";
 import {
@@ -64,7 +59,8 @@ export const middleware: Route.MiddlewareFunction[] = [
       requestContext,
       sessionManager,
       storefrontClient,
-      handlers: [acceptProductVariantId({ routeTemplates }), cartHandlers],
+      routeTemplates,
+      handlers: [cartHandlers],
     });
 
     if (shopifyRoute) return shopifyRoute;

--- a/templates/react-router/app/root.tsx
+++ b/templates/react-router/app/root.tsx
@@ -50,7 +50,12 @@ export const links: Route.LinksFunction = () => [
 export const middleware: Route.MiddlewareFunction[] = [
   async ({ context, request }, next) => {
     const env = context.get(envContext);
-    const storefrontClient = createRequestStorefrontClient(request, env);
+    const storefrontClient = createRequestStorefrontClient(
+      request,
+      env,
+      context.cache,
+      context.waitUntil,
+    );
     const requestContext = storefrontClient.requestContext;
     const sessionManager = createRequestSessionManager(request);
 

--- a/templates/react-router/app/routes/product.tsx
+++ b/templates/react-router/app/routes/product.tsx
@@ -1,4 +1,5 @@
 import {
+  buildProductSelectionSearchParams,
   canAddToCart,
   getSelectedProductOptions,
   gql,
@@ -190,9 +191,11 @@ function variantUrl(
   handle = product.handle,
   base: URLSearchParams = new URLSearchParams(),
 ) {
-  const params = new URLSearchParams(base);
-  for (const option of product.options) params.delete(option.name);
-  for (const option of selectedOptions) params.set(option.name, option.value);
+  const params = buildProductSelectionSearchParams({
+    selectedOptions,
+    optionNames: product.options.map((option) => option.name),
+    base,
+  });
   const query = params.toString();
   return `/products/${handle}${query ? `?${query}` : ""}`;
 }

--- a/templates/react-router/env.d.ts
+++ b/templates/react-router/env.d.ts
@@ -2,9 +2,12 @@
 /// <reference types="react-router" />
 /// <reference types="@shopify/oxygen-workers-types" />
 
+import type { CacheInstance } from "@shopify/hydrogen";
+
 import type { Env as AppEnv } from "./app/lib/env";
 
 type ReactRouterExampleContext = {
+  cache: CacheInstance;
   env: Env;
   waitUntil: ExecutionContext["waitUntil"];
 };

--- a/templates/react-router/server.ts
+++ b/templates/react-router/server.ts
@@ -23,6 +23,7 @@ export default {
       }
 
       const routerContext = new RouterContextProvider();
+      routerContext.cache = await caches.open("hydrogen-v1");
       routerContext.set(envContext, env);
       routerContext.env = env;
       routerContext.waitUntil = executionContext.waitUntil.bind(executionContext);


### PR DESCRIPTION
TL;DR: Let Hydrogen product pages accept Liquid-style `?variant=<numeric id>` links while keeping option params as the canonical product selection URL.

## Before

Product loaders only understood option params:

```txt
/products/snowboard?Color=Red&Size=M
```

`?variant=123` was treated like an option named `variant`, and template URL helpers could preserve stale `variant` params while switching options.

## After

`handleShopifyRoutes` now accepts the app route templates once:

```ts
handleShopifyRoutes({
  request,
  requestContext,
  sessionManager,
  storefrontClient,
  routeTemplates,
  handlers: [cartHandlers],
});
```

That lets Hydrogen recognize Liquid-style product links before framework routing:

```txt
/products/snowboard?variant=123
```

and redirect them to the canonical option-param URL for the resolved variant.

## What this changes

- Adds a built-in `handleShopifyRoutes` pre-route check for product `?variant=<numeric id>` URLs.
- Adds `routeTemplates` to `handleShopifyRoutes` options so product URLs are recognized from the app's routing manifest.
- Infers localized `pathPrefix` from `requestContext.i18n.pathPrefix` instead of asking callers to pass it separately.
- Adds `buildProductSelectionSearchParams()` so templates and examples can build option-param or explicit variant links without preserving stale selection params.
- Reserves `variant` in `getSelectedProductOptions` so loaders never treat it as a product option.
- Restricts registered route redirect statuses to `301 | 302 | 303 | 307 | 308` and validates that at runtime for JS callers.
- Updates the React Router and Next.js templates, framework examples, packaged skills, and docs for the new wiring.

## Developer impact

Includes a **minor** changeset for `@shopify/hydrogen`.

This adds `routeTemplates` to `handleShopifyRoutes`, adds `buildProductSelectionSearchParams()`, and exposes `ShopifyRedirectStatus`. The earlier optional `acceptProductVariantId` handler and generic match-handler shape are no longer part of the public API for this PR.

## UX impact

Buyers landing on Liquid-style product links like `/products/foo?variant=123` now land on the matching Hydrogen variant instead of the default variant. In-app option navigation still uses option params as the canonical URL.

## Out of scope

- No opt-out for the built-in variant redirect in this PR.
- No explicit cache or in-flight dedupe option for the variant lookup in this PR.

## Risk

- Valid numeric `?variant=` product links now do one Storefront API lookup before redirecting.
- Cross-product combined-listing redirects preserve unrelated params. Stale source-product option params may also survive, but loaders that filter with `allowedOptionNames` ignore them.

## How to Test

1. Run `pnpm install && pnpm --filter hydrogen dev`.
2. Open a product page and note a valid variant id for that product.
3. Visit `/products/{handle}?variant={numericVariantId}`.
4. Confirm the request redirects to `/products/{handle}?OptionName=value` and the matching variant renders.
5. Visit `/products/{handle}?variant=not-a-number`.
6. Confirm the page renders normally and does not redirect.