### PR TITLE
An cleanup template example configs

### DIFF
--- a/examples/hydrogen/app/root.tsx
+++ b/examples/hydrogen/app/root.tsx
@@ -91,7 +91,7 @@ export async function loader(args: Route.LoaderArgs) {
     publicStoreDomain: env.PUBLIC_STORE_DOMAIN,
     shop,
     consent: {
-      mode: "no-banner",
+      mode: "default-banner",
     } satisfies ConsentConfig,
   };
 }

--- a/examples/nuxt/pages/collections/[handle].vue
+++ b/examples/nuxt/pages/collections/[handle].vue
@@ -61,7 +61,6 @@ function publishCollectionView() {
       id: collection.value.id,
       handle: collection.value.handle,
     },
-    url: window.location.href,
   });
 }
 

--- a/templates/react-router/app/components/AnalyticsTrackers.tsx
+++ b/templates/react-router/app/components/AnalyticsTrackers.tsx
@@ -1,14 +1,9 @@
-import type { AnalyticsCart, ConsentConfig, ShopAnalytics } from "@shopify/hydrogen";
+import type { AnalyticsCart } from "@shopify/hydrogen";
 import { useCartAnalytics } from "@shopify/hydrogen/react";
 import { useEffect, useRef } from "react";
 import { useLocation } from "react-router";
 
-import {
-  AnalyticsEvent,
-  configureAnalytics,
-  getAnalytics,
-  getAnalyticsShop,
-} from "~/lib/analytics";
+import { AnalyticsEvent, getAnalytics } from "~/lib/analytics";
 
 type AnalyticsTapWindow = Window & {
   __analyticsEvents?: Array<{ event: string; payload: Record<string, unknown> }>;
@@ -25,21 +20,12 @@ const TAP_EVENTS = [
   AnalyticsEvent.PRODUCT_REMOVED_FROM_CART,
 ] as const;
 
-export function AnalyticsTracker({
-  shop,
-  consent,
-  enableTestTap,
-}: {
-  shop: ShopAnalytics;
-  consent: ConsentConfig;
-  enableTestTap: boolean;
-}) {
+export function AnalyticsTracker({ enableTestTap }: { enableTestTap: boolean }) {
   const location = useLocation();
   const pageKey = `${location.pathname}${location.search}`;
   const tapConfigured = useRef(false);
 
   useEffect(() => {
-    configureAnalytics(shop, consent);
     const analytics = getAnalytics();
     if (!analytics) return;
 
@@ -54,11 +40,8 @@ export function AnalyticsTracker({
       }
     }
 
-    analytics.publish(AnalyticsEvent.PAGE_VIEWED, {
-      url: window.location.href,
-      shop,
-    });
-  }, [pageKey, shop, consent, enableTestTap]);
+    analytics.publish(AnalyticsEvent.PAGE_VIEWED);
+  }, [pageKey, enableTestTap]);
 
   return null;
 }
@@ -135,7 +118,5 @@ export function publishCartViewed(cart: unknown) {
   if (!analytics) return;
   analytics.publish(AnalyticsEvent.CART_VIEWED, {
     cart: toAnalyticsCart(cart),
-    url: window.location.href,
-    shop: getAnalyticsShop(),
   });
 }

--- a/templates/react-router/app/lib/analytics.ts
+++ b/templates/react-router/app/lib/analytics.ts
@@ -1,22 +1,6 @@
-import {
-  AnalyticsEvent,
-  type ConsentConfig,
-  type ShopAnalytics,
-  type StorefrontAnalytics,
-} from "@shopify/hydrogen";
+import { AnalyticsEvent, type StorefrontAnalytics } from "@shopify/hydrogen";
 
 export { AnalyticsEvent };
