### PR TITLE
Fix stale CLI path and dead skill references in agent skills

### DIFF
--- a/.claude/skills/hydrogen-dev-workflow/SKILL.md
+++ b/.claude/skills/hydrogen-dev-workflow/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 # Hydrogen Development Workflow
 
-Development practices and workflow guide for engineers working on Shopify's headless storefront ecosystem. The Hydrogen framework repo is [`Shopify/hydrogen`](https://github.com/Shopify/hydrogen). For domain context, see the `headless-storefronts-context` skill. For repo locations, see the `shopify-repos` skill.
+Development practices and workflow guide for engineers working on Shopify's headless storefront ecosystem. The Hydrogen framework repo is [`Shopify/hydrogen`](https://github.com/Shopify/hydrogen).
 
 ## Testing Customer Accounts Locally
 
@@ -129,7 +129,7 @@ Do NOT add consent gating to `publish()` — it causes events to be dropped (not
 
 ## Hydrogen CLI
 
-The Hydrogen CLI source code lives at `packages/cli-hydrogen` in the Hydrogen repo. It is released to npm as its own package.
+The Hydrogen CLI source code lives at `packages/cli` in the Hydrogen repo. It is released to npm as its own package, `@shopify/cli-hydrogen` (the npm package name differs from the directory name).
 
 **Bundling in Shopify CLI**: Merchants typically do not use the Hydrogen CLI directly. Instead, it is bundled inside the Shopify CLI (in the `Shopify/cli` repo). After releasing a new version of the Hydrogen CLI to npm, you must also bump its version in the Shopify CLI.
 

--- a/.claude/skills/hydrogen-versioning/SKILL.md
+++ b/.claude/skills/hydrogen-versioning/SKILL.md
@@ -12,7 +12,7 @@ description: >
 
 # Hydrogen & Shopify API Versioning
 
-Reference for all versioning schemes in the Hydrogen ecosystem. For release *process* (how to actually ship a release), see `hydrogen-release-process`. For domain architecture context, see `headless-storefronts-context`.
+Reference for all versioning schemes in the Hydrogen ecosystem. For release *process* (how to actually ship a release), see `hydrogen-release-process`.
 
 ## Shopify GraphQL API Versioning
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4000

Three references in `.claude/skills/` resolve to nothing, so the skills actively mislead anyone — human or coding agent — who follows them.

1. **`hydrogen-dev-workflow` sends CLI contributors to a directory that does not exist.** It names `packages/cli-hydrogen` as the CLI source location. The source is at `packages/cli`; `@shopify/cli-hydrogen` is only the npm package name. This is the one line in the skill that a CLI contributor is most likely to act on first, and it fails immediately.

2. **Two skills point at sibling skills that were never vendored into this repo.** `headless-storefronts-context` and `shopify-repos` are referenced from `hydrogen-dev-workflow` and `hydrogen-versioning`, but `.claude/skills/` holds exactly four skills and neither is among them. An agent told to consult them either wastes a turn looking, or assumes it is missing context it needs to reconstruct.

I chose to **delete** the dangling pointers rather than replace them with substitutes. The surrounding sentences carry no information once the target is gone, and inventing a stand-in reference would be a guess about what those internal skills contained.

For the CLI path I added a short parenthetical noting that the npm name differs from the directory name, since that mismatch is what produced the error in the first place and is likely to reproduce it otherwise.

### WHAT is this pull request doing?

Three line edits across two skill files, no behavioural change:

- `.claude/skills/hydrogen-dev-workflow/SKILL.md:132` — `packages/cli-hydrogen` → `packages/cli`, plus a note that the npm package is `@shopify/cli-hydrogen`.
- `.claude/skills/hydrogen-dev-workflow/SKILL.md:14` — dropped the `headless-storefronts-context` and `shopify-repos` pointers.
- `.claude/skills/hydrogen-versioning/SKILL.md:15` — dropped the `headless-storefronts-context` pointer.

Scoped deliberately. `packages/cli/package.json` has the same stale `packages/cli-hydrogen` string in its `repository.directory` field (which breaks the Repository link on the npm page for `@shopify/cli-hydrogen`), but fixing it touches `packages/*/package.json` and so requires a changeset. I left it for a separate PR rather than turning a docs-only change into a version-bumping one — noted in #4000, happy to send it if wanted.

### HOW to test your changes?

Verify the stale references are gone and that everything the skills now point at exists:

```bash
# 1. No dangling references remain
grep -rn "headless-storefronts-context\|shopify-repos\|packages/cli-hydrogen" .claude/
# expect: no output

# 2. The corrected path exists and the npm name is what the skill now claims
ls packages/cli
node -p "require('./packages/cli/package.json').name"   # @shopify/cli-hydrogen

# 3. Every skill still cross-referenced by these two files exists
ls .claude/skills/
# e2e-test-writing  hydrogen-dev-workflow  hydrogen-release-process  hydrogen-versioning
```

The remaining cross-references in both files' "Related Skills" sections (`hydrogen-release-process`, `hydrogen-versioning`, `hydrogen-dev-workflow`, `CLAUDE.md`) were each checked and all resolve.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — documentation only, none
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes — not applicable, internal agent-instruction files only, no `packages/*/src` or `package.json` changes
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes — not applicable, documentation only
- [x] I've added or updated the documentation — this PR is the documentation fix
