### PR TITLE
fix: cart hydration warnings when promises resolve before hydration

### DIFF
--- a/.changeset/tidy-carts-hydrate.md
+++ b/.changeset/tidy-carts-hydrate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/hydrogen': patch
+---
+
+Prevent cart hydration mismatches when asynchronous initial cart data resolves before a `useCart` consumer hydrates.

--- a/packages/hydrogen/src/react/cart-ssr.test.tsx
+++ b/packages/hydrogen/src/react/cart-ssr.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment node
+import { PassThrough } from "node:stream";
+
 import { createElement, Suspense } from "react";
-import { renderToString } from "react-dom/server";
+import { renderToPipeableStream, renderToString } from "react-dom/server";
 import { describe, it, expect } from "vitest";
 
 import type { CartData } from "../core/cart/state";
@@ -153,5 +155,50 @@ describe("CartProvider SSR", () => {
 
     expect(html).toContain("Loading cart");
     expect(html).not.toContain(">0<");
+  });
+
+  it("streams resolved cart content from useSuspenseCart", async () => {
+    let resolveInitialData: ((value: { cart: CartData }) => void) | undefined;
+    const initialData = new Promise<{ cart: CartData }>((resolve) => {
+      resolveInitialData = resolve;
+    });
+    const tree = createElement(
+      typedCart.CartProvider,
+      { initialData },
+      createElement(
+        Suspense,
+        { fallback: createElement("span", null, "Loading cart") },
+        createElement(SuspenseCartTotalQuantity),
+      ),
+    );
+
+    const html = await new Promise<string>((resolve, reject) => {
+      const destination = new PassThrough();
+      let output = "";
+      destination.setEncoding("utf8");
+      destination.on("data", (chunk: string) => {
+        output += chunk;
+      });
+      destination.on("end", () => resolve(output));
+      destination.on("error", reject);
+
+      const stream = renderToPipeableStream(tree, {
+        onShellReady() {
+          if (!resolveInitialData) {
+            reject(new Error("Expected initialData resolver to be assigned"));
+            return;
+          }
+          resolveInitialData({ cart: MOCK_CART });
+        },
+        onAllReady() {
+          stream.pipe(destination);
+        },
+        onShellError: reject,
+        onError: reject,
+      });
+    });
+
+    expect(html).toContain(">3<");
+    expect(html).not.toContain("Loading cart");
   });
 });

