### PR TITLE
fix: prevent unhandled errors from superseded cart mutations

### DIFF
--- a/.changeset/quiet-cart-aborts.md
+++ b/.changeset/quiet-cart-aborts.md
@@ -1,0 +1,5 @@
+---
+"@shopify/hydrogen": patch
+---
+
+Prevent superseded cart mutations from producing unhandled `AbortError` console errors.

--- a/packages/hydrogen/src/core/cart/cart-transactions.test.ts
+++ b/packages/hydrogen/src/core/cart/cart-transactions.test.ts
@@ -407,6 +407,25 @@ describe("transaction cart store", () => {
     expect(store.getState().pending.lines).toEqual(new Set());
   });
 
+  it("handles an aborted correlated Standard Event promise", async () => {
+    dispatchEventsSynchronously = false;
+    store.hydrate(makeCart([makeLine("line-a", 1)]));
+    getCart.mockResolvedValueOnce({ cart: makeCart([makeLine("line-a", 3)]) });
+
+    const first = store.handleFormSubmit(submitLine("line-a"));
+    await Promise.resolve();
+    await Promise.resolve();
+    const second = store.handleFormSubmit(submitLine("line-a"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transportSignals[0].aborted).toBe(true);
+    transportDeferreds[1].resolve(serverResult([makeLine("line-a", 3)]));
+    await Promise.all([first, second]);
+
+    expect(store.getState().data.lines.nodes[0].quantity).toBe(3);
+  });
+
   it("retains references outside a transaction's scope", () => {
     const lineA = makeLine("line-a", 1);
     const lineB = makeLine("line-b", 1);

--- a/packages/hydrogen/src/core/cart/cart.ts
+++ b/packages/hydrogen/src/core/cart/cart.ts
@@ -1533,6 +1533,9 @@ function enqueueTransaction<TType extends TransactionType>(
   );
   if (expectedEventIndex !== -1) {
     store.expectedEvents.splice(expectedEventIndex, 1);
+    // The action's return promise is authoritative; this correlated event promise can reject
+    // separately when the request is cancelled and must still have an observer.
+    promise.then(NOOP, NOOP);
     return;
   }
   if (store.observedPromises.has(promise)) return;

--- a/packages/hydrogen/src/core/cart/cart.ts
+++ b/packages/hydrogen/src/core/cart/cart.ts
@@ -1533,8 +1533,7 @@ function enqueueTransaction<TType extends TransactionType>(
   );
   if (expectedEventIndex !== -1) {
     store.expectedEvents.splice(expectedEventIndex, 1);
-    // The action's return promise is authoritative; this correlated event promise can reject
-    // separately when the request is cancelled and must still have an observer.
+    // Prevent request cancellation from becoming an unhandled rejection.
     promise.then(NOOP, NOOP);
     return;
   }


### PR DESCRIPTION
TL;DR: Rapid cart updates deliberately abort superseded requests, but the correlated Standard Event promise was left unobserved and surfaced those cancellations as console errors.

## Before

Repeatedly updating the same cart line produced an unhandled `AbortError` for every superseded request, even though the cart handled the cancellation correctly.

## After

Hydrogen observes the redundant correlated event promise while keeping the caller-facing action promise authoritative. Expected cancellations stay silent; genuine mutation failures still follow the existing error path.

## What this changes

- Observes the deduplicated Standard Event promise before discarding it.
- Adds regression coverage for asynchronous correlated events cancelled by a newer cart mutation.

## Developer impact

Includes a **patch** changeset for `@shopify/hydrogen`. There are no public API or runtime contract changes.

## Out of scope

- Server-side cart conflict responses remain genuine failures and are not swallowed.

## Risk

- Low. The change only handles a redundant promise after its event has already been correlated with the authoritative action promise.

## How to Test

1. Run `pnpm --filter @shopify/hydrogen build`.
2. Run `pnpm --filter @shopify/hydrogen-template-react-router dev`.
3. Open `http://localhost:5173`, add a product, and open the cart drawer.
4. Click the line item's increase button repeatedly in quick succession.
5. Confirm the cart settles on the latest quantity without unhandled `AbortError` messages in the browser console.
