### PR TITLE
feat: add cart refresh API

### DIFF
--- a/.changeset/calm-carts-refresh.md
+++ b/.changeset/calm-carts-refresh.md
@@ -2,4 +2,4 @@
 "@shopify/hydrogen": minor
 ---
 
-Add `CartStore.refresh()` and React/Vue `useCartActions()` APIs for reconciling the current cart after an out-of-band mutation. Refreshes use the configured cart transport, wait for active optimistic mutations, update custom cart fragment fields, and report progress and failures through cart state.
+Add `CartStore.refresh()` and React/Vue `useCartActions()` APIs for reconciling the current cart after an out-of-band mutation. Refreshes use the configured cart transport, wait for active optimistic mutations, update custom cart fragment fields, and report progress and failures through cart state. When the store has no cart yet, refresh loads one so a cart created server-side (e.g. via `cartCreate`) is picked up.

--- a/.changeset/calm-carts-refresh.md
+++ b/.changeset/calm-carts-refresh.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": minor
+---
+
+Add `CartStore.refresh()` and React/Vue `useCartActions()` APIs for reconciling the current cart after an out-of-band mutation. Refreshes use the configured cart transport, wait for active optimistic mutations, update custom cart fragment fields, and report progress and failures through cart state.

--- a/.docs/dependencies.md
+++ b/.docs/dependencies.md
@@ -1,5 +1,16 @@
 # Documentation Dependencies
 
+## Hydrogen Cart Store API
+
+When changing the cart store's public surface (`CartStore`, React/Vue `createCartComponents` outputs, or the cart action hooks/composables), update these together:
+
+- `packages/hydrogen/src/core/cart/cart.ts`
+- `packages/hydrogen/src/react/cart.tsx` and `packages/hydrogen/src/react/index.ts`
+- `packages/hydrogen/src/vue/cart.ts` and `packages/hydrogen/src/vue/index.ts`
+- `packages/hydrogen/skills/hydrogen-cart-ui/SKILL.md`
+- `packages/hydrogen/skills/hydrogen-cart-ui/references/react.md`
+- `packages/hydrogen/skills/hydrogen-cart-ui/references/vue.md`
+
 ## Hydrogen Local HTTPS
 
 When changing `@shopify/hydrogen/vite` local HTTPS behaviour, update these together:

--- a/packages/hydrogen/skills/hydrogen-cart-ui/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-cart-ui/SKILL.md
@@ -41,6 +41,8 @@ On mutation:
 
 When overlapping mutations make response snapshots ambiguous, the store sets `state.revalidating` to `true`. It starts one authoritative refresh after those mutations settle and clears the flag when the refresh completes or fails. Until then, server-derived values such as costs remain at their last trustworthy value. A refresh failure preserves the locally reconciled cart and appears in `errors.network`.
 
+App-owned cart mutations outside Standard Actions do not emit the events the store normally observes. After such a mutation succeeds, call `CartStore.refresh()` directly or use the framework binding's `useCartActions().refresh()`. The refresh waits for active optimistic work, reconciles custom fragment fields from the configured cart endpoint, and is a no-op when no cart exists. Do not call it after ordinary Hydrogen cart forms; their Standard Actions events already synchronize the store.
+
 The store supersedes keyed mutations for the same line, discount batch, note, or complete attribute list. Relative additions remain independent so every submitted quantity reaches the server; their projections are reconciled together without disabling controls.
 
 ## Stable selectors
@@ -205,6 +207,10 @@ Errors survive unrelated cart work and clear when a new mutation begins for the 
 
 29. **Initial load** — Before the cart is fetched, show skeleton placeholders.
 30. **Empty cart** — After fetch completes with zero lines, show empty state.
+
+### Out-of-band mutations
+
+31. **Refresh custom data** — After an app-owned cart mutation succeeds, request a cart refresh. Every cart consumer receives the updated custom fragment data, `revalidating` represents the refresh, and a refresh failure preserves the confirmed cart while appearing in `errors.network`.
 
 ---
 

--- a/packages/hydrogen/skills/hydrogen-cart-ui/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-cart-ui/SKILL.md
@@ -41,7 +41,7 @@ On mutation:
 
 When overlapping mutations make response snapshots ambiguous, the store sets `state.revalidating` to `true`. It starts one authoritative refresh after those mutations settle and clears the flag when the refresh completes or fails. Until then, server-derived values such as costs remain at their last trustworthy value. A refresh failure preserves the locally reconciled cart and appears in `errors.network`.
 
-App-owned cart mutations outside Standard Actions do not emit the events the store normally observes. After such a mutation succeeds, call `CartStore.refresh()` directly or use the framework binding's `useCartActions().refresh()`. The refresh waits for active optimistic work, reconciles custom fragment fields from the configured cart endpoint, and is a no-op when no cart exists. Do not call it after ordinary Hydrogen cart forms; their Standard Actions events already synchronize the store.
+App-owned cart mutations outside Standard Actions do not emit the events the store normally observes. After such a mutation succeeds, call `CartStore.refresh()` directly or use the framework binding's `useCartActions().refresh()`. The refresh waits for active optimistic work, reconciles custom fragment fields from the configured cart endpoint, and loads the cart when none exists yet (e.g. one just created server-side). Do not call it after ordinary Hydrogen cart forms; their Standard Actions events already synchronize the store.
 
 The store supersedes keyed mutations for the same line, discount batch, note, or complete attribute list. Relative additions remain independent so every submitted quantity reaches the server; their projections are reconciled together without disabling controls.
 

--- a/packages/hydrogen/skills/hydrogen-cart-ui/references/react.md
+++ b/packages/hydrogen/skills/hydrogen-cart-ui/references/react.md
@@ -194,7 +194,7 @@ function CustomCartEditor() {
 }
 ```
 
-`refresh()` is non-blocking. Read `state.revalidating` for progress and `state.errors.network` for failures. It waits for active optimistic mutations and does nothing when no cart exists. Do not call it after `useCartForm()` submissions because their Standard Actions events already synchronize the store.
+`refresh()` is non-blocking. Read `state.revalidating` for progress and `state.errors.network` for failures. It waits for active optimistic mutations, and loads the cart when none exists yet (e.g. one just created server-side). Do not call it after `useCartForm()` submissions because their Standard Actions events already synchronize the store.
 
 ## Mutating Cart State
 

--- a/packages/hydrogen/skills/hydrogen-cart-ui/references/react.md
+++ b/packages/hydrogen/skills/hydrogen-cart-ui/references/react.md
@@ -5,6 +5,7 @@
 - Root Setup
 - Custom Cart Fields
 - Reading Cart State
+- Refreshing Cart State
 - Mutating Cart State
 
 For React apps, derive cart bindings once from the cart server handlers. Do not hand-roll `useState` cart state, custom mutation fetchers, or bespoke optimistic reducers unless the app is not using React.
@@ -30,7 +31,7 @@ import { createCartComponents } from "@shopify/hydrogen/react";
 
 import type { cartHandlers } from "./cart-handlers";
 
-export const { CartProvider, useCart, useSuspenseCart, useCartForm } =
+export const { CartProvider, useCart, useSuspenseCart, useCartActions, useCartForm } =
   createCartComponents<typeof cartHandlers>();
 ```
 
