### PR TITLE
Fix outdated Node.js version requirements in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 **Requirements:**
 
-- Node.js version 22.0.0 or higher
+- Node.js version 22 or 24
 
 Run the following commands to get started working on Hydrogen.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 **Requirements:**
 
-- Node.js version 16.14.0 or higher
+- Node.js version 22.0.0 or higher
 
 Run the following commands to get started working on Hydrogen.
 
@@ -12,7 +12,7 @@ Run the following commands to get started working on Hydrogen.
 | ----------------------------------------------- | --------------------------------------------- |
 | `git clone git@github.com:Shopify/hydrogen.git` | Clones the repo to your local computer        |
 | `pnpm install`                                  | Installs the dependencies with `pnpm`         |
-| `ppnpm run dev`                                  | Runs the `dev` command in all packages        |
+| `pnpm run dev`                                   | Runs the `dev` command in all packages        |
 | `pnpm run build`                                | `build`s packages for production distribution |
 
 ### Shopify Contributors

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Hydrogen legacy v1 has been moved [to a separate repo](https://github.com/Shopif
 
 **Requirements:**
 
-- Node.js version 18.0.0 or higher
+- Node.js version 22.0.0 or higher
 - `npm` (or your package manager of choice, such as `yarn` or `pnpm`)
 
 1. Install the latest version of Hydrogen:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Hydrogen legacy v1 has been moved [to a separate repo](https://github.com/Shopif
 
 **Requirements:**
 
-- Node.js version 22.0.0 or higher
+- Node.js version 22 or 24
 - `npm` (or your package manager of choice, such as `yarn` or `pnpm`)
 
 1. Install the latest version of Hydrogen:


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3969

The Node.js version requirements in `README.md` and `CONTRIBUTING.md` are both lower than what the repo supports.

Source of truth in the repo:

| Location | Requirement |
| --- | --- |
| `package.json` (root) `engines` | `^22 \|\| ^24` |
| `templates/skeleton/package.json` `engines` | `^22 \|\| ^24` |
| `packages/cli/package.json` `engines` | `^22 \|\| ^24` |
| `packages/mini-oxygen/package.json` `engines` | `^22 \|\| ^24` |
| `.nvmrc` | `v24` |
| CI (`ci.yml`) | Node 22 |

Documented today:

| File | Stated minimum |
| --- | --- |
| `README.md` | 18.0.0 |
| `CONTRIBUTING.md` | 16.14.0 |

I checked what actually happens on Node 18.20.8 before writing this, and the failure mode is worth knowing, because it is not an install-time error. Scaffolding via `npm create @shopify/hydrogen@latest` succeeds, and `npm install` succeeds with `EBADENGINE` warnings. `npm run dev` then crashes while loading `@shopify/cli` with `SyntaxError: Invalid regular expression flags`, which is the RegExp `v` flag requiring Node 20 or newer. Full detail and output are in #3969.

I used "22 or 24" rather than a minimum, since `^22 || ^24` excludes Node 23 and wording it as "22 or higher" would misstate the supported range. I went with 22 rather than the `.nvmrc` pin of 24 because 22 is both inside `engines` and the version CI runs, but happy to change both files to 24 if you would rather have the docs point at the version the team develops against.

### WHAT is this pull request doing?

- Updates the stated Node.js requirement to "22 or 24" in `README.md` and `CONTRIBUTING.md`.
- Fixes a typo in the getting started table in `CONTRIBUTING.md`, where `pnpm run dev` was written as `ppnpm run dev`.

I kept the diff to only the lines being corrected. Prettier reports pre-existing formatting differences in both files, but neither is covered by `format:check` (which is scoped to `./packages ./templates`), so I did not reformat them, as that would add a large amount of unrelated churn here. Happy to do that separately if it is wanted.

### HOW to test your changes?

1. Check the stated requirement in `README.md` and `CONTRIBUTING.md`.
2. Compare against `engines` in the root `package.json`, `templates/skeleton/package.json`, `packages/cli/package.json` and `packages/mini-oxygen/package.json`, and against `.nvmrc`.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<sub>Checklist notes: no changeset, since this touches only root markdown files and not `packages/*/src/**` or any `packages/*/package.json`. No tests, since there is no code change.</sub>
