### PR TITLE
Fix two broken relative links in docs

### DIFF
--- a/docs/CALVER.md
+++ b/docs/CALVER.md
@@ -601,5 +601,5 @@ Potential enhancements being considered:
 
 - [Hydrogen Release Process](../CLAUDE.md#hydrogen-release-process) - Complete release workflow
 - [Major Protection Workflow](../.github/workflows/major-protection.yml) - Protection implementation
-- [Protection Utilities](../.github/scripts/changeset-protection-utils.js) - Shared utilities
+- [Protection Utilities](../.changeset/changeset-protection-utils.js) - Shared utilities
 - [.changeset/README.md](../.changeset/README.md) - Changesets documentation

--- a/packages/hydrogen/README.md
+++ b/packages/hydrogen/README.md
@@ -18,5 +18,5 @@ npm create @shopify/hydrogen@latest
 - Interested in contributing to Hydrogen? [Read our contributing guide](../../CONTRIBUTING.md)
 - Want to learn more? [Check out the Hydrogen docs on Shopify.dev](https://shopify.dev/custom-storefronts/hydrogen)
 - Questions? Feedback? Feature requests? [Discussions](https://github.com/Shopify/hydrogen/discussions)
-- Upgrading from a previous version? [View the Changelog](./packages/hydrogen/CHANGELOG.md)
+- Upgrading from a previous version? [View the Changelog](./CHANGELOG.md)
 - Looking for Hydrogen v1? [The source code has been moved](https://github.com/Shopify/hydrogen-v1)


### PR DESCRIPTION
### WHY are these changes introduced?

Related to #4013.

Two relative links in the docs point at paths that do not exist.

**1. `docs/CALVER.md`**

```md
- [Protection Utilities](../.github/scripts/changeset-protection-utils.js) - Shared utilities
```

There is no `.github/scripts/` directory. The file is at [`.changeset/changeset-protection-utils.js`](https://github.com/Shopify/hydrogen/blob/main/.changeset/changeset-protection-utils.js).

**2. `packages/hydrogen/README.md`**

```md
- Upgrading from a previous version? [View the Changelog](./packages/hydrogen/CHANGELOG.md)
```

The link is relative to the README, which already lives in `packages/hydrogen/`, so it resolves to `packages/hydrogen/packages/hydrogen/CHANGELOG.md`. The changelog is at `./CHANGELOG.md` from there.

This second one is the more visible of the two. `packages/hydrogen/README.md` is the README published to npm, so "View the Changelog" is broken for anyone reading the [`@shopify/hydrogen` package page](https://www.npmjs.com/package/@shopify/hydrogen) as well as on GitHub.

### WHAT is this pull request doing?

- `docs/CALVER.md`: points the protection utilities link at `../.changeset/changeset-protection-utils.js`.
- `packages/hydrogen/README.md`: points the changelog link at `./CHANGELOG.md`.

Both targets are verified to exist at those paths on `main`.

Scope notes:

- The last bullet in the same `docs/CALVER.md` section points at `.changeset/README.md`, which does not exist either. That one needs a decision about whether to remove the bullet or add the file, so it is filed separately as #4013 rather than guessed at here.
- #4013 also suggests a CI link check, since nothing currently verifies relative links and `format:check` is scoped to `./packages ./templates`. That is deliberately not part of this PR.
- `docs/` is outside the `format:check` scope, and Prettier reports pre-existing differences in `docs/CALVER.md`, including a missing trailing newline. I left the file as it is rather than adding unrelated reformatting to a one line change.

### HOW to test your changes?

From the repository root:

```bash
test -e .changeset/changeset-protection-utils.js && echo ok
test -e packages/hydrogen/CHANGELOG.md && echo ok
```

Both paths resolve. Clicking either link on GitHub also now lands on the file.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset.
- [x] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [x] I've added or updated the documentation

<sub>Checklist notes: no changeset, since this touches only markdown and not `packages/*/src/**` or any `packages/*/package.json`. No tests, since there is no code change. The documentation box is the change itself.</sub>