-
-let configuredShop: ShopAnalytics | null = null;
-
-export function configureAnalytics(shop: ShopAnalytics, consent?: ConsentConfig): void {
-  configuredShop = shop;
-  void consent;
-}
-
-export function getAnalyticsShop(): ShopAnalytics | null {
-  return configuredShop;
-}
 
 export function getAnalytics(): StorefrontAnalytics | null {
   if (typeof window === "undefined") return null;

--- a/templates/react-router/app/lib/shop.ts
+++ b/templates/react-router/app/lib/shop.ts
@@ -33,24 +33,16 @@ export function getStoreDomain(env: Pick<Env, "PUBLIC_STORE_DOMAIN">): string {
   return env.PUBLIC_STORE_DOMAIN || storefrontConfig.storeDomain;
 }
 
-// Analytics shop identity. `shopId` is a real Shopify Shop GID.
-export const analyticsShop = {
-  shopId: "gid://shopify/Shop/55145660472", // ← replace with your Shop GID
-  channel: "hydrogen",
-  storefrontId: "1000014875", // ← replace with your storefront id
-} as const;
-
+// Shopify runtime identity. `shopId` is a real Shopify Shop GID.
 export const shop = {
-  shopId: analyticsShop.shopId,
-  storefrontId: analyticsShop.storefrontId,
+  shopId: "gid://shopify/Shop/55145660472", // ← replace with your Shop GID
+  storefrontId: "1000014875", // ← replace with your storefront id
   myshopifyDomain: storefrontConfig.storeDomain,
 } as const;
 
 // Use Shopify's default consent banner and Customer Privacy behavior.
 export const analyticsConsent = {
   mode: "default-banner",
-  country: "US",
-  language: "EN",
 } as const;
 
 // Private Storefront API token for SSR requests. Read from the worker environment

--- a/templates/react-router/app/root.tsx
+++ b/templates/react-router/app/root.tsx
@@ -20,7 +20,7 @@ import { cartHandlers } from "~/lib/cart-handlers";
 import { envContext } from "~/lib/env";
 import { routeTemplates } from "~/lib/route-templates";
 import { createRequestSessionManager } from "~/lib/session";
-import { analyticsConsent, analyticsShop, shop, storefrontConfig } from "~/lib/shop";
+import { analyticsConsent, shop, storefrontConfig } from "~/lib/shop";
 import {
   createRequestStorefrontClient,
   storefrontClientContext,
@@ -100,8 +100,6 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   return {
     cartData: cartResult.data,
     navCollections: navResult.data?.collections.nodes ?? [],
-    analyticsShop,
-    consent: analyticsConsent,
     enableAnalyticsTestTap: env.MOCK_SHOP === "1",
   };
 }
@@ -142,11 +140,7 @@ export function Layout({ children }: { children: ReactNode }) {
 export default function App({ loaderData }: Route.ComponentProps) {
   return (
     <CartProvider initialData={loaderData.cartData}>
-      <AnalyticsTracker
-        shop={loaderData.analyticsShop}
-        consent={loaderData.consent}
-        enableTestTap={loaderData.enableAnalyticsTestTap}
-      />
+      <AnalyticsTracker enableTestTap={loaderData.enableAnalyticsTestTap} />
       <CartAnalyticsTracker />
       <div
         role="region"

--- a/templates/react-router/app/routes/collection.tsx
+++ b/templates/react-router/app/routes/collection.tsx
@@ -13,7 +13,7 @@ import {
   useLoadMore,
 } from "~/components/CollectionBrowse";
 import { ProductCard } from "~/components/ProductCard";
-import { AnalyticsEvent, getAnalytics, getAnalyticsShop } from "~/lib/analytics";
+import { AnalyticsEvent, getAnalytics } from "~/lib/analytics";
 import { loadCollectionPage } from "~/lib/collection";
 import { storefrontClientContext } from "~/lib/storefront";
 
@@ -43,16 +43,13 @@ type ProductNode = Route.ComponentProps["loaderData"]["products"][number];
 function CollectionViewedTracker({ collection }: { collection: CollectionData }) {
   useEffect(() => {
     const analytics = getAnalytics();
-    const shop = getAnalyticsShop();
-    if (!analytics || !shop) return;
+    if (!analytics) return;
 
     analytics.publish(AnalyticsEvent.COLLECTION_VIEWED, {
       collection: {
         id: collection.id,
         handle: collection.handle,
       },
-      url: window.location.href,
-      shop,
     });
   }, [collection.id, collection.handle]);
 

--- a/templates/react-router/app/routes/product.tsx
+++ b/templates/react-router/app/routes/product.tsx
@@ -10,7 +10,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 
 import { ProductCard, PRODUCT_CARD_FRAGMENT } from "~/components/ProductCard";
-import { AnalyticsEvent, getAnalytics, getAnalyticsShop } from "~/lib/analytics";
+import { AnalyticsEvent, getAnalytics } from "~/lib/analytics";
 import { openCartDrawer } from "~/lib/cart-drawer";
 import { formatPrice, salePercent } from "~/lib/money";
 import { ProductProvider, useProductForm } from "~/lib/product";
@@ -226,8 +226,7 @@ function hasSwatchData(product: ProductData, optionName: string) {
 function ProductViewedTracker({ product }: { product: ProductData }) {
   useEffect(() => {
     const analytics = getAnalytics();
-    const shop = getAnalyticsShop();
-    if (!analytics || !shop) return;
+    if (!analytics) return;
 
     const selectedVariant = product.selectedOrFirstAvailableVariant;
     analytics.publish(AnalyticsEvent.PRODUCT_VIEWED, {
@@ -243,8 +242,6 @@ function ProductViewedTracker({ product }: { product: ProductData }) {
           sku: selectedVariant?.sku,
         },
       ],
-      url: window.location.href,
-      shop,
     });
   }, [product]);
 

--- a/templates/react-router/app/routes/search.tsx
+++ b/templates/react-router/app/routes/search.tsx
@@ -13,7 +13,7 @@ import {
   useLoadMore,
 } from "~/components/CollectionBrowse";
 import { ProductCard } from "~/components/ProductCard";
-import { AnalyticsEvent, getAnalytics, getAnalyticsShop } from "~/lib/analytics";
+import { AnalyticsEvent, getAnalytics } from "~/lib/analytics";
 import { loadSearchPage, type SearchPageData } from "~/lib/search";
 import { storefrontClientContext } from "~/lib/storefront";
 
@@ -48,14 +48,11 @@ function SearchViewedTracker({
     if (!searchTerm) return;
 
     const analytics = getAnalytics();
-    const shop = getAnalyticsShop();
-    if (!analytics || !shop) return;
+    if (!analytics) return;
 
     analytics.publish(AnalyticsEvent.SEARCH_VIEWED, {
       searchTerm,
       searchResults: { totalCount },
-      url: window.location.href,
-      shop,
     });
   }, [searchTerm, totalCount]);
 


### PR DESCRIPTION
TL;DR: The React Router template kept its own copy of analytics shop identity, consent, and URL, then threaded them through publish calls. `ShopifyScripts` already supplies all of this, so the template had a second source of truth that could silently drift. This removes that plumbing while preserving behavior.

## Before

```tsx
// Template carried its own shop + consent and passed them on every event.
configureAnalytics(shop, consent);
analytics.publish(AnalyticsEvent.PAGE_VIEWED, {
  url: window.location.href,
  shop,
});
```

## After

```tsx
// The analytics bus supplies shop identity and infers url from window.location.href.
analytics.publish(AnalyticsEvent.PAGE_VIEWED);
```

## What this changes

- Removes the `analyticsShop` constant, the `configureAnalytics`/`getAnalyticsShop` store, and the explicit `shop`/`url` arguments on every `publish()` call in the React Router template.
- Drops dead `country`/`language` fields from the consent config and the `consent` argument that was threaded through several hops only to be discarded with `void consent`.
- `AnalyticsTracker` no longer takes `shop`/`consent` props, and `root.tsx` no longer loads them.
- Folds the single remaining `shop` identity into `~/lib/shop.ts` as one source of truth.
- Updates the Nuxt example to stop passing a redundant `url` on collection view events.
- Fixes the Hydrogen example consent default from `no-banner` to `default-banner` for consistency with the other examples.

## Developer impact

No changeset. All changes are template- and example-local and do not ship in `@shopify/hydrogen`. There are no new exports and no runtime contract changes for library consumers.

The change is behavior-preserving: the analytics bus receives the same shop identity and consent mode, now sourced solely from `ShopifyScripts` in the document head.

## How to Test

1. Run `pnpm install && pnpm build:pkgs`.
2. Start the React Router template dev server.
3. Open a product, a collection, and a search results page.
4. Confirm `product_viewed`, `collection_viewed`, and `search_viewed` events still fire with the correct shop identity and URL (via the analytics debugger or network tab).
5. Add and remove a cart item, then open the cart drawer, and confirm the cart events still publish.
