### PR TITLE
Fix CLI monorepo detection when the repo path contains spaces

### DIFF
--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-hydrogen': patch
+'@shopify/create-hydrogen': patch
+---
+
+Fix Hydrogen monorepo detection when the repository path contains spaces or other characters that are percent-encoded in URLs. The path is now decoded before it is used to look for the skeleton template.

--- a/packages/cli/src/lib/build.test.ts
+++ b/packages/cli/src/lib/build.test.ts
@@ -1,18 +1,52 @@
 import {describe, it, expect} from 'vitest';
-import {decodedPathname} from './build.js';
+import {pathToFileURL} from 'node:url';
+import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs';
+import {joinPath} from '@shopify/cli-kit/node/path';
+import {detectHydrogenMonorepo, getMonorepoPackagesPath} from './build.js';
 
-describe('decodedPathname()', () => {
-  it('decodes percent-encoded characters', () => {
-    expect(
-      decodedPathname(
-        new URL('file:///Users/x/Open%20Source/hydrogen/packages/'),
-      ),
-    ).toBe('/Users/x/Open Source/hydrogen/packages/');
+// Mirrors the location of this file inside the monorepo, since monorepo
+// detection resolves `packages/` relative to the module that asks for it.
+const MODULE_PATH_IN_REPO = ['packages', 'cli', 'src', 'lib', 'build.ts'];
+
+function moduleUrlFor(repoRoot: string) {
+  return pathToFileURL(joinPath(repoRoot, ...MODULE_PATH_IN_REPO));
+}
+
+async function createFakeMonorepo(repoRoot: string) {
+  await mkdir(joinPath(repoRoot, ...MODULE_PATH_IN_REPO.slice(0, -1)));
+  await mkdir(joinPath(repoRoot, 'templates', 'skeleton'));
+}
+
+describe('monorepo detection', () => {
+  it('detects the monorepo when the path contains a space', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // The space is what regressed: `URL.pathname` percent-encodes it, and
+      // the encoded path does not exist on disk.
+      const repoRoot = joinPath(tmpDir, 'Open Source', 'hydrogen');
+      await createFakeMonorepo(repoRoot);
+
+      expect(detectHydrogenMonorepo(moduleUrlFor(repoRoot))).toBe(true);
+      expect(getMonorepoPackagesPath(moduleUrlFor(repoRoot))).toContain(
+        'Open Source',
+      );
+    });
   });
 
-  it('leaves paths without encoded characters untouched', () => {
-    expect(decodedPathname(new URL('file:///Users/x/hydrogen/packages/'))).toBe(
-      '/Users/x/hydrogen/packages/',
-    );
+  it('detects the monorepo when the path contains no space', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const repoRoot = joinPath(tmpDir, 'hydrogen');
+      await createFakeMonorepo(repoRoot);
+
+      expect(detectHydrogenMonorepo(moduleUrlFor(repoRoot))).toBe(true);
+    });
+  });
+
+  it('does not detect a monorepo without templates/skeleton', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const repoRoot = joinPath(tmpDir, 'Open Source', 'not-hydrogen');
+      await mkdir(joinPath(repoRoot, ...MODULE_PATH_IN_REPO.slice(0, -1)));
+
+      expect(detectHydrogenMonorepo(moduleUrlFor(repoRoot))).toBe(false);
+    });
   });
 });

--- a/packages/cli/src/lib/build.test.ts
+++ b/packages/cli/src/lib/build.test.ts
@@ -1,0 +1,18 @@
+import {describe, it, expect} from 'vitest';
+import {decodedPathname} from './build.js';
+
+describe('decodedPathname()', () => {
+  it('decodes percent-encoded characters', () => {
+    expect(
+      decodedPathname(
+        new URL('file:///Users/x/Open%20Source/hydrogen/packages/'),
+      ),
+    ).toBe('/Users/x/Open Source/hydrogen/packages/');
+  });
+
+  it('leaves paths without encoded characters untouched', () => {
+    expect(decodedPathname(new URL('file:///Users/x/hydrogen/packages/'))).toBe(
+      '/Users/x/hydrogen/packages/',
+    );
+  });
+});

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -5,8 +5,16 @@ import {AbortError} from '@shopify/cli-kit/node/error';
 import {dirname, joinPath} from '@shopify/cli-kit/node/path';
 import {execAsync} from './process.js';
 
-// Avoid using fileURLToPath here to prevent backslashes nightmare on Windows
-const monorepoPackagesPath = new URL('../../..', import.meta.url).pathname;
+// Avoid using fileURLToPath here to prevent backslashes nightmare on Windows.
+// URL pathnames are percent-encoded, so decode to support directories that
+// contain spaces or other reserved characters.
+export function decodedPathname(url: URL) {
+  return decodeURIComponent(url.pathname);
+}
+
+const monorepoPackagesPath = decodedPathname(
+  new URL('../../..', import.meta.url),
+);
 
 // Check if we're in the Hydrogen monorepo by checking the path structure
 // This was the original logic before PR #3074 that worked for over a year

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -5,25 +5,22 @@ import {AbortError} from '@shopify/cli-kit/node/error';
 import {dirname, joinPath} from '@shopify/cli-kit/node/path';
 import {execAsync} from './process.js';
 
