### PR TITLE
Allow manually dispatching Compile Preview Templates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,14 @@ name: Release
 on:
   push:
     branches: [preview]
+  # Manually recompile the preview templates for the version already
+  # published from the selected ref, without publishing anything to npm
+  workflow_dispatch:
 
 concurrency:
-  group: release-${{ github.ref_name }}
+  # Hardcoded so a workflow_dispatch from any ref queues behind preview
+  # releases instead of racing their force-push to dist-preview
+  group: release-preview
   # Queue runs instead of cancelling: a cancel that lands between npm
   # publish and tag creation strands state a rerun cannot rebuild
   cancel-in-progress: false
@@ -16,7 +21,7 @@ jobs:
   preview-release:
     name: Preview Release
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'shopify'
+    if: github.event_name == 'push' && github.repository_owner == 'shopify'
     permissions:
       contents: write # push the version branch and create git tags
       pull-requests: write # open and update the version PR
@@ -76,7 +81,12 @@ jobs:
   compile-preview-templates:
     name: Compile Preview Templates
     needs: preview-release
-    if: needs.preview-release.outputs.published == 'true'
+    # `!cancelled()` lets this run on workflow_dispatch, where preview-release
+    # is skipped and would otherwise skip every job that needs it
+    if: >-
+      !cancelled() &&
+      github.repository_owner == 'shopify' &&
+      (needs.preview-release.outputs.published == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -106,8 +116,15 @@ jobs:
         id: version
         env:
           PUBLISHED_PACKAGES: ${{ needs.preview-release.outputs.publishedPackages }}
+        # On workflow_dispatch there is no publish output, so read the version
+        # from the checked-out ref instead; the prepare and validate steps
+        # assert it is a published 2026.10.0-preview.<n> version either way
         run: |
-          version=$(node scripts/preview-template-dist.ts resolve)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version=$(node -p "require('./packages/hydrogen/package.json').version")
+          else
+            version=$(node scripts/preview-template-dist.ts resolve)
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Wait for the published package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       TURBO_TELEMETRY_DISABLED: "1"
     outputs:
       published: ${{ steps.changesets.outputs.published }}
-      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      publishedPackages: ${{ steps.changesets.outputs.published-packages }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -66,17 +66,18 @@ jobs:
 
       - name: Create preview release PR or publish
         id: changesets
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+        # v2 of the action is required for changesets v3: it detects published
+        # packages through the CHANGESETS_OUTPUT file instead of parsing the
+        # "New tag:" stdout lines that v3 no longer prints. With v1.7.0 the
+        # `published` output stayed "false" after a successful npm publish,
+        # which skipped compile-preview-templates and the tag/release push
+        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          version: pnpm changeset version
-          publish: pnpm changeset publish
-          commit: "[ci] preview release"
-          title: "[ci] preview release"
-        env:
-          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
-          # Satisfies the action's npmrc check without configuring a real
-          # token; publishing authenticates via OIDC trusted publishing
-          NPM_TOKEN: ""
+          version-script: pnpm changeset version
+          publish-script: pnpm changeset publish
+          commit-message: "[ci] preview release"
+          pr-title: "[ci] preview release"
+          github-token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 
   compile-preview-templates:
     name: Compile Preview Templates


### PR DESCRIPTION
TL;DR: Run 32159323394 published `@shopify/hydrogen@2026.10.0-preview.1` to npm, but the Compile Preview Templates job was skipped, so `dist-preview` never got the compiled templates. This fixes the broken publish detection and adds a manual `workflow_dispatch` escape hatch for the compile job, without duplicating the workflow.

## Why the job skipped

The compile job gates on `needs.preview-release.outputs.published == 'true'`. That output comes from `changesets/action@v1.7.0`, which detects a publish by parsing `changeset publish` stdout for `New tag:` lines. We publish with `changeset@3.0.0-next.8`, whose output changed to `Published @shopify/hydrogen@x.y.z!` / `Created git tag.` — no `New tag:` lines. The regex never matches, so `published` stays `false` even though the publish succeeded.

Same root cause also meant v1.7.0 never pushed the release git tag or created the GitHub release for `2026.10.0-preview.1` (both keyed off the same detection).

## Before

- Publish succeeds, `published` output is `false`, compile job skips, no git tag or GitHub release pushed.
- No way to re-run the compile job without publishing again.

## After

- `changesets/action@v2.1.0` detects publishes via the `CHANGESETS_OUTPUT` file that changesets v3 writes, instead of stdout parsing. Our pinned `@changesets/cli@3.0.0-next.8` supports this (and guarantees the file exists even when nothing publishes).
- `gh workflow run release.yml --repo Shopify/hydrogen --ref preview` recompiles the templates for the already-published version at any time, publishing nothing.

## What this changes

**Root cause fix**
- Upgrades `changesets/action` v1.7.0 → v2.1.0 (SHA-pinned to the tag commit).
- Renamed inputs per v2: `version-script`, `publish-script`, `commit-message`, `pr-title`; the token moves from the `GITHUB_TOKEN` env to the `github-token` input.
- Drops the `NPM_TOKEN: ""` workaround — v2 removed the `.npmrc` check; publishing already authenticates via OIDC trusted publishing (`id-token: write` unchanged).
- Output rename handled at the job boundary (`published-packages`), so the compile job is untouched by the upgrade.
- v2 pushes release commits/tags via the GitHub API by default, restoring git tags + GitHub releases for preview publishes.

**Manual escape hatch** (defense in depth if detection ever breaks again)
- Adds `workflow_dispatch` to `release.yml` (no new workflow file).
- `preview-release` (the npm publish) now only runs on `push`, so a manual dispatch can never publish.
- `compile-preview-templates` also runs on `workflow_dispatch`, using `!cancelled()` to override the skipped-`needs` cascade. Push behavior is unchanged.
- On dispatch, the version is read from `packages/hydrogen/package.json` on the checked-out ref; the existing `prepare`/`validate` steps still assert it is a `2026.10.0-preview.<n>` version that exists on npm, so dispatching from a never-published ref fails cleanly.
- Hardcodes the concurrency group to `release-preview` so a dispatch from any ref queues behind live releases instead of racing their force-push to `dist-preview`.
- Adds the `repository_owner == 'shopify'` guard to the compile job, which previously inherited it from `preview-release`.

## Risk

- The action upgrade changes how release commits/tags are pushed (GitHub API, signed and attributed to the token owner, instead of git CLI). Behavior change, but benign.
- Dispatching from a stale ref recompiles `dist-preview` for that ref's version — that is the point of manual control, but it can roll `dist-preview` back. The commit on `dist-preview` records the source SHA.
- The default branch's `release.yml` has no `workflow_dispatch`, so the "Run workflow" button will not appear in the Actions UI — dispatch via CLI (below). If main's release workflow later adopts changesets v3, it will need the same action upgrade.

## How to Test

After this merges to `preview`:

1. Run `gh workflow run release.yml --repo Shopify/hydrogen --ref preview`.
2. Watch the run: `Preview Release` should be skipped, `Compile Preview Templates` should run and push `Update preview templates for @shopify/hydrogen@2026.10.0-preview.1` to `dist-preview`.
3. On the next real preview publish (merge of the `[ci] preview release` PR): confirm `published` is `true`, the compile job runs on its own, and the `@shopify/hydrogen@2026.10.0-preview.<n>` git tag and GitHub release are created.
