### PR TITLE
Simplify local HTTPS development scripts

### DIFF
--- a/.changeset/quick-plums-develop.md
+++ b/.changeset/quick-plums-develop.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Rename local HTTPS development scripts from `https:dev` to `dev:https` and rely on the Vite plugin to provision certificates automatically.

--- a/.docs/dependencies.md
+++ b/.docs/dependencies.md
@@ -9,6 +9,6 @@ When changing `@shopify/hydrogen/vite` local HTTPS behaviour, update these toget
 - `templates/react-router/README.md`
 - `templates/react-router/package.json`
 - `templates/react-router/vite.config.ts`
-- framework example `https:dev` scripts and configs under `examples/*`
+- framework example `dev:https` scripts and configs under `examples/*`
 
 `scripts/preview-template-dist.ts` copies `packages/hydrogen/skills` into template `.agents/skills` when preparing the dist branch, so template source directories should not duplicate those generated skill copies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,6 @@ When designing or adjusting APIs for the `hydrogen` package, closely follow the 
 ## Local HTTPS for Examples
 
 - Account-enabled framework examples use `https://local.tryhydrogen.dev:5173` for Customer Account OAuth callback testing.
-- Vite-based examples consume Hydrogen's default certificates. Certificates are provisioned automatically on `https:dev` startup, or run `pnpm https:setup` once from the repository root (`npx hydrogen certs install` in a consumer project). Both download a pinned, checksum-verified mkcert release, trust the local certificate authority, and create the certificates under `~/.shopify/hydrogen/certs/`.
+- Vite-based examples consume Hydrogen's default certificates. Certificates are provisioned automatically on `dev:https` startup. This downloads a pinned, checksum-verified mkcert release, trusts the local certificate authority, and creates the certificates under `~/.shopify/hydrogen/certs/`. Nuxt and SolidStart may need one restart after first-run provisioning so their outer dev servers can load the certificate files.
 - The Next.js example provisions its own certificate. The Hydrogen example uses the Shopify CLI tunnel flow.
-- After setup, run the relevant example with `pnpm --filter @shopify/hydrogen-example-<name> https:dev` when that example provides the script.
+- Run the relevant example with `pnpm --filter @shopify/hydrogen-example-<name> dev:https` when that example provides the script.

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,15 +29,11 @@ From the repository root:
 - `pnpm dev` — run all workspace examples and templates in parallel.
 - `pnpm dev:hub` — run the examples with automatically allocated ports and open the browser hub with status, previews, and logs.
 - `pnpm --filter @shopify/hydrogen-example-<name> dev` — run one example.
-- `pnpm https:setup` then `pnpm --filter @shopify/hydrogen-example-<name> https:dev` — run an account-enabled example on `https://local.tryhydrogen.dev:5173` when it provides an `https:dev` script. The Hydrogen example uses `--customer-account-push` instead of local certificates.
+- `pnpm --filter @shopify/hydrogen-example-<name> dev:https` — run an account-enabled example on `https://local.tryhydrogen.dev:5173` when it provides a `dev:https` script. The Hydrogen example uses `--customer-account-push` instead of local certificates.
 
