### PR TITLE
Show an actionable error when a dependency's native binding is missing

### DIFF
--- a/.changeset/olive-donkeys-invent.md
+++ b/.changeset/olive-donkeys-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-hydrogen': patch
+---
+
+Show an actionable error when a project dependency fails to load its native binding — for example `rolldown` (used by Vite 8 and rolldown-vite) when its `@rolldown/binding-*` binary is missing from `node_modules` — instead of crashing with a raw stack trace.

--- a/packages/cli/src/lib/import-utils.test.ts
+++ b/packages/cli/src/lib/import-utils.test.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect, vi} from 'vitest';
 import {AbortError} from '@shopify/cli-kit/node/error';
-import {importVite} from './import-utils.js';
+import {importVite, missingNativeBindingError} from './import-utils.js';
 
 // Force `require.resolve('vite', ...)` to fail with MODULE_NOT_FOUND so we can
 // exercise the missing-vite path deterministically, while delegating every
@@ -35,6 +35,23 @@ vi.mock('node:module', async (importOriginal) => {
   };
 });
 
+// The package manager is detected from lockfiles on disk. Pin it so the
+// recovery steps are deterministic.
+vi.mock(
+  '@shopify/cli-kit/node/node-package-manager',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@shopify/cli-kit/node/node-package-manager')
+      >();
+
+    return {
+      ...actual,
+      getPackageManager: vi.fn(async () => 'pnpm' as const),
+    };
+  },
+);
+
 describe('importVite', () => {
   it('throws a handled AbortError when vite cannot be found in the project', async () => {
     const promise = importVite('/some/project/root');
@@ -43,5 +60,47 @@ describe('importVite', () => {
     await expect(promise).rejects.toThrowError(
       /Could not find the 'vite' package/,
     );
+  });
+});
+
+describe('missingNativeBindingError', () => {
+  it('names the failing dependency and the project package manager', async () => {
+    const error = new Error(
+      'Cannot find native binding. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828).',
+    );
+    error.stack = [
+      'Error: Cannot find native binding.',
+      '    at requireNative (/app/node_modules/rolldown/dist/shared/binding-CKyeQZen.mjs:597:34)',
+    ].join('\n');
+
+    const abortError = await missingNativeBindingError(error, '/app');
+    const nextSteps = (abortError.nextSteps ?? []).join(' ');
+
+    expect(abortError).toBeInstanceOf(AbortError);
+    expect(abortError.message).toMatch(/'rolldown'/);
+    expect(nextSteps).toMatch(/pnpm-lock\.yaml/);
+    expect(nextSteps).toMatch(/pnpm install/);
+  });
+
+  it('reads the dependency name out of a pnpm store path', async () => {
+    const error = new Error('Cannot find native binding.');
+    error.stack = [
+      'Error: Cannot find native binding.',
+      '    at requireNative (/app/node_modules/.pnpm/@ast-grep+napi@0.34.1/node_modules/@ast-grep/napi/index.js:10:1)',
+    ].join('\n');
+
+    const abortError = await missingNativeBindingError(error, '/app');
+
+    expect(abortError.message).toMatch(/'@ast-grep\/napi'/);
+  });
+
+  it('falls back to a generic message when the dependency is unknown', async () => {
+    const error = new Error('Cannot find native binding.');
+    error.stack = 'Error: Cannot find native binding.\n    at <anonymous>';
+
+    const abortError = await missingNativeBindingError(error, '/app');
+
+    expect(abortError).toBeInstanceOf(AbortError);
+    expect(abortError.message).toMatch(/A dependency could not load/);
   });
 });

--- a/packages/cli/src/lib/import-utils.ts
+++ b/packages/cli/src/lib/import-utils.ts
@@ -1,12 +1,71 @@
 import {createRequire} from 'node:module';
 import {pathToFileURL} from 'node:url';
 import {AbortError} from '@shopify/cli-kit/node/error';
-import {findUpAndReadPackageJson} from '@shopify/cli-kit/node/node-package-manager';
+import {
+  findUpAndReadPackageJson,
+  getPackageManager,
+  lockfilesByManager,
+} from '@shopify/cli-kit/node/node-package-manager';
 import {dirname, joinPath} from '@shopify/cli-kit/node/path';
 
 const require = createRequire(import.meta.url);
 
 export type Vite = typeof import('vite');
+
+// napi-rs loaders (rolldown, @ast-grep/napi, lightningcss...) throw this when
+// the platform-specific optional dependency is missing from node_modules.
+// That's a broken install in the user's project rather than a Hydrogen bug, so
+// it must not reach them as an unhandled crash.
+const MISSING_NATIVE_BINDING_MESSAGE = 'Cannot find native binding';
+
+function isMissingNativeBindingError(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    error.message.includes(MISSING_NATIVE_BINDING_MESSAGE)
+  );
+}
+
+/**
+ * Best-effort name of the dependency whose native binding failed to load,
+ * read from the topmost `node_modules` frame of the stack.
+ */
+function nativeBindingPackageName(error: Error): string | undefined {
+  const match = error.stack?.match(
+    /node_modules[\\/](?:\.pnpm[\\/][^\\/]+[\\/]node_modules[\\/])?(@[^\\/]+[\\/][^\\/]+|[^@][^\\/]*)/,
+  );
+
+  return match?.[1]?.replace(/\\/g, '/');
+}
+
+/**
+ * Turns a missing native binding failure into a handled error with recovery
+ * steps for the project's package manager. It is an `AbortError` so the CLI
+ * renders it as a user-facing error instead of reporting an unexpected crash.
+ */
+export async function missingNativeBindingError(
+  error: Error,
+  root: string,
+): Promise<AbortError> {
+  const packageManager = await getPackageManager(root);
+  const lockfile = lockfilesByManager[packageManager];
+  const installCommand =
+    packageManager === 'unknown' ? 'npm install' : `${packageManager} install`;
+  const packageName = nativeBindingPackageName(error);
+
+  return new AbortError(
+    packageName
+      ? `The '${packageName}' dependency could not load its native binding.`
+      : 'A dependency could not load its native binding.',
+    'The platform-specific binary for your operating system and CPU architecture is missing from node_modules. This is a dependency installation problem in your project, not a bug in the Hydrogen CLI.',
+    [
+      `Delete the \`node_modules\` directory${
+        lockfile ? ` and \`${lockfile}\`` : ''
+      } in your project.`,
+      `Run \`${installCommand}\` and try this command again.`,
+      'If it happens again, check that dependencies are not installed with `--no-optional`, and that the lockfile was not generated on a different operating system or CPU architecture.',
+    ],
+  );
+}
 
 export async function importVite(root: string): Promise<Vite> {
   let vitePath: string;
@@ -54,7 +113,17 @@ export async function importVite(root: string): Promise<Vite> {
     viteNodeIndexFile,
   );
 
-  return import(pathToFileURL(viteNodePath).href);
+  try {
+    return await import(pathToFileURL(viteNodePath).href);
+  } catch (error) {
+    // Vite 8 and rolldown-vite depend on rolldown, so a missing
+    // `@rolldown/binding-*` binary fails here while loading Vite itself.
+    if (isMissingNativeBindingError(error)) {
+      throw await missingNativeBindingError(error, root);
+    }
+
+    throw error;
+  }
 }
 
 export function importLocal<T>(packageName: string, path: string): Promise<T> {
@@ -63,5 +132,13 @@ export function importLocal<T>(packageName: string, path: string): Promise<T> {
     process.env.SHOPIFY_UNIT_TEST ? undefined : {paths: [path]},
   );
 
-  return import(pathToFileURL(realPath).href);
+  return (import(pathToFileURL(realPath).href) as Promise<T>).catch(
+    async (error: unknown) => {
+      if (isMissingNativeBindingError(error)) {
+        throw await missingNativeBindingError(error, path);
+      }
+
+      throw error;
+    },
+  );
 }