--- a/packages/hydrogen/src/react/cart.hydration.test.tsx
+++ b/packages/hydrogen/src/react/cart.hydration.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment happy-dom
+import { act } from "@testing-library/react";
+import { createElement, Suspense, type ReactNode } from "react";
+import { hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { CartData } from "../core/cart/state";
+import { assert } from "../core/test-utils";
+import { CartProvider, createCartComponents, useCart } from "./cart";
+
+const CART: CartData = {
+  id: "gid://shopify/Cart/123",
+  checkoutUrl: "https://example.com/checkout",
+  totalQuantity: 3,
+  cost: {
+    subtotalAmount: { amount: "30.00", currencyCode: "USD" },
+    totalAmount: { amount: "30.00", currencyCode: "USD" },
+    checkoutChargeAmount: { amount: "30.00", currencyCode: "USD" },
+  },
+  note: "",
+  attributes: [],
+  lines: { nodes: [] },
+  discountCodes: [],
+};
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve(value) {
+      assert(resolvePromise, "Expected deferred resolve to be assigned");
+      resolvePromise(value);
+    },
+  };
+}
+
+function CartSummary() {
+  const loading = useCart((state) => state.loading);
+  const quantity = useCart((state) => state.data.totalQuantity);
+  return createElement("span", { "data-testid": "cart-summary" }, loading ? "Loading" : quantity);
+}
+
+const typedCart = createCartComponents<{
+  get: () => Promise<{ data: { cart: CartData } }>;
+}>();
+
+function SuspenseCartSummary() {
+  const quantity = typedCart.useSuspenseCart((state) => state.data.totalQuantity);
+  return createElement("span", { "data-testid": "cart-summary" }, quantity);
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("CartProvider hydration", () => {
+  it("hydrates useCart from its initial snapshot when cart data resolves first", async () => {
+    const cartData = createDeferred<{ cart: CartData }>();
+    const hydrationGate = createDeferred<void>();
+    let blockHydration = false;
+
+    function HydrationGate({ children }: { children: ReactNode }) {
+      if (blockHydration) throw hydrationGate.promise;
+      return children;
+    }
+
+    function App() {
+      return createElement(
+        CartProvider,
+        { initialData: cartData.promise },
+        createElement(
+          Suspense,
+          { fallback: createElement("span", null, "Waiting") },
+          createElement(HydrationGate, null, createElement(CartSummary)),
+        ),
+      );
+    }
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(createElement(App));
+    document.body.append(container);
+    expect(container.textContent).toBe("Loading");
+
+    const onRecoverableError = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let root: Root | undefined;
+    blockHydration = true;
+
+    await act(async () => {
+      root = hydrateRoot(container, createElement(App), { onRecoverableError });
+    });
+
+    cartData.resolve({ cart: CART });
+    await act(async () => {
+      await cartData.promise;
+    });
+
+    blockHydration = false;
+    hydrationGate.resolve();
+    await act(async () => {
+      await hydrationGate.promise;
+    });
+
+    expect(container.textContent).toBe("3");
+    expect(onRecoverableError).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+
+    await act(async () => root?.unmount());
+  });
+
+  it("hydrates useSuspenseCart content from live cart data", async () => {
+    const cartData = createDeferred<{ cart: CartData }>();
+    const hydrationGate = createDeferred<void>();
+    let blockHydration = false;
+
+    function HydrationGate({ children }: { children: ReactNode }) {
+      if (blockHydration) throw hydrationGate.promise;
+      return children;
+    }
+
+    function App({
+      initialData,
+    }: {
+      initialData: { cart: CartData } | Promise<{ cart: CartData }>;
+    }) {
+      return createElement(
+        typedCart.CartProvider,
+        { initialData },
+        createElement(
+          Suspense,
+          { fallback: createElement("span", null, "Loading") },
+          createElement(HydrationGate, null, createElement(SuspenseCartSummary)),
+        ),
+      );
+    }
+
+    const container = document.createElement("div");
+    container.innerHTML = renderToString(createElement(App, { initialData: { cart: CART } }));
+    document.body.append(container);
+    expect(container.textContent).toBe("3");
+
+    const onRecoverableError = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let root: Root | undefined;
+    blockHydration = true;
+
+    await act(async () => {
+      root = hydrateRoot(container, createElement(App, { initialData: cartData.promise }), {
+        onRecoverableError,
+      });
+    });
+
+    cartData.resolve({ cart: CART });
+    await act(async () => {
+      await cartData.promise;
+    });
+
+    blockHydration = false;
+    hydrationGate.resolve();
+    await act(async () => {
+      await hydrationGate.promise;
+    });
+
+    expect(container.textContent).toBe("3");
+    expect(onRecoverableError).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+
+    await act(async () => root?.unmount());
+  });
+});

--- a/packages/hydrogen/src/react/cart.test.tsx
+++ b/packages/hydrogen/src/react/cart.test.tsx
@@ -444,6 +444,43 @@ describe("useSuspenseCart", () => {
     expect(screen.getByTestId("fallback").textContent).toBe("Loading");
   });
 
+  it("renders live cart data after the initial readyPromise settles", async () => {
+    const deferred = createDeferred<void>();
+    const typedCart = createCartComponents<{
+      get: () => Promise<{ data: { cart: CartData } }>;
+    }>();
+    const mockStore = createMockStore();
+    mockStore.setReadyPromise(deferred.promise);
+    vi.mocked(createCartStore).mockImplementation(() => mockStore);
+
+    function Consumer() {
+      const qty = typedCart.useSuspenseCart((s) => s.data.totalQuantity);
+      return createElement("span", { "data-testid": "qty" }, qty);
+    }
+
+    render(
+      createElement(
+        CartProvider,
+        null,
+        createElement(
+          Suspense,
+          { fallback: createElement("span", { "data-testid": "fallback" }, "Loading") },
+          createElement(Consumer),
+        ),
+      ),
+    );
+
+    expect(screen.getByTestId("fallback").textContent).toBe("Loading");
+
+    await act(async () => {
+      mockStore.setState(makeCartState({ totalQuantity: 8 }));
+      deferred.resolve();
+      await deferred.promise;
+    });
+
+    expect(screen.getByTestId("qty").textContent).toBe("8");
+  });
+
   it("returns selected cart state when no readyPromise is visible", () => {
     const typedCart = createCartComponents<{
       get: () => Promise<{ data: { cart: CartData } }>;

--- a/packages/hydrogen/src/react/cart.tsx
+++ b/packages/hydrogen/src/react/cart.tsx
@@ -29,7 +29,12 @@ const DEFAULT_CART_ENDPOINT = "/api/cart";
 
 let cartEndpoint = DEFAULT_CART_ENDPOINT;
 
-const CartContext = createContext<CartStore | null>(null);
+interface CartContextValue {
+  store: CartStore;
+  hydrationSnapshot: CartState;
+}
+
+const CartContext = createContext<CartContextValue | null>(null);
 
 export function configureCartEndpoint(endpoint: string): void {
   cartEndpoint = endpoint;
@@ -97,9 +102,7 @@ export function createCartComponents<THandlers>(): TypedCartComponents<
     selector: (state: CartState<TData>) => S,
     isEqual?: (a: S, b: S) => boolean,
   ): S {
-    const readyPromise = useCart((state) => state.readyPromise);
-    if (readyPromise) throw readyPromise;
-    return useCart(selector, isEqual);
+    return useSuspenseCartSelector(selector, isEqual);
   }
 
   return {
@@ -113,12 +116,16 @@ export function createCartComponents<THandlers>(): TypedCartComponents<
 }
 
 export function useCartStore(hookName = "useCart"): CartStore {
-  const store = useContext(CartContext);
-  if (!store) throw new Error(`${hookName} must be used inside <CartProvider>.`);
-  return store;
+  return useCartContext(hookName).store;
 }
 
-function useOptionalCartStore(): CartStore | null {
+function useCartContext(hookName = "useCart"): CartContextValue {
+  const context = useContext(CartContext);
+  if (!context) throw new Error(`${hookName} must be used inside <CartProvider>.`);
+  return context;
+}
+
+function useOptionalCartContext(): CartContextValue | null {
   return useContext(CartContext);
 }
 
@@ -129,8 +136,13 @@ export function CartProvider({
   initialData?: CartInitialData;
   children?: ReactNode;
 }) {
-  // oxlint-disable-next-line react-hooks/exhaustive-deps -- store is created once with the initial server data
-  const store = useMemo(() => createCartStore({ initialData }), []);
+  const context = useMemo(() => {
+    const store = createCartStore({ initialData });
+    // Plain consumers must hydrate from the state used for SSR, even if the live store settles first.
+    return { store, hydrationSnapshot: store.getState() };
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- provider initialData seeds one store for its lifetime
+  }, []);
+  const { store } = context;
 
   useEffect(() => {
     configureCoreCartEndpoint(cartEndpoint);
@@ -140,15 +152,15 @@ export function CartProvider({
     };
   }, [store]);
 
-  return <CartContext.Provider value={store}>{children}</CartContext.Provider>;
+  return <CartContext.Provider value={context}>{children}</CartContext.Provider>;
 }
 
 export function useCart<TData extends CartData = CartData, S = unknown>(
   selector: (state: CartState<TData>) => S,
   isEqual?: (a: S, b: S) => boolean,
 ): S {
-  const store = useCartStore();
-  return useCartSelector(store, selector, isEqual) as S;
+  const { store, hydrationSnapshot } = useCartContext();
+  return useCartSelector(store, hydrationSnapshot, selector, isEqual) as S;
 }
 
 export function useCartActions(): CartActions {
@@ -171,41 +183,102 @@ export function useOptionalCart<TData extends CartData = CartData, S = unknown>(
   selector: (state: CartState<TData>) => S,
   isEqual?: (a: S, b: S) => boolean,
 ): S | undefined {
-  const store = useOptionalCartStore();
-  if (!store) return undefined;
-  return useCartSelector(store, selector, isEqual);
+  const context = useOptionalCartContext();
+  if (!context) return undefined;
+  return useCartSelector(context.store, context.hydrationSnapshot, selector, isEqual);
 }
 
 function useCartSelector<TData extends CartData = CartData, S = unknown>(
   store: CartStore,
+  hydrationSnapshot: CartState,
   selector: (state: CartState<TData>) => S,
   isEqual?: (a: S, b: S) => boolean,
 ): S {
-  const cachedRef = useRef<{ state: unknown; selector: typeof selector; value: S } | null>(null);
+  const liveCacheRef = useRef<SelectorCache<S> | null>(null);
+  const hydrationCacheRef = useRef<SelectorCache<S> | null>(null);
 
+  const getSnapshot = () =>
+    selectCartSnapshot(store.getState() as CartState<TData>, selector, isEqual, liveCacheRef);
+  const getServerSnapshot = () =>
+    selectCartSnapshot(hydrationSnapshot as CartState<TData>, selector, isEqual, hydrationCacheRef);
+
+  return useSyncExternalStore(store.subscribe, getSnapshot, getServerSnapshot);
+}
+
+interface SelectorCache<S> {
+  state: unknown;
+  selector: unknown;
+  value: S;
+}
+
+function selectCartSnapshot<TData extends CartData, S>(
+  state: CartState<TData>,
+  selector: (state: CartState<TData>) => S,
+  isEqual: ((a: S, b: S) => boolean) | undefined,
+  cacheRef: { current: SelectorCache<S> | null },
+): S {
+  if (cacheRef.current?.state === state && cacheRef.current.selector === selector) {
+    return cacheRef.current.value;
+  }
+
+  const next = selector(state);
+
+  if (cacheRef.current && isEqual?.(cacheRef.current.value, next)) {
+    cacheRef.current = { state, selector, value: cacheRef.current.value };
+    return cacheRef.current.value;
+  }
+
+  cacheRef.current = { state, selector, value: next };
+  return next;
+}
+
+type SuspenseSnapshot<S> =
+  | { status: "pending"; promise: PromiseLike<void> }
+  | { status: "ready"; value: S };
+
+interface SuspenseSelectorCache<S> {
+  state: unknown;
+  selector: unknown;
+  snapshot: SuspenseSnapshot<S>;
+}
+
+function useSuspenseCartSelector<TData extends CartData, S>(
+  selector: (state: CartState<TData>) => S,
+  isEqual?: (a: S, b: S) => boolean,
+): S {
+  const { store } = useCartContext();
+  const cacheRef = useRef<SuspenseSelectorCache<S> | null>(null);
+
+  // Suspense retries must read live readiness and data; the hydration snapshot would freeze the fallback.
   const getSnapshot = () => {
     const state = store.getState() as CartState<TData>;
 
-    if (
-      cachedRef.current &&
-      cachedRef.current.state === state &&
-      cachedRef.current.selector === selector
-    ) {
-      return cachedRef.current.value;
+    if (cacheRef.current?.state === state && cacheRef.current.selector === selector) {
+      return cacheRef.current.snapshot;
     }
 
-    const next = selector(state);
-
-    if (cachedRef.current && isEqual?.(cachedRef.current.value, next)) {
-      cachedRef.current = { state, selector, value: cachedRef.current.value };
-      return cachedRef.current.value;
+    if (state.readyPromise) {
+      const snapshot: SuspenseSnapshot<S> = { status: "pending", promise: state.readyPromise };
+      cacheRef.current = { state, selector, snapshot };
+      return snapshot;
     }
 
-    cachedRef.current = { state, selector, value: next };
-    return next;
+    const value = selector(state);
+    const previous = cacheRef.current?.snapshot;
+
+    if (previous?.status === "ready" && isEqual?.(previous.value, value)) {
+      cacheRef.current = { state, selector, snapshot: previous };
+      return previous;
+    }
+
+    const snapshot: SuspenseSnapshot<S> = { status: "ready", value };
+    cacheRef.current = { state, selector, snapshot };
+    return snapshot;
   };
 
-  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
+  const snapshot = useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot);
+  if (snapshot.status === "pending") throw snapshot.promise;
+  return snapshot.value;
 }
 
 export function useCartForm() {

--- a/templates/nextjs/components/CartContent.tsx
+++ b/templates/nextjs/components/CartContent.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { useCart, useCartForm } from "@/lib/cart";
+import { useCart, useCartForm, useSuspenseCart } from "@/lib/cart";
 import { content } from "@/lib/content";
 import { formatPrice } from "@/lib/money";
 
@@ -15,8 +15,7 @@ export function CartContent() {
   const pendingRemovalDiscountCode = useRef<string | null>(null);
   const discountInputRef = useRef<HTMLInputElement>(null);
   const emptyCartRef = useRef<HTMLDivElement>(null);
-  const cart = useCart((state) => state.data);
-  const loading = useCart((state) => state.loading);
+  const cart = useSuspenseCart((state) => state.data);
   const pending = useCart((state) => state.pending);
   const networkErrors = useCart((state) => state.errors.network);
   const isPending = pending.lines.size > 0 || pending.note || pending.discountCodes.size > 0;
@@ -53,14 +52,6 @@ export function CartContent() {
       discountInputRef.current?.focus();
     }
   }, [discountCodes]);
-
-  if (loading) {
-    return (
-      <div className="divide-border divide-y" aria-busy="true">
-        <p className="text-on-surface-secondary py-8 text-center text-sm">Loading cart…</p>
-      </div>
-    );
-  }
 
   const isEmpty = totalQuantity === 0 || lines.length === 0;
 
@@ -211,11 +202,13 @@ function CartStatus({
 }
 
 function useCartStatusMessage(isPending: boolean, hasNetworkErrors: boolean): string {
-  const [sawPending, setSawPending] = useState(false);
+  const [previousPending, setPreviousPending] = useState(isPending);
+  const [sawPending, setSawPending] = useState(isPending);
 
-  useEffect(() => {
+  if (previousPending !== isPending) {
+    setPreviousPending(isPending);
     if (isPending) setSawPending(true);
-  }, [isPending]);
+  }
 
   if (isPending) return "Updating cart totals";
   if (sawPending && !hasNetworkErrors) return "Cart totals updated";


### PR DESCRIPTION
TL;DR: Cart data could settle before a retained client subtree hydrated, causing `useCart` to render different client data from the server HTML.

## Before

`useCart` used the mutable live store for both client reads and React's server snapshot. Promise timing could therefore change the first hydration render and produce a mismatch on `/cart`.

## After

Plain `useCart` consumers hydrate from the provider's immutable initial snapshot, then update from the live store. `useSuspenseCart` keeps a separate live selector so resolved cart content still streams without blocking the app shell.

## Hydration timing

This is not specifically a one-microtask delay. If async cart data has already settled, plain `useCart` intentionally hydrates the loading or empty state that produced the server HTML, then `useSyncExternalStore` reconciles it to the live cart in a follow-up React update. React may complete that update before the browser paints.

`useSuspenseCart` does not take that path. It reads the live store so streamed cart HTML hydrates against the resolved cart. The Next.js template uses this path for `CartContent`; plain `useCart` remains appropriate for UI that can render from the initial snapshot and update immediately afterward.

## What this changes

- Capture the initial cart state used for hydration inside `CartProvider`.
- Read readiness and selected cart data atomically in `useSuspenseCart`.
- Render the Next.js template's `CartContent` through its existing Suspense boundaries.
- Cover early promise settlement, streamed SSR resolution, and both hook hydration paths.

## Developer impact

No public API changes. Existing `useCart` and `useSuspenseCart` consumers keep their current interfaces. Includes a **patch** changeset for `@shopify/hydrogen` because this fixes runtime hydration behavior.

## UX impact

Direct cart-page loads no longer log a recoverable hydration error or replace the server-rendered cart subtree. The app shell remains streamed and non-blocking.

## Risk

- The plain and Suspense hooks intentionally use different hydration strategies. Regression coverage locks in both contracts.

## How to Test

1. Run `pnpm --filter @shopify/hydrogen build`.
2. Run `pnpm --filter @shopify/hydrogen-template-nextjs dev:https`.
3. Add an item to the cart.
4. Load `https://local.tryhydrogen.dev:5173/cart` directly.
5. Confirm the cart renders and the browser console has no hydration mismatch.
