### PR TITLE
Publish snapshots with OIDC trusted publishing

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
+          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
           node-version: 24
@@ -36,12 +37,11 @@ jobs:
           printf -- "---\n'@shopify/hydrogen': patch\n'@shopify/cli-hydrogen': patch\n'@shopify/create-hydrogen': patch\n---\n\nForce snapshot build.\n" > .changeset/force-snapshot-build.md
 
       - name: Create snapshot version
-        uses: Shopify/snapit@0c0d2dd62c9b0c94b7d03e1f54e72f18548e7752 # pin to a specific commit
+        uses: Shopify/snapit@efd7ad2bbc01ba82ac9a8495eb49b3a8eed0d9b9 # v0.1.0
         with:
-          github_comment_included_packages: '@shopify/hydrogen,@shopify/cli-hydrogen,@shopify/hydrogen-codegen,@shopify/mini-oxygen'
-          custom_message_suffix: "\n> Create a new project with all the released packages running `pnpm create @shopify/hydrogen@<snapshot_version>`\n>To try a new CLI plugin version, add `@shopify/cli-hydrogen` as a dependency to your project using the snapshot version."
+          comment_packages: '@shopify/hydrogen,@shopify/cli-hydrogen,@shopify/hydrogen-codegen,@shopify/mini-oxygen'
+          comment_suffix: "\n> Create a new project with all the released packages running `pnpm create @shopify/hydrogen@<snapshot_version>`\n>To try a new CLI plugin version, add `@shopify/cli-hydrogen` as a dependency to your project using the snapshot version."
           build_script: 'pnpm run build'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
#3347 moved the release workflow to npm trusted publishing but left `/snapit` on `NPM_TOKEN` because `Shopify/snapit` had no OIDC path at the time. `Shopify/snapit` v0.1.0 (Jan 14) dropped `NPM_TOKEN` and publishes over OIDC, so this PR finishes the migration:

- bumps the action to v0.1.0 and removes `NPM_TOKEN` from the step
- adds `registry-url` to `setup-node`, which snapit needs so npm knows which registry to exchange the OIDC token with (same as `release.yml`)
- renames the two inputs that changed in v0.1.0: `github_comment_included_packages` -> `comment_packages`, `custom_message_suffix` -> `comment_suffix`

## Before merging

npm trusted publishers are per package *and* per workflow file. `snapit.yml` needs to be registered for each package snapit can publish before this lands, otherwise `/snapit` fails with `ENEEDAUTH`:

- `@shopify/hydrogen`
- `@shopify/hydrogen-react`
- `@shopify/cli-hydrogen`
- `@shopify/create-hydrogen`
- `@shopify/hydrogen-codegen`
- `@shopify/mini-oxygen`
- `@shopify/remix-oxygen`

Once the first OIDC snapshot publishes, the `NPM_TOKEN` repo secret can be deleted.

## Tophatting 🎩

`issue_comment` workflows always run from `main`, so this can't be tried on this PR. After merge (and once the trusted publishers exist), comment `/snapit` on any PR: snapshots should publish and the comment should list the same four packages as before. `release.yml` is untouched.

#### Checklist

- [x] I've read the [Contributing Guidelines](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a [changeset](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing or functional changes. Test changes or internal-only config changes do not require a changeset. 
- [ ] I've added [tests](https://github.com/Shopify/hydrogen/blob/main/CONTRIBUTING.md#testing) to cover my changes
- [ ] I've added or updated the documentation