### PR DESCRIPTION
Every Hydrogen CLI command that loads the project's Vite (`dev`, `build`, `deploy`, `codegen`) pulls in rolldown on Vite 8 and rolldown-vite projects. When rolldown's platform-specific `@rolldown/binding-*` optional dependency is missing from `node_modules`, its napi loader throws `Cannot find native binding` and the CLI exits with an unhandled crash and a raw stack trace. We've been seeing a slow trickle of these in our error reports going back several CLI versions.

The CLI can't repair the install — the usual causes are https://github.com/npm/cli/issues/4828, a lockfile generated on a different OS/arch, installs with `--no-optional`, or a copied `node_modules`. What it can do is fail with something actionable.

This PR catches the failed dynamic import in `importVite` and `importLocal` and rethrows it as an `AbortError` that:

- names the failing dependency, read best-effort from the topmost `node_modules` frame of the stack (pnpm store paths included)
- gives recovery steps matched to the project's detected package manager: delete `node_modules` and the right lockfile, run the right install command
- calls out the `--no-optional` and cross-platform lockfile causes for repeat offenders

Because it's an `AbortError`, cli-kit renders it as a normal user-facing error instead of reporting an unexpected CLI crash. This covers `deploy` too: its build hook re-imports Vite through `importVite`, so Node's cached rejection gets wrapped the same way.

The recovery steps are worded without `rm -rf` on purpose — a good chunk of the reports come from Windows.

This intentionally only covers modules loaded through `importVite` and `importLocal`. Other native dependencies that fail the same way outside those paths would need a change in cli-kit's `errorMessageImpliesEnvironmentIssue` instead.

## Tophatting 🎩

You can simulate the broken install in any Vite 8 project:

```sh
rm -rf node_modules/@rolldown/binding-*
shopify hydrogen dev
```

Previously this crashed with a raw napi stack trace. Now it should exit with an error naming `rolldown` and steps to delete `node_modules` + the lockfile and reinstall.
