### PR TITLE
Add changelog.json entries for 2026.4.4 and 2026.4.5

### DIFF
--- a/docs/changelog.json
+++ b/docs/changelog.json
@@ -3,6 +3,73 @@
   "version": "1",
   "releases": [
     {
+      "title": "Customer account login and token refresh reliability",
+      "version": "2026.4.5",
+      "date": "2026-08-14",
+      "hash": "2a2738ba20487ccc07006815fe40e93b24cb5f08",
+      "commit": "https://github.com/Shopify/hydrogen/pull/3912/commits/2a2738ba20487ccc07006815fe40e93b24cb5f08",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3912",
+      "dependencies": {
+        "@shopify/hydrogen": "2026.4.5"
+      },
+      "devDependencies": {},
+      "removeDependencies": [
+        "@shopify/hydrogen"
+      ],
+      "features": [
+        {
+          "title": "Add an explicit `~` app alias to new Hydrogen projects",
+          "info": "Newly scaffolded storefronts define the `~` path alias explicitly instead of relying on an implicit default, making imports resolve consistently across editors and build tools.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3852",
+          "id": "3852"
+        },
+        {
+          "title": "Recommend the Shopify AI Toolkit in newly scaffolded storefronts",
+          "info": "New projects now point coding agents at the Shopify AI Toolkit for Shopify API and platform work.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3887",
+          "id": "3887"
+        }
+      ],
+      "fixes": [
+        {
+          "title": "Recover customer account login from OAuth state mismatches",
+          "info": "Customer account login now recovers when switching browser contexts or opening multiple login tabs, and OAuth state values use cryptographically secure randomness.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3856",
+          "id": "3856"
+        },
+        {
+          "title": "Keep customers logged in when a token refresh fails transiently",
+          "info": "The session is now only cleared when the refresh token is missing or the token endpoint returns `invalid_grant`. Other OAuth errors, HTTP failures, and network failures can be retried on a subsequent request instead of logging the customer out.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3916",
+          "id": "3916"
+        }
+      ]
+    },
+    {
+      "title": "Reduced PerfKit resource timing sampling",
+      "version": "2026.4.4",
+      "date": "2026-06-15",
+      "hash": "b4df055281f6ce279a690766405b4291e5cec77c",
+      "commit": "https://github.com/Shopify/hydrogen/pull/3791/commits/b4df055281f6ce279a690766405b4291e5cec77c",
+      "pr": "https://github.com/Shopify/hydrogen/pull/3791",
+      "dependencies": {
+        "@shopify/hydrogen": "2026.4.4"
+      },
+      "devDependencies": {},
+      "removeDependencies": [
+        "@shopify/hydrogen"
+      ],
+      "features": [],
+      "fixes": [
+        {
+          "title": "Reduce PerfKit resource timing sampling rate",
+          "info": "PerfKit now sets a resource timing sampling rate of 10 instead of 100, so storefronts report performance timings for a smaller sample of requests.",
+          "pr": "https://github.com/Shopify/hydrogen/pull/3790",
+          "id": "3790"
+        }
+      ]
+    },
+    {
       "title": "Cart, redirect, Image, and React Router compatibility fixes",
       "version": "2026.4.3",
       "date": "2026-06-08",


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4002

`@shopify/hydrogen` 2026.4.4 and 2026.4.5 are published to npm but absent from `docs/changelog.json`. Since [`getAvailableUpgrades`](https://github.com/Shopify/hydrogen/blob/main/packages/cli/src/commands/hydrogen/upgrade.ts#L499-L527) builds its list purely by filtering `releases` from that file, `h2 upgrade` currently reports "up to date" to merchants on 2026.4.3 — including those missing the two customer-account authentication fixes in 2026.4.5.

### WHAT is this pull request doing?

Adds the two missing release entries. The diff is **purely additive** — 67 insertions, 0 deletions, no reformatting of existing entries.

Content is derived from the release commits and the changesets shipped, not written from scratch:

| Version | Release commit | PR | Date |
| --- | --- | --- | --- |
| 2026.4.5 | `2a2738ba` | #3912 | 2026-08-14 |
| 2026.4.4 | `b4df0552` | #3791 | 2026-06-15 |

**2026.4.5** — fixes #3856 (OAuth state mismatch recovery) and #3916 (token refresh resilience) from `packages/hydrogen/CHANGELOG.md`; features #3852 (`~` alias) and #3887 (AI Toolkit) from the skeleton, which moved 2026.4.4 → 2026.4.6 across this release window.

**2026.4.4** — fix #3790 (PerfKit sampling rate 100 → 10).

Two things worth flagging for the reviewer:

1. **PR #3844 is titled `[ci] release 2026.4.5` but did not bump `@shopify/hydrogen`** — it stayed at 2026.4.4 in that commit, and the real bump landed in #3912. I attributed 2026.4.5 to #3912 on the basis of the actual `packages/hydrogen/package.json` version at each commit rather than the PR titles.
2. **I included the two skeleton-only changes as `features` on 2026.4.5.** Precedent supports this (2026.4.3 lists #3753, also a new-projects-only skeleton change), but they affect scaffolding rather than an upgrading merchant's runtime — easy to drop if you'd rather keep the entry to runtime changes only.

`dependencies` lists only `@shopify/hydrogen` for both, since no skeleton dependency changed in either release (`react-router` stayed 7.16.0, `@shopify/cli` stayed 3.93.2). This matches the 2026.4.1 entry, and the CLI composes a `cumulativeRelease` across intermediate versions, so unchanged deps do not need restating.

### HOW to test your changes?

**Confirm the gap and the fix**, by simulating the CLI's own upgrade filter against the file before and after:

```bash
node -e "
const semver=require('semver');
const before=JSON.parse(require('child_process').execSync('git show main:docs/changelog.json'));
const after=JSON.parse(require('fs').readFileSync('docs/changelog.json','utf8'));
const f=(j,cur)=>j.releases.filter(r=>semver.gt(r.version,semver.coerce(cur).version)).map(r=>r.version);
for (const v of ['2026.4.3','2026.4.4'])
  console.log('on '+v+':  before='+(f(before,v).join(',')||'none')+'   after='+(f(after,v).join(',')||'none'));
"
```

```
on 2026.4.3:  before=none   after=2026.4.5,2026.4.4
on 2026.4.4:  before=none   after=2026.4.5
```

**Schema validation** — the existing suite covers this file:

```bash
pnpm --dir packages/cli exec vitest run src/commands/hydrogen/changelog-schema.test.ts
# 9 passed (9)
```

**Cross-check the entries against the source of truth:**

```bash
# the changesets these releases shipped
awk '/^## 2026\.4\.5/,/^## 2026\.4\.3/' packages/hydrogen/CHANGELOG.md

# the hydrogen version at each release commit
git show b4df0552:packages/hydrogen/package.json | grep '"version"'   # 2026.4.4
git show 2a2738ba:packages/hydrogen/package.json | grep '"version"'   # 2026.4.5
```

> [!NOTE]
> If you run the schema test on a checkout whose **path contains a space**, the `is valid JSON and matches getChangelog() output` case fails — `isHydrogenMonorepo` is false there, so `getChangelog()` fetches the remote changelog and compares it against your local edit. That is #3988 (fix in #3989), not a problem with this change; I verified all 9 tests pass with that fix applied.

#### Post-merge steps

The updated file is served via https://hydrogen.shopify.dev/changelog.json, which proxies the raw content of `docs/changelog.json` on `main`. No further action beyond merging.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — data-only change, none
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes — not applicable; no `packages/*/src` or `package.json` changes, and this documents releases that already shipped
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes — existing `changelog-schema.test.ts` covers this file; verified passing
- [x] I've added or updated the documentation — this PR is the documentation fix
