### PR TITLE
fix(deps): bump react-router to patch 5 disclosed advisories

### DIFF
--- a/packages/hydrogen/package.json
+++ b/packages/hydrogen/package.json
@@ -94,8 +94,8 @@
     "@shopify/graphql-client": "1.4.1"
   },
   "devDependencies": {
-    "react-router": "7.16.0",
-    "@react-router/dev": "7.16.0",
+    "react-router": "7.18.3",
+    "@react-router/dev": "7.18.3",
     "@shopify/generate-docs": "catalog:",
     "@shopify/hydrogen-codegen": "workspace:*",
     "@testing-library/jest-dom": "^6.6.3",
@@ -113,8 +113,8 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "react-router": "~7.16.0",
-    "@react-router/dev": "~7.16.0",
+    "react-router": "~7.18.0",
+    "@react-router/dev": "~7.18.0",
     "react": "^18.3.1 || ~19.0.3 || ~19.1.4 || ^19.2.3",
     "vite": "^5.1.0 || ^6.2.1 || ^7.0.0 || ^8.0.0"
   },

--- a/packages/remix-oxygen/package.json
+++ b/packages/remix-oxygen/package.json
@@ -49,10 +49,10 @@
     "@shopify/oxygen-workers-types": "^4.1.6",
     "@shopify/hydrogen": "workspace:*",
     "@types/node": "catalog:",
-    "react-router": "7.16.0"
+    "react-router": "7.18.3"
   },
   "peerDependencies": {
     "@shopify/oxygen-workers-types": "^3.17.3 || ^4.1.2",
-    "react-router": "~7.16.0"
+    "react-router": "~7.18.0"
   }
 }

--- a/templates/skeleton/package.json
+++ b/templates/skeleton/package.json
@@ -20,16 +20,16 @@
     "isbot": "^5.1.22",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-router": "7.16.0",
-    "react-router-dom": "7.16.0"
+    "react-router": "7.18.3",
+    "react-router-dom": "7.18.3"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.5",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
     "@graphql-codegen/cli": "5.0.2",
-    "@react-router/dev": "7.16.0",
-    "@react-router/fs-routes": "7.16.0",
+    "@react-router/dev": "7.18.3",
+    "@react-router/fs-routes": "7.18.3",
     "@shopify/cli": "3.93.2",
     "@shopify/hydrogen-codegen": "workspace:*",
     "@shopify/mini-oxygen": "workspace:*",


### PR DESCRIPTION
Automated dependency bump to address 5 disclosed CVEs/advisories in `react-router`, the core SSR routing engine used by every Hydrogen storefront (both `@shopify/hydrogen`'s peer dependency and the `templates/skeleton` scaffold that `npm create @shopify/hydrogen@latest` ships to new stores).

- **Package:** `react-router` (+ matching `@react-router/dev`, `react-router-dom`, `@react-router/fs-routes` in the same release train) → `7.16.0` → `7.18.3`
- **Advisories fixed** (all previously unfixed at `7.16.0`, all fixed by `7.18.0`/`7.18.2`, verified clean via `osv.dev` at `7.18.3`):
  - [GHSA-chx6-hx7r-mcp5](https://github.com/advisories/GHSA-chx6-hx7r-mcp5) — **HIGH** — Unauthenticated Denial of Service via Inefficient Route Matching. Reachable on every request to any Hydrogen storefront (no RSC/experimental flag required).
  - [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) — **HIGH** — RSC Mode CSRF Bypass Allows Action Execution Before 400 Response (only applies if RSC mode is enabled).
  - [GHSA-337j-9hxr-rhxg](https://github.com/advisories/GHSA-337j-9hxr-rhxg) — MODERATE — Arbitrary Constructor Injection via `deserializeErrors()` in SSR hydration.
  - [GHSA-h8fp-f39c-q6mh](https://github.com/advisories/GHSA-h8fp-f39c-q6mh) — MODERATE — `RSCErrorHandler` missing protocol validation (XSS, RSC mode only).
  - [GHSA-wrjc-x8rr-h8h6](https://github.com/advisories/GHSA-wrjc-x8rr-h8h6) — MODERATE — Open redirect via backslash in `<Link>`/`useNavigate` (CVE-2025-68470 bypass).

Detected by [osv-scanner](https://google.github.io/osv-scanner/) against `pnpm-lock.yaml`.

**Scope:** manifest-only (`packages/hydrogen/package.json`, `packages/remix-oxygen/package.json`, `templates/skeleton/package.json`). This sandbox doesn't have a working `pnpm` install capable of resolving this workspace's `catalog:` protocol, so `pnpm-lock.yaml` was **not** regenerated here — please run `pnpm install` to update the lockfile before merging. No code changes; `react-router@7.18.3`'s peer dependency range (`react >=18`, `react-dom >=18`) and `engines.node >=20` are unchanged from what this repo already requires, so this should be a drop-in bump.

Filed by [Aeon](https://github.com/aeonfun/aeon).
