### PR TITLE
PROTOTYPE: consent-independent (essential) analytics destinations

### DIFF
--- a/packages/hydrogen/src/core/analytics/destination-manager.test.ts
+++ b/packages/hydrogen/src/core/analytics/destination-manager.test.ts
@@ -68,6 +68,89 @@ describe("createDestinationManager", () => {
     });
   });
 
+  describe("essential destinations (PROTOTYPE)", () => {
+    it("delivers live events while tracking is blocked", () => {
+      const { manager } = createTestManager(() => false);
+      const essential = vi.fn();
+      const gated = vi.fn();
+
+      manager.addDestination({
+        name: "essential-ga",
+        consent: "essential",
+        setup({ subscribe }) {
+          subscribe("page_viewed", essential);
+        },
+      });
+      manager.addDestination({
+        name: "gated",
+        setup({ subscribe }) {
+          subscribe("page_viewed", gated);
+        },
+      });
+
+      manager.onPublish("page_viewed", { url: "/blocked" });
+
+      expect(essential).toHaveBeenCalledWith({ url: "/blocked" });
+      expect(gated).not.toHaveBeenCalled();
+    });
+
+    it("replays buffered events to a late essential destination while blocked", () => {
+      const { manager } = createTestManager(() => false);
+      const essential = vi.fn();
+
+      manager.onPublish("page_viewed", { url: "/early" });
+
+      manager.addDestination({
+        name: "essential-ga",
+        consent: "essential",
+        setup({ subscribe }) {
+          subscribe("page_viewed", essential);
+        },
+      });
+
+      expect(essential).toHaveBeenCalledOnce();
+      expect(essential).toHaveBeenCalledWith({ url: "/early" });
+    });
+
+    it("keeps delivering after consent is declined", () => {
+      const { manager } = createTestManager(() => false);
+      const essential = vi.fn();
+
+      manager.addDestination({
+        name: "essential-ga",
+        consent: "essential",
+        setup({ subscribe }) {
+          subscribe("page_viewed", essential);
+        },
+      });
+
+      manager.replay(true);
+      manager.onPublish("page_viewed", { url: "/after-decline" });
+
+      expect(essential).toHaveBeenCalledWith({ url: "/after-decline" });
+    });
+
+    it("does not deliver an event twice to an essential destination", () => {
+      let canTrack = false;
+      const { manager } = createTestManager(() => canTrack);
+      const essential = vi.fn();
+
+      manager.addDestination({
+        name: "essential-ga",
+        consent: "essential",
+        setup({ subscribe }) {
+          subscribe("page_viewed", essential);
+        },
+      });
+
+      manager.onPublish("page_viewed", { url: "/once" });
+      canTrack = true;
+      manager.replay();
+
+      expect(essential).toHaveBeenCalledOnce();
+    });
+  });
+
   describe("replay", () => {
     it("replays buffered events after tracking is granted", () => {
       let canTrack = false;

--- a/packages/hydrogen/src/core/analytics/destination-manager.ts
+++ b/packages/hydrogen/src/core/analytics/destination-manager.ts
@@ -16,6 +16,7 @@ type ReplayEntry = {
 
 type DestinationRecord = {
   name: string;
+  essential: boolean;
   cleanup?: () => void;
   subscriptions: Map<string, Set<(payload: unknown) => void>>;
   nextReplaySequence: number;
@@ -60,6 +61,10 @@ type DestinationManagerDeps = {
  * Destinations subscribe to events during setup and receive live delivery when
  * `canTrack()` returns true. Events published while blocked are buffered and
  * replayed once tracking is allowed.
+ *
+ * PROTOTYPE: destinations registered with `consent: "essential"` skip the
+ * `canTrack()` gate entirely (live and replay). They still lose history once
+ * a declined interaction clears the buffer and stops recording.
  */
 export function createDestinationManager(deps: DestinationManagerDeps) {
   let nextReplaySequence = 0;
@@ -75,7 +80,20 @@ export function createDestinationManager(deps: DestinationManagerDeps) {
    *   replay buffer and stops recording until tracking is allowed again.
    */
   function replay(clearWhenBlocked = false): void {
-    if (!deps.canTrack()) {
+    const canTrack = deps.canTrack();
+
+    // Essential destinations catch up on buffered events even while tracking
+    // is blocked, so a late-registered essential destination still sees the
+    // page view that happened before it attached.
+    for (const destination of destinations) {
+      if (!canTrack && !destination.essential) continue;
+      for (const entry of replayBuffer) {
+        if (entry.sequence < destination.nextReplaySequence) continue;
+        deliverDestinationEvent(destination, entry);
+      }
+    }
+
+    if (!canTrack) {
       if (clearWhenBlocked) {
         replayBuffer.length = 0;
         shouldRecordReplay = false;
@@ -84,12 +102,6 @@ export function createDestinationManager(deps: DestinationManagerDeps) {
     }
 
     shouldRecordReplay = true;
-    for (const destination of destinations) {
-      for (const entry of replayBuffer) {
-        if (entry.sequence < destination.nextReplaySequence) continue;
-        deliverDestinationEvent(destination, entry);
-      }
-    }
   }
 
   /**
@@ -111,6 +123,7 @@ export function createDestinationManager(deps: DestinationManagerDeps) {
 
     const destinationRecord: DestinationRecord = {
       name: destination.name,
+      essential: destination.consent === "essential",
       subscriptions: new Map(),
       nextReplaySequence: 0,
     };
@@ -215,10 +228,10 @@ export function createDestinationManager(deps: DestinationManagerDeps) {
       }
     }
 
-    if (deps.canTrack()) {
-      for (const destination of destinations) {
-        deliverDestinationEvent(destination, replayEntry);
-      }
+    const canTrack = deps.canTrack();
+    for (const destination of destinations) {
+      if (!canTrack && !destination.essential) continue;
+      deliverDestinationEvent(destination, replayEntry);
     }
   }
 

--- a/packages/hydrogen/src/core/analytics/index.ts
+++ b/packages/hydrogen/src/core/analytics/index.ts
@@ -21,5 +21,6 @@ export type {
   ShopAnalytics,
   StorefrontAnalyticsConfig,
   StorefrontAnalyticsDestination,
+  StorefrontAnalyticsDestinationConsent,
   StorefrontAnalyticsDestinationSetupContext,
 } from "./types";

--- a/packages/hydrogen/src/core/analytics/types.ts
+++ b/packages/hydrogen/src/core/analytics/types.ts
@@ -164,8 +164,23 @@ export type StorefrontAnalyticsDestinationSetupContext = {
   getConfig: () => StorefrontAnalyticsConfig;
 };
 
+/**
+ * PROTOTYPE: Consent purpose a destination requires before it receives events.
+ *
+ * - `"analytics"` (default): delivered only when Customer Privacy reports
+ *   analytics processing is allowed. Events published before consent are
+ *   buffered and replayed once granted.
+ * - `"essential"`: delivered regardless of consent state, including before
+ *   Customer Privacy loads and after the shopper declines. Only use for
+ *   first-party processing the merchant has classified as strictly necessary
+ *   (equivalent to a Liquid custom pixel with permission "Not required").
+ *   The merchant, not Hydrogen, owns that classification.
+ */
+export type StorefrontAnalyticsDestinationConsent = "analytics" | "essential";
+
 export type StorefrontAnalyticsDestination = {
   name: string;
+  consent?: StorefrontAnalyticsDestinationConsent;
   setup: (
     context: StorefrontAnalyticsDestinationSetupContext,
   ) => void | (() => void) | Promise<void | (() => void)>;

--- a/packages/hydrogen/src/core/index.ts
+++ b/packages/hydrogen/src/core/index.ts
@@ -70,6 +70,7 @@ export type {
   StorefrontAnalytics,
   StorefrontAnalyticsConfig,
   StorefrontAnalyticsDestination,
+  StorefrontAnalyticsDestinationConsent,
   StorefrontAnalyticsDestinationSetupContext,
 } from "./analytics";
 export {


### PR DESCRIPTION
> **PROTOTYPE** - throwaway spike, not reviewed for production. Exists to make a design discussion concrete. If we want this for real it gets rewritten and goes through the normal review lifecycle.

TL;DR: Some merchants run first-party server-side Google Analytics the way a Liquid custom pixel can be configured with permission "Not required". In `preview`, `addDestination()` is hard-gated on analytics consent and the only consent-independent path is raw `subscribe()`, which our docs say not to use for destinations and which has no replay. This spike adds a per-destination consent policy so an essential destination can be registered through the sanctioned API.

## Before

Every destination goes through the same `canTrack()` gate. There is no way to declare a destination as consent-independent.

```ts
window.Shopify.analytics.addDestination({
  name: "first-party-ga",
  setup({ subscribe }) {
    subscribe("page_viewed", sendToGa); // never fires until analytics consent is "yes"
  },
});
```

## After

```ts
window.Shopify.analytics.addDestination({
  name: "first-party-ga",
  consent: "essential",
  setup({ subscribe }) {
    subscribe("page_viewed", sendToGa); // fires live and replays regardless of consent
  },
});
```

`consent` defaults to `"analytics"`, so existing destinations behave exactly as before.

## What this changes

- `StorefrontAnalyticsDestination` gains an optional `consent: "analytics" | "essential"` field (new exported type `StorefrontAnalyticsDestinationConsent`).
- `destination-manager.ts` evaluates the gate per destination instead of globally: essential destinations receive live events and replay while `canTrack()` is false, including before Customer Privacy loads and after a decline.
- Four sanity tests for the essential path.

## Developer impact

No changeset. Prototype only.

If graduated, this would be a **minor** bump for `@shopify/hydrogen`: additive field on a public type, default preserves current behavior.

## Out of scope

- Per-purpose gating (`marketing`, `preferences`, `sale_of_data`). The bus only reads analytics consent today; this spike does not change that.
- Docs and packaged skills. `analytics.md` still says "do not bypass this gate in production", which is the right default and would need careful wording if this ships.
- Any change to raw `subscribe()`.

## Risk

- **Policy, not engineering.** The code is small. The real question is whether Hydrogen should offer a consent bypass at all, and how we frame merchant responsibility for classifying processing as "strictly necessary". Liquid custom pixels already do this, so there is precedent.
- After a declined interaction the replay buffer is cleared and recording stops. An essential destination registered *after* that point misses history (live delivery still works). Acceptable for a spike; needs a decision if graduated.
- `"essential"` also bypasses the default-banner pre-interaction wait, which is intended, but worth a second look.

## How to Test

1. Run `pnpm install && pnpm build:pkgs`.
2. Run `pnpm --filter @shopify/hydrogen-example-hydrogen dev` and open the storefront.
3. In devtools console, register an essential destination:
   ```js
   window.Shopify.analytics.addDestination({
     name: "essential-probe",
     consent: "essential",
     setup({ subscribe }) { subscribe("page_viewed", (p) => console.log("essential", p)); },
   });
   ```
4. Register a second destination without `consent` and a different name, logging `"gated"`.
5. Decline the privacy banner (or call `window.Shopify.customerPrivacy.setTrackingConsent({analytics: false, marketing: false, preferences: false, sale_of_data: false}, () => {})`).
6. Navigate between pages. `essential` logs on every page view; `gated` never logs.
7. Accept consent and navigate again. Both log.