@@ -99,7 +100,7 @@ import { createCartComponents } from "@shopify/hydrogen/react";
 
 import type { cartHandlers } from "./cart-handlers";
 
-export const { CartProvider, useCart, useSuspenseCart, useCartForm } =
+export const { CartProvider, useCart, useSuspenseCart, useCartActions, useCartForm } =
   createCartComponents<typeof cartHandlers>();
 
 function CartLines() {
@@ -173,6 +174,27 @@ function CartContentBody() {
 ```
 
 Keep using `useCart(selector)` for non-blocking UI such as cart counts, pending states, and optimistic controls.
+
+## Refreshing Cart State
+
+Use `useCartActions().refresh()` after an app-owned cart mutation that bypasses Standard Actions. This refetches the current cart through the configured cart endpoint, so custom fields selected by `CartFragment` update for every `useCart()` consumer.
+
+```tsx
+import { useCartActions } from "~/lib/cart";
+
+function CustomCartEditor() {
+  const { refresh } = useCartActions();
+
+  async function save() {
+    await saveCustomCartData();
+    refresh();
+  }
+
+  // Render the app-specific editor.
+}
+```
+
+`refresh()` is non-blocking. Read `state.revalidating` for progress and `state.errors.network` for failures. It waits for active optimistic mutations and does nothing when no cart exists. Do not call it after `useCartForm()` submissions because their Standard Actions events already synchronize the store.
 
 ## Mutating Cart State
 

--- a/packages/hydrogen/skills/hydrogen-cart-ui/references/vue.md
+++ b/packages/hydrogen/skills/hydrogen-cart-ui/references/vue.md
@@ -161,7 +161,7 @@ async function save() {
 </template>
 ```
 
-`refresh()` is non-blocking. Read `state.revalidating` for progress and `state.errors.network` for failures. It waits for active optimistic mutations and does nothing when no cart exists. Do not call it after `useCartForm()` submissions because their Standard Actions events already synchronize the store.
+`refresh()` is non-blocking. Read `state.revalidating` for progress and `state.errors.network` for failures. It waits for active optimistic mutations, and loads the cart when none exists yet (e.g. one just created server-side). Do not call it after `useCartForm()` submissions because their Standard Actions events already synchronize the store.
 
 ## Mutating Cart State
 

--- a/packages/hydrogen/skills/hydrogen-cart-ui/references/vue.md
+++ b/packages/hydrogen/skills/hydrogen-cart-ui/references/vue.md
@@ -5,6 +5,7 @@
 - Root Setup
 - Custom Cart Fields
 - Reading Cart State
+- Refreshing Cart State
 - Mutating Cart State
 - Pending Helpers
 
@@ -23,7 +24,7 @@ import { createCartComponents } from "@shopify/hydrogen/vue";
 
 import type { cartHandlers } from "./cart-handlers";
 
-export const { CartProvider, useCart, useCartForm } =
+export const { CartProvider, useCart, useCartActions, useCartForm } =
   createCartComponents<typeof cartHandlers>();
 ```
 
@@ -78,7 +79,7 @@ import { createCartComponents } from "@shopify/hydrogen/vue";
 
 import type { cartHandlers } from "./cart-handlers";
 
-export const { CartProvider, useCart, useCartForm } =
+export const { CartProvider, useCart, useCartActions, useCartForm } =
   createCartComponents<typeof cartHandlers>();
 ```
 
@@ -138,6 +139,29 @@ const attributeErrors = useCart((state) => state.errors.attributes);
 ```
 
 Use this for the navbar cart count, cart line list, totals, pending state, and scoped errors. Do not mirror selected cart state into local refs; the store already publishes updates.
+
+## Refreshing Cart State
+
+Use `useCartActions().refresh()` after an app-owned cart mutation that bypasses Standard Actions. This refetches the current cart through the configured cart endpoint, so custom fields selected by `CartFragment` update for every `useCart()` consumer.
+
+```vue
+<script setup lang="ts">
+import { useCartActions } from "~/lib/cart";
+
+const { refresh } = useCartActions();
+
+async function save() {
+  await saveCustomCartData();
+  refresh();
+}
+</script>
+
+<template>
+  <button type="button" @click="save">Save custom cart data</button>
+</template>
+```
+
+`refresh()` is non-blocking. Read `state.revalidating` for progress and `state.errors.network` for failures. It waits for active optimistic mutations and does nothing when no cart exists. Do not call it after `useCartForm()` submissions because their Standard Actions events already synchronize the store.
 
 ## Mutating Cart State
 

--- a/packages/hydrogen/src/core/cart/cart.test.ts
+++ b/packages/hydrogen/src/core/cart/cart.test.ts
@@ -2911,12 +2911,15 @@ describe("CartStore.refresh", () => {
     expect(store.getState().data.note).toBe("after refresh");
   });
 
-  it("is a no-op when no cart exists", async () => {
-    store.refresh();
-    await nextTick();
+  it("loads the cart when none exists yet (e.g. created out of band)", async () => {
+    mockGetCart.mockResolvedValueOnce({
+      cart: makeCartState({ id: "gid://shopify/Cart/created", totalQuantity: 1 }),
+    });
 
-    expect(mockGetCart).not.toHaveBeenCalled();
-    expect(store.getState().revalidating).toBeUndefined();
+    store.refresh();
+
+    await vi.waitFor(() => expect(mockGetCart).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(store.getState().data.id).toBe("gid://shopify/Cart/created"));
   });
 
   it("waits for an active mutation before refreshing", async () => {

--- a/packages/hydrogen/src/core/cart/cart.test.ts
+++ b/packages/hydrogen/src/core/cart/cart.test.ts
@@ -3047,6 +3047,55 @@ describe("CartStore.refresh", () => {
     expect(store.getState().data.note).toBe("keep me");
     expect(store.getState().revalidating).toBeUndefined();
   });
+
+  it("adopts a replacement cart when the endpoint returns a different id", async () => {
+    const originalCartId = "gid://shopify/Cart/original";
+    const replacementCartId = "gid://shopify/Cart/replacement";
+    store.hydrate(makeCartState({ id: originalCartId }));
+    // A configured endpoint resolves the cart from its cookie; an external
+    // operation swapped it, so the response carries a brand-new cart id.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json({ cart: makeCartState({ id: replacementCartId, note: "replaced" }) }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    configureCartEndpoint("/api/cart");
+
+    store.refresh();
+
+    await vi.waitFor(() => expect(store.getState().revalidating).toBeUndefined());
+    expect(store.getState().data.id).toBe(replacementCartId);
+    expect(store.getState().data.note).toBe("replaced");
+    expect(store.getState().errors.network).toHaveLength(0);
+  });
+
+  it("keeps the fetched cart when refresh runs during the initial fetch", async () => {
+    const fetchedCartId = "gid://shopify/Cart/fetched";
+    const initialFetch = createDeferred<{ cart: CartData }>();
+    const revalidation = createDeferred<{ cart: CartData }>();
+    mockGetCart.mockReturnValueOnce(initialFetch.promise).mockReturnValueOnce(revalidation.promise);
+
+    const fetchPromise = store.fetch();
+    // Refresh while the initial load is in flight: it must queue behind the
+    // load instead of publishing over it and discarding the fetched cart.
+    store.refresh();
+    expect(store.getState().readyPromise).toBeDefined();
+    await vi.waitFor(() => expect(mockGetCart).toHaveBeenCalledTimes(1));
+
+    initialFetch.resolve({ cart: makeCartState({ id: fetchedCartId, totalQuantity: 2 }) });
+    await fetchPromise;
+    expect(store.getState().data.id).toBe(fetchedCartId);
+
+    // The queued refresh runs after the load settles, revalidating the cart
+    // the fetch applied rather than starting an id-less discovery.
+    await vi.waitFor(() => expect(mockGetCart).toHaveBeenCalledTimes(2));
+    revalidation.resolve({ cart: makeCartState({ id: fetchedCartId, totalQuantity: 2 }) });
+    await vi.waitFor(() => expect(store.getState().revalidating).toBeUndefined());
+    expect(store.getState().data.id).toBe(fetchedCartId);
+    expect(store.getState().data.totalQuantity).toBe(2);
+    expect(store.getState().errors.network).toHaveLength(0);
+  });
 });
 
 describe("CartStore.fetch", () => {

--- a/packages/hydrogen/src/core/cart/cart.test.ts
+++ b/packages/hydrogen/src/core/cart/cart.test.ts
@@ -2869,6 +2869,110 @@ describe("CartStore.handleFormSubmit — timeout", () => {
   });
 });
 
+describe("CartStore.refresh", () => {
+  it("refreshes custom fields on the existing cart", async () => {
+    store.hydrate(
+      makeCartState({
+        metafields: [{ key: "custom.instructions", value: "Front door" }],
+      }),
+    );
+    mockGetCart.mockResolvedValueOnce({
+      cart: makeCartState({
+        metafields: [{ key: "custom.instructions", value: "Back door" }],
+      }),
+    });
+
+    store.refresh();
+
+    expect(store.getState().revalidating).toBe(true);
+    await vi.waitFor(() => expect(store.getState().revalidating).toBeUndefined());
+    expect(store.getState().data.metafields).toEqual([
+      { key: "custom.instructions", value: "Back door" },
+    ]);
+  });
+
+  it("uses the configured cart endpoint", async () => {
+    store.hydrate(makeCartState({ note: "before refresh" }));
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        cart: makeCartState({ note: "after refresh" }),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    configureCartEndpoint("/api/cart");
+
+    store.refresh();
+
+    await vi.waitFor(() => expect(store.getState().revalidating).toBeUndefined());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/cart",
+      expect.objectContaining({ cache: "no-store", signal: expect.any(AbortSignal) }),
+    );
+    expect(store.getState().data.note).toBe("after refresh");
+  });
+
+  it("is a no-op when no cart exists", async () => {
+    store.refresh();
+    await nextTick();
+
+    expect(mockGetCart).not.toHaveBeenCalled();
+    expect(store.getState().revalidating).toBeUndefined();
+  });
+
+  it("waits for an active mutation before refreshing", async () => {
+    const line = makeLine({ id: "line-1", quantity: 1 });
+    store.hydrate(makeCartState({ lines: [line], totalQuantity: 1 }));
+    mockGetCart.mockResolvedValueOnce({
+      cart: makeCartState({ lines: [line], totalQuantity: 1 }),
+    });
+
+    const mutation = store.handleFormSubmit(submitForm({ lineId: "line-1" }, "intent", "increase"));
+    await nextTick();
+
+    store.refresh();
+
+    expect(store.getState().revalidating).toBe(true);
+    expect(mockGetCart).not.toHaveBeenCalled();
+
+    resolveUpdate(0, serverResult({ totalQuantity: 2 }));
+    await mutation;
+    await vi.waitFor(() => expect(mockGetCart).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(store.getState().revalidating).toBeUndefined());
+  });
+
+  it("does not apply an aborted refresh response", async () => {
+    const firstRefresh = createDeferred<{ cart: CartData }>();
+    const secondRefresh = createDeferred<{ cart: CartData }>();
+    store.hydrate(makeCartState({ note: "current" }));
+    mockGetCart
+      .mockReturnValueOnce(firstRefresh.promise)
+      .mockReturnValueOnce(secondRefresh.promise);
+
+    store.refresh();
+    await vi.waitFor(() => expect(mockGetCart).toHaveBeenCalledTimes(1));
+    store.refresh();
+
+    firstRefresh.resolve({ cart: makeCartState({ note: "stale" }) });
+    await vi.waitFor(() => expect(mockGetCart).toHaveBeenCalledTimes(2));
+    expect(store.getState().data.note).toBe("current");
+
+    secondRefresh.resolve({ cart: makeCartState({ note: "fresh" }) });
+    await vi.waitFor(() => expect(store.getState().revalidating).toBeUndefined());
+    expect(store.getState().data.note).toBe("fresh");
+  });
+
+  it("surfaces refresh failures without replacing cart data", async () => {
+    store.hydrate(makeCartState({ note: "keep me" }));
+    mockGetCart.mockRejectedValueOnce(new Error("refresh failed"));
+
+    store.refresh();
+
+    await vi.waitFor(() => expect(store.getState().errors.network).toHaveLength(1));
+    expect(store.getState().data.note).toBe("keep me");
+    expect(store.getState().revalidating).toBeUndefined();
+  });
+});
+
 describe("CartStore.fetch", () => {
   it("reuses an in-flight fetch while state is unchanged", async () => {
     const deferred = createDeferred<{ cart: CartData }>();

--- a/packages/hydrogen/src/core/cart/cart.test.ts
+++ b/packages/hydrogen/src/core/cart/cart.test.ts
@@ -2922,6 +2922,79 @@ describe("CartStore.refresh", () => {
     await vi.waitFor(() => expect(store.getState().data.id).toBe("gid://shopify/Cart/created"));
   });
 
+  it("reports revalidating progress without suspending while discovering a cart", async () => {
+    const discovery = createDeferred<{ cart: CartData }>();
+    mockGetCart.mockReturnValueOnce(discovery.promise);
+
+    store.refresh();
+
+    // Progress shows, but no readyPromise (must not suspend useSuspenseCart).
+    expect(store.getState().revalidating).toBe(true);
+    expect(store.getState().readyPromise).toBeUndefined();
+    expect(store.getState().data.id).toBeNull();
+
+    discovery.resolve({
+      cart: makeCartState({ id: "gid://shopify/Cart/created", totalQuantity: 1 }),
+    });
+    await vi.waitFor(() => expect(store.getState().revalidating).toBeUndefined());
+    expect(store.getState().readyPromise).toBeUndefined();
+    expect(store.getState().data.id).toBe("gid://shopify/Cart/created");
+  });
+
+  it("treats a null discovery result as no cart yet, not an error", async () => {
+    mockGetCart.mockResolvedValueOnce({ cart: null });
+
+    store.refresh();
+
+    await vi.waitFor(() => expect(store.getState().revalidating).toBeUndefined());
+    expect(store.getState().errors.network).toHaveLength(0);
+    expect(store.getState().data.id).toBeNull();
+  });
+
+  it("surfaces network failures during discovery instead of only logging", async () => {
+    mockGetCart.mockRejectedValueOnce(new Error("discovery failed"));
+
+    store.refresh();
+
+    await vi.waitFor(() => expect(store.getState().errors.network).toHaveLength(1));
+    expect(store.getState().revalidating).toBeUndefined();
+    expect(store.getState().data.id).toBeNull();
+  });
+
+  it("during an initial add, waits for cart creation then revalidates instead of discarding it", async () => {
+    const cartId = "gid://shopify/Cart/created";
+    const event = submitForm(
+      { merchandiseId: "gid://shopify/ProductVariant/1", quantity: "1" },
+      "intent",
+      "add",
+    );
+    const mutation = store.handleFormSubmit(event);
+    await nextTick();
+
+    // Refresh mid-creation: the queue must wait, not observe pre-creation state.
+    store.refresh();
+    expect(store.getState().revalidating).toBe(true);
+    expect(store.getState().readyPromise).toBeUndefined();
+    expect(mockGetCart).not.toHaveBeenCalled();
+
+    // After settlement the requested reconciliation runs and is not lost.
+    mockGetCart.mockResolvedValueOnce({
+      cart: makeCartState({
+        id: cartId,
+        totalQuantity: 1,
+        metafields: [{ key: "custom.instructions", value: "Back door" }],
+      }),
+    });
+    resolveUpdate(0, serverResult({ id: cartId, totalQuantity: 1 }));
+    await mutation;
+
+    await vi.waitFor(() => expect(mockGetCart).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(store.getState().revalidating).toBeUndefined());
+    expect(store.getState().data.metafields).toEqual([
+      { key: "custom.instructions", value: "Back door" },
+    ]);
+  });
+
   it("waits for an active mutation before refreshing", async () => {
     const line = makeLine({ id: "line-1", quantity: 1 });
     store.hydrate(makeCartState({ lines: [line], totalQuantity: 1 }));

--- a/packages/hydrogen/src/core/cart/cart.ts
+++ b/packages/hydrogen/src/core/cart/cart.ts
@@ -101,6 +101,7 @@ export type CartStore = {
   getState(): CartState;
   subscribe(listener: (state: CartState) => void): () => void;
   fetch(): Promise<void>;
+  refresh(): void;
   reset(): void;
   handleFormSubmit(event: SubmitEvent, eventDetail?: Record<string, unknown>): Promise<void>;
 };
@@ -730,7 +731,9 @@ function createNetworkEntry(error: unknown): CartNetworkEntry {
   if (error instanceof CartNetworkError) {
     return { message: error.message, status: error.status };
   }
-  return { message: error instanceof Error ? error.message : "Cart update failed" };
+  return {
+    message: error instanceof Error ? error.message : "Cart update failed",
+  };
 }
 
 function mergeErrorGroups(left: CartErrorGroup, right: CartErrorGroup): CartErrorGroup {
@@ -916,7 +919,10 @@ function withAdditionMerchandise(
   const product = products.find((candidate) => candidate.id === addition.merchandiseId);
   if (!product) return line;
   const { price: _price, ...merchandise } = product;
-  return { ...line, merchandise: merchandise as unknown as CartLine["merchandise"] };
+  return {
+    ...line,
+    merchandise: merchandise as unknown as CartLine["merchandise"],
+  };
 }
 
 function replaceOrPrependLine(
@@ -1079,7 +1085,10 @@ export const CART_TRANSACTION_TYPES = defineTransactionTypes({
 
       const addedQuantity = payload.lines.reduce((total, line) => total + line.quantity, 0);
       const data = setLines(
-        { ...state.data, totalQuantity: state.data.totalQuantity + addedQuantity },
+        {
+          ...state.data,
+          totalQuantity: state.data.totalQuantity + addedQuantity,
+        },
         linesChanged ? lines : getLines(state.data),
       );
       return { ...state, data };
@@ -1189,7 +1198,10 @@ export const CART_TRANSACTION_TYPES = defineTransactionTypes({
       if (options.mergeServerCart) {
         return { ...state, data: mergeAuthoritativeCartData(state.data, cart) };
       }
-      return { ...state, data: { ...state.data, discountCodes: cart.discountCodes } };
+      return {
+        ...state,
+        data: { ...state.data, discountCodes: cart.discountCodes },
+      };
     },
     getSignalKeys: () => DISCOUNT_CODES_KEY,
     getPendingKeys: (state, payload) => {
@@ -1231,7 +1243,10 @@ export const CART_TRANSACTION_TYPES = defineTransactionTypes({
         );
       }
       if (!result.cart || (result.userErrors?.length ?? 0) > 0) return state;
-      return { ...state, data: { ...state.data, attributes: payload.attributes } };
+      return {
+        ...state,
+        data: { ...state.data, attributes: payload.attributes },
+      };
     },
     getSignalKeys: () => ATTRIBUTES_KEY,
   },
@@ -1377,7 +1392,11 @@ function trimPendingTransaction<TType extends TransactionType>(
     );
     if (!trimmed) return undefined;
     remaining = trimmed;
-    nextIdentity = { ...identity, pendingKeys: undefined, errorKeys: undefined };
+    nextIdentity = {
+      ...identity,
+      pendingKeys: undefined,
+      errorKeys: undefined,
+    };
   }
   return createPendingTransaction(
     store,
@@ -1553,6 +1572,10 @@ function markOverlappingTransactionForRevalidation(
   }
   transaction.requiresRevalidation = true;
   for (const pending of store.transactions) pending.requiresRevalidation = true;
+  requestCartRevalidation(store);
+}
+
+function requestCartRevalidation(store: CartStoreContext): void {
   store.revalidation.requested = true;
   store.revalidation.visible = true;
   store.revalidation.active?.controller.abort();
@@ -1584,7 +1607,10 @@ function withTransactionEventToken(
       ...options,
       event: {
         ...options?.event,
-        detail: { ...options?.event?.detail, [TRANSACTION_EVENT_TOKEN_KEY]: token },
+        detail: {
+          ...options?.event?.detail,
+          [TRANSACTION_EVENT_TOKEN_KEY]: token,
+        },
       },
     });
 }
@@ -2131,6 +2157,7 @@ export function createCartStore<TData extends CartData = CartData>(
     getState: () => store.observable.state,
     subscribe: (listener) => store.observable.subscribe(listener),
     fetch: () => loadCartInStore(store),
+    refresh: () => refreshCartInStore(store),
     reset: () => resetCartStore(store),
     handleFormSubmit: (event, eventDetail) =>
       handleFormSubmitInStore(store, handlers, event, eventDetail),
@@ -2317,7 +2344,9 @@ export function getShopifyStandardActions(): Promise<ShopifyStandardActions> {
     };
 
     if (typeof document !== "undefined" && document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", configure, { once: true });
+      document.addEventListener("DOMContentLoaded", configure, {
+        once: true,
+      });
       return;
     }
     configure();
@@ -2412,6 +2441,7 @@ function isCurrentCartRevalidationRequest(
   request: ActiveCartRevalidation,
 ): boolean {
   return (
+    !request.controller.signal.aborted &&
     store.revalidation.active === request &&
     store.generation === request.generation &&
     store.mutationRevision === request.mutationRevision &&
@@ -2426,6 +2456,13 @@ function isCurrentCartRevalidation(
   cart: CartData,
 ): boolean {
   return isCurrentCartRevalidationRequest(store, request) && cart.id === request.cartId;
+}
+
+function refreshCartInStore(store: CartStoreContext): void {
+  if (!store.settled.data.id) return;
+  requestCartRevalidation(store);
+  publishVisibleState(store);
+  revalidateCartWhenIdle(store);
 }
 
 function revalidateCartWhenIdle(store: CartStoreContext): void {
@@ -2490,7 +2527,10 @@ async function refreshCheckoutUrl(store: CartStoreContext): Promise<void> {
   if (!cart || (current.data.id && current.data.id !== cart.id)) return;
   const checkoutUrl = cart.checkoutUrl ?? null;
   if (current.data.checkoutUrl === checkoutUrl) return;
-  store.settled = { ...store.settled, data: { ...store.settled.data, checkoutUrl } };
+  store.settled = {
+    ...store.settled,
+    data: { ...store.settled.data, checkoutUrl },
+  };
   publishVisibleState(store);
 }
 

--- a/packages/hydrogen/src/core/cart/cart.ts
+++ b/packages/hydrogen/src/core/cart/cart.ts
@@ -101,6 +101,10 @@ export type CartStore = {
   getState(): CartState;
   subscribe(listener: (state: CartState) => void): () => void;
   fetch(): Promise<void>;
+  /**
+   * Reconciles the cart after an out-of-band mutation: revalidates the current
+   * cart, or loads one when none is present yet (e.g. just created server-side).
+   */
   refresh(): void;
   reset(): void;
   handleFormSubmit(event: SubmitEvent, eventDetail?: Record<string, unknown>): Promise<void>;
@@ -2459,7 +2463,16 @@ function isCurrentCartRevalidation(
 }
 
 function refreshCartInStore(store: CartStoreContext): void {
-  if (!store.settled.data.id) return;
+  // With no local cart, an out-of-band mutation may have just created one
+  // server-side (e.g. cartCreate writing the cart cookie). A same-cart
+  // revalidation would have nothing to target, so discover the cart with a
+  // full load instead of no-oping.
+  if (!store.settled.data.id) {
+    void loadCartInStore(store).catch((error: unknown) =>
+      log.error("cart refresh load failed", { error }),
+    );
+    return;
+  }
   requestCartRevalidation(store);
   publishVisibleState(store);
   revalidateCartWhenIdle(store);

--- a/packages/hydrogen/src/core/cart/cart.ts
+++ b/packages/hydrogen/src/core/cart/cart.ts
@@ -223,7 +223,8 @@ type ActiveCartLoad = {
 };
 
 type ActiveCartRevalidation = {
-  cartId: string;
+  // Null for a discovery load (no local cart to target).
+  cartId: string | null;
   controller: AbortController;
   generation: number;
   mutationRevision: number;
@@ -2399,8 +2400,8 @@ async function fetchCart(
   return { cart: result.cart };
 }
 
-function fetchCartData(cartId?: string | null): Promise<CartData | null> {
-  return fetchCart(cartId).then(({ cart }) =>
+function fetchCartData(cartId?: string | null, signal?: AbortSignal): Promise<CartData | null> {
+  return fetchCart(cartId, signal).then(({ cart }) =>
     cart
       ? {
           ...cart,
@@ -2454,25 +2455,42 @@ function isCurrentCartRevalidationRequest(
   );
 }
 
-function isCurrentCartRevalidation(
+// Merges authoritative fields for a same-cart revalidation, or adopts a
+// discovered cart when the refresh had no cart id.
+function applyCartRevalidation(
   store: CartStoreContext,
   request: ActiveCartRevalidation,
-  cart: CartData,
-): boolean {
-  return isCurrentCartRevalidationRequest(store, request) && cart.id === request.cartId;
+  cart: CartData | null,
+): void {
+  if (!isCurrentCartRevalidationRequest(store, request)) return;
+
+  if (request.cartId === null) {
+    // A null result isn't an error (an out-of-band creation hasn't propagated
+    // yet); adopt the cart once it appears. hydrateCartInStore resets
+    // revalidation state.
+    if (cart) {
+      hydrateCartInStore(store, cart);
+      return;
+    }
+    store.revalidation.visible = false;
+    publishVisibleState(store);
+    return;
+  }
+
+  if (!cart) throw new Error(CART_REVALIDATION_ERROR_MESSAGE);
+  if (cart.id !== request.cartId) return;
+  store.settled = {
+    ...store.settled,
+    data: mergeAuthoritativeCartData(store.settled.data, cart),
+  };
+  store.revalidation.visible = false;
+  publishVisibleState(store);
 }
 
 function refreshCartInStore(store: CartStoreContext): void {
-  // With no local cart, an out-of-band mutation may have just created one
-  // server-side (e.g. cartCreate writing the cart cookie). A same-cart
-  // revalidation would have nothing to target, so discover the cart with a
-  // full load instead of no-oping.
-  if (!store.settled.data.id) {
-    void loadCartInStore(store).catch((error: unknown) =>
-      log.error("cart refresh load failed", { error }),
-    );
-    return;
-  }
+  // Reconcile through the queue so the refresh stays non-blocking. With no cart
+  // id, revalidateCartWhenIdle waits for in-flight work then discovers a cart
+  // created out of band.
   requestCartRevalidation(store);
   publishVisibleState(store);
   revalidateCartWhenIdle(store);
@@ -2488,30 +2506,19 @@ function revalidateCartWhenIdle(store: CartStoreContext): void {
     return;
   }
 
-  const cartId = store.settled.data.id;
-  if (!cartId) {
-    store.revalidation.requested = false;
-    store.revalidation.visible = false;
-    publishVisibleState(store);
-    return;
-  }
-
   store.revalidation.requested = false;
   clearProjectedErrors(store, [REVALIDATION_ERROR_KEY]);
   publishVisibleState(store);
+
+  // No cart id: discover one with a full-cart load instead of revalidating.
+  const cartId = store.settled.data.id;
   const controller = new AbortController();
   let request: ActiveCartRevalidation;
-  const promise = fetchCartRevalidationData(cartId, controller.signal)
-    .then((cart) => {
-      if (!cart) throw new Error(CART_REVALIDATION_ERROR_MESSAGE);
-      if (!isCurrentCartRevalidation(store, request, cart)) return;
-      store.settled = {
-        ...store.settled,
-        data: mergeAuthoritativeCartData(store.settled.data, cart),
-      };
-      store.revalidation.visible = false;
-      publishVisibleState(store);
-    })
+  const revalidationFetch = cartId
+    ? fetchCartRevalidationData(cartId, controller.signal)
+    : fetchCartData(null, controller.signal);
+  const promise = revalidationFetch
+    .then((cart) => applyCartRevalidation(store, request, cart))
     .catch((error: unknown) => {
       if (isAbortError(error) || !isCurrentCartRevalidationRequest(store, request)) return;
       store.revalidation.visible = false;

--- a/packages/hydrogen/src/core/cart/cart.ts
+++ b/packages/hydrogen/src/core/cart/cart.ts
@@ -2478,7 +2478,14 @@ function applyCartRevalidation(
   }
 
   if (!cart) throw new Error(CART_REVALIDATION_ERROR_MESSAGE);
-  if (cart.id !== request.cartId) return;
+  if (cart.id !== request.cartId) {
+    // A configured endpoint resolves the cart from its cookie, which an external
+    // operation can swap for a different cart. Treat the response as an
+    // authoritative replacement; hydrateCartInStore adopts it and clears
+    // revalidation state so clients don't stay stuck with revalidating: true.
+    hydrateCartInStore(store, cart);
+    return;
+  }
   store.settled = {
     ...store.settled,
     data: mergeAuthoritativeCartData(store.settled.data, cart),
@@ -2488,6 +2495,15 @@ function applyCartRevalidation(
 }
 
 function refreshCartInStore(store: CartStoreContext): void {
+  // Publishing over an in-flight initial load invalidates it (the ready state
+  // carries the load's identity), which would discard the fetched cart. Wait
+  // for the load to settle, then reconcile against whatever cart it produced.
+  const activeCartLoad = store.activeCartLoad;
+  if (activeCartLoad) {
+    const runAfterLoad = () => refreshCartInStore(store);
+    activeCartLoad.promise.then(runAfterLoad, runAfterLoad);
+    return;
+  }
   // Reconcile through the queue so the refresh stays non-blocking. With no cart
   // id, revalidateCartWhenIdle waits for in-flight work then discovers a cart
   // created out of band.

--- a/packages/hydrogen/src/core/product/product-form.test.ts
+++ b/packages/hydrogen/src/core/product/product-form.test.ts
@@ -387,6 +387,7 @@ function createMockCartStore(initialState?: CartStateOverrides): CartStore & {
     getState: () => observable.state,
     subscribe: (listener: (state: CartState) => void) => observable.subscribe(listener),
     fetch: vi.fn(() => Promise.resolve()),
+    refresh: vi.fn(),
     reset: vi.fn(),
     handleFormSubmit: vi.fn(() => Promise.resolve()),
     _setState: (next) => observable.setState(next),

--- a/packages/hydrogen/src/react/cart.test.tsx
+++ b/packages/hydrogen/src/react/cart.test.tsx
@@ -17,6 +17,7 @@ import {
   configureCartEndpoint,
   createCartComponents,
   useCart,
+  useCartActions,
   useCartForm,
   useOptionalCart,
 } from "./cart";
@@ -123,6 +124,7 @@ function createMockStore(initialData?: MockInitialData): MockCartStore {
       };
     }),
     fetch: vi.fn(() => Promise.resolve()),
+    refresh: vi.fn(),
     reset: vi.fn(),
     handleFormSubmit: vi.fn(() => Promise.resolve()),
     setReadyPromise(readyPromise: Promise<void> | undefined) {
@@ -195,6 +197,35 @@ describe("CartProvider", () => {
     expect(createCartStore).toHaveBeenCalledWith({ initialData: undefined });
     expect(latestStore.connect).toHaveBeenCalledTimes(1);
     expect(latestStore.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("useCartActions", () => {
+  it("refreshes the cart store", () => {
+    let actions: ReturnType<typeof useCartActions> | undefined;
+
+    function Consumer() {
+      actions = useCartActions();
+      return null;
+    }
+
+    render(createElement(CartProvider, null, createElement(Consumer)));
+    assert(actions, "Expected cart actions to be available");
+
+    actions.refresh();
+
+    expect(latestStore.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a hook-specific error outside CartProvider", () => {
+    function Consumer() {
+      useCartActions();
+      return null;
+    }
+
+    expect(() => render(createElement(Consumer))).toThrow(
+      "useCartActions must be used inside <CartProvider>",
+    );
   });
 });
 

--- a/packages/hydrogen/src/react/cart.tsx
+++ b/packages/hydrogen/src/react/cart.tsx
@@ -48,6 +48,9 @@ type TypedCartProviderProps<TData extends CartData> = {
 type CartInitialData<TData extends CartData = CartData> =
   CreateCartStoreOptions<TData>["initialData"];
 
+/** Actions for reconciling cart state after updates outside Standard Actions. */
+export type CartActions = Pick<CartStore, "refresh">;
+
 type TypedCartComponents<TData extends CartData> = {
   CartProvider: (props: TypedCartProviderProps<TData>) => ReactNode;
   useCart: <S>(selector: (state: CartState<TData>) => S, isEqual?: (a: S, b: S) => boolean) => S;
@@ -59,6 +62,7 @@ type TypedCartComponents<TData extends CartData> = {
     selector: (state: CartState<TData>) => S,
     isEqual?: (a: S, b: S) => boolean,
   ) => S | undefined;
+  useCartActions: typeof useCartActions;
   useCartForm: typeof useCartForm;
 };
 
@@ -103,13 +107,14 @@ export function createCartComponents<THandlers>(): TypedCartComponents<
     useCart: useTypedCart,
     useSuspenseCart,
     useOptionalCart: useTypedOptionalCart,
+    useCartActions,
     useCartForm,
   } as const;
 }
 
-export function useCartStore(): CartStore {
+export function useCartStore(hookName = "useCart"): CartStore {
   const store = useContext(CartContext);
-  if (!store) throw new Error("useCart must be used inside <CartProvider>.");
+  if (!store) throw new Error(`${hookName} must be used inside <CartProvider>.`);
   return store;
 }
 
@@ -144,6 +149,13 @@ export function useCart<TData extends CartData = CartData, S = unknown>(
 ): S {
   const store = useCartStore();
   return useCartSelector(store, selector, isEqual) as S;
+}
+
+/** Returns actions that operate on the shared cart store. */
+export function useCartActions(): CartActions {
+  const store = useCartStore("useCartActions");
+
+  return useMemo(() => ({ refresh: store.refresh }), [store]);
 }
 
 export function useCartAnalytics(): void {

--- a/packages/hydrogen/src/react/cart.tsx
+++ b/packages/hydrogen/src/react/cart.tsx
@@ -151,7 +151,6 @@ export function useCart<TData extends CartData = CartData, S = unknown>(
   return useCartSelector(store, selector, isEqual) as S;
 }
 
-/** Returns actions that operate on the shared cart store. */
 export function useCartActions(): CartActions {
   const store = useCartStore("useCartActions");
 

--- a/packages/hydrogen/src/react/cart.type-test.ts
+++ b/packages/hydrogen/src/react/cart.type-test.ts
@@ -110,7 +110,11 @@ describe("createCartComponents", () => {
     expectTypeOf<Merchandise>().toHaveProperty("availableForSale");
   });
 
-  it("keeps cart form helpers available on typed components", () => {
+  it("keeps cart actions and form helpers available on typed components", () => {
+    expectTypeOf(typedCart.useCartActions).toBeFunction();
+    expectTypeOf<ReturnType<typeof typedCart.useCartActions>["refresh"]>().toEqualTypeOf<
+      () => void
+    >();
     expectTypeOf(typedCart.useCartForm).toBeFunction();
   });
 });

--- a/packages/hydrogen/src/react/index.ts
+++ b/packages/hydrogen/src/react/index.ts
@@ -1,7 +1,15 @@
 "use client";
 
 export type { ShopifyStandardActions } from "../../vendor/standard-actions";
-export { CartProvider, createCartComponents, useCart, useCartAnalytics, useCartForm } from "./cart";
+export {
+  CartProvider,
+  createCartComponents,
+  useCart,
+  useCartActions,
+  useCartAnalytics,
+  useCartForm,
+} from "./cart";
+export type { CartActions } from "./cart";
 export type { ShopifyGlobal } from "../globals";
 export type { QuantityInputAttributes, SetButtonAttributes } from "../core/cart/form";
 export {

--- a/packages/hydrogen/src/react/product.test.tsx
+++ b/packages/hydrogen/src/react/product.test.tsx
@@ -98,6 +98,7 @@ function createMockCartStore(initialData?: CartData | CartState | null): MockCar
       };
     }),
     fetch: vi.fn(() => Promise.resolve()),
+    refresh: vi.fn(),
     reset: vi.fn(),
     handleFormSubmit: vi.fn(() => Promise.resolve()),
     setState(next: CartState) {

--- a/packages/hydrogen/src/vue/cart.test.ts
+++ b/packages/hydrogen/src/vue/cart.test.ts
@@ -16,6 +16,7 @@ import {
   CartProvider,
   configureCartEndpoint,
   useCart,
+  useCartActions,
   useCartAnalytics,
   useCartForm,
   useOptionalCart,
@@ -97,6 +98,7 @@ function createMockStore(initialState: MockInitialData = { ...EMPTY_CART_STATE }
       };
     }),
     fetch: vi.fn(() => Promise.resolve()),
+    refresh: vi.fn(),
     reset: vi.fn(),
     handleFormSubmit: vi.fn(() => Promise.resolve()),
     setState(next: CartState) {
@@ -134,6 +136,30 @@ beforeEach(() => {
   vi.mocked(createCartStore).mockImplementation((options) => createMockStore(options?.initialData));
   configureCartEndpoint("/api/cart");
   delete (window as { Shopify?: unknown }).Shopify;
+});
+
+describe("useCartActions", () => {
+  it("refreshes the cart store", () => {
+    const actions = mountWithConsumer(() => ({
+      exposed: useCartActions(),
+      render: () => null,
+    }));
+
+    actions.refresh();
+
+    expect(latestStore.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a composable-specific error outside CartProvider", () => {
+    const Consumer = defineComponent({
+      setup() {
+        useCartActions();
+        return () => null;
+      },
+    });
+
+    expect(() => mount(Consumer)).toThrow("useCartActions must be used inside a <CartProvider>.");
+  });
 });
 
 describe("useCartAnalytics", () => {

--- a/packages/hydrogen/src/vue/cart.ts
+++ b/packages/hydrogen/src/vue/cart.ts
@@ -138,7 +138,6 @@ export function useCart<TData extends CartData = CartData, S = unknown>(
   return useCartSelector(store, resolve, isEqual) as Readonly<ShallowRef<S>>;
 }
 
-/** Returns actions that operate on the shared cart store. */
 export function useCartActions(): CartActions {
   const store = useCartStore("useCartActions");
   return { refresh: store.refresh };

--- a/packages/hydrogen/src/vue/cart.ts
+++ b/packages/hydrogen/src/vue/cart.ts
@@ -60,10 +60,14 @@ type TypedCartProvider<TData extends CartData> = {
   new (): { $props: { initialData?: CartInitialData<TData> } };
 };
 
+/** Actions for reconciling cart state after updates outside Standard Actions. */
+export type CartActions = Pick<CartStore, "refresh">;
+
 type TypedCartComponents<TData extends CartData> = {
   CartProvider: TypedCartProvider<TData>;
   useCart: TypedUseCart<TData>;
   useOptionalCart: TypedUseOptionalCart<TData>;
+  useCartActions: typeof useCartActions;
   useCartForm: typeof useCartForm;
 };
 
@@ -132,6 +136,12 @@ export function useCart<TData extends CartData = CartData, S = unknown>(
   const store = useCartStore("useCart");
   const resolve = selector ?? ((state: CartState<TData>) => state as unknown as S);
   return useCartSelector(store, resolve, isEqual) as Readonly<ShallowRef<S>>;
+}
+
+/** Returns actions that operate on the shared cart store. */
+export function useCartActions(): CartActions {
+  const store = useCartStore("useCartActions");
+  return { refresh: store.refresh };
 }
 
 export function useCartAnalytics(): void {
@@ -239,6 +249,7 @@ export function createCartComponents<THandlers>(): TypedCartComponents<
     CartProvider: TypedCartProvider,
     useCart: useTypedCart,
     useOptionalCart: useTypedOptionalCart,
+    useCartActions,
     useCartForm,
   };
 }

--- a/packages/hydrogen/src/vue/cart.type-test.ts
+++ b/packages/hydrogen/src/vue/cart.type-test.ts
@@ -48,4 +48,11 @@ describe("createCartComponents", () => {
     expectTypeOf<InitialCart>().toHaveProperty("attributes");
     expectTypeOf<Merchandise>().toHaveProperty("availableForSale");
   });
+
+  it("keeps cart actions available on typed components", () => {
+    expectTypeOf(typedCart.useCartActions).toBeFunction();
+    expectTypeOf<ReturnType<typeof typedCart.useCartActions>["refresh"]>().toEqualTypeOf<
+      () => void
+    >();
+  });
 });

--- a/packages/hydrogen/src/vue/index.ts
+++ b/packages/hydrogen/src/vue/index.ts
@@ -1,4 +1,5 @@
-export { createCartComponents, useCartAnalytics } from "./cart";
+export { createCartComponents, useCartActions, useCartAnalytics } from "./cart";
+export type { CartActions } from "./cart";
 export type { ShopifyGlobal } from "../globals";
 export {
   CollectionProvider,

--- a/packages/hydrogen/src/vue/product.test.ts
+++ b/packages/hydrogen/src/vue/product.test.ts
@@ -98,6 +98,7 @@ function createMockCartStore(initialData?: CartData | CartState | null): MockCar
       };
     }),
     fetch: vi.fn(() => Promise.resolve()),
+    refresh: vi.fn(),
     reset: vi.fn(),
     handleFormSubmit: vi.fn(() => Promise.resolve()),
     setState(next: CartState) {


### PR DESCRIPTION
TL;DR: Gives developers a way to refresh the client-side cart after something outside Hydrogen changes it — like a third-party app, a direct API call, or a webhook.

Today, if the cart gets changed outside of Hydrogen's built-in cart forms, the client has no idea until the next full page load. `refresh()` fixes that.

## Before

After an out-of-band cart change, the client-side cart is stale. No way to pull the latest state without a page reload.

## After

```tsx
import { useCartActions } from "~/lib/cart";

function CustomCartEditor() {
  const { refresh } = useCartActions();

  async function save() {
    await saveCustomCartData();
    refresh();
  }
}
```

`refresh()` is fire-and-forget. You can watch `state.revalidating` for progress and `state.errors.network` for failures. Existing cart data is preserved if the refresh fails.

## What this changes

- Adds `CartStore.refresh()` to the core cart store. It waits for any in-flight optimistic mutations to finish, fetches the cart from the configured endpoint, and merges the response — including custom fragment fields like metafields.
- Adds a `useCartActions()` hook for React and Vue. Both return `{ refresh }` and throw a clear error if used outside `<CartProvider>`.
- Exports `useCartActions` and the `CartActions` type from `@shopify/hydrogen/react` and `@shopify/hydrogen/vue`.
- Includes `useCartActions` in the `createCartComponents()` factory so typed cart setups get it automatically.
- Updates the `hydrogen-cart-ui` skill docs and React/Vue references with usage guidance.
- Adds a dependency map entry for the cart store API surface.

## Developer impact

Includes a **minor** changeset for `@shopify/hydrogen`. New exports only, nothing breaks.

Don't call `refresh()` after normal Hydrogen cart form submissions — those already sync the store automatically.

## Out of scope

- `refresh()` returns `void`, not a `Promise`. This is intentional — a newer `refresh()` call cancels the previous one, so there's no clear value a Promise would resolve to. Watch `state.revalidating` instead.
- Refresh errors and mutation errors look the same in `state.errors.network`. Fine for now; a separate error field could be added later without breaking anything.

## Risk

Low. The refresh reuses the store's existing revalidation pipeline — same concurrency guards, same abort handling, same staleness checks. No new state machine paths. Calling `refresh()` during an in-flight mutation is safe; it queues up and runs after.