+// Resolve the `packages/` directory that contains this file.
 // Avoid using fileURLToPath here to prevent backslashes nightmare on Windows.
 // URL pathnames are percent-encoded, so decode to support directories that
 // contain spaces or other reserved characters.
-export function decodedPathname(url: URL) {
-  return decodeURIComponent(url.pathname);
+export function getMonorepoPackagesPath(moduleUrl: string | URL) {
+  return decodeURIComponent(new URL('../../..', moduleUrl).pathname);
 }
-
-const monorepoPackagesPath = decodedPathname(
-  new URL('../../..', import.meta.url),
-);
 
 // Check if we're in the Hydrogen monorepo by checking the path structure
 // This was the original logic before PR #3074 that worked for over a year
 // Check if we're in the monorepo by looking for the templates/skeleton directory
 // This works both in development and when built as npm package
-export const isHydrogenMonorepo = (() => {
+export function detectHydrogenMonorepo(moduleUrl: string | URL) {
   try {
     const skeletonPath = joinPath(
-      dirname(monorepoPackagesPath),
+      dirname(getMonorepoPackagesPath(moduleUrl)),
       'templates',
       'skeleton',
     );
@@ -33,7 +30,11 @@ export const isHydrogenMonorepo = (() => {
   } catch {
     return false;
   }
-})();
+}
+
+const monorepoPackagesPath = getMonorepoPackagesPath(import.meta.url);
+
+export const isHydrogenMonorepo = detectHydrogenMonorepo(import.meta.url);
 export const hydrogenPackagesPath = isHydrogenMonorepo
   ? monorepoPackagesPath
   : undefined;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3988

`packages/cli/src/lib/build.ts` derives the monorepo root from `import.meta.url`:

```ts
const monorepoPackagesPath = new URL('../../..', import.meta.url).pathname;
```

`URL.pathname` is percent-encoded. A checkout at `/Users/me/Open Source/hydrogen` produces `/Users/me/Open%20Source/hydrogen/packages/`, which does not exist on disk, so the `existsSync` check for `templates/skeleton` fails and `isHydrogenMonorepo` becomes `false`. Building `packages/cli` then fails in `tsup.config.ts` with "Trying to use skeleton source dir outside of Hydrogen monorepo", and the CLI test suite fails as well.

Measured on one machine, toggling only that expression:

| | `packages/cli` build | `packages/cli` tests |
| --- | --- | --- |
| Current `main` | fails | 11 files / 39 tests failed |
| With this change | succeeds | 57 files / 434 tests passed |

This affects contributors only. Installed npm packages are unaffected, since `isHydrogenMonorepo` is `false` there regardless. The failure is easy to misread, because the error names the monorepo layout rather than the directory name.

I kept `fileURLToPath` out of this path, since the existing comment says it is avoided deliberately for Windows backslash handling. Decoding the pathname preserves that while fixing the encoding.

I checked for the same pattern elsewhere. `packages/hydrogen/src/vite/plugin.ts` also reads `new URL(...).pathname`, but is not affected: it only tests `endsWith('/packages/')`, and an encoded segment always appears earlier in the path. I left it alone rather than making an unnecessary change.

### WHAT is this pull request doing?

- Decodes the percent-encoded pathname before it is used for monorepo detection, via a small exported `decodedPathname` helper.
- Adds `packages/cli/src/lib/build.test.ts` covering an encoded path and a plain one. I verified the test fails if the `decodeURIComponent` call is removed.
- Adds a patch changeset for `@shopify/cli-hydrogen` and `@shopify/create-hydrogen`. `build.ts` is reachable from the `init` path through `lib/template-downloader.ts`, so per CLAUDE.md both are bumped.

The helper exists mainly so the behaviour is testable, since the original expression runs at module scope off `import.meta.url` and cannot be exercised directly.

### HOW to test your changes?

```bash
git clone https://github.com/Shopify/hydrogen.git "/tmp/Open Source/hydrogen"
cd "/tmp/Open Source/hydrogen"
pnpm install
pnpm --dir packages/cli build   # fails on main, succeeds with this change
pnpm --dir packages/cli test
```

The added unit test also covers the decoding directly:

```bash
pnpm --dir packages/cli test src/lib/build.test.ts
```

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation

<sub>On cross-platform impact: Windows paths percent-encode too, so the same decode applies. `fileURLToPath` was deliberately avoided here per the existing comment, and this change keeps that. Documentation is unchecked because there is nothing user-facing to document.</sub>
