### PR TITLE
Add UCP business profile proxy on a generalized proxy interceptor

### DIFF
--- a/.changeset/ucp-business-profile-proxy.md
+++ b/.changeset/ucp-business-profile-proxy.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Serve Shopify's managed UCP business profile from headless storefront origins through `handleShopifyRoutes`.

--- a/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
+++ b/packages/hydrogen/skills/hydrogen-request-handlers/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Guide for wiring Hydrogen request handlers in server frameworks. Use when
   adding, modifying, or reviewing handleShopifyRoutes, handleShopifyRedirects,
   SFAPI proxy routes, cart, predictive search, and Customer Account server handlers,
-  checkout redirects, cart permalinks, AJAX cart proxy routes, /admin redirects, Storefront URL redirects,
+  UCP business profiles, checkout redirects, cart permalinks, AJAX cart proxy routes,
+  /admin redirects, Storefront URL redirects,
   requestContext response-header propagation, or framework middleware,
   not-found, and catch-all integration.
 ---
@@ -27,7 +28,13 @@ Request
   -> framework 404 page
 ```
 
-`handleShopifyRoutes` owns Hydrogen routes the framework should never see: SFAPI proxy URLs, `/checkout`, cart permalinks like `/cart/{variantId}:{quantity}`, AJAX cart URLs like `/cart.js` and `/cart/add.js`, `/api/mcp`, `/agent/*`, `/graphiql` in development, Liquid-style `?variant=<numeric id>` product URLs, and app-registered handler groups such as `createCartServerHandlers()` or `createCustomerAccountServerHandlers()`.
+`handleShopifyRoutes` owns Hydrogen routes the framework should never see: SFAPI proxy URLs, `/.well-known/ucp`, `/checkout`, cart permalinks like `/cart/{variantId}:{quantity}`, AJAX cart URLs like `/cart.js` and `/cart/add.js`, `/api/mcp`, `/agent/*`, `/graphiql` in development, Liquid-style `?variant=<numeric id>` product URLs, and app-registered handler groups such as `createCartServerHandlers()` or `createCustomerAccountServerHandlers()`.
+
+## UCP Business Profile
+
+`GET /.well-known/ucp` serves Shopify's managed UCP business profile from the headless storefront origin. Hydrogen fetches the profile without shopper cookies or authorization, preserves Shopify's status and validation headers, and applies edge-first caching only to successful responses. Upstream errors and unpublished profiles are returned with `Cache-Control: no-store`.
+
+Serve the storefront over HTTPS and wire `handleShopifyRoutes` before framework routing so the profile is available without an app-owned route. Return the matched response directly without adding session headers or applying request-context headers again.
 
 ## Variant Id Redirects
 
@@ -96,12 +103,13 @@ import { createCustomerAccountServerHandlers } from "@shopify/hydrogen/customer-
 
 Run the app in dev and production modes, then check:
 
-1. `POST /api/{api-version}/graphql.json` returns Storefront API JSON, not the app 404.
-2. `GET /api/cart` returns cart handler JSON when cart handlers are registered. With no cart id, the body is `{cart: null}` and no Storefront API cart lookup is made.
-3. `GET /api/predictive-search?q=snow` returns predictive search JSON when predictive search handlers are registered.
-4. `GET /account/login`, `GET /account/authorize`, `GET /account/refresh`, and `POST /account/logout` are handled before the app router when Customer Account handlers are registered.
-5. `GET /admin` returns a redirect to the shop admin URL.
-6. An unknown path returns the framework 404 when no Shopify redirect exists.
-7. `GET /products/{handle}?variant={numeric id}` returns a 302 to the option-params URL when `routeTemplates` is passed to `handleShopifyRoutes`; `?variant=garbage` falls through to the product page.
-8. Cart, predictive search, Customer Account, and SFAPI responses preserve `Set-Cookie` and `Server-Timing` headers where the framework exposes them.
-9. Authenticated Customer Account responses do not preserve public or CDN cache-control headers.
+1. `GET /.well-known/ucp` returns Shopify's UCP business profile with a public cache policy and no shopper cookies.
+2. `POST /api/{api-version}/graphql.json` returns Storefront API JSON, not the app 404.
+3. `GET /api/cart` returns cart handler JSON when cart handlers are registered. With no cart id, the body is `{cart: null}` and no Storefront API cart lookup is made.
+4. `GET /api/predictive-search?q=snow` returns predictive search JSON when predictive search handlers are registered.
+5. `GET /account/login`, `GET /account/authorize`, `GET /account/refresh`, and `POST /account/logout` are handled before the app router when Customer Account handlers are registered.
+6. `GET /admin` returns a redirect to the shop admin URL.
+7. An unknown path returns the framework 404 when no Shopify redirect exists.
+8. `GET /products/{handle}?variant={numeric id}` returns a 302 to the option-params URL when `routeTemplates` is passed to `handleShopifyRoutes`; `?variant=garbage` falls through to the product page.
+9. Cart, predictive search, Customer Account, and SFAPI responses preserve `Set-Cookie` and `Server-Timing` headers where the framework exposes them.
+10. Authenticated Customer Account responses do not preserve public or CDN cache-control headers.

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -207,13 +207,12 @@ describe("handleShopifyRoutes", () => {
     });
 
     assert(result, "expected UCP response");
-    expect(mockFetch).toHaveBeenCalledWith(
-      new URL("https://test-store.myshopify.com/.well-known/ucp"),
-      expect.objectContaining({
-        headers: { accept: "application/json" },
-        redirect: "manual",
-      }),
-    );
+    const ucpCall = mockFetch.mock.calls[0];
+    assert(ucpCall, "expected fetch to be called");
+    const [ucpUrl, ucpInit] = ucpCall;
+    expect(ucpUrl.href).toBe("https://test-store.myshopify.com/.well-known/ucp");
+    expect(ucpInit.redirect).toBe("manual");
+    expect([...new Headers(ucpInit.headers)]).toEqual([["accept", "application/json"]]);
     expect(result.headers.get("cache-control")).toBe(
       "public, max-age=60, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400",
     );

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.test.ts
@@ -189,6 +189,39 @@ describe("handleShopifyRoutes", () => {
     expect(result).toBeInstanceOf(Response);
   });
 
+  it("returns the UCP business profile from the Online Store origin", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('{"ucp":{"version":"2026-01-11"}}', {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "set-cookie": "shopper=secret",
+        },
+      }),
+    );
+
+    const result = await handleShopifyRoutes({
+      request: new Request("https://my-app.com/.well-known/ucp", {
+        headers: { accept: "text/html", cookie: "shopper=secret" },
+      }),
+    });
+
+    assert(result, "expected UCP response");
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL("https://test-store.myshopify.com/.well-known/ucp"),
+      expect.objectContaining({
+        headers: { accept: "application/json" },
+        redirect: "manual",
+      }),
+    );
+    expect(result.headers.get("cache-control")).toBe(
+      "public, max-age=60, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400",
+    );
+    expect(result.headers.get("set-cookie")).toBeNull();
+    expect(result.headers.get("server-timing")).toBeNull();
+    expect(result.headers.get("powered-by")).toBe("Shopify, Hydrogen");
+  });
+
   it("returns the Apple Pay domain association from the Online Store origin", async () => {
     mockFetch.mockResolvedValueOnce(
       new Response("association-file", {

--- a/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
+++ b/packages/hydrogen/src/core/request-routing/handle-shopify-routes.ts
@@ -5,6 +5,7 @@ import { handleShopifyApiProxy } from "./interceptors/api-proxy";
 import { handleCheckoutRedirect } from "./interceptors/checkout";
 import { handleMcpProxy } from "./interceptors/mcp-proxy";
 import { handleSfapiProxy } from "./interceptors/sfapi-proxy";
+import { handleUcpProxy } from "./interceptors/ucp";
 import { handleWellKnownProxy } from "./interceptors/well-known";
 import { handleShopifyRouteHandlers } from "./registered-routes";
 import type { HydrogenRouteHandler, HydrogenRouteInterceptor } from "./route-types";
@@ -16,6 +17,7 @@ const SHOPIFY_ROUTE_INTERCEPTORS = [
   handleProductVariantId,
   handleShopifyRouteHandlers,
   handleCheckoutRedirect,
+  handleUcpProxy,
   handleWellKnownProxy,
   handleMcpProxy,
   handleAgentProxy,

--- a/packages/hydrogen/src/core/request-routing/interceptors/proxy.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/proxy.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { configureLogging, resetLoggingForTests } from "../../logging";
+import { createShopifyRequestContext } from "../../request-context";
+import { assert, createTestLogger } from "../../test-utils";
+import type { HydrogenRouteInterceptor } from "../route-types";
+import { createProxyInterceptor } from "./proxy";
+
+const STORE_URL = "https://test-store.myshopify.com";
+
+function run(
+  interceptor: HydrogenRouteInterceptor,
+  request: Request,
+  { storeUrl = STORE_URL }: { storeUrl?: string } = {},
+) {
+  const requestContext = createShopifyRequestContext({
+    request,
+    i18n: { country: "US", language: "EN" },
+  });
+
+  return interceptor(new URL(request.url), {
+    request,
+    requestContext,
+    sessionManager: {
+      getSessionOrigin: () => new URL(request.url).origin,
+      getSessionItem: () => undefined,
+      setSessionItem: () => undefined,
+      removeSessionItem: () => undefined,
+    },
+    storefrontClient: {
+      type: "public",
+      i18n: { country: "US", language: "EN", pathPrefix: "" },
+      storeUrl,
+      apiUrl: `${storeUrl}/api/2026-04/graphql.json`,
+      requestContext,
+      graphql: vi.fn(),
+    },
+  });
+}
+
+async function getResponse(result: ReturnType<HydrogenRouteInterceptor>): Promise<Response> {
+  assert(result, "expected a proxy response");
+  return result;
+}
+
+describe("createProxyInterceptor", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockResolvedValue(new Response("ok"));
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    resetLoggingForTests();
+  });
+
+  it("returns a 500 error response instead of throwing when the upstream URL is invalid", async () => {
+    const logger = createTestLogger();
+    configureLogging({ logger });
+    const interceptor = createProxyInterceptor({
+      match: /.*/,
+      scope: "test-proxy",
+      requestHeaders: { allow: [] },
+    });
+
+    let result: ReturnType<HydrogenRouteInterceptor> | undefined;
+    expect(() => {
+      result = run(interceptor, new Request("https://app.example/anything"), {
+        storeUrl: "::not-a-valid-url::",
+      });
+    }).not.toThrow();
+
+    assert(result, "expected the interceptor to return a result");
+    const response = await getResponse(result);
+    expect(response.status).toBe(500);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      "request failed",
+      expect.objectContaining({ scope: "test-proxy" }),
+    );
+  });
+
+  it("forwards no request headers for an empty allowlist with storefront headers off", async () => {
+    const interceptor = createProxyInterceptor({
+      match: /.*/,
+      scope: "test-proxy",
+      requestHeaders: { allow: [], applyStorefrontHeaders: false },
+    });
+
+    await run(
+      interceptor,
+      new Request("https://app.example/x", {
+        headers: { authorization: "Bearer secret", cookie: "a=b" },
+      }),
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    expect([...new Headers(call[1].headers)]).toEqual([]);
+  });
+
+  it("rejects a response: drains the upstream body, returns the from-scratch error, and leaks no upstream headers", async () => {
+    const cancel = vi.fn();
+    const upstreamBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("UPSTREAM-BYTES"));
+      },
+      cancel,
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(upstreamBody, {
+        status: 302,
+        headers: {
+          location: "https://elsewhere.example/",
+          "set-cookie": "shopper=secret",
+          "content-type": "text/plain",
+        },
+      }),
+    );
+
+    const interceptor = createProxyInterceptor({
+      match: /.*/,
+      scope: "test-proxy",
+      requestHeaders: { allow: [] },
+      responseValidation: (upstream) =>
+        upstream.status >= 300 && upstream.status < 400
+          ? {
+              status: 502,
+              body: { error: "rejected" },
+              headers: { "cache-control": "no-store" },
+            }
+          : null,
+    });
+
+    const response = await getResponse(run(interceptor, new Request("https://app.example/x")));
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("set-cookie")).toBeNull();
+    await expect(response.json()).resolves.toEqual({ error: "rejected" });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the setup->500 / fetch->502 split when mapError is omitted", async () => {
+    const setupThrows = createProxyInterceptor({
+      match: /.*/,
+      scope: "test-proxy",
+      requestHeaders: { allow: [] },
+      rewritePathname: () => {
+        throw new Error("boom");
+      },
+    });
+    const setup = await getResponse(run(setupThrows, new Request("https://app.example/x")));
+    expect(setup.status).toBe(500);
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    const fetchFails = createProxyInterceptor({
+      match: /.*/,
+      scope: "test-proxy",
+      requestHeaders: { allow: [] },
+    });
+    mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+    const fetched = await getResponse(run(fetchFails, new Request("https://app.example/x")));
+    expect(fetched.status).toBe(502);
+  });
+});