-Local HTTPS certificates are provisioned automatically the first time an `https:dev` script starts, or explicitly with:
+The local HTTPS plugin provisions certificates automatically the first time a `dev:https` script starts. It downloads a pinned, checksum-verified [mkcert](https://github.com/FiloSottile/mkcert) release, installs the local certificate authority (this may prompt for your password), and creates trusted `local.tryhydrogen.dev` certificates under `~/.shopify/hydrogen/certs/` so Customer Account OAuth can redirect to `https://local.tryhydrogen.dev:5173/account/authorize`.
 
-```sh
-pnpm https:setup
-```
-
-Both download a pinned, checksum-verified [mkcert](https://github.com/FiloSottile/mkcert) release, install the local certificate authority (this may prompt for your password), and create trusted `local.tryhydrogen.dev` certificates under `~/.shopify/hydrogen/certs/` so Customer Account OAuth can redirect to `https://local.tryhydrogen.dev:5173/account/authorize`.
+Nuxt and SolidStart may need the command restarted once after first-run provisioning so their outer dev servers can load the certificate files.
 
 The Next.js template provisions its own development certificate and does not use the Hydrogen certificates.
 

--- a/examples/astro/README.md
+++ b/examples/astro/README.md
@@ -40,8 +40,7 @@ The account flow uses `createCustomerSession` and `createCustomerAccountServerHa
 Customer Account OAuth requires a public HTTPS origin. To test locally without a tunnel, register `https://local.tryhydrogen.dev:5173/account/authorize` as the callback URI and run:
 
 ```sh
-pnpm https:setup
-pnpm --filter @shopify/hydrogen-example-astro https:dev
+pnpm --filter @shopify/hydrogen-example-astro dev:https
 ```
 
 ## Run

--- a/examples/astro/astro.config.mjs
+++ b/examples/astro/astro.config.mjs
@@ -5,7 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
 const enabled =
-  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "https:dev";
+  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "dev:https";
 const httpsOptions = { enabled };
 
 export default defineConfig({

--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "https:dev": "astro dev",
+    "dev:https": "astro dev",
     "build": "astro build",
     "start": "node ./dist/server/entry.mjs",
     "typecheck": "astro check"

--- a/examples/hydrogen/README.md
+++ b/examples/hydrogen/README.md
@@ -49,5 +49,5 @@ Follow step 1 and 2 of <https://shopify.dev/docs/custom-storefronts/building-wit
 For local account testing, use the Customer Account push flow:
 
 ```bash
-pnpm --dir examples/hydrogen https:dev
+pnpm --dir examples/hydrogen dev:https
 ```

--- a/examples/hydrogen/package.json
+++ b/examples/hydrogen/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "shopify hydrogen build --no-lockfile-check",
     "dev": "react-router dev",
-    "https:dev": "shopify hydrogen dev --customer-account-push",
+    "dev:https": "shopify hydrogen dev --customer-account-push",
     "preview": "shopify hydrogen preview --build",
     "typecheck": "react-router typegen && tsc --noEmit",
     "e2e": "playwright test",

--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -5,7 +5,7 @@ import type { NuxtConfig } from "nuxt/schema";
 type VitePlugin = NonNullable<NonNullable<NuxtConfig["vite"]>["plugins"]>[number];
 
 const enabled =
-  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "https:dev";
+  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "dev:https";
 const httpsOptions = { enabled };
 const httpsPlugin = localHttps(httpsOptions);
 

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "nuxt dev",
-    "https:dev": "nuxt dev",
+    "dev:https": "nuxt dev",
     "build": "nuxt build",
     "start": "node .output/server/index.mjs",
     "typecheck": "nuxt typecheck"

--- a/examples/solid-start/README.md
+++ b/examples/solid-start/README.md
@@ -42,9 +42,10 @@ The account flow uses `createCustomerSession` and `createCustomerAccountServerHa
 Customer Account OAuth requires a public HTTPS origin. To test locally without a tunnel, register `https://local.tryhydrogen.dev:5173/account/authorize` as the callback URI and run:
 
 ```sh
-pnpm https:setup
-pnpm --filter @shopify/hydrogen-example-solid-start https:dev
+pnpm --filter @shopify/hydrogen-example-solid-start dev:https
 ```
+
+On the first run, restart the command after the Vite plugin provisions the certificate so Vinxi can load it.
 
 ## Run
 

--- a/examples/solid-start/app.config.ts
+++ b/examples/solid-start/app.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@solidjs/start/config";
 import tailwindcss from "@tailwindcss/vite";
 
 const enabled =
-  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "https:dev";
+  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "dev:https";
 const httpsOptions = { enabled };
 const httpsPlugin = localHttps(httpsOptions);
 const devServer = httpsPlugin.api.getDevServerConfig();

--- a/examples/solid-start/package.json
+++ b/examples/solid-start/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "HOST=localhost vinxi dev",
-    "https:dev": "vinxi dev --host local.tryhydrogen.dev --port 5173",
+    "dev:https": "vinxi dev --host local.tryhydrogen.dev --port 5173",
     "build": "vinxi build",
     "start": "HOST=localhost vinxi start",
     "typecheck": "tsc"

--- a/examples/sveltekit/README.md
+++ b/examples/sveltekit/README.md
@@ -42,8 +42,7 @@ The account flow uses `createCustomerSession` and `createCustomerAccountServerHa
 Customer Account OAuth requires a public HTTPS origin. To test locally without a tunnel, register `https://local.tryhydrogen.dev:5173/account/authorize` as the callback URI and run:
 
 ```sh
-pnpm https:setup
-pnpm --filter @shopify/hydrogen-example-sveltekit https:dev
+pnpm --filter @shopify/hydrogen-example-sveltekit dev:https
 ```
 
 ## Run

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "https:dev": "vite dev",
+    "dev:https": "vite dev",
     "build": "vite build",
     "start": "node --env-file-if-exists=.env build",
     "prepare": "svelte-kit sync || echo ''",

--- a/examples/sveltekit/vite.config.ts
+++ b/examples/sveltekit/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
 const enabled =
-  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "https:dev";
+  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "dev:https";
 const httpsOptions = { enabled };
 
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "dev:svelte": "turbo run dev --filter=@shopify/hydrogen-example-sveltekit...",
     "dev:hydrogen": "pnpm --dir examples/hydrogen dev",
     "dev:hub": "node scripts/examples-dev.ts",
-    "https:setup": "turbo run build --filter=@shopify/hydrogen && node packages/hydrogen/bin/hydrogen.mjs certs install",
     "download:standard-types": "node scripts/download-standard-types.ts",
     "prepare:preview-dist": "node scripts/preview-template-dist.ts prepare",
     "validate:preview-dist": "node scripts/preview-template-dist.ts validate",

--- a/packages/hydrogen/skills/hydrogen-local-https/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-local-https/SKILL.md
@@ -30,7 +30,7 @@ import { localHttps } from "@shopify/hydrogen/vite";
 import { defineConfig } from "vite";
 
 const httpsOptions = {
-  enabled: process.env.npm_lifecycle_event === "https:dev" || process.env.VITE_LOCAL_HTTPS === "1",
+  enabled: process.env.npm_lifecycle_event === "dev:https" || process.env.VITE_LOCAL_HTTPS === "1",
 };
 
 export default defineConfig({
@@ -38,13 +38,13 @@ export default defineConfig({
 });
 ```
 
-Start Vite through an `https:dev` package script. A normal `vite dev` remains plain HTTP.
+Start Vite through a `dev:https` package script. A normal `vite dev` remains plain HTTP.
 
 ```json
 {
   "scripts": {
     "dev": "vite dev",
-    "https:dev": "vite dev"
+    "dev:https": "vite dev"
   }
 }
 ```
@@ -57,7 +57,7 @@ Astro needs its own host and port in addition to the Vite plugin:
 import { LOCAL_HTTPS_DEFAULTS, localHttps } from "@shopify/hydrogen/vite";
 import { defineConfig } from "astro/config";
 
-const enabled = process.env.npm_lifecycle_event === "https:dev" || process.env.VITE_LOCAL_HTTPS === "1";
+const enabled = process.env.npm_lifecycle_event === "dev:https" || process.env.VITE_LOCAL_HTTPS === "1";
 const httpsOptions = { enabled };
 
 export default defineConfig({
@@ -79,7 +79,7 @@ import type { NuxtConfig } from "nuxt/schema";
 type VitePlugin = NonNullable<NonNullable<NuxtConfig["vite"]>["plugins"]>[number];
 
 const httpsOptions = {
-  enabled: process.env.npm_lifecycle_event === "https:dev" || process.env.VITE_LOCAL_HTTPS === "1",
+  enabled: process.env.npm_lifecycle_event === "dev:https" || process.env.VITE_LOCAL_HTTPS === "1",
 };
 const httpsPlugin = localHttps(httpsOptions);
 
@@ -100,7 +100,7 @@ import { defineConfig } from "@solidjs/start/config";
 import { localHttps } from "@shopify/hydrogen/vite";
 
 const httpsOptions = {
-  enabled: process.env.npm_lifecycle_event === "https:dev" || process.env.VITE_LOCAL_HTTPS === "1",
+  enabled: process.env.npm_lifecycle_event === "dev:https" || process.env.VITE_LOCAL_HTTPS === "1",
 };
 const httpsPlugin = localHttps(httpsOptions);
 const devServer = httpsPlugin.api.getDevServerConfig();
@@ -116,7 +116,7 @@ Vinxi also needs its bind target and port on startup:
 ```json
 {
   "scripts": {
-    "https:dev": "vinxi dev --host local.tryhydrogen.dev --port 5173"
+    "dev:https": "vinxi dev --host local.tryhydrogen.dev --port 5173"
   }
 }
 ```

--- a/skills/create-oxygen-template/SKILL.md
+++ b/skills/create-oxygen-template/SKILL.md
@@ -27,7 +27,7 @@ Maintain `templates/react-router` as the canonical source for a professional sta
    - no `@shared/*` imports
    - no `examples/shared/*` runtime dependency
    - no `localCdnAssets`
-   - keep the Hydrogen local HTTPS Vite plugin and `https:dev` script, using its portable default certificate paths
+   - keep the Hydrogen local HTTPS Vite plugin and `dev:https` script, using its portable default certificate paths
    - no `@shopify/hydrogen-classic`
    - no Hydrogen Vite plugin from classic Hydrogen
    - no `@react-router/node`, `@react-router/serve`, or `react-router-serve` unless the template intentionally supports a Node server path

--- a/skills/create-vercel-template/SKILL.md
+++ b/skills/create-vercel-template/SKILL.md
@@ -28,7 +28,7 @@ Next.js on Vercel runs on the Node/serverless runtime, so `process.env` works an
    - no `@shared/*` imports
    - no `examples/shared/*` runtime dependency
    - no `localCdnAssets` (drop the turbopack rule from `next.config.ts`)
-   - keep the Next.js `https:dev` script for local Customer Account OAuth
+   - keep the Next.js `dev:https` script for local Customer Account OAuth
    - no `catalog:` dependency ranges in the final template package
    - use `@shopify/hydrogen: workspace:*` in this repository so template E2E exercises the package under development
      (see "Hydrogen dependency" below). Do not use repo-local `file:` dependencies or vendored package tarballs.
@@ -70,7 +70,7 @@ must expose the template's required APIs, subpaths, TypeScript plugin, and schem
 - Keep `"packageManager": "pnpm@10.33.0"` so the eventual standalone distribution uses the intended manager.
 - Do not add `@vercel/functions` unless the app reintroduces an explicit Storefront cache adapter; the current Next template uses Next Cache Components (`"use cache"`, `cacheLife`, `cacheTag`).
 - Replace `typescript: catalog:` with a real npm range (e.g. `^5.9.3`).
-- Keep the `https:dev` script alongside `dev`, `build`, `start`, `lint`, and `typecheck`.
+- Keep the `dev:https` script alongside `dev`, `build`, `start`, `lint`, and `typecheck`.
 - Deploy uses the Vercel CLI, not a build dependency: document `npx vercel` / `npx vercel --prod` (optionally add a
   `"deploy": "vercel --prod"` script and tell the user to have the Vercel CLI available).
 

--- a/templates/nextjs/README.md
+++ b/templates/nextjs/README.md
@@ -23,7 +23,7 @@ Open <http://localhost:3000>.
 Customer Accounts require an HTTPS origin because Shopify OAuth rejects `http`. Run the HTTPS development server and open <https://local.tryhydrogen.dev:5173>:
 
 ```sh
-pnpm https:dev
+pnpm dev:https
 ```
 
 Next.js provisions and reuses a trusted development certificate under `certificates/`. On first run, it may prompt to install the local certificate authority.
@@ -63,7 +63,7 @@ If `PRIVATE_STOREFRONT_API_TOKEN` is unset, the app uses `mock.shop`. If you set
 | Script | Does |
 | --- | --- |
 | `pnpm dev` | Start the Next.js dev server. |
-| `pnpm https:dev` | Start the Next.js dev server with trusted local HTTPS. |
+| `pnpm dev:https` | Start the Next.js dev server with trusted local HTTPS. |
 | `pnpm build` | Build the production app. |
 | `pnpm start` | Start the production server after `pnpm build`. |
 | `pnpm lint` | Run ESLint. |

--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "https:dev": "next dev --experimental-https --hostname local.tryhydrogen.dev --port 5173",
+    "dev:https": "next dev --experimental-https --hostname local.tryhydrogen.dev --port 5173",
     "build": "next build --debug-prerender",
     "start": "next start",
     "lint": "eslint",

--- a/templates/react-router/README.md
+++ b/templates/react-router/README.md
@@ -50,24 +50,13 @@ cp .env.example .env   # set PUBLIC_STORE_DOMAIN + PUBLIC_STOREFRONT_ID + PRIVAT
 npm run dev               # Vite/Mini Oxygen loads .env into the worker environment
 ```
 
-Customer Account OAuth requires trusted local HTTPS. Install [mkcert](https://github.com/FiloSottile/mkcert), then create the default `local.tryhydrogen.dev` certificates:
+Customer Account OAuth requires trusted local HTTPS. Run:
 
 ```bash
-mkcert -install
-mkdir -p ~/.shopify/hydrogen/certs
-mkcert \
-  -cert-file ~/.shopify/hydrogen/certs/local.tryhydrogen.dev.pem \
-  -key-file ~/.shopify/hydrogen/certs/local.tryhydrogen.dev-key.pem \
-  local.tryhydrogen.dev
+npm run dev:https
 ```
 
-Then run:
-
-```bash
-npm run https:dev
-```
-
-Open <https://local.tryhydrogen.dev:5173>.
+The local HTTPS plugin provisions and reuses a trusted certificate under `~/.shopify/hydrogen/certs/`. On first run, it may prompt to install the local certificate authority. Open <https://local.tryhydrogen.dev:5173>.
 
 Mode is **auto-detected**: when a `PRIVATE_STOREFRONT_API_TOKEN` is present the
 app talks to the real store (`PUBLIC_STORE_DOMAIN`, falling back to the default in
@@ -82,7 +71,7 @@ automatically** — the deployed site connects to your store with no extra confi
 | Script | Does |
 | --- | --- |
 | `npm run dev` | Start the Vite dev server with Mini Oxygen. |
-| `npm run https:dev` | Start the Vite dev server with trusted local HTTPS. |
+| `npm run dev:https` | Start the Vite dev server with trusted local HTTPS. |
 | `npm run build` | Production React Router build for Oxygen. |
 | `npm run preview` | Build and preview locally with Vite and Mini Oxygen. |
 | `npm run deploy` | Deploy to Oxygen with the Shopify CLI. |

--- a/templates/react-router/package.json
+++ b/templates/react-router/package.json
@@ -7,7 +7,7 @@
     "build": "react-router build",
     "deploy": "shopify hydrogen deploy --assets-dir dist/client --worker-dir dist/server",
     "dev": "vite dev",
-    "https:dev": "vite dev",
+    "dev:https": "vite dev",
     "preview": "react-router build && vite preview",
     "typecheck": "react-router typegen && tsc && hydrogen gql check --fail-on-warn"
   },

--- a/templates/react-router/vite.config.ts
+++ b/templates/react-router/vite.config.ts
@@ -7,7 +7,7 @@ import { defineConfig } from "vite";
 const oxygenPlugins = oxygen();
 const oxygenPlugin = oxygenPlugins.find((plugin) => plugin.name === "oxygen:main");
 const enabled =
-  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "https:dev";
+  process.env.VITE_LOCAL_HTTPS === "1" || process.env.npm_lifecycle_event === "dev:https";
 const httpsOptions = { enabled };
 
 if (!oxygenPlugin?.api) {


### PR DESCRIPTION
TL;DR: `localHttps` now provisions missing certificates during Vite startup, so the repository no longer needs a separate `https:setup` command. This also standardises local HTTPS scripts as `dev:https`.

## Before

Local HTTPS workflows used `https:setup` followed by framework-specific `https:dev` scripts.

## After

Templates and examples use `dev:https`. Vite-based projects provision missing certificates when that command starts.

## What this changes

- Removes the root `https:setup` script and its documentation.
- Renames local HTTPS scripts and lifecycle checks from `https:dev` to `dev:https`.
- Updates template, example, and packaged skill guidance.
- Documents the possible first-run restart for Nuxt and SolidStart.

## Developer impact

Includes a patch changeset for `@shopify/hydrogen` because the packaged local HTTPS skill now teaches `dev:https`. No runtime API changes.

## Risk

- Existing repository workflows using `https:dev` must switch to `dev:https`.
- Nuxt and SolidStart may need one restart after first-run certificate provisioning so their outer dev servers can load the files.

## How to Test

1. Run `pnpm --filter @shopify/hydrogen-template-react-router dev:https`.
2. Accept the certificate installation prompt if certificates are missing.
3. Open `https://local.tryhydrogen.dev:5173`.
4. Confirm the template loads over trusted HTTPS.