### PR TITLE
Gate Shopify response state on established sessions

### DIFF
--- a/packages/hydrogen/src/core/headers.ts
+++ b/packages/hydrogen/src/core/headers.ts
@@ -1,4 +1,5 @@
 export const CACHE_CONTROL_HEADER = "Cache-Control";
+export const CONSENT_MANAGEMENT_HEADER = "Shopify-Storefront-Consent-Management";
 export const HYDROGEN_VERSION_HEADER = "X-Hydrogen-Version";
 export const SERVER_TIMING_HEADER = "Server-Timing";
 export const SURROGATE_CONTROL_HEADER = "Surrogate-Control";
@@ -46,6 +47,7 @@ export type StandardHeaderName =
   | "x-requested-with";
 
 export type ShopifyHeaderName =
+  | typeof CONSENT_MANAGEMENT_HEADER
   | typeof HYDROGEN_VERSION_HEADER
   | typeof REQUEST_GROUP_ID_HEADER
   | typeof SDK_VARIANT_HEADER

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -298,7 +298,7 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get(SHOPIFY_STOREFRONT_S_HEADER)).toBe("visit-token");
   });
 
-  it("applies tracking tokens as server-timing", () => {
+  it("does not apply legacy tracking tokens to document server-timing", () => {
     const context = createTestRequestContext(
       new Request("https://example.com", {
         headers: {
@@ -313,9 +313,7 @@ describe("createShopifyRequestContext", () => {
 
     context.applyResponseHeaders(headers);
 
-    expect(headers.get("server-timing")).toBe(
-      "existing;dur=1, _y;desc=unique-token, _s;desc=visit-token",
-    );
+    expect(headers.get("server-timing")).toBe("existing;dur=1");
   });
 
   it("applies the Hydrogen powered-by header", () => {
@@ -327,16 +325,16 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("powered-by")).toBe("Shopify, Hydrogen");
   });
 
-  it("applies generated tracking tokens as server-timing when cookies are missing", () => {
+  it("does not apply generated tracking tokens to document server-timing", () => {
     const context = createTestRequestContext(new Request("https://example.com"));
     const headers = new Headers({ "content-type": "text/html" });
 
     context.applyResponseHeaders(headers);
 
-    expect(headers.get("server-timing")).toMatch(/^_y;desc=[0-9a-f-]+, _s;desc=[0-9a-f-]+$/);
+    expect(headers.get("server-timing")).toBeNull();
   });
 
-  it("applies generated tracking tokens from a document request before response content-type is known", () => {
+  it("does not apply generated tracking tokens from a document request", () => {
     const context = createTestRequestContext(
       new Request("https://example.com", {
         headers: { "sec-fetch-dest": "document" },
@@ -346,7 +344,7 @@ describe("createShopifyRequestContext", () => {
 
     context.applyResponseHeaders(headers);
 
-    expect(headers.get("server-timing")).toMatch(/^_y;desc=[0-9a-f-]+, _s;desc=[0-9a-f-]+$/);
+    expect(headers.get("server-timing")).toBeNull();
   });
 
   it("does not use accept text/html as a document signal for non-GET requests", () => {

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -163,15 +163,19 @@ describe("createShopifyRequestContext", () => {
     expect(result.visitToken).toBeUndefined();
   });
 
-  it("does not create fallback tokens when the Shopify essential cookie is present", () => {
+  it("reuses legacy tracking cookies when only the Shopify essential cookie is present", () => {
     const result = createTestRequestContext(
       new Request("https://example.com", {
-        headers: { cookie: "_shopify_essential=declined-session" },
+        headers: {
+          cookie:
+            "_shopify_essential=declined-session; _shopify_y=unique-token; _shopify_s=visit-token",
+        },
       }),
     );
 
-    expect(result.uniqueToken).toBeUndefined();
-    expect(result.visitToken).toBeUndefined();
+    expect(result.uniqueToken).toBe("unique-token");
+    expect(result.visitToken).toBe("visit-token");
+    expect(result.legacyTokens).toBe(true);
   });
 
   it("reuses legacy Shopify tracking cookies when present", () => {

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -341,6 +341,29 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("powered-by")).toBe("Shopify, Hydrogen");
   });
 
+  it("preserves user-provided Shopify state and disables caching", () => {
+    const context = createTestRequestContext(
+      new Request("https://example.com/api/data", {
+        headers: { cookie: "_shopify_essential=established" },
+      }),
+    );
+    const headers = new Headers({
+      "cache-control": "public, max-age=60",
+      "server-timing": 'db;dur=2, _y;desc="unique", app;desc="one, two", _s;desc="visit"',
+    });
+    headers.append("set-cookie", "_shopify_essential=updated; Path=/; Secure; HttpOnly");
+
+    context.applyResponseHeaders(headers);
+
+    expect(headers.getSetCookie()).toEqual([
+      "_shopify_essential=updated; Path=/; Secure; HttpOnly",
+    ]);
+    expect(headers.get("server-timing")).toBe(
+      'db;dur=2, _y;desc="unique", app;desc="one, two", _s;desc="visit"',
+    );
+    expect(headers.get("cache-control")).toBe("private, no-store, max-age=0, must-revalidate");
+  });
+
   it("applies captured SFAPI subrequest headers for an established essential session", () => {
     const context = createTestRequestContext(
       new Request("https://example.com", {
@@ -377,7 +400,7 @@ describe("createShopifyRequestContext", () => {
         headers: { cookie: "_shopify_essential=established" },
       }),
     );
-    const subrequestHeaders = new Headers({ "server-timing": "shopify;dur=10" });
+    const subrequestHeaders = new Headers({ "server-timing": '_y;desc="unique"' });
     subrequestHeaders.append("set-cookie", "_shopify_essential=updated; Path=/; Secure; HttpOnly");
     context.captureSubrequestHeaders(subrequestHeaders);
     const headers = new Headers({
@@ -394,7 +417,7 @@ describe("createShopifyRequestContext", () => {
 
   it("does not apply captured SFAPI headers without an established essential session", () => {
     const context = createTestRequestContext(new Request("https://example.com/api/data"));
-    const subrequestHeaders = new Headers({ "server-timing": "shopify;dur=10" });
+    const subrequestHeaders = new Headers({ "server-timing": '_y;desc="unique"' });
     subrequestHeaders.append("set-cookie", "_shopify_essential=cold; Path=/; Secure; HttpOnly");
     subrequestHeaders.append("set-cookie", "_shopify_analytics=cold; Path=/; Secure; HttpOnly");
     subrequestHeaders.append("set-cookie", "unknown_cookie=not-returned; Path=/; Secure; HttpOnly");
@@ -416,7 +439,8 @@ describe("createShopifyRequestContext", () => {
     );
     const subrequestHeaders = new Headers();
     subrequestHeaders.append("set-cookie", "_shopify_essential=updated; Path=/; Secure; HttpOnly");
-    context.captureSubrequestHeaders(subrequestHeaders);
+    subrequestHeaders.set("server-timing", '_y;desc="unique"');
+    context.consumeStorefrontResponseHeaders(subrequestHeaders);
     const headers = new Headers({
       "cache-control": "public, max-age=60",
       "content-type": "application/json",
@@ -427,6 +451,9 @@ describe("createShopifyRequestContext", () => {
     expect(headers.getSetCookie()).toEqual([
       "_shopify_essential=updated; Path=/; Secure; HttpOnly",
     ]);
+    expect(subrequestHeaders.getSetCookie()).toEqual([]);
+    expect(subrequestHeaders.get("server-timing")).toBeNull();
+    expect(headers.get("server-timing")).toBe('_y;desc="unique"');
     expect(headers.get("cache-control")).toBe("private, no-store, max-age=0, must-revalidate");
   });
 
@@ -452,7 +479,7 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("cache-control")).toBe("private, no-store, max-age=0, must-revalidate");
   });
 
-  it("forces no-store when captured headers already exist on the response", () => {
+  it("forces no-store when captured state already exists on the response", () => {
     const context = createTestRequestContext(
       new Request("https://example.com/api/data", {
         method: "POST",
@@ -476,6 +503,38 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("cache-control")).toBe("private, no-store, max-age=0, must-revalidate");
   });
 
+  it("merges captured server-timing into user timing only once", () => {
+    const context = createTestRequestContext(
+      new Request("https://example.com/api/data", {
+        method: "POST",
+        headers: { cookie: "_shopify_essential=established" },
+      }),
+    );
+    context.captureSubrequestHeaders(
+      new Headers({ "server-timing": '_y;desc="unique", _s;desc="visit"' }),
+    );
+    const headers = new Headers({
+      "content-type": "application/json",
+      "server-timing": "app;dur=1",
+    });
+
+    context.applyResponseHeaders(headers);
+    context.applyResponseHeaders(headers);
+
+    expect(headers.get("server-timing")).toBe('app;dur=1, _y;desc="unique", _s;desc="visit"');
+
+    const headersWithCapturedTimingFirst = new Headers({
+      "content-type": "application/json",
+      "server-timing": '_y;desc="unique", _s;desc="visit", app;dur=1',
+    });
+
+    context.applyResponseHeaders(headersWithCapturedTimingFirst);
+
+    expect(headersWithCapturedTimingFirst.get("server-timing")).toBe(
+      '_y;desc="unique", _s;desc="visit", app;dur=1',
+    );
+  });
+
   it("returns Shopify cookies for a marked consent-management request", () => {
     const context = createTestRequestContext(
       new Request("https://example.com/api/unstable/graphql.json", {
@@ -493,7 +552,7 @@ describe("createShopifyRequestContext", () => {
     ]);
   });
 
-  it("never returns Shopify cookies on document responses", () => {
+  it("never replays captured Shopify state on document responses", () => {
     const context = createTestRequestContext(
       new Request("https://example.com", {
         headers: {
@@ -502,12 +561,17 @@ describe("createShopifyRequestContext", () => {
         },
       }),
     );
+    const subrequestHeaders = new Headers({
+      "server-timing": '_y;desc="unique", _s;desc="visit"',
+    });
+    subrequestHeaders.append("set-cookie", "_shopify_essential=updated; Path=/; Secure; HttpOnly");
+    context.captureSubrequestHeaders(subrequestHeaders);
     const headers = new Headers({ "content-type": "text/html" });
-    headers.append("set-cookie", "_shopify_essential=updated; Path=/; Secure; HttpOnly");
 
     context.applyResponseHeaders(headers);
 
     expect(headers.getSetCookie()).toEqual([]);
+    expect(headers.get("server-timing")).toBeNull();
   });
 
   it("keeps the first captured SFAPI subrequest headers", () => {

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -33,7 +33,7 @@ describe("createShopifyRequestContext", () => {
     ).toThrow("i18n with country and language is required");
   });
 
-  it("creates stable tracking tokens from a request", () => {
+  it("does not generate tracking tokens from a request", () => {
     const request = new Request("https://example.com/products/snowboard");
 
     const result = createTestRequestContext(request);
@@ -41,8 +41,8 @@ describe("createShopifyRequestContext", () => {
     expect(result.url).toBe("https://example.com/products/snowboard");
     expect(result.storefrontOrigin).toBe("https://example.com");
     expect(result.requestGroupId).toBeTruthy();
-    expect(result.uniqueToken).toBeTruthy();
-    expect(result.visitToken).toBeTruthy();
+    expect(result.uniqueToken).toBeUndefined();
+    expect(result.visitToken).toBeUndefined();
   });
 
   it("keeps a reference to the request signal", () => {
@@ -151,7 +151,7 @@ describe("createShopifyRequestContext", () => {
     expect(result.i18n.pathPrefix).toBe("/fr-ca");
   });
 
-  it("does not create fallback tokens when modern Shopify analytics cookies are present", () => {
+  it("does not create tracking tokens when modern Shopify analytics cookies are present", () => {
     const result = createTestRequestContext(
       new Request("https://example.com", {
         headers: { cookie: "_shopify_analytics=1; _shopify_marketing=1" },
@@ -341,7 +341,7 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("powered-by")).toBe("Shopify, Hydrogen");
   });
 
-  it("does not apply generated tracking tokens to document server-timing", () => {
+  it("does not apply tracking tokens to document server-timing", () => {
     const context = createTestRequestContext(new Request("https://example.com"));
     const headers = new Headers({ "content-type": "text/html" });
 
@@ -350,7 +350,7 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("server-timing")).toBeNull();
   });
 
-  it("does not apply generated tracking tokens from a document request", () => {
+  it("does not apply tracking tokens from a document request", () => {
     const context = createTestRequestContext(
       new Request("https://example.com", {
         headers: { "sec-fetch-dest": "document" },
@@ -377,7 +377,7 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("server-timing")).toBeNull();
   });
 
-  it("does not apply fallback tracking tokens to non-document responses", () => {
+  it("does not apply tracking tokens to non-document responses", () => {
     const context = createTestRequestContext(new Request("https://example.com/__manifest"));
     const headers = new Headers();
 

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  CONSENT_MANAGEMENT_HEADER,
   HYDROGEN_VERSION_HEADER,
   REQUEST_GROUP_ID_HEADER,
   SDK_VARIANT_HEADER,
@@ -158,6 +159,17 @@ describe("createShopifyRequestContext", () => {
     );
 
     expect(result.cookie).toBe("_shopify_analytics=1; _shopify_marketing=1");
+    expect(result.uniqueToken).toBeUndefined();
+    expect(result.visitToken).toBeUndefined();
+  });
+
+  it("does not create fallback tokens when the Shopify essential cookie is present", () => {
+    const result = createTestRequestContext(
+      new Request("https://example.com", {
+        headers: { cookie: "_shopify_essential=declined-session" },
+      }),
+    );
+
     expect(result.uniqueToken).toBeUndefined();
     expect(result.visitToken).toBeUndefined();
   });
@@ -370,10 +382,12 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("server-timing")).toBeNull();
   });
 
-  it("applies captured SFAPI subrequest cookies and server-timing", () => {
+  it("applies captured SFAPI subrequest headers for an established essential session", () => {
     const context = createTestRequestContext(
       new Request("https://example.com", {
-        headers: { cookie: "_shopify_analytics=1; _shopify_marketing=1" },
+        headers: {
+          cookie: "_shopify_essential=established; _shopify_analytics=1; _shopify_marketing=1",
+        },
       }),
     );
     const subrequestHeaders = new Headers({
@@ -382,7 +396,10 @@ describe("createShopifyRequestContext", () => {
     subrequestHeaders.append("set-cookie", "_shopify_y=collected-y; Path=/; Secure");
     subrequestHeaders.append("set-cookie", "_shopify_s=collected-s; Path=/; Secure");
     context.captureSubrequestHeaders(subrequestHeaders);
-    const headers = new Headers({ "content-type": "text/html" });
+    const headers = new Headers({
+      "cache-control": "public, max-age=60",
+      "content-type": "application/json",
+    });
 
     context.applyResponseHeaders(headers);
 
@@ -391,10 +408,130 @@ describe("createShopifyRequestContext", () => {
       "_shopify_s=collected-s; Path=/; Secure",
     ]);
     expect(headers.get("server-timing")).toBe('_y;desc="collected-y", _s;desc="collected-s"');
+    expect(headers.get("cache-control")).toBe("private, no-store, max-age=0, must-revalidate");
+  });
+
+  it("does not apply captured SFAPI headers without an established essential session", () => {
+    const context = createTestRequestContext(new Request("https://example.com/api/data"));
+    const subrequestHeaders = new Headers({ "server-timing": "shopify;dur=10" });
+    subrequestHeaders.append("set-cookie", "_shopify_essential=cold; Path=/; Secure; HttpOnly");
+    subrequestHeaders.append("set-cookie", "_shopify_analytics=cold; Path=/; Secure; HttpOnly");
+    subrequestHeaders.append("set-cookie", "unknown_cookie=not-returned; Path=/; Secure; HttpOnly");
+    context.captureSubrequestHeaders(subrequestHeaders);
+    const headers = new Headers({ "content-type": "application/json" });
+
+    context.applyResponseHeaders(headers);
+
+    expect(headers.getSetCookie()).toEqual([]);
+    expect(headers.get("server-timing")).toBeNull();
+  });
+
+  it("returns Shopify cookies for an established essential session", () => {
+    const context = createTestRequestContext(
+      new Request("https://example.com/api/data", {
+        headers: { cookie: "_shopify_essential=established" },
+      }),
+    );
+    const subrequestHeaders = new Headers();
+    subrequestHeaders.append("set-cookie", "_shopify_essential=updated; Path=/; Secure; HttpOnly");
+    context.captureSubrequestHeaders(subrequestHeaders);
+    const headers = new Headers({
+      "cache-control": "public, max-age=60",
+      "content-type": "application/json",
+    });
+
+    context.applyResponseHeaders(headers);
+
+    expect(headers.getSetCookie()).toEqual([
+      "_shopify_essential=updated; Path=/; Secure; HttpOnly",
+    ]);
+    expect(headers.get("cache-control")).toBe("private, no-store, max-age=0, must-revalidate");
+  });
+
+  it("forces no-store when returning an unrecognized captured cookie", () => {
+    const context = createTestRequestContext(
+      new Request("https://example.com/api/data", {
+        headers: { cookie: "_shopify_essential=established" },
+      }),
+    );
+    const subrequestHeaders = new Headers();
+    subrequestHeaders.append("set-cookie", "unknown_cookie=returned; Path=/; Secure; HttpOnly");
+    subrequestHeaders.append("set-cookie", "unknown_cookie=returned; Path=/; Secure; HttpOnly");
+    context.captureSubrequestHeaders(subrequestHeaders);
+    const headers = new Headers({
+      "cache-control": "public, max-age=60",
+      "content-type": "application/json",
+    });
+
+    context.applyResponseHeaders(headers);
+
+    expect(headers.getSetCookie()).toEqual(["unknown_cookie=returned; Path=/; Secure; HttpOnly"]);
+    expect(headers.get("cache-control")).toBe("private, no-store, max-age=0, must-revalidate");
+  });
+
+  it("forces no-store when captured headers already exist on the response", () => {
+    const context = createTestRequestContext(
+      new Request("https://example.com/api/data", {
+        headers: { cookie: "_shopify_essential=established" },
+      }),
+    );
+    const subrequestHeaders = new Headers({ "server-timing": "shopify;dur=10" });
+    subrequestHeaders.append("set-cookie", "unknown_cookie=returned; Path=/; Secure; HttpOnly");
+    context.captureSubrequestHeaders(subrequestHeaders);
+    const headers = new Headers({
+      "cache-control": "public, max-age=60",
+      "content-type": "application/json",
+      "server-timing": "shopify;dur=10",
+    });
+    headers.append("set-cookie", "unknown_cookie=returned; Path=/; Secure; HttpOnly");
+
+    context.applyResponseHeaders(headers);
+
+    expect(headers.getSetCookie()).toEqual(["unknown_cookie=returned; Path=/; Secure; HttpOnly"]);
+    expect(headers.get("server-timing")).toBe("shopify;dur=10");
+    expect(headers.get("cache-control")).toBe("private, no-store, max-age=0, must-revalidate");
+  });
+
+  it("returns Shopify cookies for a marked consent-management request", () => {
+    const context = createTestRequestContext(
+      new Request("https://example.com/api/unstable/graphql.json", {
+        method: "POST",
+        headers: { [CONSENT_MANAGEMENT_HEADER]: "1" },
+      }),
+    );
+    const headers = new Headers({ "content-type": "application/json" });
+    headers.append("set-cookie", "_shopify_essential=established; Path=/; Secure; HttpOnly");
+
+    context.applyResponseHeaders(headers);
+
+    expect(headers.getSetCookie()).toEqual([
+      "_shopify_essential=established; Path=/; Secure; HttpOnly",
+    ]);
+  });
+
+  it("never returns Shopify cookies on document responses", () => {
+    const context = createTestRequestContext(
+      new Request("https://example.com", {
+        headers: {
+          accept: "text/html",
+          cookie: "_shopify_essential=established",
+        },
+      }),
+    );
+    const headers = new Headers({ "content-type": "text/html" });
+    headers.append("set-cookie", "_shopify_essential=updated; Path=/; Secure; HttpOnly");
+
+    context.applyResponseHeaders(headers);
+
+    expect(headers.getSetCookie()).toEqual([]);
   });
 
   it("keeps the first captured SFAPI subrequest headers", () => {
-    const context = createTestRequestContext(new Request("https://example.com"));
+    const context = createTestRequestContext(
+      new Request("https://example.com", {
+        headers: { cookie: "_shopify_essential=established" },
+      }),
+    );
     context.captureSubrequestHeaders(
       new Headers({ "server-timing": '_y;desc="first-y", _s;desc="first-s"' }),
     );
@@ -438,7 +575,11 @@ describe("createShopifyRequestContext", () => {
   });
 
   it("preserves set-cookie and server-timing when applying personalized cache safety", () => {
-    const context = createTestRequestContext(new Request("https://example.com/account"));
+    const context = createTestRequestContext(
+      new Request("https://example.com/account", {
+        headers: { cookie: "_shopify_essential=established" },
+      }),
+    );
     const subrequestHeaders = new Headers({ "server-timing": "shopify;dur=10" });
     subrequestHeaders.append("set-cookie", "session=1; Path=/; Secure");
     context.captureSubrequestHeaders(subrequestHeaders);

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -341,51 +341,6 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("powered-by")).toBe("Shopify, Hydrogen");
   });
 
-  it("does not apply tracking tokens to document server-timing", () => {
-    const context = createTestRequestContext(new Request("https://example.com"));
-    const headers = new Headers({ "content-type": "text/html" });
-
-    context.applyResponseHeaders(headers);
-
-    expect(headers.get("server-timing")).toBeNull();
-  });
-
-  it("does not apply tracking tokens from a document request", () => {
-    const context = createTestRequestContext(
-      new Request("https://example.com", {
-        headers: { "sec-fetch-dest": "document" },
-      }),
-    );
-    const headers = new Headers();
-
-    context.applyResponseHeaders(headers);
-
-    expect(headers.get("server-timing")).toBeNull();
-  });
-
-  it("does not use accept text/html as a document signal for non-GET requests", () => {
-    const context = createTestRequestContext(
-      new Request("https://example.com/api", {
-        method: "POST",
-        headers: { accept: "text/html" },
-      }),
-    );
-    const headers = new Headers();
-
-    context.applyResponseHeaders(headers);
-
-    expect(headers.get("server-timing")).toBeNull();
-  });
-
-  it("does not apply tracking tokens to non-document responses", () => {
-    const context = createTestRequestContext(new Request("https://example.com/__manifest"));
-    const headers = new Headers();
-
-    context.applyResponseHeaders(headers);
-
-    expect(headers.get("server-timing")).toBeNull();
-  });
-
   it("applies captured SFAPI subrequest headers for an established essential session", () => {
     const context = createTestRequestContext(
       new Request("https://example.com", {
@@ -423,10 +378,7 @@ describe("createShopifyRequestContext", () => {
       }),
     );
     const subrequestHeaders = new Headers({ "server-timing": "shopify;dur=10" });
-    subrequestHeaders.append(
-      "set-cookie",
-      "_shopify_essential=updated; Path=/; Secure; HttpOnly",
-    );
+    subrequestHeaders.append("set-cookie", "_shopify_essential=updated; Path=/; Secure; HttpOnly");
     context.captureSubrequestHeaders(subrequestHeaders);
     const headers = new Headers({
       "cache-control": "public, max-age=60",

--- a/packages/hydrogen/src/core/request-context.test.ts
+++ b/packages/hydrogen/src/core/request-context.test.ts
@@ -389,6 +389,7 @@ describe("createShopifyRequestContext", () => {
   it("applies captured SFAPI subrequest headers for an established essential session", () => {
     const context = createTestRequestContext(
       new Request("https://example.com", {
+        method: "POST",
         headers: {
           cookie: "_shopify_essential=established; _shopify_analytics=1; _shopify_marketing=1",
         },
@@ -415,6 +416,30 @@ describe("createShopifyRequestContext", () => {
     expect(headers.get("cache-control")).toBe("private, no-store, max-age=0, must-revalidate");
   });
 
+  it("does not return Shopify state or disable caching for GET requests", () => {
+    const context = createTestRequestContext(
+      new Request("https://example.com/api/data", {
+        headers: { cookie: "_shopify_essential=established" },
+      }),
+    );
+    const subrequestHeaders = new Headers({ "server-timing": "shopify;dur=10" });
+    subrequestHeaders.append(
+      "set-cookie",
+      "_shopify_essential=updated; Path=/; Secure; HttpOnly",
+    );
+    context.captureSubrequestHeaders(subrequestHeaders);
+    const headers = new Headers({
+      "cache-control": "public, max-age=60",
+      "content-type": "application/json",
+    });
+
+    context.applyResponseHeaders(headers);
+
+    expect(headers.getSetCookie()).toEqual([]);
+    expect(headers.get("server-timing")).toBeNull();
+    expect(headers.get("cache-control")).toBe("public, max-age=60");
+  });
+
   it("does not apply captured SFAPI headers without an established essential session", () => {
     const context = createTestRequestContext(new Request("https://example.com/api/data"));
     const subrequestHeaders = new Headers({ "server-timing": "shopify;dur=10" });
@@ -433,6 +458,7 @@ describe("createShopifyRequestContext", () => {
   it("returns Shopify cookies for an established essential session", () => {
     const context = createTestRequestContext(
       new Request("https://example.com/api/data", {
+        method: "POST",
         headers: { cookie: "_shopify_essential=established" },
       }),
     );
@@ -455,6 +481,7 @@ describe("createShopifyRequestContext", () => {
   it("forces no-store when returning an unrecognized captured cookie", () => {
     const context = createTestRequestContext(
       new Request("https://example.com/api/data", {
+        method: "POST",
         headers: { cookie: "_shopify_essential=established" },
       }),
     );
@@ -476,6 +503,7 @@ describe("createShopifyRequestContext", () => {
   it("forces no-store when captured headers already exist on the response", () => {
     const context = createTestRequestContext(
       new Request("https://example.com/api/data", {
+        method: "POST",
         headers: { cookie: "_shopify_essential=established" },
       }),
     );
@@ -533,6 +561,7 @@ describe("createShopifyRequestContext", () => {
   it("keeps the first captured SFAPI subrequest headers", () => {
     const context = createTestRequestContext(
       new Request("https://example.com", {
+        method: "POST",
         headers: { cookie: "_shopify_essential=established" },
       }),
     );
@@ -581,6 +610,7 @@ describe("createShopifyRequestContext", () => {
   it("preserves set-cookie and server-timing when applying personalized cache safety", () => {
     const context = createTestRequestContext(
       new Request("https://example.com/account", {
+        method: "POST",
         headers: { cookie: "_shopify_essential=established" },
       }),
     );

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -88,10 +88,15 @@ type ShopifyRequestContextBase = {
    */
   applyStorefrontRequestHeaders(headers: Headers): void;
   /**
-   * Capture the first fresh SFAPI response headers for replay onto the final app response.
+   * Capture the first fresh storefront response headers for replay onto the final app response.
    * @internal
    */
   captureSubrequestHeaders(headers: Headers): void;
+  /**
+   * Consume storefront proxy response state for gated replay onto the final app response.
+   * @internal
+   */
+  consumeStorefrontResponseHeaders(headers: Headers): void;
   /**
    * Mark the final app response as influenced by private customer state.
    * @internal
@@ -179,6 +184,17 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
     | undefined;
   let personalizedResponseReason: string | undefined;
 
+  const captureSubrequestHeaders = (headers: Headers): void => {
+    // Capture this the first time we get a fresh response to increase the
+    // chance of returning it from the main server response. The main response
+    // needs headers set at send time, while the body can stream later, so this
+    // may not be used if subrequests finish after the main response is sent.
+    capturedSubrequestHeaders ??= {
+      serverTiming: headers.get(SERVER_TIMING_HEADER) ?? "",
+      setCookie: headers.getSetCookie(),
+    };
+  };
+
   if (!hasTrackingCookie) {
     const legacyUniqueToken = inboundCookies.get("_shopify_y");
     const legacyVisitToken = inboundCookies.get("_shopify_s");
@@ -202,15 +218,13 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
     applyStorefrontRequestHeaders(headers) {
       applyStorefrontRequestHeaders(context, headers);
     },
-    captureSubrequestHeaders(headers) {
-      // Capture this the first time we get a fresh response to increase the
-      // chance of returning it from the main server response. The main response
-      // needs headers set at send time, while the body can stream later, so this
-      // may not be used if subrequests finish after the main response is sent.
-      capturedSubrequestHeaders ??= {
-        serverTiming: headers.get(SERVER_TIMING_HEADER) ?? "",
-        setCookie: headers.getSetCookie(),
-      };
+    captureSubrequestHeaders,
+    consumeStorefrontResponseHeaders(headers) {
+      if (headers.has(SERVER_TIMING_HEADER) || headers.getSetCookie().length > 0) {
+        captureSubrequestHeaders(headers);
+      }
+      headers.delete("set-cookie");
+      headers.delete(SERVER_TIMING_HEADER);
     },
     markResponseAsPersonalized(reason) {
       personalizedResponseReason ??= reason;
@@ -231,7 +245,7 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
         !isDocumentResponse &&
         (hasEssentialCookie || isConsentManagementRequest);
 
-      // Replay state captured from the first fresh Storefront API subrequest when allowed.
+      // Replay state captured from fresh SFAPI and proxy responses when allowed.
       if (capturedSubrequestHeaders && mayReturnShopifyState) {
         const existingSetCookies = new Set(headers.getSetCookie());
         for (const value of capturedSubrequestHeaders.setCookie) {
@@ -239,20 +253,26 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
           headers.append("set-cookie", value);
           existingSetCookies.add(value);
         }
+
+        const capturedServerTiming = capturedSubrequestHeaders.serverTiming;
         const existingServerTiming = headers.get(SERVER_TIMING_HEADER) ?? "";
-        if (
-          capturedSubrequestHeaders.serverTiming &&
-          !hasServerTimingValue(existingServerTiming, capturedSubrequestHeaders.serverTiming)
-        ) {
-          headers.append(SERVER_TIMING_HEADER, capturedSubrequestHeaders.serverTiming);
+        const shouldAppendServerTiming =
+          capturedServerTiming !== "" &&
+          existingServerTiming !== capturedServerTiming &&
+          !existingServerTiming.startsWith(`${capturedServerTiming}, `) &&
+          !existingServerTiming.endsWith(`, ${capturedServerTiming}`);
+        if (shouldAppendServerTiming) {
+          headers.set(
+            SERVER_TIMING_HEADER,
+            existingServerTiming
+              ? `${existingServerTiming}, ${capturedServerTiming}`
+              : capturedServerTiming,
+          );
         }
       }
 
-      // Apply the same policy to Shopify cookies already present on the app response.
-      if (!mayReturnShopifyState) removeShopifySetCookies(headers);
-
       // Responses containing buyer-specific or replayed state must not enter shared caches.
-      const returnsCapturedHeaders =
+      const returnsCapturedState =
         mayReturnShopifyState &&
         Boolean(
           capturedSubrequestHeaders?.serverTiming || capturedSubrequestHeaders?.setCookie.length,
@@ -260,7 +280,7 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
 
       if (
         personalizedResponseReason ||
-        returnsCapturedHeaders ||
+        returnsCapturedState ||
         headers.getSetCookie().some(isShopifySetCookie)
       ) {
         applyPrivateResponseCacheHeaders(headers);
@@ -336,18 +356,4 @@ function parseCookieHeader(cookieHeader: string | undefined): Map<string, string
 function isShopifySetCookie(value: string): boolean {
   const name = value.match(/^\s*([^=;\s]+)\s*=/)?.[1];
   return name !== undefined && SHOPIFY_COOKIES.has(name);
-}
-
-function removeShopifySetCookies(headers: Headers): void {
-  const setCookies = headers.getSetCookie();
-  const filtered = setCookies.filter((value) => !isShopifySetCookie(value));
-  if (filtered.length === setCookies.length) return;
-
-  headers.delete("set-cookie");
-  for (const value of filtered) headers.append("set-cookie", value);
-}
-
-function hasServerTimingValue(existing: string, next: string): boolean {
-  const existingParts = new Set(existing.split(",").map((part) => part.trim()));
-  return next.split(",").every((part) => existingParts.has(part.trim()));
 }

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -147,6 +147,7 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
     throw new Error("buyerIp must be non-empty when provided");
   }
 
+  const requestMethod = request.method?.toUpperCase();
   const i18n = normalizeI18n(input.i18n);
   const cookieHeader = request.headers.get("cookie") || undefined;
   const inboundCookies = parseCookieHeader(cookieHeader);
@@ -217,17 +218,21 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
     applyResponseHeaders(headers) {
       headers.set("powered-by", "Shopify, Hydrogen");
 
+      // Documents may be shared or streamed, so they must not carry buyer-specific state.
       const isDocumentResponse =
         context.documentRequest || (headers.get("content-type")?.startsWith("text/html") ?? false);
-      const mayReturnShopifyCookies =
-        !isDocumentResponse && (hasEssentialCookie || isConsentManagementRequest);
-      const returnsCapturedHeaders =
-        mayReturnShopifyCookies &&
-        Boolean(
-          capturedSubrequestHeaders?.serverTiming || capturedSubrequestHeaders?.setCookie.length,
-        );
 
-      if (capturedSubrequestHeaders && mayReturnShopifyCookies) {
+      // Keep GET and HEAD responses cacheable, and fail closed when the request method is unknown.
+      // Cold sessions may only be established by the explicitly marked consent request.
+      const mayReturnShopifyState =
+        requestMethod !== undefined &&
+        requestMethod !== "GET" &&
+        requestMethod !== "HEAD" &&
+        !isDocumentResponse &&
+        (hasEssentialCookie || isConsentManagementRequest);
+
+      // Replay state captured from the first fresh Storefront API subrequest when allowed.
+      if (capturedSubrequestHeaders && mayReturnShopifyState) {
         const existingSetCookies = new Set(headers.getSetCookie());
         for (const value of capturedSubrequestHeaders.setCookie) {
           if (existingSetCookies.has(value)) continue;
@@ -243,7 +248,15 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
         }
       }
 
-      if (!mayReturnShopifyCookies) removeShopifySetCookies(headers);
+      // Apply the same policy to Shopify cookies already present on the app response.
+      if (!mayReturnShopifyState) removeShopifySetCookies(headers);
+
+      // Responses containing buyer-specific or replayed state must not enter shared caches.
+      const returnsCapturedHeaders =
+        mayReturnShopifyState &&
+        Boolean(
+          capturedSubrequestHeaders?.serverTiming || capturedSubrequestHeaders?.setCookie.length,
+        );
 
       if (
         personalizedResponseReason ||

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -26,11 +26,8 @@ import {
 import { normalizePathPrefix } from "./standard-routes/path";
 
 const SHOPIFY_ESSENTIAL_COOKIE = "_shopify_essential";
-const SHOPIFY_COOKIES = new Set([
-  SHOPIFY_ESSENTIAL_COOKIE,
-  "_shopify_analytics",
-  "_shopify_marketing",
-]);
+const SHOPIFY_TRACKING_COOKIES = ["_shopify_analytics", "_shopify_marketing"];
+const SHOPIFY_COOKIES = new Set([SHOPIFY_ESSENTIAL_COOKIE, ...SHOPIFY_TRACKING_COOKIES]);
 
 type StorefrontRequest = Pick<Request, "headers"> &
   Partial<Pick<Request, "method" | "signal" | "url">>;
@@ -151,14 +148,15 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
   }
 
   const i18n = normalizeI18n(input.i18n);
-  const cookie = request.headers.get("cookie") || undefined;
-  const hasEssentialCookie = hasCookie(cookie, SHOPIFY_ESSENTIAL_COOKIE);
-  const hasShopifyCookie = Array.from(SHOPIFY_COOKIES).some((name) => hasCookie(cookie, name));
+  const cookieHeader = request.headers.get("cookie") || undefined;
+  const inboundCookies = parseCookieHeader(cookieHeader);
+  const hasEssentialCookie = inboundCookies.has(SHOPIFY_ESSENTIAL_COOKIE);
+  const hasTrackingCookie = SHOPIFY_TRACKING_COOKIES.some((name) => inboundCookies.has(name));
   const isConsentManagementRequest = request.headers.get(CONSENT_MANAGEMENT_HEADER) === "1";
   const url = request.url ?? request.headers.get(STOREFRONT_URL_HEADER) ?? undefined;
   const storefrontOrigin = getUrlOrigin(url);
   const context = {
-    ...(cookie && { cookie }),
+    ...(cookieHeader && { cookie: cookieHeader }),
     i18n,
     ...(url && { url }),
     ...(storefrontOrigin && { storefrontOrigin }),
@@ -180,9 +178,9 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
     | undefined;
   let personalizedResponseReason: string | undefined;
 
-  if (!hasShopifyCookie) {
-    const legacyUniqueToken = cookie?.match(/\b_shopify_y=([^;]+)/)?.[1];
-    const legacyVisitToken = cookie?.match(/\b_shopify_s=([^;]+)/)?.[1];
+  if (!hasTrackingCookie) {
+    const legacyUniqueToken = inboundCookies.get("_shopify_y");
+    const legacyVisitToken = inboundCookies.get("_shopify_s");
     const headerUniqueToken = request.headers.get(SHOPIFY_UNIQUE_TOKEN_HEADER) ?? undefined;
     const headerVisitToken = request.headers.get(SHOPIFY_VISIT_TOKEN_HEADER) ?? undefined;
 
@@ -307,10 +305,19 @@ function isDocumentRequest(request: StorefrontRequest): boolean {
   return request.headers.get("accept")?.includes("text/html") ?? false;
 }
 
-function hasCookie(cookieHeader: string | undefined, name: string): boolean {
-  return (
-    cookieHeader?.split(";").some((cookie) => cookie.trimStart().startsWith(`${name}=`)) ?? false
-  );
+function parseCookieHeader(cookieHeader: string | undefined): Map<string, string> {
+  const cookies = new Map<string, string>();
+  if (!cookieHeader) return cookies;
+
+  for (const cookie of cookieHeader.split(";")) {
+    const separator = cookie.indexOf("=");
+    if (separator < 0) continue;
+
+    const name = cookie.slice(0, separator).trim();
+    if (!cookies.has(name)) cookies.set(name, cookie.slice(separator + 1));
+  }
+
+  return cookies;
 }
 
 function isShopifySetCookie(value: string): boolean {

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -187,8 +187,8 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
 
     if (legacyUniqueToken || legacyVisitToken) context.legacyTokens = true;
 
-    context.uniqueToken = legacyUniqueToken ?? headerUniqueToken ?? crypto.randomUUID();
-    context.visitToken = legacyVisitToken ?? headerVisitToken ?? crypto.randomUUID();
+    context.uniqueToken = legacyUniqueToken ?? headerUniqueToken;
+    context.visitToken = legacyVisitToken ?? headerVisitToken;
   }
 
   return {

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -24,9 +24,6 @@ import {
 } from "./headers";
 import { normalizePathPrefix } from "./standard-routes/path";
 
-const UNIQUE_TOKEN_MARKER = "_y";
-const VISIT_TOKEN_MARKER = "_s";
-
 type StorefrontRequest = Pick<Request, "headers"> &
   Partial<Pick<Request, "method" | "signal" | "url">>;
 
@@ -229,18 +226,6 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
       if (personalizedResponseReason) {
         applyPrivateResponseCacheHeaders(headers);
       }
-
-      // Generated fallback tokens are only for document navigation bootstrap.
-      const isHtmlResponse = headers.get("content-type")?.startsWith("text/html") ?? false;
-      if (!isHtmlResponse && !context.documentRequest) return;
-
-      const existing = headers.get(SERVER_TIMING_HEADER) ?? "";
-      if (context.uniqueToken && !hasServerTimingMetric(existing, UNIQUE_TOKEN_MARKER)) {
-        headers.append(SERVER_TIMING_HEADER, `${UNIQUE_TOKEN_MARKER};desc=${context.uniqueToken}`);
-      }
-      if (context.visitToken && !hasServerTimingMetric(existing, VISIT_TOKEN_MARKER)) {
-        headers.append(SERVER_TIMING_HEADER, `${VISIT_TOKEN_MARKER};desc=${context.visitToken}`);
-      }
     },
   } as ShopifyRequestContext<I18n>;
 }
@@ -291,10 +276,6 @@ function isDocumentRequest(request: StorefrontRequest): boolean {
   if (destination === "document") return true;
 
   return request.headers.get("accept")?.includes("text/html") ?? false;
-}
-
-function hasServerTimingMetric(value: string, name: string): boolean {
-  return value.split(",").some((part) => part.trim().startsWith(`${name};`));
 }
 
 function hasServerTimingValue(existing: string, next: string): boolean {

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -278,6 +278,7 @@ function applyStorefrontRequestHeaders(context: Context, headers: Headers): void
     headers.set(SHOPIFY_STOREFRONT_ORIGIN_HEADER, context.storefrontOrigin);
   } else headers.delete(SHOPIFY_STOREFRONT_ORIGIN_HEADER);
 
+  // Some Storefront API consumers still rely on these headers instead of cookies.
   if (context.uniqueToken) headers.set(SHOPIFY_UNIQUE_TOKEN_HEADER, context.uniqueToken);
   if (context.visitToken) headers.set(SHOPIFY_VISIT_TOKEN_HEADER, context.visitToken);
   if (context.legacyTokens && context.uniqueToken) {

--- a/packages/hydrogen/src/core/request-context.ts
+++ b/packages/hydrogen/src/core/request-context.ts
@@ -9,6 +9,7 @@ import type {
 import { STOREFRONT_API_VERSION } from "./constants";
 import {
   applyPrivateResponseCacheHeaders,
+  CONSENT_MANAGEMENT_HEADER,
   HYDROGEN_VERSION_HEADER,
   REQUEST_GROUP_ID_HEADER,
   SDK_VARIANT_HEADER,
@@ -23,6 +24,13 @@ import {
   STOREFRONT_URL_HEADER,
 } from "./headers";
 import { normalizePathPrefix } from "./standard-routes/path";
+
+const SHOPIFY_ESSENTIAL_COOKIE = "_shopify_essential";
+const SHOPIFY_COOKIES = new Set([
+  SHOPIFY_ESSENTIAL_COOKIE,
+  "_shopify_analytics",
+  "_shopify_marketing",
+]);
 
 type StorefrontRequest = Pick<Request, "headers"> &
   Partial<Pick<Request, "method" | "signal" | "url">>;
@@ -144,6 +152,9 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
 
   const i18n = normalizeI18n(input.i18n);
   const cookie = request.headers.get("cookie") || undefined;
+  const hasEssentialCookie = hasCookie(cookie, SHOPIFY_ESSENTIAL_COOKIE);
+  const hasShopifyCookie = Array.from(SHOPIFY_COOKIES).some((name) => hasCookie(cookie, name));
+  const isConsentManagementRequest = request.headers.get(CONSENT_MANAGEMENT_HEADER) === "1";
   const url = request.url ?? request.headers.get(STOREFRONT_URL_HEADER) ?? undefined;
   const storefrontOrigin = getUrlOrigin(url);
   const context = {
@@ -169,7 +180,7 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
     | undefined;
   let personalizedResponseReason: string | undefined;
 
-  if (!cookie || !/\b_shopify_(analytics|marketing)=/.test(cookie)) {
+  if (!hasShopifyCookie) {
     const legacyUniqueToken = cookie?.match(/\b_shopify_y=([^;]+)/)?.[1];
     const legacyVisitToken = cookie?.match(/\b_shopify_s=([^;]+)/)?.[1];
     const headerUniqueToken = request.headers.get(SHOPIFY_UNIQUE_TOKEN_HEADER) ?? undefined;
@@ -208,11 +219,22 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
     applyResponseHeaders(headers) {
       headers.set("powered-by", "Shopify, Hydrogen");
 
-      if (capturedSubrequestHeaders) {
-        const existingSetCookies = headers.getSetCookie();
+      const isDocumentResponse =
+        context.documentRequest || (headers.get("content-type")?.startsWith("text/html") ?? false);
+      const mayReturnShopifyCookies =
+        !isDocumentResponse && (hasEssentialCookie || isConsentManagementRequest);
+      const returnsCapturedHeaders =
+        mayReturnShopifyCookies &&
+        Boolean(
+          capturedSubrequestHeaders?.serverTiming || capturedSubrequestHeaders?.setCookie.length,
+        );
+
+      if (capturedSubrequestHeaders && mayReturnShopifyCookies) {
+        const existingSetCookies = new Set(headers.getSetCookie());
         for (const value of capturedSubrequestHeaders.setCookie) {
-          if (existingSetCookies.includes(value)) continue;
+          if (existingSetCookies.has(value)) continue;
           headers.append("set-cookie", value);
+          existingSetCookies.add(value);
         }
         const existingServerTiming = headers.get(SERVER_TIMING_HEADER) ?? "";
         if (
@@ -223,7 +245,13 @@ export function createShopifyRequestContext<const I18n extends I18nConfig>(
         }
       }
 
-      if (personalizedResponseReason) {
+      if (!mayReturnShopifyCookies) removeShopifySetCookies(headers);
+
+      if (
+        personalizedResponseReason ||
+        returnsCapturedHeaders ||
+        headers.getSetCookie().some(isShopifySetCookie)
+      ) {
         applyPrivateResponseCacheHeaders(headers);
       }
     },
@@ -276,6 +304,26 @@ function isDocumentRequest(request: StorefrontRequest): boolean {
   if (destination === "document") return true;
 
   return request.headers.get("accept")?.includes("text/html") ?? false;
+}
+
+function hasCookie(cookieHeader: string | undefined, name: string): boolean {
+  return (
+    cookieHeader?.split(";").some((cookie) => cookie.trimStart().startsWith(`${name}=`)) ?? false
+  );
+}
+
+function isShopifySetCookie(value: string): boolean {
+  const name = value.match(/^\s*([^=;\s]+)\s*=/)?.[1];
+  return name !== undefined && SHOPIFY_COOKIES.has(name);
+}
+
+function removeShopifySetCookies(headers: Headers): void {
+  const setCookies = headers.getSetCookie();
+  const filtered = setCookies.filter((value) => !isShopifySetCookie(value));
+  if (filtered.length === setCookies.length) return;
+
+  headers.delete("set-cookie");
+  for (const value of filtered) headers.append("set-cookie", value);
 }
 
 function hasServerTimingValue(existing: string, next: string): boolean {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-redirects.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-redirects.test.ts
@@ -97,14 +97,16 @@ describe("handleShopifyRedirects", () => {
       ),
     );
 
-    const request = new Request("https://my-app.com/old-page");
+    const request = new Request("https://my-app.com/old-page", {
+      headers: { "sec-fetch-dest": "document" },
+    });
     const result = await handleShopifyRedirects(redirectOptions(request));
 
     assert(result, "expected URL redirect response");
     expect(result.status).toBe(301);
     expect(result.headers.get("location")).toBe("/new-page");
-    expect(result.headers.get("server-timing")).toBe("shopify;dur=10");
-    expect(result.headers.getSetCookie()).toEqual(["tracking=1; Path=/; Secure"]);
+    expect(result.headers.get("server-timing")).toBeNull();
+    expect(result.headers.getSetCookie()).toEqual([]);
   });
 
   it("returns URL redirect using a tokenless public client", async () => {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.development.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.development.test.ts
@@ -66,7 +66,7 @@ describe("handleShopifyRoutesDev", () => {
     assert(result, "expected GraphiQL response");
     expect(result.status).toBe(200);
     expect(result.headers.get("content-type")).toBe("text/html");
-    expect(result.headers.get("server-timing")).toMatch(/^_y;desc=[0-9a-f-]+, _s;desc=[0-9a-f-]+$/);
+    expect(result.headers.get("server-timing")).toBeNull();
   });
 
   it("falls through to production Hydrogen routes", async () => {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.development.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.development.test.ts
@@ -66,7 +66,6 @@ describe("handleShopifyRoutesDev", () => {
     assert(result, "expected GraphiQL response");
     expect(result.status).toBe(200);
     expect(result.headers.get("content-type")).toBe("text/html");
-    expect(result.headers.get("server-timing")).toBeNull();
   });
 
   it("falls through to production Hydrogen routes", async () => {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -111,6 +111,51 @@ describe("handleShopifyRoutes", () => {
     ]);
   });
 
+  it("strips Server-Timing from cold non-consent SFAPI proxy responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("{}", { headers: { "server-timing": "db;dur=2, _y;desc=unique" } }),
+    );
+
+    const result = await handleShopifyRoutes({
+      request: new Request("https://my-app.com/api/unstable/graphql.json", {
+        method: "POST",
+        body: "{}",
+      }),
+    });
+
+    expect(result?.headers.has("server-timing")).toBe(false);
+  });
+
+  it("returns Server-Timing from marked consent-management proxy responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("{}", { headers: { "server-timing": "db;dur=2, _y;desc=unique" } }),
+    );
+
+    const result = await handleShopifyRoutes({
+      request: new Request("https://my-app.com/api/unstable/graphql.json", {
+        method: "POST",
+        body: "{}",
+        headers: { [CONSENT_MANAGEMENT_HEADER]: "1" },
+      }),
+    });
+
+    expect(result?.headers.get("server-timing")).toBe("db;dur=2, _y;desc=unique");
+  });
+
+  it("strips Server-Timing from cacheable SFAPI proxy responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("{}", { headers: { "server-timing": "db;dur=2, _y;desc=unique" } }),
+    );
+
+    const result = await handleShopifyRoutes({
+      request: new Request("https://my-app.com/api/unstable/graphql.json", {
+        headers: { cookie: "_shopify_essential=established" },
+      }),
+    });
+
+    expect(result?.headers.has("server-timing")).toBe(false);
+  });
+
   it("returns Shopify cookies from marked consent-management proxy responses", async () => {
     const upstreamHeaders = new Headers();
     upstreamHeaders.append(

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { createStorefrontClient } from "../../client/client";
 import { createCartServerHandlers } from "../cart/server-handlers";
+import { CONSENT_MANAGEMENT_HEADER } from "../headers";
 import { createShopifyRequestContext } from "../request-context";
 import { assert } from "../test-utils";
 import { handleShopifyRoutes as handleShopifyRoutesImpl } from "./handle-shopify-routes";
@@ -90,6 +91,47 @@ describe("handleShopifyRoutes", () => {
 
     expect(result).not.toBeNull();
     expect(result).toBeInstanceOf(Response);
+  });
+
+  it("strips Shopify cookies from cold non-consent SFAPI proxy responses", async () => {
+    const upstreamHeaders = new Headers();
+    upstreamHeaders.append("set-cookie", "_shopify_essential=cold; Path=/; Secure; HttpOnly");
+    upstreamHeaders.append("set-cookie", "app_session=preserved; Path=/; Secure; HttpOnly");
+    mockFetch.mockResolvedValueOnce(new Response("{}", { headers: upstreamHeaders }));
+
+    const result = await handleShopifyRoutes({
+      request: new Request("https://my-app.com/api/unstable/graphql.json", {
+        method: "POST",
+        body: "{}",
+      }),
+    });
+
+    expect(result?.headers.getSetCookie()).toEqual([
+      "app_session=preserved; Path=/; Secure; HttpOnly",
+    ]);
+  });
+
+  it("returns Shopify cookies from marked consent-management proxy responses", async () => {
+    const upstreamHeaders = new Headers();
+    upstreamHeaders.append(
+      "set-cookie",
+      "_shopify_essential=established; Path=/; Secure; HttpOnly",
+    );
+    mockFetch.mockResolvedValueOnce(new Response("{}", { headers: upstreamHeaders }));
+
+    const result = await handleShopifyRoutes({
+      request: new Request("https://my-app.com/api/unstable/graphql.json", {
+        method: "POST",
+        body: "{}",
+        headers: { [CONSENT_MANAGEMENT_HEADER]: "1" },
+      }),
+    });
+
+    expect(result?.headers.getSetCookie()).toEqual([
+      "_shopify_essential=established; Path=/; Secure; HttpOnly",
+    ]);
+    const [, init] = mockFetch.mock.calls[0];
+    expect(new Headers(init.headers).has(CONSENT_MANAGEMENT_HEADER)).toBe(false);
   });
 
   it("returns Response for Shopify API proxy requests", async () => {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -138,6 +138,9 @@ describe("handleShopifyRoutes", () => {
     });
 
     expect(result?.headers.get("server-timing")).toBe("db;dur=2, _y;desc=unique");
+    expect(result?.headers.get("cache-control")).toBe(
+      "private, no-store, max-age=0, must-revalidate",
+    );
   });
 
   it("strips Server-Timing from cacheable SFAPI proxy responses", async () => {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -93,7 +93,7 @@ describe("handleShopifyRoutes", () => {
     expect(result).toBeInstanceOf(Response);
   });
 
-  it("strips Shopify cookies from cold non-consent SFAPI proxy responses", async () => {
+  it("strips upstream cookies from cold non-consent SFAPI proxy responses", async () => {
     const upstreamHeaders = new Headers();
     upstreamHeaders.append("set-cookie", "_shopify_essential=cold; Path=/; Secure; HttpOnly");
     upstreamHeaders.append("set-cookie", "app_session=preserved; Path=/; Secure; HttpOnly");
@@ -106,9 +106,7 @@ describe("handleShopifyRoutes", () => {
       }),
     });
 
-    expect(result?.headers.getSetCookie()).toEqual([
-      "app_session=preserved; Path=/; Secure; HttpOnly",
-    ]);
+    expect(result?.headers.getSetCookie()).toEqual([]);
   });
 
   it("strips Server-Timing from cold non-consent SFAPI proxy responses", async () => {

--- a/packages/hydrogen/src/core/request-routing/interceptors/agent-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/agent-proxy.ts
@@ -4,7 +4,7 @@ import { createProxyInterceptor } from "./proxy";
 
 export const handleAgentProxy = createProxyInterceptor({
   match: AGENT_BUYER_CLAIMS_RE,
-  headers: {
+  requestHeaders: {
     allow: AGENT_REQUEST_HEADER_ALLOWLIST,
     prepare(headers, _options, url) {
       headers.set(SHOPIFY_CHAT_FRAME_ORIGIN_HEADER, url.origin);

--- a/packages/hydrogen/src/core/request-routing/interceptors/ajax-api.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/ajax-api.ts
@@ -8,7 +8,7 @@ export const rewriteShopifyJsPathname = (pathname: string): string =>
 
 export const handleAjaxApi = createProxyInterceptor({
   match: AJAX_CART_RE,
-  headers: { allow: AJAX_API_REQUEST_HEADER_ALLOWLIST },
+  requestHeaders: { allow: AJAX_API_REQUEST_HEADER_ALLOWLIST },
   rewritePathname: rewriteShopifyJsPathname,
   scope: "ajax-api",
 });

--- a/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.test.ts
@@ -146,6 +146,20 @@ describe("handleShopifyApiProxy", () => {
     expect(headers.get("x-custom-header")).toBe("custom-value");
   });
 
+  it("consumes upstream state from SFR responses", async () => {
+    const headers = new Headers({ "server-timing": '_y;desc="unique"' });
+    headers.append("set-cookie", "future_cookie=value; Path=/; Secure");
+    mockFetch.mockResolvedValueOnce(new Response("ok", { headers }));
+
+    const result = await handleShopifyApiProxy(
+      new Request("https://my-app.com/__shopify/events", { method: "POST" }),
+    );
+
+    assert(result, "expected proxy to return a response");
+    expect(result.headers.getSetCookie()).toEqual([]);
+    expect(result.headers.get("server-timing")).toBeNull();
+  });
+
   it.each([
     "cf-connecting-ip",
     "connection",

--- a/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/api-proxy.ts
@@ -5,7 +5,7 @@ import { createProxyInterceptor } from "./proxy";
 
 export const handleShopifyApiProxy = createProxyInterceptor({
   match: SHOPIFY_API_PROXY_RE,
-  headers: { deny: PROXY_REQUEST_HEADER_DENYLIST },
+  requestHeaders: { deny: PROXY_REQUEST_HEADER_DENYLIST },
   rewritePathname: (pathname) => {
     const upstreamPathname =
       "/" + pathname.slice(SHOPIFY_API_PROXY_PREFIX.length).replace(/^\/+/, "");

--- a/packages/hydrogen/src/core/request-routing/interceptors/mcp-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/mcp-proxy.ts
@@ -6,7 +6,7 @@ const JSON_RPC_INTERNAL_ERROR = -32603;
 
 export const handleMcpProxy = createProxyInterceptor({
   match: MCP_RE,
-  headers: { allow: MCP_REQUEST_HEADER_ALLOWLIST },
+  requestHeaders: { allow: MCP_REQUEST_HEADER_ALLOWLIST },
   formatError: (message) => ({
     jsonrpc: "2.0",
     error: { code: JSON_RPC_INTERNAL_ERROR, message },

--- a/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
@@ -66,6 +66,7 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
       .then((upstreamResponse) => {
         const headers = createProxyResponseHeaders(upstreamResponse.headers);
         descriptor.responseHeaders?.prepare?.(headers, options, url);
+        options.requestContext.consumeStorefrontResponseHeaders(headers);
 
         return new Response(upstreamResponse.body, {
           status: upstreamResponse.status,

--- a/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
@@ -4,23 +4,29 @@ import type { HydrogenRouteInterceptor, HydrogenRoutesOptions } from "../route-t
 
 const PROXY_TIMEOUT_MS = 30_000;
 
-type ProxyHeaderOptions = (
+type PrepareHeaders = (headers: Headers, options: HydrogenRoutesOptions, url: URL) => void;
+
+type ProxyRequestHeaderOptions = (
   | { allow: readonly string[]; deny?: never }
   | { allow?: never; deny: readonly string[] }
 ) & {
-  prepare?: (headers: Headers, options: HydrogenRoutesOptions, url: URL) => void;
+  prepare?: PrepareHeaders;
+};
+
+type ProxyResponseHeaderOptions = {
+  prepare?: PrepareHeaders;
 };
 
 type ProxyDescriptor = {
-  headers: ProxyHeaderOptions;
   match: RegExp;
   methods?: readonly string[];
   formatError?: (message: string) => unknown;
-  prepareResponseHeaders?: (headers: Headers, options: HydrogenRoutesOptions, url: URL) => void;
   redirect?: RequestRedirect;
   scope: string;
   timeoutMs?: number;
   rewritePathname?: (pathname: string) => string;
+  requestHeaders: ProxyRequestHeaderOptions;
+  responseHeaders?: ProxyResponseHeaderOptions;
 };
 
 export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRouteInterceptor {
@@ -39,7 +45,7 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
       upstreamUrl = new URL(upstreamPathname + url.search, storefrontClient.storeUrl);
       const forwardedHeaders = createProxyRequestHeaders(descriptor, request);
       options.requestContext.applyStorefrontRequestHeaders(forwardedHeaders);
-      descriptor.headers.prepare?.(forwardedHeaders, options, url);
+      descriptor.requestHeaders.prepare?.(forwardedHeaders, options, url);
 
       init = {
         method: request.method,
@@ -59,7 +65,7 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
     return fetch(upstreamUrl, init)
       .then((upstreamResponse) => {
         const headers = createProxyResponseHeaders(upstreamResponse.headers);
-        descriptor.prepareResponseHeaders?.(headers, options, url);
+        descriptor.responseHeaders?.prepare?.(headers, options, url);
 
         return new Response(upstreamResponse.body, {
           status: upstreamResponse.status,
@@ -91,7 +97,7 @@ function createProxyErrorResponse(
 }
 
 function createProxyRequestHeaders(descriptor: ProxyDescriptor, request: Request): Headers {
-  const { allow, deny } = descriptor.headers;
+  const { allow, deny } = descriptor.requestHeaders;
   const headers = allow
     ? new Headers(extractHeaders((key) => request.headers.get(key), allow))
     : new Headers(request.headers);

--- a/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
@@ -16,6 +16,7 @@ type ProxyDescriptor = {
   match: RegExp;
   methods?: readonly string[];
   formatError?: (message: string) => unknown;
+  prepareResponseHeaders?: (headers: Headers, options: HydrogenRoutesOptions, url: URL) => void;
   redirect?: RequestRedirect;
   scope: string;
   timeoutMs?: number;
@@ -56,14 +57,16 @@ export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRou
     }
 
     return fetch(upstreamUrl, init)
-      .then(
-        (upstreamResponse) =>
-          new Response(upstreamResponse.body, {
-            status: upstreamResponse.status,
-            statusText: upstreamResponse.statusText,
-            headers: createProxyResponseHeaders(upstreamResponse.headers),
-          }),
-      )
+      .then((upstreamResponse) => {
+        const headers = createProxyResponseHeaders(upstreamResponse.headers);
+        descriptor.prepareResponseHeaders?.(headers, options, url);
+
+        return new Response(upstreamResponse.body, {
+          status: upstreamResponse.status,
+          statusText: upstreamResponse.statusText,
+          headers,
+        });
+      })
       .catch((error) => {
         log.error("request failed", { error });
         return createProxyErrorResponse(error, 502, formatError);

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
@@ -424,7 +424,7 @@ describe("handleSfapiProxy", () => {
     expect(text).toBe('{"data":{"shop":{"name":"Test"}}}');
   });
 
-  it("captures SFAPI response state for gated replay", async () => {
+  it("consumes upstream response state for gated replay", async () => {
     const headers = new Headers({
       "content-type": "application/json",
       "server-timing": '_y;desc="unique", _s;desc="visit"',

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
@@ -424,7 +424,7 @@ describe("handleSfapiProxy", () => {
     expect(text).toBe('{"data":{"shop":{"name":"Test"}}}');
   });
 
-  it("forwards SFAPI server-timing and set-cookie response headers", async () => {
+  it("captures SFAPI Server-Timing for gated replay and forwards set-cookie headers", async () => {
     const headers = new Headers({
       "content-type": "application/json",
       "server-timing": '_y;desc="unique", _s;desc="visit"',
@@ -445,7 +445,7 @@ describe("handleSfapiProxy", () => {
     );
 
     assert(result, "expected proxy to return a response");
-    expect(result.headers.get("server-timing")).toBe('_y;desc="unique", _s;desc="visit"');
+    expect(result.headers.get("server-timing")).toBeNull();
     expect(result.headers.getSetCookie()).toEqual([
       "_shopify_y=unique; Path=/; Secure",
       "_shopify_s=visit; Path=/; Secure",
@@ -474,7 +474,7 @@ describe("handleSfapiProxy", () => {
     expect(result.headers.get("content-encoding")).toBeNull();
     expect(result.headers.get("content-length")).toBeNull();
     expect(result.headers.get("content-type")).toBe("application/json");
-    expect(result.headers.get("server-timing")).toBe('_y;desc="unique"');
+    expect(result.headers.get("server-timing")).toBeNull();
   });
 
   it("returns 502 on upstream fetch failure", async () => {

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.test.ts
@@ -424,7 +424,7 @@ describe("handleSfapiProxy", () => {
     expect(text).toBe('{"data":{"shop":{"name":"Test"}}}');
   });
 
-  it("captures SFAPI Server-Timing for gated replay and forwards set-cookie headers", async () => {
+  it("captures SFAPI response state for gated replay", async () => {
     const headers = new Headers({
       "content-type": "application/json",
       "server-timing": '_y;desc="unique", _s;desc="visit"',
@@ -446,10 +446,7 @@ describe("handleSfapiProxy", () => {
 
     assert(result, "expected proxy to return a response");
     expect(result.headers.get("server-timing")).toBeNull();
-    expect(result.headers.getSetCookie()).toEqual([
-      "_shopify_y=unique; Path=/; Secure",
-      "_shopify_s=visit; Path=/; Secure",
-    ]);
+    expect(result.headers.getSetCookie()).toEqual([]);
   });
 
   it("drops body-specific upstream response headers", async () => {

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
@@ -1,5 +1,6 @@
 import {
   SFAPI_REQUEST_HEADER_ALLOWLIST,
+  SERVER_TIMING_HEADER,
   STOREFRONT_BUYER_IP_HEADER,
   STOREFRONT_ID_HEADER,
 } from "../../headers";
@@ -28,6 +29,12 @@ export const handleSfapiProxy = createProxyInterceptor({
         );
       }
     },
+  },
+  prepareResponseHeaders: (headers, { requestContext }) => {
+    // Route upstream state through the request-context gate instead of returning
+    // it directly from proxy responses.
+    requestContext.captureSubrequestHeaders(headers);
+    headers.delete(SERVER_TIMING_HEADER);
   },
   scope: "sfapi-proxy",
 });

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
@@ -9,7 +9,7 @@ import { createProxyInterceptor } from "./proxy";
 
 export const handleSfapiProxy = createProxyInterceptor({
   match: SFAPI_RE,
-  headers: {
+  requestHeaders: {
     allow: SFAPI_REQUEST_HEADER_ALLOWLIST,
     prepare: (headers, { requestContext, storefrontClient }) => {
       headers.delete(STOREFRONT_ID_HEADER);
@@ -30,12 +30,14 @@ export const handleSfapiProxy = createProxyInterceptor({
       }
     },
   },
-  prepareResponseHeaders: (headers, { requestContext }) => {
-    // Route upstream state through the request-context gate instead of returning
-    // it directly from proxy responses.
-    requestContext.captureSubrequestHeaders(headers);
-    headers.delete("set-cookie");
-    headers.delete(SERVER_TIMING_HEADER);
+  responseHeaders: {
+    prepare: (headers, { requestContext }) => {
+      // Route upstream state through the request-context gate instead of returning
+      // it directly from proxy responses.
+      requestContext.captureSubrequestHeaders(headers);
+      headers.delete("set-cookie");
+      headers.delete(SERVER_TIMING_HEADER);
+    },
   },
   scope: "sfapi-proxy",
 });

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
@@ -34,6 +34,7 @@ export const handleSfapiProxy = createProxyInterceptor({
     // Route upstream state through the request-context gate instead of returning
     // it directly from proxy responses.
     requestContext.captureSubrequestHeaders(headers);
+    headers.delete("set-cookie");
     headers.delete(SERVER_TIMING_HEADER);
   },
   scope: "sfapi-proxy",

--- a/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/sfapi-proxy.ts
@@ -1,6 +1,5 @@
 import {
   SFAPI_REQUEST_HEADER_ALLOWLIST,
-  SERVER_TIMING_HEADER,
   STOREFRONT_BUYER_IP_HEADER,
   STOREFRONT_ID_HEADER,
 } from "../../headers";
@@ -28,15 +27,6 @@ export const handleSfapiProxy = createProxyInterceptor({
           "requestContext.buyerIp is required for private Storefront API proxy requests",
         );
       }
-    },
-  },
-  responseHeaders: {
-    prepare: (headers, { requestContext }) => {
-      // Route upstream state through the request-context gate instead of returning
-      // it directly from proxy responses.
-      requestContext.captureSubrequestHeaders(headers);
-      headers.delete("set-cookie");
-      headers.delete(SERVER_TIMING_HEADER);
     },
   },
   scope: "sfapi-proxy",

--- a/packages/hydrogen/src/core/request-routing/interceptors/well-known.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/well-known.test.ts
@@ -117,7 +117,7 @@ describe("handleWellKnownProxy", () => {
     expect(headers.get("Sec-Shopify-Storefront-Origin")).toBe("https://headless.example");
   });
 
-  it("preserves upstream response headers", async () => {
+  it("preserves upstream response metadata while consuming cookies", async () => {
     const result = await handleWellKnownProxy(
       new Request(`https://headless.example${ASSOCIATION_PATH}`),
     );
@@ -125,7 +125,7 @@ describe("handleWellKnownProxy", () => {
     assert(result, "expected association response");
     expect(result.headers.get("content-type")).toBe("text/plain");
     expect(result.headers.get("cache-control")).toBe("public, max-age=3600");
-    expect(result.headers.get("set-cookie")).toBe("upstream-cookie=secret");
+    expect(result.headers.getSetCookie()).toEqual([]);
     expect(result.headers.get("x-upstream-internal")).toBe("secret");
   });
 

--- a/packages/hydrogen/src/core/request-routing/interceptors/well-known.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/well-known.ts
@@ -8,7 +8,7 @@ import { createProxyInterceptor } from "./proxy";
  */
 export const handleWellKnownProxy = createProxyInterceptor({
   match: WELL_KNOWN_RE,
-  headers: { deny: PROXY_REQUEST_HEADER_DENYLIST },
+  requestHeaders: { deny: PROXY_REQUEST_HEADER_DENYLIST },
   redirect: "follow",
   scope: "well-known-proxy",
 });


### PR DESCRIPTION
## TL;DR

Prevent concurrent cold Storefront API responses from installing conflicting Shopify browser state before the marked consent request completes, while keeping cacheable responses free of replayed state.

## Why

A new session can issue several Storefront API requests concurrently. If each response is allowed to return captured cookies or timing state, an unrelated response can race with and eclipse the response that establishes consent. The response gate needs a single explicit bootstrap path without changing established-session behavior.

## What changed

- Allow Shopify response state on cold sessions only for the marked consent-management request.
- Continue returning updates for requests that arrive with an established essential session.
- Do not apply captured cookies or Server-Timing to GET, HEAD, document, or methodless responses, preserving shared-cache eligibility.
- Stop Hydrogen from inventing visitor and visit tokens when no tracking state exists.
- Preserve guarded legacy tracking headers for consumers that still require header-based compatibility, without allowing legacy values to override newer cookie state.
- Add focused coverage for cold-session races, established sessions, request methods, documents, and legacy token compatibility.

## Review boundary

This PR contains only the server-side response-state and token behavior. The async consent/bootstrap integration is intentionally left for a follow-up branch and should not ship until the corresponding consent-tracking-api bundle is released. Data SHS enablement is also out of scope.

## Testing

- Focused request-context tests passed (39 tests).
- Shopify route and redirect tests passed.

## Versioning

No changeset is included because this changes internal request/response coordination and does not add or change a public API.