--- a/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/proxy.ts
@@ -4,6 +4,8 @@ import type { HydrogenRouteInterceptor, HydrogenRoutesOptions } from "../route-t
 
 const PROXY_TIMEOUT_MS = 30_000;
 
+type ScopedLogger = ReturnType<typeof getLogger>;
+
 type PrepareHeaders = (headers: Headers, options: HydrogenRoutesOptions, url: URL) => void;
 
 type ProxyRequestHeaderOptions = (
@@ -11,11 +13,51 @@ type ProxyRequestHeaderOptions = (
   | { allow?: never; deny: readonly string[] }
 ) & {
   prepare?: PrepareHeaders;
+
+  applyStorefrontHeaders?: boolean;
 };
 
-type ProxyResponseHeaderOptions = {
-  prepare?: PrepareHeaders;
+type ProxyUpstreamInfo = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Headers;
 };
+
+type ProxyResponseHeaderMode = "forward" | { allow: readonly string[] };
+
+type ProxyResponseHeaderInjector = (
+  upstream: ProxyUpstreamInfo,
+  options: HydrogenRoutesOptions,
+  url: URL,
+) => Record<string, string> | void;
+
+type ProxyResponseHeaderOptions = {
+  mode?: ProxyResponseHeaderMode;
+  inject?: ProxyResponseHeaderInjector;
+  prepare?: PrepareHeaders;
+  consumeStorefrontHeaders?: boolean;
+};
+
+type ProxyResponseRejection = {
+  status: number;
+  body: unknown;
+  headers?: Record<string, string>;
+  logMessage?: string;
+  log?: Record<string, unknown>;
+};
+
+type ProxyResponseValidation = (
+  upstream: ProxyUpstreamInfo,
+  options: HydrogenRoutesOptions,
+  url: URL,
+) => ProxyResponseRejection | null;
+
+type ProxyErrorPhase = "setup" | "fetch";
+
+type ProxyErrorMapping = { status?: number; headers?: Record<string, string> };
+
+type MapProxyError = (error: unknown, phase: ProxyErrorPhase) => ProxyErrorMapping;
 
 type ProxyDescriptor = {
   match: RegExp;
@@ -24,61 +66,124 @@ type ProxyDescriptor = {
   redirect?: RequestRedirect;
   scope: string;
   timeoutMs?: number;
+  forwardSearch?: boolean;
   rewritePathname?: (pathname: string) => string;
   requestHeaders: ProxyRequestHeaderOptions;
   responseHeaders?: ProxyResponseHeaderOptions;
+  responseValidation?: ProxyResponseValidation;
+  mapError?: MapProxyError;
 };
+
+type ProxyRequestInit = { upstreamUrl: URL; init: RequestInit & { duplex?: "half" } };
 
 export function createProxyInterceptor(descriptor: ProxyDescriptor): HydrogenRouteInterceptor {
   const log = getLogger(descriptor.scope);
   const formatError = descriptor.formatError ?? defaultFormatError;
 
   return (url, options) => {
-    const { request, storefrontClient } = options;
+    const { request } = options;
     if (!descriptor.match.test(url.pathname)) return null;
     if (descriptor.methods && !descriptor.methods.includes(request.method)) return null;
 
-    let upstreamUrl: URL;
-    let init: RequestInit & { duplex?: "half" };
+    let requestInit: ProxyRequestInit;
     try {
-      const upstreamPathname = descriptor.rewritePathname?.(url.pathname) ?? url.pathname;
-      upstreamUrl = new URL(upstreamPathname + url.search, storefrontClient.storeUrl);
-      const forwardedHeaders = createProxyRequestHeaders(descriptor, request);
-      options.requestContext.applyStorefrontRequestHeaders(forwardedHeaders);
-      descriptor.requestHeaders.prepare?.(forwardedHeaders, options, url);
-
-      init = {
-        method: request.method,
-        body: request.body,
-        headers: forwardedHeaders,
-        signal: AbortSignal.timeout(descriptor.timeoutMs ?? PROXY_TIMEOUT_MS),
-        redirect: descriptor.redirect ?? "manual",
-      };
-
-      // Node's fetch requires this when forwarding a streaming request body.
-      if (request.body) init.duplex = "half";
+      requestInit = createProxyRequestInit(descriptor, options, url);
     } catch (error) {
       log.error("request failed", { error });
-      return Promise.resolve(createProxyErrorResponse(error, 500, formatError));
+      return Promise.resolve(
+        createProxyErrorResponse(error, "setup", descriptor.mapError, formatError),
+      );
     }
 
-    return fetch(upstreamUrl, init)
-      .then((upstreamResponse) => {
-        const headers = createProxyResponseHeaders(upstreamResponse.headers);
-        descriptor.responseHeaders?.prepare?.(headers, options, url);
-        options.requestContext.consumeStorefrontResponseHeaders(headers);
-
-        return new Response(upstreamResponse.body, {
-          status: upstreamResponse.status,
-          statusText: upstreamResponse.statusText,
-          headers,
-        });
-      })
+    return fetch(requestInit.upstreamUrl, requestInit.init)
+      .then((upstreamResponse) =>
+        buildProxyResponse(upstreamResponse, descriptor, options, url, log),
+      )
       .catch((error) => {
         log.error("request failed", { error });
-        return createProxyErrorResponse(error, 502, formatError);
+        return createProxyErrorResponse(error, "fetch", descriptor.mapError, formatError);
       });
   };
+}
+
+function createProxyRequestInit(
+  descriptor: ProxyDescriptor,
+  options: HydrogenRoutesOptions,
+  url: URL,
+): ProxyRequestInit {
+  const { request, storefrontClient } = options;
+  const upstreamPathname = descriptor.rewritePathname?.(url.pathname) ?? url.pathname;
+  const search = descriptor.forwardSearch === false ? "" : url.search;
+  const upstreamUrl = new URL(upstreamPathname + search, storefrontClient.storeUrl);
+  const headers = createProxyRequestHeaders(descriptor, request);
+  if (descriptor.requestHeaders.applyStorefrontHeaders !== false) {
+    options.requestContext.applyStorefrontRequestHeaders(headers);
+  }
+  descriptor.requestHeaders.prepare?.(headers, options, url);
+
+  const init: RequestInit & { duplex?: "half" } = {
+    method: request.method,
+    body: request.body,
+    headers,
+    signal: AbortSignal.timeout(descriptor.timeoutMs ?? PROXY_TIMEOUT_MS),
+    redirect: descriptor.redirect ?? "manual",
+  };
+
+  // Node's fetch requires this when forwarding a streaming request body.
+  if (request.body) init.duplex = "half";
+  return { upstreamUrl, init };
+}
+function buildProxyResponse(
+  upstreamResponse: Response,
+  descriptor: ProxyDescriptor,
+  options: HydrogenRoutesOptions,
+  url: URL,
+  log: ScopedLogger,
+): Response {
+  const upstream: ProxyUpstreamInfo = {
+    ok: upstreamResponse.ok,
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: upstreamResponse.headers,
+  };
+
+  const rejection = descriptor.responseValidation?.(upstream, options, url);
+  if (rejection) {
+    // Centralized drain: response hooks receive only a body-less view, so the factory
+    // owns the sole cancellation and no validator can leak the upstream connection.
+    upstreamResponse.body?.cancel().catch(() => {});
+    if (rejection.logMessage) log.error(rejection.logMessage, rejection.log ?? {});
+    return createProxyRejectionResponse(rejection);
+  }
+
+  const headers = buildProxyResponseHeaders(
+    upstreamResponse.headers,
+    descriptor.responseHeaders?.mode,
+  );
+  applyProxyResponseHeaders(headers, upstream, descriptor, options, url);
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers,
+  });
+}
+
+function applyProxyResponseHeaders(
+  headers: Headers,
+  upstream: ProxyUpstreamInfo,
+  descriptor: ProxyDescriptor,
+  options: HydrogenRoutesOptions,
+  url: URL,
+): void {
+  const injected = descriptor.responseHeaders?.inject?.(upstream, options, url);
+  if (injected) {
+    for (const [name, value] of Object.entries(injected)) headers.set(name, value);
+  }
+  descriptor.responseHeaders?.prepare?.(headers, options, url);
+  if (descriptor.responseHeaders?.consumeStorefrontHeaders !== false) {
+    options.requestContext.consumeStorefrontResponseHeaders(headers);
+  }
 }
 
 function defaultFormatError(message: string): { error: string } {
@@ -87,13 +192,23 @@ function defaultFormatError(message: string): { error: string } {
 
 function createProxyErrorResponse(
   error: unknown,
-  status: number,
+  phase: ProxyErrorPhase,
+  mapError: MapProxyError | undefined,
   formatError: (message: string) => unknown,
 ): Response {
   const message = error instanceof Error ? error.message : "Internal proxy error";
+  const mapping = mapError?.(error, phase);
+  const status = mapping?.status ?? (phase === "setup" ? 500 : 502);
   return new Response(JSON.stringify(formatError(message)), {
     status,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...mapping?.headers },
+  });
+}
+
+function createProxyRejectionResponse(rejection: ProxyResponseRejection): Response {
+  return new Response(JSON.stringify(rejection.body), {
+    status: rejection.status,
+    headers: { "content-type": "application/json", ...rejection.headers },
   });
 }
 
@@ -104,6 +219,22 @@ function createProxyRequestHeaders(descriptor: ProxyDescriptor, request: Request
     : new Headers(request.headers);
   for (const header of deny ?? []) headers.delete(header);
   return headers;
+}
+
+function buildProxyResponseHeaders(
+  upstreamHeaders: Headers,
+  mode?: ProxyResponseHeaderMode,
+): Headers {
+  if (mode && mode !== "forward") {
+    const headers = new Headers();
+    for (const name of mode.allow) {
+      const value = upstreamHeaders.get(name);
+
+      if (value) headers.set(name, value);
+    }
+    return headers;
+  }
+  return createProxyResponseHeaders(upstreamHeaders);
 }
 
 export function createProxyResponseHeaders(upstreamHeaders: Headers): Headers {

--- a/packages/hydrogen/src/core/request-routing/interceptors/ucp.test.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/ucp.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { configureLogging, resetLoggingForTests } from "../../logging";
+import { createShopifyRequestContext } from "../../request-context";
+import { assert, createTestLogger } from "../../test-utils";
+import { handleUcpProxy as handleUcpProxyImpl } from "./ucp";
+
+const STORE_URL = "https://test-store.myshopify.com";
+const UCP_PATH = "/.well-known/ucp";
+const UCP_CACHE_CONTROL =
+  "public, max-age=60, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400";
+
+function handleUcpProxy(request: Request) {
+  const requestContext = createShopifyRequestContext({
+    request,
+    i18n: { country: "US", language: "EN" },
+  });
+
+  return handleUcpProxyImpl(new URL(request.url), {
+    request,
+    requestContext,
+    sessionManager: {
+      getSessionOrigin: () => new URL(request.url).origin,
+      getSessionItem: () => undefined,
+      setSessionItem: () => undefined,
+      removeSessionItem: () => undefined,
+    },
+    storefrontClient: {
+      type: "private",
+      i18n: { country: "US", language: "EN", pathPrefix: "" },
+      storeUrl: STORE_URL,
+      apiUrl: `${STORE_URL}/api/2026-04/graphql.json`,
+      requestContext,
+      graphql: vi.fn(),
+    },
+  });
+}
+
+function getResponse(result: Awaited<ReturnType<typeof handleUcpProxy>>): Response {
+  assert(result, "expected UCP response");
+  return result;
+}
+
+describe("handleUcpProxy", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockResolvedValue(
+      new Response('{"ucp":{"version":"2026-01-11"}}', {
+        status: 200,
+        headers: {
+          "cache-control": "private, max-age=0",
+          "content-type": "application/json",
+          etag: '"profile-etag"',
+          "last-modified": "Thu, 27 Aug 2026 20:00:00 GMT",
+          "set-cookie": "shopper=secret",
+          vary: "Accept-Encoding",
+          "x-shopify-internal": "secret",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    resetLoggingForTests();
+  });
+
+  it("proxies the UCP profile to the Online Store origin", async () => {
+    const result = await handleUcpProxy(
+      new Request(`https://headless.example${UCP_PATH}?ignored=true`),
+    );
+
+    getResponse(result);
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const [url, init] = call;
+    expect(url.href).toBe(`${STORE_URL}${UCP_PATH}`);
+    expect(init.redirect).toBe("manual");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("only handles exact GET requests", async () => {
+    for (const request of [
+      new Request("https://headless.example/.well-known/ucp/"),
+      new Request(`https://headless.example${UCP_PATH}`, { method: "POST" }),
+    ]) {
+      expect(handleUcpProxy(request)).toBeNull();
+    }
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("does not forward shopper or conditional request headers", async () => {
+    await handleUcpProxy(
+      new Request(`https://headless.example${UCP_PATH}`, {
+        headers: {
+          accept: "text/html",
+          authorization: "Bearer secret",
+          cookie: "shopper=secret",
+          "if-none-match": '"old-profile"',
+          "user-agent": "commerce-agent",
+        },
+      }),
+    );
+
+    const call = mockFetch.mock.calls[0];
+    assert(call, "expected fetch to be called");
+    const headers = new Headers(call[1].headers);
+    expect([...headers]).toEqual([["accept", "application/json"]]);
+  });
+
+  it("streams successful profiles with edge-first caching and validation headers", async () => {
+    const response = getResponse(
+      await handleUcpProxy(new Request(`https://headless.example${UCP_PATH}`)),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(UCP_CACHE_CONTROL);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("etag")).toBe('"profile-etag"');
+    expect(response.headers.get("last-modified")).toBe("Thu, 27 Aug 2026 20:00:00 GMT");
+    expect(response.headers.get("vary")).toBe("Accept-Encoding");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("x-shopify-internal")).toBeNull();
+    await expect(response.json()).resolves.toEqual({ ucp: { version: "2026-01-11" } });
+  });
+
+  it.each([
+    [302, { location: "https://other.example/.well-known/ucp" }],
+    [200, { "content-type": "text/html" }],
+  ])("rejects invalid upstream responses", async (status, headers) => {
+    const logger = createTestLogger();
+    configureLogging({ logger });
+    mockFetch.mockResolvedValueOnce(new Response("invalid profile", { status, headers }));
+
+    const response = getResponse(
+      await handleUcpProxy(new Request(`https://headless.example${UCP_PATH}`)),
+    );
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("location")).toBeNull();
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid Shopify UCP profile response",
+    });
+    expect(logger.error).toHaveBeenCalledWith("invalid profile response", {
+      scope: "ucp-proxy",
+      status,
+      contentType: status === 200 ? "text/html" : "text/plain;charset=UTF-8",
+    });
+  });
+
+  it.each([404, 500])("does not cache upstream %s responses", async (status) => {
+    mockFetch.mockResolvedValueOnce(
+      Response.json(
+        { error: "upstream error" },
+        { status, headers: { "cache-control": "public" } },
+      ),
+    );
+
+    const response = getResponse(
+      await handleUcpProxy(new Request(`https://headless.example${UCP_PATH}`)),
+    );
+
+    expect(response.status).toBe(status);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it.each([
+    [new DOMException("Timed out", "TimeoutError"), 504],
+    [new Error("Connection refused"), 502],
+  ])("logs fetch failures and returns an uncached response", async (error, status) => {
+    const logger = createTestLogger();
+    configureLogging({ logger });
+    mockFetch.mockRejectedValueOnce(error);
+
+    const response = getResponse(
+      await handleUcpProxy(new Request(`https://headless.example${UCP_PATH}`)),
+    );
+
+    expect(response.status).toBe(status);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      error: "Unable to fetch the Shopify UCP profile",
+    });
+    expect(logger.error).toHaveBeenCalledWith("request failed", {
+      scope: "ucp-proxy",
+      error,
+    });
+  });
+});

--- a/packages/hydrogen/src/core/request-routing/interceptors/ucp.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/ucp.ts
@@ -1,0 +1,67 @@
+import { getLogger } from "../../logging";
+import { UCP_RE } from "../../url";
+import type { HydrogenRouteInterceptor } from "../route-types";
+
+const UCP_CACHE_CONTROL =
+  "public, max-age=60, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400";
+const UCP_NO_CACHE_CONTROL = "no-store";
+const UCP_PROFILE_PATH = "/.well-known/ucp";
+const UCP_FETCH_TIMEOUT_MS = 5_000;
+const UCP_RESPONSE_HEADERS = ["content-type", "etag", "last-modified", "vary"] as const;
+
+const log = getLogger("ucp-proxy");
+
+/**
+ * Serves Shopify's managed UCP business profile from the headless storefront origin.
+ */
+export const handleUcpProxy: HydrogenRouteInterceptor = (url, { request, storefrontClient }) => {
+  if (!UCP_RE.test(url.pathname) || request.method !== "GET") return null;
+
+  const upstreamUrl = new URL(UCP_PROFILE_PATH, storefrontClient.storeUrl);
+
+  return fetch(upstreamUrl, {
+    headers: { accept: "application/json" },
+    redirect: "manual",
+    signal: AbortSignal.timeout(UCP_FETCH_TIMEOUT_MS),
+  })
+    .then((upstreamResponse) => {
+      const contentType = upstreamResponse.headers.get("content-type");
+      const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
+      if (
+        (upstreamResponse.status >= 300 && upstreamResponse.status < 400) ||
+        (upstreamResponse.ok && mediaType !== "application/json")
+      ) {
+        log.error("invalid profile response", {
+          status: upstreamResponse.status,
+          contentType,
+        });
+        return Response.json(
+          { error: "Invalid Shopify UCP profile response" },
+          { headers: { "cache-control": UCP_NO_CACHE_CONTROL }, status: 502 },
+        );
+      }
+
+      const headers = new Headers({
+        "cache-control": upstreamResponse.ok ? UCP_CACHE_CONTROL : UCP_NO_CACHE_CONTROL,
+      });
+
+      for (const name of UCP_RESPONSE_HEADERS) {
+        const value = upstreamResponse.headers.get(name);
+        if (value) headers.set(name, value);
+      }
+
+      return new Response(upstreamResponse.body, {
+        headers,
+        status: upstreamResponse.status,
+        statusText: upstreamResponse.statusText,
+      });
+    })
+    .catch((error) => {
+      log.error("request failed", { error });
+      const status = error instanceof DOMException && error.name === "TimeoutError" ? 504 : 502;
+      return Response.json(
+        { error: "Unable to fetch the Shopify UCP profile" },
+        { headers: { "cache-control": UCP_NO_CACHE_CONTROL }, status },
+      );
+    });
+};

--- a/packages/hydrogen/src/core/request-routing/interceptors/ucp.ts
+++ b/packages/hydrogen/src/core/request-routing/interceptors/ucp.ts
@@ -1,6 +1,5 @@
-import { getLogger } from "../../logging";
 import { UCP_RE } from "../../url";
-import type { HydrogenRouteInterceptor } from "../route-types";
+import { createProxyInterceptor } from "./proxy";
 
 const UCP_CACHE_CONTROL =
   "public, max-age=60, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400";
@@ -9,59 +8,47 @@ const UCP_PROFILE_PATH = "/.well-known/ucp";
 const UCP_FETCH_TIMEOUT_MS = 5_000;
 const UCP_RESPONSE_HEADERS = ["content-type", "etag", "last-modified", "vary"] as const;
 
-const log = getLogger("ucp-proxy");
-
-/**
- * Serves Shopify's managed UCP business profile from the headless storefront origin.
- */
-export const handleUcpProxy: HydrogenRouteInterceptor = (url, { request, storefrontClient }) => {
-  if (!UCP_RE.test(url.pathname) || request.method !== "GET") return null;
-
-  const upstreamUrl = new URL(UCP_PROFILE_PATH, storefrontClient.storeUrl);
-
-  return fetch(upstreamUrl, {
-    headers: { accept: "application/json" },
-    redirect: "manual",
-    signal: AbortSignal.timeout(UCP_FETCH_TIMEOUT_MS),
-  })
-    .then((upstreamResponse) => {
-      const contentType = upstreamResponse.headers.get("content-type");
-      const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
-      if (
-        (upstreamResponse.status >= 300 && upstreamResponse.status < 400) ||
-        (upstreamResponse.ok && mediaType !== "application/json")
-      ) {
-        log.error("invalid profile response", {
-          status: upstreamResponse.status,
-          contentType,
-        });
-        return Response.json(
-          { error: "Invalid Shopify UCP profile response" },
-          { headers: { "cache-control": UCP_NO_CACHE_CONTROL }, status: 502 },
-        );
-      }
-
-      const headers = new Headers({
-        "cache-control": upstreamResponse.ok ? UCP_CACHE_CONTROL : UCP_NO_CACHE_CONTROL,
-      });
-
-      for (const name of UCP_RESPONSE_HEADERS) {
-        const value = upstreamResponse.headers.get(name);
-        if (value) headers.set(name, value);
-      }
-
-      return new Response(upstreamResponse.body, {
-        headers,
-        status: upstreamResponse.status,
-        statusText: upstreamResponse.statusText,
-      });
-    })
-    .catch((error) => {
-      log.error("request failed", { error });
-      const status = error instanceof DOMException && error.name === "TimeoutError" ? 504 : 502;
-      return Response.json(
-        { error: "Unable to fetch the Shopify UCP profile" },
-        { headers: { "cache-control": UCP_NO_CACHE_CONTROL }, status },
-      );
-    });
-};
+export const handleUcpProxy = createProxyInterceptor({
+  match: UCP_RE,
+  methods: ["GET"],
+  scope: "ucp-proxy",
+  timeoutMs: UCP_FETCH_TIMEOUT_MS,
+  forwardSearch: false,
+  rewritePathname: () => UCP_PROFILE_PATH,
+  requestHeaders: {
+    allow: [],
+    applyStorefrontHeaders: false,
+    prepare: (headers) => {
+      headers.set("accept", "application/json");
+    },
+  },
+  responseHeaders: {
+    mode: { allow: UCP_RESPONSE_HEADERS },
+    consumeStorefrontHeaders: false,
+    inject: (upstream) => ({
+      "cache-control": upstream.ok ? UCP_CACHE_CONTROL : UCP_NO_CACHE_CONTROL,
+    }),
+  },
+  responseValidation: (upstream) => {
+    const contentType = upstream.headers.get("content-type");
+    const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
+    if (
+      (upstream.status >= 300 && upstream.status < 400) ||
+      (upstream.ok && mediaType !== "application/json")
+    ) {
+      return {
+        status: 502,
+        body: { error: "Invalid Shopify UCP profile response" },
+        headers: { "cache-control": UCP_NO_CACHE_CONTROL },
+        logMessage: "invalid profile response",
+        log: { status: upstream.status, contentType },
+      };
+    }
+    return null;
+  },
+  mapError: (error) => ({
+    status: error instanceof DOMException && error.name === "TimeoutError" ? 504 : 502,
+    headers: { "cache-control": UCP_NO_CACHE_CONTROL },
+  }),
+  formatError: () => ({ error: "Unable to fetch the Shopify UCP profile" }),
+});

--- a/packages/hydrogen/src/core/url.ts
+++ b/packages/hydrogen/src/core/url.ts
@@ -31,6 +31,7 @@ export function isHydrogenServerHandoffPath(pathname: string): boolean {
 
 export const AGENT_BUYER_CLAIMS_RE =
   /^(?:\/[a-z]{2}(?:-[a-z]{2})?)?\/agent\/(?:handoff|buyer-claims)(?:\.[^/.]+)?\/?$/i;
+export const UCP_RE = /^\/\.well-known\/ucp$/;
 export const WELL_KNOWN_RE = /^\/\.well-known\/(?:apple-developer-merchantid-domain-association)$/;
 export const AJAX_CART_RE =
   /^(?:\/[a-z]{2}(?:-[a-z]{2})?)?\/cart(?:\.(?:js|json)|\/(?:add|update|change|clear)(?:\.(?:js|json))?)$/i;


### PR DESCRIPTION
### WHY are these changes introduced?

Headless storefronts do not currently expose Shopify's managed UCP business profile on their public origin. Agents that begin discovery from a headless domain therefore cannot discover the authoritative UCP services and endpoints hosted on the store's `myshopify.com` domain.

### WHAT is this pull request doing?

This adds `GET /.well-known/ucp` to `handleShopifyRoutes`, serving Shopify's managed UCP business profile from the headless storefront origin.

Rather than a bespoke fetch implementation, the UCP route is now built on the existing `createProxyInterceptor`, which was generalized to support the behavior UCP needs. This keeps a single proxy code path for all Shopify-owned routes.

#### UCP route behavior

- Fetches the profile from the storefront client's `myshopify.com` origin with `accept: application/json`, no shopper cookies, and no authorization.
- Rewrites the upstream path to `/.well-known/ucp` and does not forward the request query string.
- Forwards only safe validation headers (`content-type`, `etag`, `last-modified`, `vary`) and drops `Set-Cookie` and internal upstream headers.
- Applies `Cache-Control: public, max-age=60, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400` to successful profiles, and `Cache-Control: no-store` to every error and unpublished profile.
- Rejects redirects (3xx) and non-JSON success responses with an uncached `502`.
- Maps a fetch timeout (5s) to `504` and other network failures to `502`, both uncached.

#### Proxy interceptor generalization

`createProxyInterceptor` gained opt-in hooks so a single implementation can back UCP and the existing proxies:

- `forwardSearch` to drop the query string from the upstream request.
- `requestHeaders.applyStorefrontHeaders` to skip storefront request-header propagation.
- `responseHeaders.mode` to switch between forwarding all upstream headers and an allowlist.
- `responseHeaders.inject` to set computed response headers (used for the UCP cache policy).
- `responseHeaders.consumeStorefrontHeaders` to skip request-context response-header consumption.
- `responseValidation` to reject an upstream response with a from-scratch body; the factory centrally drains the upstream body so no validator can leak the connection.
- `mapError` to set the error status and headers per phase, preserving the setup→`500` / fetch→`502` default split.

#### Documentation

- Adds the UCP route and integration guidance to the `hydrogen-request-handlers` skill.

#### Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. This is an internal refactor plus a new Shopify-owned route; there is no new public API. Applications that already call `handleShopifyRoutes` before framework routing serve the discovery profile automatically, and no migration is required.

#### Risk

- The route depends on the configured storefront domain serving a valid Shopify-managed UCP profile.
- Successful profiles are cached publicly for 60 seconds with edge stale directives, so profile publication changes may not appear immediately.
- Only the exact `GET /.well-known/ucp` route is intercepted. Other methods and paths continue to framework routing.
- The generalized `createProxyInterceptor` now backs the existing proxies as well, so its new response-validation and error-mapping paths are shared code. Behavior for the existing proxies is unchanged because the new hooks are opt-in.

### HOW to test your changes?

1. Configure a Hydrogen storefront for a Shopify store with a published UCP profile.
2. Start the storefront over HTTPS.
3. Run `curl -i https://<storefront-origin>/.well-known/ucp`.
4. Confirm the response is `200`, uses `Content-Type: application/json`, and includes `Cache-Control: public, max-age=60, s-maxage=60, stale-while-revalidate=300, stale-if-error=86400`.
5. Confirm the profile's service and version URLs use the authoritative `myshopify.com` origin.
6. Confirm the response does not include shopper cookies.
7. Run `curl -i -X POST https://<storefront-origin>/.well-known/ucp` and confirm the request falls through to the application's normal routing.

#### Post-merge steps

None.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) because this PR contains a user-facing functional change
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation
