### PR TITLE
fix: collection cursor reset on browse changes

### DIFF
--- a/.changeset/clean-cursors-paginate.md
+++ b/.changeset/clean-cursors-paginate.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Reset `before` and `after` pagination cursors when collection filters or sorting change.

--- a/packages/hydrogen/skills/hydrogen-collection-browser/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-collection-browser/SKILL.md
@@ -44,6 +44,7 @@ Use `parseCollectionParams(searchParams)` before Storefront API queries. Pass pa
 - Use `formProps()` on the browse form: spread it, then add the literal `method="get"` and `action`. On hydrated changes, call `form.requestSubmit()` for **checkboxes and `<select>`**. For **text/number inputs (price min/max)** use `onBlur` + `onKeyDown` Enter instead — `onChange` fires per keystroke and would submit the GET form (and re-query Storefront) on every character.
 - Render a `noscript` submit button for filter sidebars that auto-submit when hydrated.
 - Render "load more" / pagination as a GET link (the framework's link component) carrying the next-page cursor (e.g. `?after=<endCursor>`), so it works without JavaScript. Hydration may upgrade it to append-in-place; the bare link must still load the next page server-side (it replaces the page rather than appending when JS is off).
+- Clear both `before` and `after` whenever filters or sorting change so the new browse state starts from its first page.
 - Show stale products with a pending visual state while `state.status === "loading"`; do not replace the grid with a skeleton.
 - Serialize active filter chips from `serializeCollectionParams(state)` and remove filters with `getFilterRemovalUrl(...)`.
 - Use `isFilterInputActive(state.filters, value.input)` to mark checked filter inputs.

--- a/packages/hydrogen/src/core/collection/__tests__/url.test.ts
+++ b/packages/hydrogen/src/core/collection/__tests__/url.test.ts
@@ -541,6 +541,15 @@ describe("getFilterRemovalUrl", () => {
     expect(result.get("view")).toBe("grid");
   });
 
+  it.each(["before", "after"])("clears the %s pagination cursor", (cursor) => {
+    const current = params(`${cursor}=page&filter.p.tag=men&view=grid`);
+    const url = getFilterRemovalUrl(current, { tag: "men" });
+    const result = new URLSearchParams(url.slice(1));
+
+    expect(result.has(cursor)).toBe(false);
+    expect(result.get("view")).toBe("grid");
+  });
+
   it("returns bare ? when all params removed", () => {
     const current = params("filter.p.tag=men");
     const url = getFilterRemovalUrl(current, { tag: "men" });
@@ -719,6 +728,30 @@ describe("mergeCollectionParams", () => {
     expect(merged.get("filter.p.tag")).toBe("women");
     expect(merged.get("sort_by")).toBe("title-descending");
     expect(merged.getAll("filter.p.tag")).not.toContain("men");
+  });
+
+  it("clears the forward cursor when filters change", () => {
+    const merged = mergeCollectionParams(new URLSearchParams("after=next&grid=3"), {
+      filters: [{ tag: "women" }],
+      sortKey: undefined,
+      reverse: false,
+    });
+
+    expect(merged.get("grid")).toBe("3");
+    expect(merged.get("filter.p.tag")).toBe("women");
+    expect(merged.has("after")).toBe(false);
+  });
+
+  it("clears the backward cursor when sorting changes", () => {
+    const merged = mergeCollectionParams(new URLSearchParams("before=previous&grid=3"), {
+      filters: [],
+      sortKey: "TITLE",
+      reverse: true,
+    });
+
+    expect(merged.get("grid")).toBe("3");
+    expect(merged.get("sort_by")).toBe("title-descending");
+    expect(merged.has("before")).toBe(false);
   });
 });
 

--- a/packages/hydrogen/src/core/collection/url.ts
+++ b/packages/hydrogen/src/core/collection/url.ts
@@ -14,6 +14,7 @@ export interface CollectionParams {
 
 const SORT_BY_DESCENDING_SUFFIX = "-descending";
 const SORT_BY_ASCENDING_SUFFIX = "-ascending";
+const PAGINATION_CURSOR_PARAMS: readonly string[] = ["before", "after"];
 
 const SORT_KEY_TO_SORT_BY: Record<string, string> = {
   BEST_SELLING: "best-selling",
@@ -97,7 +98,9 @@ export function normalizeCollectionSearch(search: string): string {
 
 /**
  * Merges store-owned params from `state` into `existing`, preserving
- * non-store keys (e.g. `grid`, `view`) already present in the URL.
+ * unrelated keys (e.g. `grid`, `view`) already present in the URL. Collection
+ * pagination cursors (`before`, `after`) are cleared so changed browse intent
+ * starts from the first page.
  */
 export function mergeCollectionParams(
   existing: URLSearchParams,
@@ -110,6 +113,8 @@ export function mergeCollectionParams(
       merged.delete(key);
     }
   }
+
+  clearPaginationCursors(merged);
 
   for (const [key, value] of serializeCollectionParams(state)) {
     merged.append(key, value);
@@ -147,12 +152,14 @@ export function collectionParamsMatchState(
 /**
  * Builds a URL query string with the given filter removed from the current params.
  *
+ * Clears pagination cursors so the changed filter state starts from its first page.
  * Returns `"?"` when removing the filter leaves no params. Useful for
  * rendering "remove filter" links without updating store state.
  */
 export function getFilterRemovalUrl(currentParams: URLSearchParams, filter: ProductFilter): string {
   const result = new URLSearchParams(currentParams);
   removeFilterParams(result, filter);
+  clearPaginationCursors(result);
   const serialized = result.toString();
   return serialized ? `?${serialized}` : "?";
 }
@@ -385,6 +392,12 @@ function serializeFilter(params: URLSearchParams, filter: ProductFilter): void {
 function removeFilterParams(params: URLSearchParams, filter: ProductFilter): void {
   for (const { key, value } of getFilterParamEntries(filter)) {
     removeParamValue(params, key, value);
+  }
+}
+
+function clearPaginationCursors(params: URLSearchParams): void {
+  for (const key of PAGINATION_CURSOR_PARAMS) {
+    params.delete(key);
   }
 }
 


### PR DESCRIPTION
TL;DR: Reset collection pagination when filters or sorting change so stale cursors cannot request the wrong page. This is the first PR in the React Router template refresh sequence.

## Before

Collection URL updates and active-filter removal preserved `before` and `after`. Changing browse state from a paginated URL could therefore reuse a cursor from the previous result set.

## After

Both cursor directions are removed whenever filters or sorting change. Unrelated query parameters remain intact.

## What this changes

- Centralises pagination cursor cleanup across collection state merges and filter-removal URLs.
- Adds regression coverage for forward and backward pagination.
- Updates collection-browser guidance with the cursor reset contract.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. This fixes existing collection URL behaviour without adding or changing public exports.

## Out of scope

- React Router template implementation.
- Collection or search UI changes.
- Framework-specific pagination examples.

## Risk

Code that intentionally preserved a collection cursor while changing filters or sorting will now restart from the first page.