### PR TITLE
Allow protected dist-preview updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   # Hardcoded so a workflow_dispatch from any ref queues behind preview
-  # releases instead of racing their force-push to dist-preview
+  # releases instead of racing their update to dist-preview
   group: release-preview
   # Queue runs instead of cancelling: a cancel that lands between npm
   # publish and tag creation strands state a rerun cannot rebuild
@@ -217,8 +217,10 @@ jobs:
           export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
           export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 
+          # Preserve dist-preview history so branch protection accepts the update.
+          git fetch origin dist-preview
           tree=$(git write-tree)
-          commit=$(printf 'Update preview templates for @shopify/hydrogen@%s\n\nSource: %s\n' "$VERSION" "$SOURCE_SHA" | git commit-tree "$tree")
+          commit=$(printf 'Update preview templates for @shopify/hydrogen@%s\n\nSource: %s\n' "$VERSION" "$SOURCE_SHA" | git commit-tree "$tree" -p FETCH_HEAD)
           auth=$(printf 'x-access-token:%s' "$DIST_PUSH_TOKEN" | base64 | tr -d '\n')
           git -c http.https://github.com/.extraheader="AUTHORIZATION: basic $auth" \
-            push origin "$commit:refs/heads/dist-preview" --force
+            push origin "$commit:refs/heads/dist-preview"


### PR DESCRIPTION
TL;DR: The manual Compile Preview Templates run built and validated both templates, then failed because it tried to force-push to protected `dist-preview`. Preserve the branch history and use a normal fast-forward push instead.

## Before

The generated snapshot commit had no parent, so updating `dist-preview` always required `--force`. Branch protection has force pushes disabled, and rejected run 32163781007.

## After

The workflow fetches the current `dist-preview` tip and uses `FETCH_HEAD` as the generated commit's parent. The resulting commit still contains the exact generated snapshot, but is now a fast-forward update accepted by branch protection.

Concurrent external updates fail safely as non-fast-forward pushes. Existing workflow concurrency serialises preview release and manual compile runs.

## How to Test

After this merges to `preview`:

1. Run `gh workflow run release.yml --repo Shopify/hydrogen --ref preview`.
2. Confirm `Preview Release` is skipped and `Compile Preview Templates` succeeds.
3. Confirm `dist-preview` receives `Update preview templates for @shopify/hydrogen@2026.10.0-preview.1` as a child of its previous tip.
